### PR TITLE
[DMS-363] Paging tests failing

### DIFF
--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -57,6 +57,9 @@ also append `-v`. Examples:
 # Start everything
 ./start-local-dms.ps1
 
+# Start everything for E2E testing
+./start-local-dms.ps1 -EnvironmentFile ./.env.e2e
+
 # Stop the services, keeping volumes
 ./start-local-dms.ps1 -d
 

--- a/src/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -3,15 +3,13 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
         @addwait
         Scenario: 00 Background
             Given the system has these "schools"
-                | schoolId | nameOfInstitution | gradeLevels                                                                        | educationOrganizationCategories                                                                                                               |
-                | 1        | School 1          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Educator Preparation Provider"} ] |
-                | 2        | School 2          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ]   | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
-                | 3        | School 3          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Seventh grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
-                | 4        | School 4          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
-                | 5        | School 5          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Educator Preparation Provider"} ] |
+                  | schoolId | nameOfInstitution | gradeLevels                                                                        | educationOrganizationCategories                                                                                                               |
+                  | 1        | School 1          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Educator Preparation Provider"} ] |
+                  | 2        | School 2          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ]   | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
+                  | 3        | School 3          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Seventh grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
+                  | 4        | School 4          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ]                        |
+                  | 5        | School 5          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Educator Preparation Provider"} ] |
 
-        # DMS-363
-        @ignore
         Scenario: 01 Ensure clients can get information when filtering by limit and and a valid offset
              When a GET request is made to "/ed-fi/schools?offset=3&limit=5"
              Then it should respond with 200
@@ -59,8 +57,6 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   []
                   """
 
-        # DMS-363
-        @ignore
         Scenario: 03 Ensure clients can GET information when querying using an offset without providing any limit in the query string
              When a GET request is made to "/ed-fi/schools?offset=4"
              Then it should respond with 200

--- a/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -4,24 +4,36 @@ This is a suite of end to end tests that will cover different scenarios. They
 are run against a local DMS container that must be rebuilt to stay in sync with
 the codebase.
 
-## Testing On Containers Locally
+## Testing Process
 
-### Compose the docker environment
+You may either run the E2E tests locally from docker containers as is done in
+the github actions, or you may run them against your locally debugged API
+instance. See the steps below. 
+
+### Testing locally with docker compose
 
 From the `eng` directory:
 
-- If you have stale volumes with old data run `./start-local-dms.ps1 -d -v` to stop services and delete volumes
+- If you have stale volumes with old data run `./start-local-dms.ps1 -d -v` to
+  stop services and delete volumes
 - Run `./start-local-dms.ps1 -EnvironmentFile ./.env.e2e`
 
-## Debugging API Locally
+### Testing locally with API in debug mode
 
-To debug the API while running the tests, change `ApiUrl` in `OpenSearchContainerSetup.cs` to `http://localhost:5198/`. 
+To debug the API while running the tests, change `ApiUrl` in
+`OpenSearchContainerSetup.cs` to `http://localhost:5198/` and run
+`EdFi.DataManagementService.Frontend.AspNetCore` in debug mode as usual.
+
+> [!WARNING] Database Warning 
+> Your database tables will be truncated after each
+> feature file runs. Double check your `DatabaseConnection` in
+> `appSettings.json` and be aware of this before you run the tests.
 
 ## Running The Tests
 
 - Run from the Visual Studio Test Explorer.
-- cd into `/src/tests` and run:
-  `dotnet test EdFi.DataManagementService.Tests.E2E`.
+- cd into `/src/tests` and run: `dotnet test
+  EdFi.DataManagementService.Tests.E2E`.
 
 ### Setup
 

--- a/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -24,15 +24,17 @@ To debug the API while running the tests, change `ApiUrl` in
 `OpenSearchContainerSetup.cs` to `http://localhost:5198/` and run
 `EdFi.DataManagementService.Frontend.AspNetCore` in debug mode as usual.
 
-> [!WARNING] Database Warning 
+> [!WARNING] Database Warning
 > Your database tables will be truncated after each
 > feature file runs. Double check your `DatabaseConnection` in
 > `appSettings.json` and be aware of this before you run the tests.
 
 ## Running The Tests
 
-- Run from the Visual Studio Test Explorer.
-- cd into `/src/tests` and run: `dotnet test
+Run the tests how you run any other test suite. For example:
+
+- Visual Studio Test Explorer
+- from `/src/tests` run: `dotnet test
   EdFi.DataManagementService.Tests.E2E`.
 
 ### Setup

--- a/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -4,33 +4,24 @@ This is a suite of end to end tests that will cover different scenarios. They
 are run against a local DMS container that must be rebuilt to stay in sync with
 the codebase.
 
-## Building the DMS container
+## Testing On Containers Locally
 
-From the `src` directory, and run:
-`docker build -t local/data-management-service . -f Dockerfile`
-This will copy the current DMS solution into the container, build it and start
-it.
+### Compose the docker environment
+
+From the `eng` directory:
+
+- If you have stale volumes with old data run `./start-local-dms.ps1 -d -v` to stop services and delete volumes
+- Run `./start-local-dms.ps1 -EnvironmentFile ./.env.e2e`
+
+## Debugging API Locally
+
+To debug the API while running the tests, change `ApiUrl` in `OpenSearchContainerSetup.cs` to `http://localhost:5198/`. 
 
 ## Running The Tests
 
 - Run from the Visual Studio Test Explorer.
 - cd into `/src/tests` and run:
   `dotnet test EdFi.DataManagementService.Tests.E2E`.
-
-## Test Environments
-
-The tests can be executed against an isolated environment or your current
-running environment.
-
-By default, the tests run against an isolated
-[TestContainers](https://dotnet.testcontainers.org/) environment. This will
-setup the Docker containers for the API and the Backend, see
-[ContainerSetup.cs](./Management/ContainerSetup.cs) for more information.
-
-You can also run the tests against your current running environment, by setting
-UseTestContainers to false in the [appsettings](./appsettings.json)
-
-## Adding new Tests
 
 ### Setup
 


### PR DESCRIPTION
`GET` requests with paging and offset parameters were previously failing. Unable to reproduce. Some documentation updates in this pull request, and re-enable ignored tests but otherwise no material changes. 