### PR TITLE
[DMS-437] E2E testing for Elasticsearch

### DIFF
--- a/eng/docker-compose/kafka-elasticsearch-ui.yml
+++ b/eng/docker-compose/kafka-elasticsearch-ui.yml
@@ -15,14 +15,22 @@ services:
       DYNAMIC_CONFIG_ENABLED: 'true'
       KAFKA_CLUSTERS_0_NAME: kafka1
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    networks:
+      - dms
 
   kibana:
-      image: docker.elastic.co/kibana/kibana:8.5.1
-      environment:
-        ELASTICSEARCH_HOSTS: http://dms-search:9200
-        ELASTICSEARCH_USERNAME: ${ELASTICSEARCH_ADMIN_USERNAME:-admin}
-        ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_ADMIN_PASSWORD:-abcdefgh1!}
-      ports:
-        - "${ELASTICSEARCH_DASHBOARD_PORT:-5601}:5601"
-      depends_on:
-        - elasticsearch
+    image: docker.elastic.co/kibana/kibana:8.5.1
+    environment:
+      ELASTICSEARCH_HOSTS: http://dms-search:9200
+      ELASTICSEARCH_USERNAME: ${ELASTICSEARCH_ADMIN_USERNAME:-admin}
+      ELASTICSEARCH_PASSWORD: ${ELASTICSEARCH_ADMIN_PASSWORD:-abcdefgh1!}
+    ports:
+      - "${ELASTICSEARCH_DASHBOARD_PORT:-5601}:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - dms
+
+networks:
+  dms:
+    external: true

--- a/eng/docker-compose/kafka-elasticsearch.yml
+++ b/eng/docker-compose/kafka-elasticsearch.yml
@@ -91,6 +91,8 @@ services:
       - "${ELASTICSEARCH_ANALYZER_PORT:-9300}:9300"
     volumes:
       - esdata:/usr/share/elasticsearch/data
+    networks:
+      - dms
 
 volumes:
   zookeeper-logs:

--- a/eng/docker-compose/kafka-elasticsearch.yml
+++ b/eng/docker-compose/kafka-elasticsearch.yml
@@ -13,6 +13,8 @@ services:
       - zookeeper-data:/zookeeper/data
       - zookeeper-txns:/zookeeper/txns
       - zookeeper-conf:/zookeeper/conf
+    networks:
+      - dms
 
   kafka:
     hostname: dms-kafka1
@@ -28,6 +30,8 @@ services:
     volumes:
       - kafka-data:/kafka/data
       - kafka-logs:/kafka/logs
+    networks:
+      - dms
 
   kafka-postgresql-source:
     hostname: kafka-postgresql-source
@@ -47,6 +51,8 @@ services:
     volumes:
       - kafka-postgresql-source-logs:/kafka/logs
       - kafka-postgresql-source-config:/kafka/config
+    networks:
+      - dms
 
   kafka-elasticsearch-sink:
     hostname: kafka-elasticsearch-sink
@@ -66,6 +72,8 @@ services:
     volumes:
       - kafka-elasticsearch-sink-logs:/kafka/logs
       - kafka-elasticsearch-sink-config:/kafka/config
+    networks:
+      - dms
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:8.5.1
@@ -96,3 +104,7 @@ volumes:
   kafka-elasticsearch-sink-logs:
   kafka-elasticsearch-sink-config:
   esdata:
+
+networks:
+  dms:
+    external: true

--- a/src/config/.config/dotnet-tools.json
+++ b/src/config/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.30.0",
+      "version": "0.30.1",
       "commands": [
         "dotnet-csharpier"
       ]

--- a/src/dms/.config/dotnet-tools.json
+++ b/src/dms/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.30.0",
+      "version": "0.30.1",
       "commands": [
         "dotnet-csharpier"
       ]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/OpenSearchContainerSetup.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/OpenSearchContainerSetup.cs
@@ -21,7 +21,7 @@ public class OpenSearchContainerSetup : ContainerSetupBase
 
     public override string ApiUrl()
     {
-        return "http://localhost:8080/";
+        return "http://localhost:5198/";
     }
 
     public override async Task ResetData()
@@ -35,9 +35,17 @@ public class OpenSearchContainerSetup : ContainerSetupBase
         OpenSearchClient openSearchClient = new();
         var indices = await openSearchClient.Cat.IndicesAsync();
 
-        foreach (var index in indices.Records.Where(x => x.Index.Contains("ed-fi")))
+        foreach (var index in indices.Records.Where(x => x.Index.Contains("ed-fi$")))
         {
             await openSearchClient.Indices.DeleteAsync(index.Index);
+
+            // Recreate the index with default or custom settings if needed
+            await openSearchClient.Indices.CreateAsync(index.Index, c => c
+                .Settings(s => s
+                    .NumberOfShards(1)
+                    .NumberOfReplicas(1)
+                )
+            );
         }
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/OpenSearchContainerSetup.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Management/OpenSearchContainerSetup.cs
@@ -21,7 +21,7 @@ public class OpenSearchContainerSetup : ContainerSetupBase
 
     public override string ApiUrl()
     {
-        return "http://localhost:5198/";
+        return "http://localhost:8080/";
     }
 
     public override async Task ResetData()


### PR DESCRIPTION
Before running the E2E tests (recommended to delete the docker-compose container, associated volumes and images): 
`.\start-local-dms.ps1 -EnvironmentFile ./.env.e2e -EnableSearchEngineUI -SearchEngine "ElasticSearch" -r`

- No changes are needed in `.env.e2e` file.