### PR TITLE
[DMS-44] Pluralized Env name

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -5,7 +5,7 @@
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.201-jammy@sha256:9aacef90e2773ff7d13a2f2687739778ed39312678b3669de06ec5fbeb0e86af AS build
 
-ENV ASPNETCORE_HTTP_PORT=8080
+ENV ASPNETCORE_HTTP_PORTS=8080
 
 WORKDIR /app
 COPY services/EdFi.DataManagementService.Api/*.csproj ./services/EdFi.DataManagementService.Api/
@@ -26,6 +26,6 @@ COPY --from=build /app/out/appsettings.json ./
 COPY --from=build /app/out/*runtimeconfig.json ./
 COPY --from=build /app/out/*.deps.json ./
 
-EXPOSE $ASPNETCORE_HTTP_PORT
+EXPOSE $ASPNETCORE_HTTP_PORTS
 USER app
 ENTRYPOINT ["dotnet", "EdFi.DataManagementService.Api.dll"]


### PR DESCRIPTION
The Dockerfile tried to use ASPNETCORE_HTTP_PORT env var, which does not work right now as some web pages have claimed.

With further investigation, it seems that this needs to be pluralized, as shown in this output:

```
docker run -it -e ASPNETCORE_HTTP_PORTS=93 local/edfi-data-management-service:latest .
2024-03-18 14:22:30.223 INF Now listening on: http://[::]:93
2024-03-18 14:22:30.249 INF Application started. Press Ctrl+C to shut down.
2024-03-18 14:22:30.250 INF Hosting environment: Production
2024-03-18 14:22:30.250 INF Content root path: /app
```

