### PR TITLE
[DMS-397] Case insensitive limit, offset, totalCount params.

### DIFF
--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -9,7 +9,6 @@ using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure.Extensions;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
 using AppSettings = EdFi.DataManagementService.Frontend.AspNetCore.Configuration.AppSettings;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore;

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using AppSettings = EdFi.DataManagementService.Frontend.AspNetCore.Configuration.AppSettings;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore;
@@ -52,6 +53,21 @@ public static class AspNetCoreFrontend
         return new TraceId(request.HttpContext.TraceIdentifier);
     }
 
+    private static string FromValidatedQueryParam(KeyValuePair<string, StringValues> queryParam)
+    {
+        switch (queryParam.Key.ToLower())
+        {
+            case "limit":
+                return "limit";
+            case "offset":
+                return "offset";
+            case "totalcount":
+                return "totalCount";
+            default:
+                return queryParam.Key;
+        }
+    }
+
     /// <summary>
     /// Converts an AspNetCore HttpRequest to a DMS FrontendRequest
     /// </summary>
@@ -64,7 +80,7 @@ public static class AspNetCoreFrontend
         return new(
             Body: await ExtractJsonBodyFrom(HttpRequest),
             Path: $"/{dmsPath}",
-            QueryParameters: HttpRequest.Query.ToDictionary(x => x.Key, x => x.Value[^1] ?? ""),
+            QueryParameters: HttpRequest.Query.ToDictionary(FromValidatedQueryParam, x => x.Value[^1] ?? ""),
             TraceId: ExtractTraceIdFrom(HttpRequest, options)
         );
     }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using AppSettings = EdFi.DataManagementService.Frontend.AspNetCore.Configuration.AppSettings;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore;

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -433,10 +433,10 @@ Feature: Validation of the structure of the URLs
                   }
                   """
 
-        @API-252 @ignore
+        @API-252
         # DMS-397
         Scenario: 15 Ensure client can retrieve information through case insensitive LIMIT parameter
-             When a GET request is made to "/ed-fi/schools?lImIt=1"
+             When a GET request is made to "/ed-fi/schools?liMIt=2"
              Then it should respond with 200
               And the response body is
                   """
@@ -445,16 +445,16 @@ Feature: Validation of the structure of the URLs
                       "id": "{id}",
                       "educationOrganizationCategories": [
                           {
-                              "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution"
+                              "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"
                           }
                       ],
                       "gradeLevels": [
                           {
-                              "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
+                              "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Sixth grade"
                           }
                       ],
-                      "nameOfInstitution": "Middle School Test",
-                      "schoolId": 745672453832456000
+                      "nameOfInstitution": "Grand Bend Middle School",
+                      "schoolId": 255901044
                     }
                   ]
                   """
@@ -465,7 +465,7 @@ Feature: Validation of the structure of the URLs
                     }
                   """
 
-        @API-253 @ignore
+        @API-253
         # DMS-397
         Scenario: 16 Ensure client can retrieve information through case insensitive OFFSET parameter
              # There is only one item, and offset=1 skips that one item.
@@ -476,7 +476,7 @@ Feature: Validation of the structure of the URLs
                   []
                   """
 
-        @API-254 @ignore
+        @API-254
         # DMS-397
         Scenario: 17 Ensure client can retrieve information through case insensitive TOTALCOUNT parameter
              When a GET request is made to "/ed-fi/SCHOOLS?tOtAlCoUnT=trUE"


### PR DESCRIPTION
Adds support for mixed case query params.

E.g. `/ed-fi/schools?liMIt=2`  becomes acceptable with the applied changes.

The original solutionwas to evaluate the toLower cases of each of the params from within the Context.FrontendRequest object. This resulted in performing the correct validation for the values, but validation failed downstream with 400 even after parsing.

This solution performs a check for the reserve params `totalCount`, `limit`, and `offset` by intercepting the query params and writing the correct form prior to creating the FrontendRequest object. This allows the validation to still occur while leaving the original HTTP Request Context intact.