### PR TITLE
[DMS-9] Pre-wire for appSettings

### DIFF
--- a/src/services/EdFi.DataManagementService.Api/Configuration/AppSettings.cs
+++ b/src/services/EdFi.DataManagementService.Api/Configuration/AppSettings.cs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Api.Configuration
+{
+    public class AppSettings
+    {
+        public int BeginAllowedSchoolYear { get; set; }
+        public int EndAllowedSchoolYear { get; set; }
+    }
+}

--- a/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
+++ b/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Api.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DataManagementService.Api.Infrastructure
+{
+    // Example class for IOptions 
+    public class LogAppSettingsService()
+    {
+        private readonly ILogger<LogAppSettingsService>? _logger;
+        private readonly IOptions<AppSettings>? _options;
+
+        public LogAppSettingsService(ILogger<LogAppSettingsService>? logger,
+            IOptions<AppSettings>? options) : this()
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        public void Log()
+        {
+            var appSettings = _options?.Value;
+            _logger?.LogInformation("BeginAllowedSchoolYear = {year}.", appSettings?.BeginAllowedSchoolYear);
+            _logger?.LogInformation("EndAllowedSchoolYear = {year}.", appSettings?.EndAllowedSchoolYear);
+        }
+    }
+}

--- a/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
+++ b/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
@@ -22,6 +22,6 @@ namespace EdFi.DataManagementService.Api.Infrastructure
             _options = options;
         }
 
-        public void LogToConsole() => _logger.LogInformation(message: JsonSerializer.Serialize(_options?.Value));
+        public void LogToConsole() => _logger.LogInformation(message: JsonSerializer.Serialize(_options.Value));
     }
 }

--- a/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
+++ b/src/services/EdFi.DataManagementService.Api/Infrastructure/LogAppSettingsService.cs
@@ -5,27 +5,23 @@
 
 using EdFi.DataManagementService.Api.Configuration;
 using Microsoft.Extensions.Options;
+using System.Text.Json;
 
 namespace EdFi.DataManagementService.Api.Infrastructure
 {
     // Example class for IOptions 
     public class LogAppSettingsService()
     {
-        private readonly ILogger<LogAppSettingsService>? _logger;
-        private readonly IOptions<AppSettings>? _options;
+        private readonly ILogger<LogAppSettingsService> _logger = null!;
+        private readonly IOptions<AppSettings> _options = null!;
 
-        public LogAppSettingsService(ILogger<LogAppSettingsService>? logger,
-            IOptions<AppSettings>? options) : this()
+        public LogAppSettingsService(ILogger<LogAppSettingsService> logger,
+            IOptions<AppSettings> options) : this()
         {
             _logger = logger;
             _options = options;
         }
 
-        public void Log()
-        {
-            var appSettings = _options?.Value;
-            _logger?.LogInformation("BeginAllowedSchoolYear = {year}.", appSettings?.BeginAllowedSchoolYear);
-            _logger?.LogInformation("EndAllowedSchoolYear = {year}.", appSettings?.EndAllowedSchoolYear);
-        }
+        public void LogToConsole() => _logger.LogInformation(message: JsonSerializer.Serialize(_options?.Value));
     }
 }

--- a/src/services/EdFi.DataManagementService.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/services/EdFi.DataManagementService.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Api.Configuration;
-using Microsoft.Extensions.Options;
 
 namespace EdFi.DataManagementService.Api.Infrastructure
 {
@@ -13,27 +12,8 @@ namespace EdFi.DataManagementService.Api.Infrastructure
         public static void AddServices(this WebApplicationBuilder webAppBuilder)
         {
             webAppBuilder.Services.Configure<AppSettings>(webAppBuilder.Configuration.GetSection("AppSettings"));
-        }
-    }
-
-    // Example class for IOptions 
-    public class LogAppSettingsService()
-    {
-        private readonly ILogger<LogAppSettingsService>? _logger;
-        private readonly IOptions<AppSettings>? _options;
-
-        public LogAppSettingsService(ILogger<LogAppSettingsService>? logger,
-            IOptions<AppSettings>? options) : this()
-        {
-            _logger = logger;
-            _options = options;
-        }
-
-        public void Log()
-        {
-            var appSettings = _options?.Value;
-            _logger?.LogInformation("BeginAllowedSchoolYear = {year}.", appSettings?.BeginAllowedSchoolYear);
-            _logger?.LogInformation("EndAllowedSchoolYear = {year}.", appSettings?.EndAllowedSchoolYear);
+            webAppBuilder.Services.AddLogging(builder => builder.AddConsole());
+            webAppBuilder.Services.AddSingleton<LogAppSettingsService>();
         }
     }
 }

--- a/src/services/EdFi.DataManagementService.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/services/EdFi.DataManagementService.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Api.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DataManagementService.Api.Infrastructure
+{
+    public static class WebApplicationBuilderExtensions
+    {
+        public static void AddServices(this WebApplicationBuilder webAppBuilder)
+        {
+            webAppBuilder.Services.Configure<AppSettings>(webAppBuilder.Configuration.GetSection("AppSettings"));
+        }
+    }
+
+    // Example class for IOptions 
+    public class LogAppSettingsService()
+    {
+        private readonly ILogger<LogAppSettingsService>? _logger;
+        private readonly IOptions<AppSettings>? _options;
+
+        public LogAppSettingsService(ILogger<LogAppSettingsService>? logger,
+            IOptions<AppSettings>? options) : this()
+        {
+            _logger = logger;
+            _options = options;
+        }
+
+        public void Log()
+        {
+            var appSettings = _options?.Value;
+            _logger?.LogInformation("BeginAllowedSchoolYear = {year}.", appSettings?.BeginAllowedSchoolYear);
+            _logger?.LogInformation("EndAllowedSchoolYear = {year}.", appSettings?.EndAllowedSchoolYear);
+        }
+    }
+}

--- a/src/services/EdFi.DataManagementService.Api/Program.cs
+++ b/src/services/EdFi.DataManagementService.Api/Program.cs
@@ -3,7 +3,14 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Api.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
+builder.AddServices();
+
+builder.Services.AddLogging(builder => builder.AddConsole());
+builder.Services.AddSingleton<LogAppSettingsService>();
+
 var app = builder.Build();
 
 app.UsePathBase("/api");
@@ -11,6 +18,9 @@ app.UseRouting();
 
 app.MapGet("/", () => "Data Management Service");
 app.MapGet("/ping", () => Results.Ok(DateTime.Now));
+
+var appSettingsService = app.Services.GetRequiredService<LogAppSettingsService>();
+appSettingsService.Log();
 
 app.Run();
 

--- a/src/services/EdFi.DataManagementService.Api/Program.cs
+++ b/src/services/EdFi.DataManagementService.Api/Program.cs
@@ -8,9 +8,6 @@ using EdFi.DataManagementService.Api.Infrastructure;
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServices();
 
-builder.Services.AddLogging(builder => builder.AddConsole());
-builder.Services.AddSingleton<LogAppSettingsService>();
-
 var app = builder.Build();
 
 app.UsePathBase("/api");

--- a/src/services/EdFi.DataManagementService.Api/Program.cs
+++ b/src/services/EdFi.DataManagementService.Api/Program.cs
@@ -16,8 +16,8 @@ app.UseRouting();
 app.MapGet("/", () => "Data Management Service");
 app.MapGet("/ping", () => Results.Ok(DateTime.Now));
 
-var appSettingsService = app.Services.GetRequiredService<LogAppSettingsService>();
-appSettingsService.Log();
+var logAppSettingsService = app.Services.GetRequiredService<LogAppSettingsService>();
+logAppSettingsService.LogToConsole();
 
 app.Run();
 

--- a/src/services/EdFi.DataManagementService.Api/appsettings.json
+++ b/src/services/EdFi.DataManagementService.Api/appsettings.json
@@ -1,4 +1,11 @@
 {
+  "AppSettings": {
+    "BeginAllowedSchoolYear": 2022,
+    "EndAllowedSchoolYear": 2035
+  },
+  "ConnectionStrings": {
+    "DatabaseConnection": "Data Source=.\\;Initial Catalog=master;Integrated Security=True;"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
Added LogAppSettingsService for enabling the IOptions pattern to do dependency injection on AppSettings. "LogAppSettingsService" may be refactored to work with logging.