### PR TITLE
[DMS-387] Refactor application startup for future support of alternate IdP

### DIFF
--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakClientRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakClientRepository.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EdFi.DmsConfigurationService.Backend.Keycloak;
 
-public class ClientRepository(KeycloakContext keycloakContext, ILogger<ClientRepository> logger)
+public class KeycloakClientRepository(KeycloakContext keycloakContext, ILogger<KeycloakClientRepository> logger)
     : IClientRepository
 {
     private readonly KeycloakClient _keycloakClient =

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakServiceExtensions.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakServiceExtensions.cs
@@ -33,8 +33,8 @@ public static class KeycloakServiceExtensions
             Scope
         ));
 
-        services.AddTransient<IClientRepository, ClientRepository>();
-        services.AddTransient<ITokenManager, TokenManager>();
+        services.AddTransient<IClientRepository, KeycloakClientRepository>();
+        services.AddTransient<ITokenManager, KeycloakTokenManager>();
 
         return services;
     }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakServiceExtensions.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakServiceExtensions.cs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Backend.Repositories;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace EdFi.DmsConfigurationService.Backend.Keycloak;
+
+/// <summary>
+/// Service extensions to register keycloak access points 
+/// </summary>
+public static class KeycloakServiceExtensions
+{
+    public static IServiceCollection AddKeycloakServices(
+        this IServiceCollection services,
+        string Url,
+        string Realm,
+        string ClientId,
+        string ClientSecret,
+        string RoleClaimType,
+        string ServiceRole,
+        string Scope)
+    {
+        services.AddScoped(x => new KeycloakContext(
+            Url,
+            Realm,
+            ClientId,
+            ClientSecret,
+            RoleClaimType,
+            ServiceRole,
+            Scope
+        ));
+
+        services.AddTransient<IClientRepository, ClientRepository>();
+        services.AddTransient<ITokenManager, TokenManager>();
+
+        return services;
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakSettings.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakSettings.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DmsConfigurationService.Backend.Keycloak;
+
+public class KeycloakSettings
+{
+    public required string Url { get; set; }
+    public required string Realm { get; set; }
+}
+
+public class KeycloakSettingsValidator : IValidateOptions<KeycloakSettings>
+{
+    public ValidateOptionsResult Validate(string? name, KeycloakSettings options)
+    {
+        if (string.IsNullOrWhiteSpace(options.Url))
+        {
+            return ValidateOptionsResult.Fail("Missing required KeycloakSettings value: Url");
+        }
+        if (string.IsNullOrWhiteSpace(options.Realm))
+        {
+            return ValidateOptionsResult.Fail("Missing required KeycloakSettings value: Realm");
+        }
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakTokenManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakTokenManager.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EdFi.DmsConfigurationService.Backend.Keycloak;
 
-public class TokenManager(KeycloakContext keycloakContext, ILogger<TokenManager> logger) : ITokenManager
+public class KeycloakTokenManager(KeycloakContext keycloakContext, ILogger<KeycloakTokenManager> logger) : ITokenManager
 {
     public async Task<TokenResult> GetAccessTokenAsync(IEnumerable<KeyValuePair<string, string>> credentials)
     {

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -11,6 +11,7 @@ public class AppSettings
 {
     public bool DeployDatabaseOnStartup { get; set; }
     public required string Datastore { get; set; }
+    public required string IdentityProvider { get; set; }
 }
 
 public class AppSettingsValidator : IValidateOptions<AppSettings>
@@ -29,6 +30,19 @@ public class AppSettingsValidator : IValidateOptions<AppSettings>
         {
             return ValidateOptionsResult.Fail(
                 "AppSettings value Datastore must be one of: postgresql, mssql"
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(options.IdentityProvider))
+        {
+            return ValidateOptionsResult.Fail("Missing required AppSettings value: IdentityProvider");
+        }
+
+        // We only support keycloak for now
+        if (!options.IdentityProvider.Equals("keycloak", StringComparison.CurrentCultureIgnoreCase))
+        {
+            return ValidateOptionsResult.Fail(
+                "AppSettings value IdentityProvider must be one of: keycloak"
             );
         }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/IdentitySettings.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/IdentitySettings.cs
@@ -10,10 +10,8 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
 public class IdentitySettings
 {
     public required string Authority { get; set; }
-    public required string IdentityServer { get; set; }
     public required string ClientId { get; set; }
     public required string ClientSecret { get; set; }
-    public required string Realm { get; set; }
     public bool RequireHttpsMetadata { get; set; }
     public bool AllowRegistration { get; set; }
     public required string Audience { get; set; }
@@ -30,12 +28,6 @@ public class IdentitySettingsValidator : IValidateOptions<IdentitySettings>
         {
             return ValidateOptionsResult.Fail("Missing required IdentitySettings value: Authority");
         }
-
-        if (string.IsNullOrWhiteSpace(options.IdentityServer))
-        {
-            return ValidateOptionsResult.Fail("Missing required IdentitySettings value: IdentityServer");
-        }
-
         if (string.IsNullOrWhiteSpace(options.ClientId))
         {
             return ValidateOptionsResult.Fail("Missing required IdentitySettings value: ClientId");
@@ -43,10 +35,6 @@ public class IdentitySettingsValidator : IValidateOptions<IdentitySettings>
         if (string.IsNullOrWhiteSpace(options.ClientSecret))
         {
             return ValidateOptionsResult.Fail("Missing required IdentitySettings value: ClientSecret");
-        }
-        if (string.IsNullOrWhiteSpace(options.Realm))
-        {
-            return ValidateOptionsResult.Fail("Missing required IdentitySettings value: Realm");
         }
         if (string.IsNullOrEmpty(options.Audience))
         {

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Program.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Program.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DmsConfigurationService.Backend;
 using EdFi.DmsConfigurationService.Backend.Deploy;
+using EdFi.DmsConfigurationService.Backend.Keycloak;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Middleware;
@@ -37,7 +38,18 @@ bool ReportInvalidConfiguration(WebApplication app)
     try
     {
         // Accessing IOptions<T> forces validation
+        _ = app.Services.GetRequiredService<IOptions<AppSettings>>().Value;
         _ = app.Services.GetRequiredService<IOptions<IdentitySettings>>().Value;
+        if (
+            string.Equals(
+                app.Configuration.GetSection("AppSettings:IdentityProvider").Value,
+                "keycloak",
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            _ = app.Services.GetRequiredService<IOptions<KeycloakSettings>>().Value;
+        }
     }
     catch (OptionsValidationException ex)
     {

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.json
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.json
@@ -1,7 +1,8 @@
 {
     "AppSettings": {
         "DeployDatabaseOnStartup": true,
-        "Datastore": "postgresql"
+        "Datastore": "postgresql",
+        "IdentityProvider":  "keycloak"
     },
     "ConnectionStrings": {
         "DatabaseConnection": "host=localhost;port=5432;username=postgres;database=edfi_configurationservice;"
@@ -11,13 +12,15 @@
         "ServiceRole": "config-service-app",
         "Authority": "http://localhost:8045/realms/dms",
         "Audience": "account",
-        "IdentityServer": "http://localhost:8045",
-        "Realm": "dms",
         "ClientId": "DmsConfigurationService",
         "ClientSecret": "",
         "RequireHttpsMetadata": false,
         "RoleClaimType": "http://schemas\\.microsoft\\.com/ws/2008/06/identity/claims/role",
         "Scope": "scp:edfi_dms_configuration_service/full_access"
+    },
+    "KeycloakSettings": {
+        "Url": "http://localhost:8045",
+        "Realm": "dms"
     },
     "AllowedHosts": "*",
     "Serilog": {


### PR DESCRIPTION
- Separated keycloak specific settings from broader identity settings 
- Introduced `IdentityProvider` app setting for future use (currently only support Keycloak)
- Moved keycloak service configuration to the keycloak backend project
- More settings validation