### PR TITLE
[DMS-404] Accept application/x-www-form-urlencoded for configuration service token endpoint

### DIFF
--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -152,13 +152,23 @@ $parameters = @{
     # Configuration service client, then use "config-service-app"
     NewClientId = "test-client"                # Client id (default: test-client)
     NewClientName = "test-client"              # Client name (default: Test client)
-    NewClientSecret = "s3creT@09"              # Client id (default: s3creT@09)
+    NewClientSecret = "s3creT@09"              # Client secret (default: s3creT@09)
     ClientScopeName = "sis-vendor"             # Scope name (default: sis-vendor) We are including the 
     # claim set name as a scope in the token. This can be customized to any claim set name (e.g., 'Ed-Fi-Sandbox').
     # Please note that the claim name cannot contain spaces; use a hyphen (-) instead.
     TokenLifespan  = 1800                      # Token life span (default: 1800)
 }
+
 # To set up the Keycloak with Realm and client 
 ./setup-keycloak.ps1  @parameters
 
+# Optionally use the $SetClientAsRealmAdmin switch to assign realm admin role to the new client. 
+# This is required for DMS Configuration Service. 
+$parameters = @{
+    NewClientRole = "config-service-ap"         # Defined in Configuration Service appsettings
+    NewClientId = "DmsConfigurationService"     # Defined in Configuration Service appsettings
+    NewClientName = "DmsConfigurationService"   
+    NewClientSecret = "s3creT@09"               # Must match Configuration Service appsettings. Use appsettings.developer.json
+}
+./setup-keycloak.ps1  @parameters -SetClientAsRealmAdmin
 ```

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/ClientRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/ClientRepository.cs
@@ -8,6 +8,7 @@ using Flurl.Http;
 using Keycloak.Net;
 using Keycloak.Net.Models.Clients;
 using Keycloak.Net.Models.ClientScopes;
+using Keycloak.Net.Models.ProtocolMappers;
 using Keycloak.Net.Models.Roles;
 using Microsoft.Extensions.Logging;
 
@@ -51,6 +52,16 @@ public class ClientRepository(KeycloakContext keycloakContext, ILogger<ClientRep
                 x.Name.Equals(keycloakContext.ServiceRole, StringComparison.InvariantCultureIgnoreCase)
             );
 
+            if (clientRole is null)
+            {
+                await _keycloakClient.CreateRoleAsync(
+                    _realm,
+                    new Role() { Name = keycloakContext.ServiceRole }
+                );
+
+                clientRole = await _keycloakClient.GetRoleByNameAsync(_realm, keycloakContext.ServiceRole);
+            }
+
             ClientScope? clientScope = realmScopes.FirstOrDefault(x =>
                 x.Name.Equals("scp:edfi_dmscs/full_access")
             );
@@ -61,8 +72,9 @@ public class ClientRepository(KeycloakContext keycloakContext, ILogger<ClientRep
                     _realm,
                     new ClientScope()
                     {
-                        Id = "scp:edfi_dmscs/full_access",
                         Name = "scp:edfi_dmscs/full_access",
+                        Description = "",
+                        Protocol = "openid-connect",
                     }
                 );
             }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakContext.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakContext.cs
@@ -5,4 +5,11 @@
 
 namespace EdFi.DmsConfigurationService.Backend.Keycloak;
 
-public record KeycloakContext(string Url, string Realm, string ClientId, string ClientSecret, string RoleClaimType, string ServiceRole);
+public record KeycloakContext(
+    string Url,
+    string Realm,
+    string ClientId,
+    string ClientSecret,
+    string RoleClaimType,
+    string ServiceRole
+);

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakContext.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakContext.cs
@@ -11,5 +11,6 @@ public record KeycloakContext(
     string ClientId,
     string ClientSecret,
     string RoleClaimType,
-    string ServiceRole
+    string ServiceRole,
+    string FullAccessScope
 );

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/TokenManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/TokenManager.cs
@@ -17,7 +17,6 @@ public class TokenManager(KeycloakContext keycloakContext, ILogger<TokenManager>
             using var client = new HttpClient();
 
             var contentList = credentials.ToList();
-            contentList.AddRange([new KeyValuePair<string, string>("grant_type", "client_credentials")]);
 
             var content = new FormUrlEncodedContent(contentList);
             string path =

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/SecurityConstants.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/SecurityConstants.cs
@@ -8,4 +8,5 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
 public static class SecurityConstants
 {
     public const string ServicePolicy = "ServicePolicy";
+    public const string ScopeFullAccess = "scp:edfi_dms_configuration_service/full_access";
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -67,7 +67,8 @@ public static class WebApplicationBuilderExtensions
             identitySettings.ClientId,
             identitySettings.ClientSecret,
             identitySettings.RoleClaimType,
-            identitySettings.ServiceRole
+            identitySettings.ServiceRole,
+            SecurityConstants.ScopeFullAccess
         ));
 
         webApplicationBuilder.Services.AddHttpClient();

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/TokenRequest.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Model/TokenRequest.cs
@@ -9,15 +9,21 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
 
 public class TokenRequest
 {
-    public string? ClientId { get; set; }
-    public string? ClientSecret { get; set; }
+    public string client_id { get; set; } = "";
+
+    public string client_secret { get; set; } = "";
+
+    public string grant_type { get; set; } = "";
+
+    public string scope { get; set; } = "";
 
     public class Validator : AbstractValidator<TokenRequest>
     {
         public Validator()
         {
-            RuleFor(m => m.ClientId).NotEmpty();
-            RuleFor(m => m.ClientSecret).NotEmpty();
+            RuleFor(m => m.client_id).NotEmpty();
+            RuleFor(m => m.client_secret).NotEmpty();
+            RuleFor(m => m.grant_type).NotEmpty();
         }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/IdentityModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/IdentityModule.cs
@@ -11,6 +11,7 @@ using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Model;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using static EdFi.DmsConfigurationService.Backend.IdentityProviderError;
 
@@ -21,7 +22,7 @@ public class IdentityModule : IEndpointModule
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapPost("/connect/register", RegisterClient);
-        endpoints.MapPost("/connect/token", GetClientAccessToken);
+        endpoints.MapPost("/connect/token", GetClientAccessToken).DisableAntiforgery();
     }
 
     private async Task<IResult> RegisterClient(
@@ -97,7 +98,7 @@ public class IdentityModule : IEndpointModule
 
     private static async Task<IResult> GetClientAccessToken(
         TokenRequest.Validator validator,
-        TokenRequest model,
+        [FromForm] TokenRequest model,
         ITokenManager tokenManager,
         HttpContext httpContext
     )
@@ -106,8 +107,10 @@ public class IdentityModule : IEndpointModule
 
         var tokenResult = await tokenManager.GetAccessTokenAsync(
             [
-                new KeyValuePair<string, string>("client_id", model.ClientId!),
-                new KeyValuePair<string, string>("client_secret", model.ClientSecret!),
+                new KeyValuePair<string, string>("client_id", model.client_id),
+                new KeyValuePair<string, string>("client_secret", model.client_secret),
+                new KeyValuePair<string, string>("grant_type", model.grant_type),
+                new KeyValuePair<string, string>("scope", model.scope),
             ]
         );
 


### PR DESCRIPTION
To Test:
Starting from a Keycloak instance with no realms defined, in powershell run this
```
$parameters = @{
    NewClientRole = "config-service-ap"         # Defined in Configuration Service appsettings
    NewClientId = "DmsConfigurationService"     # Defined in Configuration Service appsettings
    NewClientName = "DmsConfigurationService"   
    NewClientSecret = "s3creT@09"               # Must match Configuration Service appsettings. Use appsettings.developer.json
}
./setup-keycloak.ps1  @parameters -SetClientAsRealmAdmin
```

1: Register client
```
curl --location 'http://localhost:5126/connect/register' \
--header 'Content-Type: application/json' \
--data-raw '{    
    "clientId":"client1",
    "clientSecret":"test1@Secret",
    "displayName":"client1"
}'
```
2: Request token
```
curl --location 'http://localhost:5126/connect/token' \
--header 'Content-Type: application/x-www-form-urlencoded' \
--data-urlencode 'client_id=client1' \
--data-urlencode 'client_secret=test1@Secret' \
--data-urlencode 'grant_type=client_credentials' \
--data-urlencode 'scope=scp:edfi_dms_configuration_service/full_access'
```
3: The decoded JSON web token should resemble this:
```
{
  "exp": 1731689063,
  "iat": 1731687263,
  "jti": "5dddd10c-3893-4f21-b0de-fbeb45ea5a89",
  "iss": "http://localhost:8045/realms/edfi",
  "sub": "0aee4ab8-e4cd-4c4d-aa6b-0f3434ccd022",
  "typ": "Bearer",
  "azp": "client1",
  "scope": "scp:edfi_dms_configuration_service/full_access",
  "clientHost": "172.19.0.1",
  "http://schemas.microsoft.com/ws/2008/06/identity/claims/role": [
    "offline_access",
    "default-roles-edfi",
    "uma_authorization",
    "config-service-app"
  ],
  "clientAddress": "172.19.0.1",
  "client_id": "client1"
}
```
