### PR TITLE
PowerShell fix and apostrophes

### DIFF
--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -60,8 +60,8 @@ if ($d) {
     }
 }
 else {
-    $upArgs = @()
-    if ($r) { $upArgs += "--build" }
+    $upArg = ""
+    if ($r) { $upArg = "--build" }
 
     Write-Output "Starting locally-built DMS"
     if($EnforceAuthorization)
@@ -71,6 +71,7 @@ else {
     else {
         $env:IDENTITY_ENFORCE_AUTHORIZATION=$false
     }
+
     docker compose $files --env-file $EnvironmentFile up -d $upArg
 
     Start-Sleep 20

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ParsePathMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ParsePathMiddleware.cs
@@ -102,17 +102,17 @@ internal class ParsePathMiddleware(ILogger _logger) : IPipelineStep
         {
             case RequestMethod.DELETE when pathInfo.DocumentUuid == null:
                 {
-                    NotAllowed(["Resource collections cannot be deleted. To delete a specific item, use DELETE and include the \"id\" in the route."]);
+                    NotAllowed(["Resource collections cannot be deleted. To delete a specific item, use DELETE and include the 'id' in the route."]);
                     return;
                 }
             case RequestMethod.PUT when pathInfo.DocumentUuid == null:
                 {
-                    NotAllowed(["Resource collections cannot be replaced. To \"upsert\" an item in the collection, use POST. To update a specific item, use PUT and include the \"id\" in the route."]);
+                    NotAllowed(["Resource collections cannot be replaced. To 'upsert' an item in the collection, use POST. To update a specific item, use PUT and include the 'id' in the route."]);
                     return;
                 }
             case RequestMethod.POST when pathInfo.DocumentUuid != null:
                 {
-                    NotAllowed(["Resource items can only be updated using PUT. To \"upsert\" an item in the resource collection using POST, remove the \"id\" from the route."]);
+                    NotAllowed(["Resource items can only be updated using PUT. To 'upsert' an item in the resource collection using POST, remove the 'id' from the route."]);
                     return;
                 }
         }


### PR DESCRIPTION
For the quotation --> apostrophe, I'm tired of seeing this:

![image](https://github.com/user-attachments/assets/2240f68f-ebfb-4638-8555-70696a21d6d0)

I should look for other places we have quotation marks in error messages and fix those too. At another time.