### PR TITLE
[DMS-229] Developer settings for running app and/or integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -412,3 +412,7 @@ coveragereport
 # Reqnroll
 **/Features/*.feature.cs
 **/Features/**/*.feature.cs
+
+# Development appsettings
+**/*.Test.Integration/appsettings.Test.json
+**/*.Frontend.AspNetCore/appsettings.Development.json

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -4,6 +4,8 @@
 > This describes command line operations in the immediate "local" context,
 > without using Kubernetes and not running the application in Docker.
 
+> Note: If using a custom connection string or custom app settings in your .NET application, it's highly recommended to add an `appsettings.Development.json` file for your local development environment. This file should be based on the `appsettings.json` file and can override settings specifically for local development.
+
 1. Start a PostgreSQL instance on port 5432, if not already running, with username `postgres` and password configured in a `pgpass.conf` file.
    1. If using an alternate port or location, edit the connection string in `appSettings.Development.json`.
    2. Option: use Docker Compose to run [postgresql-compose.yml](../eng/postgresql-compose.yml)
@@ -21,3 +23,6 @@ cd ../
 ./build.ps1 build
 ./build.ps1 run
 ```
+
+## Running the EdFi.DataManagementService.Api.Tests.Integration
+> Note: If using a custom connection string for your integration tests, it's highly recommended to add an `appsettings.Test.json` file for your local development environment testing. This file should be based on the `appsettings.json` file on EdFi.DataManagementService.Api.Tests.Integration folder.

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -1,14 +1,20 @@
 # Running the Application Locally
 
-> [!TIP]
-> This describes command line operations in the immediate "local" context,
-> without using Kubernetes and not running the application in Docker.
+> [!TIP] This describes command line operations in the immediate "local"
+> context, without using Kubernetes and not running the application in Docker.
 
-> Note: If using a custom connection string or custom app settings in your .NET application, it's highly recommended to add an `appsettings.Development.json` file for your local development environment. This file should be based on the `appsettings.json` file and can override settings specifically for local development.
+> [!NOTE] If using a custom connection string or custom app settings in your
+> .NET application, it's highly recommended to add an
+> `appsettings.Development.json` file for your local development environment.
+> This file should be based on the `appsettings.json` file and can override
+> settings specifically for local development.
 
-1. Start a PostgreSQL instance on port 5432, if not already running, with username `postgres` and password configured in a `pgpass.conf` file.
-   1. If using an alternate port or location, edit the connection string in `appSettings.Development.json`.
-   2. Option: use Docker Compose to run [postgresql-compose.yml](../eng/postgresql-compose.yml)
+1. Start a PostgreSQL instance on port 5432, if not already running, with
+   username `postgres` and password configured in a `pgpass.conf` file.
+   1. If using an alternate port or location, edit the connection string in
+      `appSettings.Development.json`.
+   2. Option: use Docker Compose to run
+      [postgresql-compose.yml](../eng/postgresql-compose.yml)
 2. Adjust `appSettings.Development.json` if needed.
 3. Build the AspNetCore project.
 4. Run the AspNetCore project.
@@ -25,4 +31,9 @@ cd ../
 ```
 
 ## Running the EdFi.DataManagementService.Api.Tests.Integration
-> Note: If using a custom connection string for your integration tests, it's highly recommended to add an `appsettings.Test.json` file for your local development environment testing. This file should be based on the `appsettings.json` file on EdFi.DataManagementService.Api.Tests.Integration folder.
+
+> [!NOTE] If using a custom connection string for your integration tests, it's
+> highly recommended to add an `appsettings.Test.json` file for your local
+> development environment testing. This file should be based on the
+> `appsettings.json` file on EdFi.DataManagementService.Api.Tests.Integration
+> folder.

--- a/src/backend/EdFi.DataManagementService.Backend.Postgresql.Test.Integration/Configuration.cs
+++ b/src/backend/EdFi.DataManagementService.Backend.Postgresql.Test.Integration/Configuration.cs
@@ -10,14 +10,21 @@ namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration
 {
     public static class Configuration
     {
-        private static IConfigurationRoot? _config;
+        private static ConfigurationBuilder? _configurationBuilder;
 
         public static IConfiguration Config()
         {
-            _config ??= new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .Build();
-            return _config;
+            var testAppSettingsFileName = "appsettings.Test.json";
+
+            _configurationBuilder = new ConfigurationBuilder();
+            _configurationBuilder.AddJsonFile("appsettings.json");
+
+            if (_configurationBuilder != null && File.Exists(testAppSettingsFileName))
+            {
+                _configurationBuilder.AddJsonFile(testAppSettingsFileName);
+            }
+
+            return _configurationBuilder!.Build();
         }
 
         public static string? DatabaseConnectionString => Config().GetConnectionString("DatabaseConnection");

--- a/src/backend/EdFi.DataManagementService.Backend.Postgresql.Test.Integration/EdFi.DataManagementService.Backend.Postgresql.Test.Integration.csproj
+++ b/src/backend/EdFi.DataManagementService.Backend.Postgresql.Test.Integration/EdFi.DataManagementService.Backend.Postgresql.Test.Integration.csproj
@@ -29,6 +29,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="appsettings.Test.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
As per the team's conclusion. 
1.  Added a provision to include appsettings.Test.json in the integration tests project, if needed.
2.  The appsettings.Development.json file has been removed from the AspNetCore project.
3.  The RUNNING-LOCALLY.md document has been updated with the relevant details.





