### PR TITLE
[DMS-556] Kafka transform failing on Hierarchy with mixed INT and BIGINT 

### DIFF
--- a/eng/docker-compose/opensearch_connector.json
+++ b/eng/docker-compose/opensearch_connector.json
@@ -20,22 +20,15 @@
 
     "compact.map.entries": "true",
 
-    "transforms": "castHierarchy, removeId, toOpenSearchIndex, deletedToTombstone",
-
-    "transforms.castHierarchy.type": "org.edfi.kafka.connect.transforms.CastHierarchyToInt64",
-    "transforms.castHierarchy.predicate": "castHierarchyPredicate",
-
+    "transforms": "removeId, toOpenSearchIndex, deletedToTombstone",
     "transforms.removeId.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
     "transforms.removeId.exclude": "id",
 
     "transforms.toOpenSearchIndex.type":"org.edfi.kafka.connect.transforms.RenameDmsTopicToOpenSearchIndex",
     "transforms.toOpenSearchIndex.predicate": "documentTopicOnly",
-    "predicates": "documentTopicOnly, castHierarchyPredicate",
+    "predicates": "documentTopicOnly",
     "predicates.documentTopicOnly.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
     "predicates.documentTopicOnly.pattern": "edfi\\.dms\\.document",
-
-    "predicates.castHierarchyPredicate.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
-    "predicates.castHierarchyPredicate.pattern": "edfi\\.dms\\.educationorganizationhierarchytermslookup",
 
     "transforms.deletedToTombstone.type": "org.edfi.kafka.connect.transforms.DebeziumDeletedToTombstone",
 

--- a/eng/docker-compose/opensearch_connector.json
+++ b/eng/docker-compose/opensearch_connector.json
@@ -20,15 +20,22 @@
 
     "compact.map.entries": "true",
 
-    "transforms": "removeId, toOpenSearchIndex, deletedToTombstone",
+    "transforms": "castHierarchy, removeId, toOpenSearchIndex, deletedToTombstone",
+
+    "transforms.castHierarchy.type": "org.edfi.kafka.connect.transforms.CastHierarchyToInt64",
+    "transforms.castHierarchy.predicate": "castHierarchyPredicate",
+
     "transforms.removeId.type": "org.apache.kafka.connect.transforms.ReplaceField$Value",
     "transforms.removeId.exclude": "id",
 
     "transforms.toOpenSearchIndex.type":"org.edfi.kafka.connect.transforms.RenameDmsTopicToOpenSearchIndex",
     "transforms.toOpenSearchIndex.predicate": "documentTopicOnly",
-    "predicates": "documentTopicOnly",
+    "predicates": "documentTopicOnly, castHierarchyPredicate",
     "predicates.documentTopicOnly.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
     "predicates.documentTopicOnly.pattern": "edfi\\.dms\\.document",
+
+    "predicates.castHierarchyPredicate.type": "org.apache.kafka.connect.transforms.predicates.TopicNameMatches",
+    "predicates.castHierarchyPredicate.pattern": "edfi\\.dms\\.educationorganizationhierarchytermslookup",
 
     "transforms.deletedToTombstone.type": "org.edfi.kafka.connect.transforms.DebeziumDeletedToTombstone",
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0101_Create_EducationOrganizationHierarchy_Triggers.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0101_Create_EducationOrganizationHierarchy_Triggers.sql
@@ -12,7 +12,7 @@ BEGIN
  IF (TG_OP = 'INSERT') THEN
     -- Add the new record, hierarchies always start with themselves as the single element in the array
     INSERT INTO dms.EducationOrganizationHierarchyTermsLookup(Id, Hierarchy)
-    VALUES (NEW.EducationOrganizationId, jsonb_build_array(NEW.EducationOrganizationId));
+    VALUES (NEW.EducationOrganizationId, jsonb_build_array(NEW.EducationOrganizationId::TEXT));
 
     -- Find all ancestors of the new education organization using recursive CTE
     WITH RECURSIVE ancestors AS (
@@ -33,7 +33,7 @@ BEGIN
     SET Hierarchy = jsonb_insert(
         Hierarchy,
         '{-1}',  -- Insert at the end
-        to_jsonb(NEW.EducationOrganizationId),
+        to_jsonb(NEW.EducationOrganizationId::TEXT),
         true
     )
     WHERE Id IN (SELECT EducationOrganizationId FROM ancestors);
@@ -58,7 +58,7 @@ BEGIN
     SET Hierarchy = (
         SELECT jsonb_agg(elem)
         FROM jsonb_array_elements(Hierarchy) elem
-        WHERE elem <> to_jsonb(OLD.EducationOrganizationId)
+        WHERE elem <> to_jsonb(OLD.EducationOrganizationId::TEXT)
     )
     WHERE Id IN (SELECT EducationOrganizationId FROM old_ancestors);
 
@@ -81,7 +81,7 @@ BEGIN
     SET Hierarchy = jsonb_insert(
         Hierarchy,
         '{-1}',  -- Insert at the end
-        to_jsonb(NEW.EducationOrganizationId),
+        to_jsonb(NEW.EducationOrganizationId::TEXT),
         true
     )
     WHERE Id IN (SELECT EducationOrganizationId FROM new_ancestors);
@@ -110,7 +110,7 @@ BEGIN
     SET Hierarchy = (
         SELECT jsonb_agg(elem)
         FROM jsonb_array_elements(Hierarchy) elem
-        WHERE elem <> to_jsonb(OLD.EducationOrganizationId)
+        WHERE elem <> to_jsonb(OLD.EducationOrganizationId::TEXT)
     )
     WHERE Id IN (SELECT EducationOrganizationId FROM ancestors);
  END IF;
@@ -123,3 +123,4 @@ CREATE OR REPLACE TRIGGER EducationOrganizationHierarchyTrigger
 AFTER INSERT OR UPDATE OR DELETE ON dms.EducationOrganizationHierarchy
     FOR EACH ROW
     EXECUTE PROCEDURE dms.EducationOrganizationHierarchyTriggerFunction();
+

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
@@ -757,12 +757,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | weekIdentifier | schoolReference              | beginDate  | endDate    | totalInstructionalDays |
                   | week 1         | { "schoolId": 201019999999 } | 2023-08-01 | 2023-08-07 | 5                      |
                   @addwait
-
-                  # DMS-556
-                  # Kafka bug when mixed INT and BIGINT in the hierarchy array
-                  # SEA and LEA below have INT id's while School has BIGINT. This hierarchy row will not replicate to OpenSearch
-                  # Couldn't process json field: array=BsonArray{values=[BsonInt32{value=2}, BsonInt32{value=201}, BsonInt64{value=201019999999}]}   [com.redhat.insights.expandjsonsmt.SchemaParser]
-                  # org.apache.kafka.connect.errors.ConnectException: Field is not a homogenous array (BsonInt32{value=201} x INT64).
+                                   
         Scenario: 19 Ensure client with access to state education agency 244901 gets query results for school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a GET request is made to "/ed-fi/academicWeeks"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
@@ -739,7 +739,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   }
                   """
 
-    @ignore
+
     Rule: Search for a resource in the EducationOrganizationHierarchy with RelationshipsWithEdOrgsOnly authorization and LONG schoolId
         Background:
                   # Build a hierarchy
@@ -757,7 +757,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | weekIdentifier | schoolReference              | beginDate  | endDate    | totalInstructionalDays |
                   | week 1         | { "schoolId": 201019999999 } | 2023-08-01 | 2023-08-07 | 5                      |
                   @addwait
-                  @ignore
+
                   # DMS-556
                   # Kafka bug when mixed INT and BIGINT in the hierarchy array
                   # SEA and LEA below have INT id's while School has BIGINT. This hierarchy row will not replicate to OpenSearch


### PR DESCRIPTION
After trying several unsuccessful ways to transform the values to int64 (transformations in postgresql_connector.json and using a custom SMT), I ended up validating the option to store the EducationOrganizationId values as Text in the Hierarchy field of the EducationOrganizationHierarchyTermsLookup table and that's what worked.
In my local environment all the e2e tests passed (using OpenSearch and ElasticSearch).
Steps to test:
1. run one of this command:
For Opensearch
./start-local-dms.ps1 -EnvironmentFile "./.env.e2e" -SearchEngine "OpenSearch" -EnableConfig -r -EnableSearchEngineUI
or for ElasticSearch
./start-local-dms.ps1 -EnvironmentFile "./.env.e2e" -SearchEngine "ElasticSearch" -EnableConfig -r -EnableSearchEngineUI
2. .\setup-keycloak.ps1
3. Execute E2E test from VS.