### PR TITLE
[DMS-392] Configuration Service Release Management

### DIFF
--- a/.github/workflows/on-config-merge-or-tag.yml
+++ b/.github/workflows/on-config-merge-or-tag.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     tags:
-      - "cs-v*.*.*"
+      - "v*.*.*"
     paths:
       - "src/config/**"
 
@@ -40,12 +40,12 @@ jobs:
         id: versions
         run: |
           Import-Module ./package-helpers.psm1
-          Get-VersionNumber
+          Get-VersionNumber -projectPrefix "cs"
 
       - name: Create CS API Pre-Release
         run: |
           $version = "${{ steps.versions.outputs.dms-semver }}"
-          $tag = $version -replace "v","cs-pre-"
+          $tag = $version -replace "cs-v","cs-pre-"
 
           $body = @{
             tag_name = "$tag"

--- a/.github/workflows/on-config-merge-or-tag.yml
+++ b/.github/workflows/on-config-merge-or-tag.yml
@@ -3,15 +3,15 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
-name: On DMS Merge to Main or Releasable Tag
+name: On Config Merge to Main or Releasable Tag
 on:
   push:
     branches:
       - main
     tags:
-      - "dms-v*.*.*"
+      - "cs-v*.*.*"
     paths:
-      - "src/dms/**"
+      - "src/config/**"
 
 env:
   API_URL: https://api.github.com/repos/${{ github.repository }}
@@ -42,10 +42,10 @@ jobs:
           Import-Module ./package-helpers.psm1
           Get-VersionNumber
 
-      - name: Create Dms API Pre-Release
+      - name: Create CS API Pre-Release
         run: |
           $version = "${{ steps.versions.outputs.dms-semver }}"
-          $tag = $version -replace "v","dms-pre-"
+          $tag = $version -replace "v","cs-pre-"
 
           $body = @{
             tag_name = "$tag"

--- a/.github/workflows/on-config-prerelease.yml
+++ b/.github/workflows/on-config-prerelease.yml
@@ -23,8 +23,26 @@ env:
 permissions: read-all
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      valid_tag: ${{ steps.check.outputs.valid_tag }}
+    steps:
+      - name: Check tag prefix
+        id: check
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == cs-* ]]; then
+            echo "Tag is valid."
+            echo "valid_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag is not valid."
+            echo "valid_tag=false" >> $GITHUB_OUTPUT
+          fi
+
   pack:
     name: Build and Pack
+    needs: check_tag
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,11 +60,11 @@ jobs:
         id: versions
         run: |
           Import-Module ./package-helpers.psm1
-          Get-VersionNumber
+          Get-VersionNumber -projectPrefix "cs"
 
       - name: Publish .NET Assemblies
         run: |
-          $packageVersion = "${{ steps.versions.outputs.dms-semver }}"
+          $packageVersion = "${{ steps.versions.outputs.dms-semver }}" -replace "cs-v", ""
 
           ./build-config.ps1 -Command BuildAndPublish `
               -Configuration Release `
@@ -65,7 +83,6 @@ jobs:
         run: |
           "hash-code=$(sha256sum *.nupkg | base64 -w0)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-
       - name: Upload Packages as Artifacts
         if: success()
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
@@ -77,6 +94,7 @@ jobs:
 
   sbom-create:
     name: Create SBOM
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -135,6 +153,7 @@ jobs:
 
   sbom-attach:
     name: Attach SBOM file
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - sbom-create
@@ -181,6 +200,7 @@ jobs:
 
   provenance-create:
     name: Create Provenance
+    if: needs.check_tag.outputs.valid_tag == 'true'
     needs: pack
     permissions:
       actions: read
@@ -196,6 +216,7 @@ jobs:
 
   publish-package:
     name: Publish NuGet Package
+    if: needs.check_tag.outputs.valid_tag == 'true'
     needs: pack
     runs-on: ubuntu-latest
     defaults:
@@ -214,19 +235,20 @@ jobs:
 
       - name: Push Package to Azure Artifacts
         run: |
-         $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
-         $arguments = @{
-           EdFiNuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
-           NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
-         }
-
-         $artifact | ForEach-Object {
-             $arguments.PackageFile = $_
-             ./build-config.ps1 Push @arguments
+          $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
+          $arguments = @{
+            EdFiNuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
+            NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
           }
+
+          $artifact | ForEach-Object {
+              $arguments.PackageFile = $_
+              ./build-config.ps1 Push @arguments
+           }
 
   docker-publish:
     name: Publish to Docker Hub
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - publish-package
@@ -258,22 +280,22 @@ jobs:
           echo "VERSION=$SEMVERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3.0.0
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_HUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Configuration Service image
         id: metadataconfigurationservice
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build and push CS image
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09  # v5.0.0
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: "{{defaultContext}}:src/config"
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:pre

--- a/.github/workflows/on-config-prerelease.yml
+++ b/.github/workflows/on-config-prerelease.yml
@@ -1,0 +1,285 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: On Config Service Pre-Release
+on:
+  release:
+    types:
+      - prereleased
+
+env:
+  ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
+  ARTIFACTS_FEED_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+  VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: '{"endpointCredentials": [{"endpoint": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json","password": "${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}"}]}'
+  MANIFEST_FILE: "_manifest/spdx_2.2/manifest.spdx.json"
+  PACKAGE_NAME: "EdFi.DmsConfigurationService"
+  IMAGE_NAME: ${{ vars.IMAGE_NAME }}
+  DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
+  DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+  REF: ${{ github.ref_name }}
+
+permissions: read-all
+
+jobs:
+  pack:
+    name: Build and Pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    outputs:
+      hash-code: ${{ steps.hash-code.outputs.hash-code }}
+      dms-version: ${{ steps.versions.outputs.dms-v }}
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+
+      - name: Set Version Numbers
+        id: versions
+        run: |
+          Import-Module ./package-helpers.psm1
+          Get-VersionNumber
+
+      - name: Publish .NET Assemblies
+        run: |
+          $packageVersion = "${{ steps.versions.outputs.dms-semver }}"
+
+          ./build-config.ps1 -Command BuildAndPublish `
+              -Configuration Release `
+              -DmsCSVersion $packageVersion
+
+      - name: Create NuGet Package
+        run: |
+          $packageVersion = "${{ steps.versions.outputs.dms-semver }}"
+
+          ./build-config.ps1 -Command Package `
+              -DmsCSVersion $packageVersion `
+              -Configuration Release
+
+      - name: Generate hash for NuGet package
+        id: hash-code
+        run: |
+          "hash-code=$(sha256sum *.nupkg | base64 -w0)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+
+      - name: Upload Packages as Artifacts
+        if: success()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: "${{ env.PACKAGE_NAME }}-NuGet"
+          path: ${{ github.workspace }}/*DmsConfigurationService*.nupkg
+          if-no-files-found: error
+          retention-days: 30
+
+  sbom-create:
+    name: Create SBOM
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    needs: pack
+    permissions:
+      actions: read
+      contents: write
+    outputs:
+      sbom-hash-code: ${{ steps.sbom-hash-code.outputs.sbom-hash-code }}
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Artifacts
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #v4.1.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Generate Software Bill of Materials (SBOM)
+        run: |
+          $packageName = "${{ env.PACKAGE_NAME }}"
+          $version = "${{ needs.pack.outputs.dms-version }}"
+
+          Get-ChildItem -Include "$packageName.*.nupkg" -Recurse | ForEach-Object { $_.FullName } > buildfilelist.txt
+
+          dotnet tool install --global Microsoft.Sbom.DotNetTool
+
+          sbom-tool generate `
+              -b ./ `
+              -bl ./buildfilelist.txt `
+              -bc "./" `
+              -pn "$packageName" `
+              -pv $version `
+              -nsb https://ed-fi.org `
+              -m ./ `
+              -ps "Ed-Fi Alliance"
+
+          cp _manifest/spdx_2.2/manifest.spdx.* .
+
+      - name: Upload SBOM
+        if: success()
+        uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4.3.0
+        with:
+          name: ${{ env.PACKAGE_NAME }}-SBOM
+          path: ${{ env.MANIFEST_FILE }}
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Generate hash code for SBOM
+        id: sbom-hash-code
+        shell: bash
+        run: |
+          # sha256sum returns "<hashcode>  <name of file". Split that and return only the <hashcode>.
+          sbom_hash=$(sha256sum ./${{ env.MANIFEST_FILE }} | awk '{split($0,a); print a[1]}')
+          echo "sbom-hash-code=$sbom_hash" >> $GITHUB_OUTPUT
+
+  sbom-attach:
+    name: Attach SBOM file
+    runs-on: ubuntu-latest
+    needs:
+      - sbom-create
+      - pack
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: Download the SBOM
+        uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/actions/secure-download-artifact@v2.0.0
+        with:
+          name: "${{ env.PACKAGE_NAME }}-SBOM"
+          path: ${{ env.MANIFEST_FILE }}
+          sha256: "${{ needs.sbom-create.outputs.sbom-hash-code }}"
+
+      - name: Attach to release
+        shell: pwsh
+        run: |
+          $release = "${{ github.ref_name }}"
+          $repo = "${{ github.repository }}"
+          $token = "${{ secrets.GITHUB_TOKEN }}"
+          $file = "${{ env.MANIFEST_FILE }}"
+          $uploadName = "${{ env.PACKAGE_NAME }}-SBOM.zip"
+
+          $url = "https://api.github.com/repos/$repo/releases/tags/$release"
+
+          $gh_headers = @{
+              "Accept"        = "application/vnd.github+json"
+              "Authorization" = "Bearer $token"
+          }
+
+          $response = Invoke-RestMethod -Uri $url -Headers $gh_headers
+          $releaseId = $response.id
+
+          $url = "https://uploads.github.com/repos/$repo/releases/$releaseId/assets"
+
+          Compress-Archive $file -DestinationPath $uploadName
+
+          $gh_headers["Content-Type"] = "application/octet"
+          Invoke-RestMethod -Method POST `
+              -Uri "$($url)?name=$($uploadName)" `
+              -Headers $gh_headers `
+              -InFile $uploadName
+
+  provenance-create:
+    name: Create Provenance
+    needs: pack
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    with:
+      base64-subjects: ${{ needs.pack.outputs.hash-code }}
+      provenance-name: dmsCSApi.intoto.jsonl
+      upload-assets: true
+      # TODO: remove this after this issue is resolved: https://github.com/slsa-framework/slsa-github-generator/issues/876
+      compile-generator: true
+
+  publish-package:
+    name: Publish NuGet Package
+    needs: pack
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Get Artifact
+        uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 #4.1.1
+        with:
+          name: ${{ env.PACKAGE_NAME }}-NuGet
+
+      - name: Install-credential-handler
+        run: iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"
+
+      - name: Push Package to Azure Artifacts
+        run: |
+         $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
+         $arguments = @{
+           EdFiNuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
+           NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
+         }
+
+         $artifact | ForEach-Object {
+             $arguments.PackageFile = $_
+             ./build-config.ps1 Push @arguments
+          }
+
+  docker-publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    needs:
+      - publish-package
+    steps:
+      - name: Wait 20s
+        # Give Azure Artifacts caching a moment to catch up
+        run: sleep 20
+
+      - name: Prepare Tags
+        id: prepare-tags
+        run: |
+          REF="${{ env.REF }}"
+          PACKAGEVERSION=${REF}
+
+          if [[ $PACKAGEVERSION =~ "alpha" ]]
+          then
+            # Pre-releases get the tag "pre"
+            DMSTAGS="${{ env.IMAGE_NAME }}:pre"
+          else
+            # Releases get the version, plus shortened form for minor release.
+            # We are not using shortened form for major or using "latest"
+            # because they are too imprecise.
+            MINOR=`echo ${PACKAGEVERSION} | awk -F"." '{print $1"."$2}'`
+            DMSTAGS="${{ env.IMAGE_NAME }}:${PACKAGEVERSION},${{ env.IMAGE_NAME }}:${MINOR}"
+          fi
+
+          SEMVERSION=${PACKAGEVERSION}  # strip off the leading 'v'
+          echo "DMSTAGS=$DMSTAGS" >> $GITHUB_OUTPUT
+          echo "VERSION=$SEMVERSION" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3.0.0
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_HUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Configuration Service image
+        id: metadataconfigurationservice
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+        with:
+          images: ${{ env.IMAGE_NAME }}
+
+      - name: Build and push CS image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09  # v5.0.0
+        with:
+          context: "{{defaultContext}}:src/config"
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:pre
+          cache-to: type=inline
+          build-args: VERSION=${{ steps.prepare-tags.outputs.VERSION }}
+          file: Nuget.Dockerfile
+          tags: ${{ steps.prepare-tags.outputs.DMSTAGS }}
+          labels: ${{ steps.metadataconfigurationservice.outputs.labels }}
+          push: true

--- a/.github/workflows/on-dms-merge-or-tag.yml
+++ b/.github/workflows/on-dms-merge-or-tag.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
     tags:
-      - "dms-v*.*.*"
+      - "v*.*.*"
     paths:
       - "src/dms/**"
 
@@ -40,12 +40,12 @@ jobs:
         id: versions
         run: |
           Import-Module ./package-helpers.psm1
-          Get-VersionNumber
+          Get-VersionNumber -projectPrefix "dms"
 
       - name: Create Dms API Pre-Release
         run: |
           $version = "${{ steps.versions.outputs.dms-semver }}"
-          $tag = $version -replace "v","dms-pre-"
+          $tag = $version -replace "dms-v","dms-pre-"
 
           $body = @{
             tag_name = "$tag"

--- a/.github/workflows/on-dms-prerelease.yml
+++ b/.github/workflows/on-dms-prerelease.yml
@@ -23,8 +23,26 @@ env:
 permissions: read-all
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      valid_tag: ${{ steps.check.outputs.valid_tag }}
+    steps:
+      - name: Check tag prefix
+        id: check
+        run: |
+          if [[ "${{ github.event.release.tag_name }}" == dms-* ]]; then
+            echo "Tag is valid."
+            echo "valid_tag=true" >> $GITHUB_OUTPUT
+          else
+            echo "Tag is not valid."
+            echo "valid_tag=false" >> $GITHUB_OUTPUT
+          fi
+
   pack:
     name: Build and Pack
+    needs: check_tag
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -42,11 +60,11 @@ jobs:
         id: versions
         run: |
           Import-Module ./package-helpers.psm1
-          Get-VersionNumber
+          Get-VersionNumber -projectPrefix "dms"
 
       - name: Publish .NET Assemblies
         run: |
-          $packageVersion = "${{ steps.versions.outputs.dms-semver }}"
+          $packageVersion = "${{ steps.versions.outputs.dms-semver }}" -replace "dms-v", ""
 
           ./build-dms.ps1 -Command BuildAndPublish `
               -Configuration Release `
@@ -76,6 +94,7 @@ jobs:
 
   sbom-create:
     name: Create SBOM
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -134,6 +153,7 @@ jobs:
 
   sbom-attach:
     name: Attach SBOM file
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - sbom-create
@@ -180,6 +200,7 @@ jobs:
 
   provenance-create:
     name: Create Provenance
+    if: needs.check_tag.outputs.valid_tag == 'true'
     needs: pack
     permissions:
       actions: read
@@ -213,19 +234,20 @@ jobs:
 
       - name: Push Package to Azure Artifacts
         run: |
-         $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
-         $arguments = @{
-           EdFiNuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
-           NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
-         }
-
-         $artifact | ForEach-Object {
-             $arguments.PackageFile = $_
-             ./build-dms.ps1 Push @arguments
+          $artifact = (Get-ChildItem -Path $_ -Name -Include *.nupkg)
+          $arguments = @{
+            EdFiNuGetFeed = "${{ env.ARTIFACTS_FEED_URL }}"
+            NuGetApiKey = "${{ env.ARTIFACTS_API_KEY }}"
           }
+
+          $artifact | ForEach-Object {
+              $arguments.PackageFile = $_
+              ./build-dms.ps1 Push @arguments
+           }
 
   docker-publish:
     name: Publish to Docker Hub
+    if: needs.check_tag.outputs.valid_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - publish-package
@@ -257,22 +279,22 @@ jobs:
           echo "VERSION=$SEMVERSION" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226  # v3.0.0
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3.0.0
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_HUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Data Management Service image
         id: metadatamanagementservice
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Build and push DMS image
-        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09  # v5.0.0
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: "{{defaultContext}}:src/dms"
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:pre

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -8,7 +8,6 @@ on:
   release:
     types:
       - released
-  workflow_dispatch:
 
 env:
   ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
@@ -65,7 +64,22 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - name: Promote Package
+      - name: Promote DataManagementService Package
+        shell: pwsh
+        run: |
+          $arguments = @{
+            PackagesURL = "${{ env.ARTIFACTS_PACKAGES_URL }}"
+            Username    = "${{ env.ARTIFACTS_USERNAME }}"
+            ViewId        = "release"
+            ReleaseRef  = "${{ github.ref_name }}"
+            Password    = (ConvertTo-SecureString -String "${{ env.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
+            PackageName = "EdFi.DataManagementService"
+          }
+
+          Import-Module ./package-helpers.psm1
+          Invoke-Promote @arguments
+
+      - name: Promote DmsConfigurationService Package
         shell: pwsh
         run: |
           $arguments = @{
@@ -74,6 +88,7 @@ jobs:
             ViewId      = "release"
             ReleaseRef  = "${{ github.ref_name }}"
             Password    = (ConvertTo-SecureString -String "${{ env.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
+            PackageName = "EdFi.DmsConfigurationService"
           }
 
           Import-Module ./package-helpers.psm1

--- a/build-config.ps1
+++ b/build-config.ps1
@@ -72,7 +72,7 @@ param(
 
     # Full path of a package file to push to the NuGet feed. Optional, only
     # applies with the Push command. If not set, then the script looks for a
-    # NuGet package corresponding to the provided $DmsConfigurationServiceVersion and $BuildCounter.
+    # NuGet package corresponding to the provided $DmsCSVersion and $BuildCounter.
     [string]
     $PackageFile,
 
@@ -106,7 +106,7 @@ function Restore {
 
 function SetDMSAssemblyInfo {
     Invoke-Execute {
-        $assembly_version = $DmsConfigurationServiceVersion
+        $assembly_version = $DmsCSVersion
 
         Invoke-RegenerateFile "$solutionRoot/Directory.Build.props" @"
 <Project>
@@ -226,7 +226,13 @@ function RunNuGetPack {
     # NU5100 is the warning about DLLs outside of a "lib" folder. We're
     # deliberately using that pattern, therefore we bypass the
     # warning.
-    dotnet pack $ProjectPath --no-build --no-restore --output $PSScriptRoot -p:NuspecFile=$nuspecPath -p:NuspecProperties="version=$PackageVersion;year=$copyrightYear" /p:NoWarn=NU5100
+    dotnet pack $ProjectPath `
+        --no-build `
+        --no-restore `
+        --output $PSScriptRoot `
+        -p:NuspecFile=$nuspecPath `
+        -p:NuspecProperties="version=$PackageVersion;year=$copyrightYear" `
+        /p:NoWarn=NU5100
 }
 
 function BuildPackage {
@@ -234,7 +240,7 @@ function BuildPackage {
     $projectPath = "$mainPath/$projectName.csproj"
     $nugetSpecPath = "$mainPath/publish/$projectName.nuspec"
 
-    RunNuGetPack -ProjectPath $projectPath -PackageVersion $DmsConfigurationServiceVersion $nugetSpecPath
+    RunNuGetPack -ProjectPath $projectPath -PackageVersion $DmsCSVersion $nugetSpecPath
 }
 
 function Invoke-Build {
@@ -250,7 +256,7 @@ function Invoke-SetAssemblyInfo {
 }
 
 function Invoke-Publish {
-    Write-Output "Building Version ($DmsConfigurationServiceVersion)"
+    Write-Output "Building Version ($DmsCSVersion)"
 
     Invoke-Step { PublishApi }
 }
@@ -295,7 +301,7 @@ function PushPackage {
         }
 
         if (-not $PackageFile) {
-            $PackageFile = "$PSScriptRoot/$packageName.$DmsConfigurationServiceVersion.nupkg"
+            $PackageFile = "$PSScriptRoot/$packageName.$DmsCSVersion.nupkg"
         }
 
         if ($DryRun) {
@@ -314,7 +320,7 @@ function Invoke-PushPackage {
 }
 
 $dockerTagBase = "local"
-$dockerTagDMS = "$($dockerTagBase)/edfi-dms-configuration-service"
+$dockerTagDMS = "$($dockerTagBase)/dms-configuration-service"
 
 function DockerBuild {
     Push-Location src/config/

--- a/build-config.ps1
+++ b/build-config.ps1
@@ -51,7 +51,7 @@ param(
     # current package number is configured in the build automation tool and
     # passed to this script.
     [string]
-    $DmsConfigurationServiceVersion = "0.1",
+    $DmsCSVersion = "0.1",
 
     # .NET project build configuration, defaults to "Debug". Options are: Debug, Release.
     [string]

--- a/package-helpers.psm1
+++ b/package-helpers.psm1
@@ -25,9 +25,6 @@ function Get-VersionNumber {
 
     $version = $(&minver -t $prefix)
 
-    Write-Output "The Version is"
-    Write-Output $version
-
     "dms-v=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
     $dmsSemver = "$projectPrefix-v$($version)"
@@ -43,6 +40,7 @@ Promotes a package in Azure Artifacts to a view, e.g. pre-release or release.
 #>
 function Invoke-Promote {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'False positive')]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     param(
         # NuGet Packages API URL
         [Parameter(Mandatory = $true)]
@@ -93,15 +91,17 @@ function Invoke-Promote {
         Method      = "POST"
         ContentType = "application/json"
         Credential  = New-Object -TypeName PSCredential -ArgumentList $Username, $Password
-        URI         = $PackagesURL
+        URI         = "$PackagesURL/nuget/packagesBatch?api-version=5.0-preview.1"
         Body        = $body
     }
 
     Write-Output "Web request parameters:"
     $parameters | Out-Host
 
-    $response = Invoke-WebRequest @parameters -UseBasicParsing
-    $response | ConvertTo-Json -Depth 10 | Out-Host
+    if ($PSCmdlet.ShouldProcess($PackagesURL)) {
+        $response = Invoke-WebRequest @parameters -UseBasicParsing
+        $response | ConvertTo-Json -Depth 10 | Out-Host
+    }
 }
 
 Export-ModuleMember -Function Get-VersionNumber, Invoke-Promote


### PR DESCRIPTION
To test it I performed the following tasks:
1. Create a fork of this repository.

2. Generate a Tag and sent it to my fork
```
git tag -a v0.3.30 -m “v0.3.30”
git push origin v0.3.30
```
2.1 This way in the Tags section of Github we will have: `v0.3.30`
2.2 The following actions will be executed:

- cs-v0.3.30 On DMS Pre-Release # Release cs-pre-0.3.3
- cs-v0.3.30 On Config Pre-Release # Release cs-pre-0.3.3
- dms-v0.3.30 On DMS Pre-Release # Release dms-pre-0.3.3
- dms-v0.3.30 On Config Pre-Release # Release dms-pre-0.3.3
**Note**: at this moment 4 actions are being generated due to on: release: types: - prereleased. 
               Two of them only execute check_tag and terminate if they do not represent the corresponding Tag.

4. At the end of the actions in the Tags / Releases section can be identified as: dms-v0.3.30 and cs-v0.3.30.

5. Also in the Tags section you can identify 3 tags: 

- v0.3.30 # Create from the git tag command of point 2.
- dms-pre-0.3.30 # created from the action On DMS Pre-Release
- cs-pre-0.3.30 # created from the On Config Pre-Release action

**Additional tests:**
1. Make any change in DMS, generate a PR, then Merge and the result is: Release and  TAG: dms-v0.3.31-alpha.0.1
2. Make any changes in Config, generate a PR, Merge it and the result is:  Release and a TAG: cs-v0.3.31-alpha.0.2