### PR TITLE
[DO NOT MERGE] An experiment with relational storage

### DIFF
--- a/eng/docker-compose/.env.e2e
+++ b/eng/docker-compose/.env.e2e
@@ -6,6 +6,12 @@ POSTGRES_DB_NAME=edfi_datamanagementservice
 POSTGRES_PORT=5435
 
 # ----------------
+# MSSQL
+# ----------------
+MSSQL_SA_PASSWORD=abcdefgh1!
+MSSQL_HEALTH_CHECK=/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P "${MSSQL_SA_PASSWORD}" -Q "SELECT 1/0"
+
+# ----------------
 # Search Database
 # ----------------
 

--- a/eng/docker-compose/mssql.yml
+++ b/eng/docker-compose/mssql.yml
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+services:
+
+  db:
+    image: mcr.microsoft.com/mssql/server:2022-CU18-ubuntu-22.04@sha256:ea73825f3d88a23c355ac2f9fdc6bd960fec90171c12c572109b36a558f77bb8
+    container_name: mssql
+    volumes:
+      - dms-mssql:/var/opt/mssql
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=${MSSQL_SA_PASSWORD:-abcdefgh1!}
+      - MSSQL_PID=Express
+    ports:
+      # - '127.0.0.1:1435:1433'
+      - '1435:1433'
+    healthcheck:
+      test: ${MSSQL_HEALTH_CHECK}
+      interval: 10s
+      timeout: 3s
+      retries: 10
+      start_period: 10s
+    networks:
+      - dms
+
+volumes:
+  dms-mssql:
+
+networks:
+  dms:
+    external: true

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="4.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.11.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />

--- a/src/dms/EdFi.DataManagementService-Docker.sln
+++ b/src/dms/EdFi.DataManagementService-Docker.sln
@@ -24,6 +24,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Backend.NormalizedSqlServer", "backend\NormalizedSqlServer\EdFi.DataManagementService.Backend.NormalizedSqlServer.csproj", "{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,10 @@ Global
 		{AF9E2120-206E-4318-8A2B-2DB798D39C4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF9E2120-206E-4318-8A2B-2DB798D39C4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF9E2120-206E-4318-8A2B-2DB798D39C4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +66,7 @@ Global
 		{3B8DB16B-0A35-4565-B8CA-73DE662424BC} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 		{53914CA2-E0E6-4D84-8899-D9C5CE40AA76} = {5B7BB270-905C-4D2F-BD3C-3374707FE1E3}
 		{AF9E2120-206E-4318-8A2B-2DB798D39C4D} = {71E181BF-2E72-45F2-9DAD-6B1D18FAD164}
+		{0BF06AAE-BFE3-4669-8E79-0B8348D66EAA} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAB3D5DE-BC6C-44FD-831C-9C7BE3935343}

--- a/src/dms/EdFi.DataManagementService.sln
+++ b/src/dms/EdFi.DataManagementService.sln
@@ -52,6 +52,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Backend.Postgresql.Tests.Integration", "backend\EdFi.DataManagementService.Backend.Postgresql.Tests.Integration\EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj", "{30E62A03-302F-95A5-32B8-E2D4D5E0A3AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Backend.NormalizedSqlServer", "backend\NormalizedSqlServer\EdFi.DataManagementService.Backend.NormalizedSqlServer.csproj", "{A86A6E50-47A8-4E4A-9982-3C04789BA72B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,10 @@ Global
 		{30E62A03-302F-95A5-32B8-E2D4D5E0A3AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30E62A03-302F-95A5-32B8-E2D4D5E0A3AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30E62A03-302F-95A5-32B8-E2D4D5E0A3AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A86A6E50-47A8-4E4A-9982-3C04789BA72B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A86A6E50-47A8-4E4A-9982-3C04789BA72B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A86A6E50-47A8-4E4A-9982-3C04789BA72B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A86A6E50-47A8-4E4A-9982-3C04789BA72B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{CEACE0CE-FE27-4039-9F30-F585B418FCEB} = {2B193382-DF21-4223-888A-CE5CD3B52C25}
 		{116E8864-FF2F-B2C0-8009-741468CA9346} = {2B193382-DF21-4223-888A-CE5CD3B52C25}
 		{30E62A03-302F-95A5-32B8-E2D4D5E0A3AC} = {75AE8F7B-B980-48AE-8518-073830FA6471}
+		{A86A6E50-47A8-4E4A-9982-3C04789BA72B} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAB3D5DE-BC6C-44FD-831C-9C7BE3935343}

--- a/src/dms/backend/NormalizedSqlServer/CreateTables.cs
+++ b/src/dms/backend/NormalizedSqlServer/CreateTables.cs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Text.Json;
+using Microsoft.Data.SqlClient;
+
+public class JsonToSqlTableCreator
+{
+    private readonly SqlConnection _connection;
+
+    public JsonToSqlTableCreator(SqlConnection connection)
+    {
+        _connection = connection;
+    }
+
+    public async Task CreateTablesAsync(string json)
+    {
+        var jsonObject = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+
+        if (jsonObject == null)
+        {
+            throw new ArgumentException("Invalid JSON object.");
+        }
+
+        using var transaction = _connection.BeginTransaction();
+
+        try
+        {
+            await CreateTableAsync("StudentEducationOrganizationAssociation", jsonObject, transaction);
+
+            await transaction.CommitAsync();
+        }
+        catch (Exception ex)
+        {
+            await transaction.RollbackAsync();
+            Console.WriteLine($"Error: {ex.Message}");
+            throw;
+        }
+    }
+
+    private async Task CreateTableAsync(
+        string tableName,
+        Dictionary<string, object> data,
+        SqlTransaction transaction
+    )
+    {
+        var columns = new List<string>();
+        var foreignKeys = new List<string>();
+
+        foreach (var (key, value) in data)
+        {
+            if (
+                key.EndsWith("Reference")
+                && value is JsonElement referenceElement
+                && referenceElement.ValueKind == JsonValueKind.Object
+            )
+            {
+                // Handle foreign key references
+                var referenceData = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                    referenceElement.GetRawText()
+                );
+
+                if (referenceData == null)
+                {
+                    throw new InvalidOperationException($"Invalid reference data for key '{key}'.");
+                }
+
+                var referenceTableName = key.Replace("Reference", "");
+                await CreateTableAsync(referenceTableName, referenceData, transaction);
+
+                foreignKeys.Add(
+                    $"[{referenceTableName}Id] INT FOREIGN KEY REFERENCES [{referenceTableName}](DocumentId)"
+                );
+            }
+            else if (value is JsonElement arrayElement && arrayElement.ValueKind == JsonValueKind.Array)
+            {
+                // Handle nested arrays
+                var nestedTableName = $"{tableName}{key}";
+                foreach (var item in arrayElement.EnumerateArray())
+                {
+                    var nestedData = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                        item.GetRawText()
+                    );
+
+                    if (nestedData == null)
+                    {
+                        throw new InvalidOperationException($"Invalid reference data for key '{key}'.");
+                    }
+
+                    await CreateTableAsync(nestedTableName, nestedData, transaction);
+                }
+            }
+            else if (value is JsonElement scalarElement)
+            {
+                // Handle scalar values
+                var columnType = GetSqlColumnType(scalarElement);
+                if (columnType != null)
+                {
+                    columns.Add($"[{key}] {columnType}");
+                }
+            }
+        }
+
+        // Create the table
+        var createTableSql =
+            $@"
+            IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='{tableName}' AND xtype='U')
+            CREATE TABLE [{tableName}] (
+                DocumentId INT IDENTITY(1,1) PRIMARY KEY,
+                {string.Join(", ", columns.Concat(foreignKeys))}
+            )";
+
+        using var command = new SqlCommand(createTableSql, _connection, transaction);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private string? GetSqlColumnType(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => "NVARCHAR(MAX)",
+            JsonValueKind.Number => element.TryGetInt32(out _) ? "INT" : "FLOAT",
+            JsonValueKind.True or JsonValueKind.False => "BIT",
+            _ => null, // Ignore unsupported types
+        };
+    }
+}

--- a/src/dms/backend/NormalizedSqlServer/EdFi.DataManagementService.Backend.NormalizedSqlServer.csproj
+++ b/src/dms/backend/NormalizedSqlServer/EdFi.DataManagementService.Backend.NormalizedSqlServer.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EdFi.DataManagementService.Backend\EdFi.DataManagementService.Backend.csproj" />
+    <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core.External\EdFi.DataManagementService.Core.External.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+  </ItemGroup>
+</Project>

--- a/src/dms/backend/NormalizedSqlServer/Program.cs
+++ b/src/dms/backend/NormalizedSqlServer/Program.cs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.DataManagementService.Backend.NormalizedSqlServer;
+
+public static class Program
+{
+    public static async Task Main(string[] args)
+    {
+        if (args.Length == 0)
+        {
+            Console.WriteLine("Usage: Program <path-to-json-file>");
+            return;
+        }
+
+        var jsonFilePath = args[0];
+
+        if (!File.Exists(jsonFilePath))
+        {
+            Console.WriteLine($"Error: File not found at path '{jsonFilePath}'.");
+            return;
+        }
+
+        var jsonContent = await File.ReadAllTextAsync(jsonFilePath);
+
+        // Retrieve the connection string from an environment variable or configuration
+        var connectionString =
+            Environment.GetEnvironmentVariable("SQL_CONNECTION_STRING")
+            ?? "Server=localhost,1435;Database=master;User Id=sa;Password=abcdefgh1!;Encrypt=false;TrustServerCertificate=true;";
+
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        await new JsonToSqlTableCreator(connection).CreateTablesAsync(jsonContent);
+        await new JsonToSqlSaver(connection).SaveJsonAsync(jsonContent);
+
+        Console.WriteLine("JSON data successfully saved to the database.");
+    }
+}

--- a/src/dms/backend/NormalizedSqlServer/SaveJsonToTables.cs
+++ b/src/dms/backend/NormalizedSqlServer/SaveJsonToTables.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Text.Json;
+using Dapper;
+using Microsoft.Data.SqlClient;
+
+public class JsonToSqlSaver
+{
+    private readonly SqlConnection _connection;
+
+    public JsonToSqlSaver(SqlConnection connection)
+    {
+        _connection = connection;
+    }
+
+    public async Task SaveJsonAsync(string json)
+    {
+        var jsonObject = JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+
+        if (jsonObject == null)
+        {
+            throw new ArgumentException("Invalid JSON object.");
+        }
+
+        using var transaction = _connection.BeginTransaction();
+
+        try
+        {
+            await SaveObjectAsync("StudentEducationOrganizationAssociation", jsonObject, transaction);
+
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    private async Task<int> SaveObjectAsync(
+        string tableName,
+        Dictionary<string, object> data,
+        SqlTransaction transaction
+    )
+    {
+        var columns = new List<string>();
+        var values = new List<string>();
+        var parameters = new DynamicParameters();
+
+        foreach (var (key, value) in data)
+        {
+            if (
+                key.EndsWith("Reference")
+                && value is JsonElement referenceElement
+                && referenceElement.ValueKind == JsonValueKind.Object
+            )
+            {
+                // Handle foreign key references
+                var referenceData = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                    referenceElement.GetRawText()
+                );
+
+                if (referenceData == null)
+                {
+                    throw new InvalidOperationException($"Invalid reference data for key '{key}'.");
+                }
+                var referenceTableName = key.Replace("Reference", "");
+                var referenceId = await SaveObjectAsync(referenceTableName, referenceData, transaction);
+
+                columns.Add($"{referenceTableName}Id");
+                values.Add($"@{referenceTableName}Id");
+                parameters.Add($"@{referenceTableName}Id", referenceId);
+            }
+            else if (value is JsonElement arrayElement && arrayElement.ValueKind == JsonValueKind.Array)
+            {
+                // Handle nested arrays
+                var nestedTableName = $"{tableName}{key}";
+                foreach (var item in arrayElement.EnumerateArray())
+                {
+                    var nestedData = JsonSerializer.Deserialize<Dictionary<string, object>>(
+                        item.GetRawText()
+                    );
+
+                    if (nestedData == null)
+                    {
+                        throw new InvalidOperationException($"Invalid nested data for key '{key}'.");
+                    }
+
+                    await SaveObjectAsync(nestedTableName, nestedData, transaction);
+                }
+            }
+            else
+            {
+                // Handle scalar values
+                columns.Add(key);
+                values.Add($"@{key}");
+                parameters.Add($"@{key}", value.ToString());
+            }
+        }
+
+        var sql =
+            $"INSERT INTO {tableName} ({string.Join(", ", columns)}) OUTPUT INSERTED.DocumentId VALUES ({string.Join(", ", values)})";
+
+        return await _connection.ExecuteScalarAsync<int>(sql, parameters, transaction);
+    }
+}

--- a/src/dms/backend/NormalizedSqlServer/create table prompt.md
+++ b/src/dms/backend/NormalizedSqlServer/create table prompt.md
@@ -1,0 +1,57 @@
+Create a C# class that accepts a JSON object and creates SQL Sever tables. Each
+JSON key that has a string, number, or boolean value becomes a column in the
+table. Each key with a value that is an object is saved to a linked table, and
+each node with a key whose name is suffixed with "Reference" becomes a foreign
+key reference. Ignore the `link` nodes.
+
+For example, the JSON object might look like this:
+
+```json
+{
+    "id": "string",
+    "educationOrganizationReference": {
+      "educationOrganizationId": 0
+    },
+    "studentReference": {
+      "studentUniqueId": "string"
+    },
+    "addresses": [
+      {
+        "addressTypeDescriptor": "string",
+        "stateAbbreviationDescriptor": "string",
+        "periods": [
+          {
+            "beginDate": "2025-03-29",
+            "endDate": "2025-03-29"
+          }
+        ]
+      }
+    ],
+    "ancestryEthnicOrigins": [
+      {
+        "ancestryEthnicOriginDescriptor": "string"
+      }
+    ],
+    "barrierToInternetAccessInResidenceDescriptor": "string",
+    "cohortYears": [
+      {
+        "cohortYearTypeDescriptor": "string",
+        "termDescriptor": "string",
+        "schoolYearTypeReference": {
+          "schoolYear": 0
+        }
+      }
+    ]
+}
+```
+
+And this document would create the following tables
+
+- StudentEducationOrganizationAssociation
+  - with foreign keys to:
+    - EducationOrganization
+    - Student
+- StudentEducationOrganizationAssociationAddress
+- StudentEducationOrganizationAssociationAddressPeriod
+- StudentEducationOrganizationAssociationAncestryEthnicOrigin
+- StudentEducationOrganizationAssociationCohortYear

--- a/src/dms/backend/NormalizedSqlServer/initial prompt.md
+++ b/src/dms/backend/NormalizedSqlServer/initial prompt.md
@@ -1,0 +1,56 @@
+Create a C# class that accepts a JSON object and saves into SQL Server using
+Dapper. Each dictionary within the JSON object is saved to a linked table, and
+each node with a key whose name is suffixed with "Reference" becomes a foreign
+key reference.
+
+For example, the JSON object might look like this:
+
+```json
+{
+    "id": "string",
+    "educationOrganizationReference": {
+      "educationOrganizationId": 0
+    },
+    "studentReference": {
+      "studentUniqueId": "string"
+    },
+    "addresses": [
+      {
+        "addressTypeDescriptor": "string",
+        "stateAbbreviationDescriptor": "string",
+        "periods": [
+          {
+            "beginDate": "2025-03-29",
+            "endDate": "2025-03-29"
+          }
+        ]
+      }
+    ],
+    "ancestryEthnicOrigins": [
+      {
+        "ancestryEthnicOriginDescriptor": "string"
+      }
+    ],
+    "barrierToInternetAccessInResidenceDescriptor": "string",
+    "cohortYears": [
+      {
+        "cohortYearTypeDescriptor": "string",
+        "termDescriptor": "string",
+        "schoolYearTypeReference": {
+          "schoolYear": 0
+        }
+      }
+    ]
+}
+```
+
+And this document would saved into the following database tables:
+
+- StudentEducationOrganizationAssociation
+  - with foreign keys to:
+    - EducationOrganization
+    - Student
+- StudentEducationOrganizationAssociationAddress
+- StudentEducationOrganizationAssociationAddressPeriod
+- StudentEducationOrganizationAssociationAncestryEthnicOrigin
+- StudentEducationOrganizationAssociationCohortYear

--- a/src/dms/backend/NormalizedSqlServer/sample.json
+++ b/src/dms/backend/NormalizedSqlServer/sample.json
@@ -1,0 +1,95 @@
+{
+    "id": "4f720ef47b2c41d4b06b4d3efa725abc",
+    "educationOrganizationReference": {
+      "educationOrganizationId": 255901
+    },
+    "studentReference": {
+      "studentUniqueId": "604824"
+    },
+    "hispanicLatinoEthnicity": true,
+    "internetAccessInResidence": true,
+    "internetAccessTypeInResidenceDescriptor": "uri://ed-fi.org/InternetAccessTypeInResidenceDescriptor#Other",
+    "internetPerformanceInResidenceDescriptor": "uri://ed-fi.org/InternetPerformanceInResidenceDescriptor#Sometimes",
+    "primaryLearningDeviceAwayFromSchoolDescriptor": "uri://ed-fi.org/PrimaryLearningDeviceAwayFromSchoolDescriptor#None",
+    "sexDescriptor": "uri://ed-fi.org/SexDescriptor#Female",
+    "supporterMilitaryConnectionDescriptor": "uri://ed-fi.org/SupporterMilitaryConnectionDescriptor#Reserve",
+    "addresses": [
+      {
+        "addressTypeDescriptor": "uri://ed-fi.org/AddressTypeDescriptor#Home",
+        "city": "Grand Bend",
+        "postalCode": "78834",
+        "stateAbbreviationDescriptor": "uri://ed-fi.org/StateAbbreviationDescriptor#TX",
+        "streetNumberName": "980 Green New Boulevard",
+        "nameOfCounty": "WILLISTON",
+        "periods": []
+      }
+    ],
+    "ancestryEthnicOrigins": [],
+    "cohortYears": [],
+    "disabilities": [],
+    "displacedStudents": [],
+    "electronicMails": [
+      {
+        "electronicMailAddress": "vevqpza@example.com",
+        "electronicMailTypeDescriptor": "uri://ed-fi.org/ElectronicMailTypeDescriptor#Home/Personal"
+      }
+    ],
+    "internationalAddresses": [],
+    "languages": [],
+    "races": [
+      {
+        "raceDescriptor": "uri://ed-fi.org/RaceDescriptor#Asian"
+      }
+    ],
+    "studentCharacteristics": [],
+    "studentIdentificationCodes": [
+      {
+        "assigningOrganizationIdentificationCode": "Local",
+        "studentIdentificationSystemDescriptor": "uri://ed-fi.org/StudentIdentificationSystemDescriptor#Local",
+        "identificationCode": "824"
+      },
+      {
+        "assigningOrganizationIdentificationCode": "SSN",
+        "studentIdentificationSystemDescriptor": "uri://ed-fi.org/StudentIdentificationSystemDescriptor#SSN",
+        "identificationCode": "1990607651"
+      }
+    ],
+    "studentIndicators": [
+      {
+        "indicatorName": "Primary Learning Device Away From School",
+        "indicator": "None",
+        "indicatorGroup": "Digital Equity",
+        "periods": []
+      },
+      {
+        "indicatorName": "Internet Access In Residence",
+        "indicator": "true",
+        "indicatorGroup": "Digital Equity",
+        "periods": []
+      },
+      {
+        "indicatorName": "Internet Access Type In Residence",
+        "indicator": "Other",
+        "indicatorGroup": "Digital Equity",
+        "periods": []
+      },
+      {
+        "indicatorName": "Internet Performance In Residence",
+        "indicator": "Sometimes",
+        "indicatorGroup": "Digital Equity",
+        "periods": []
+      }
+    ],
+    "telephones": [
+      {
+        "telephoneNumber": "(950) 615 3165",
+        "telephoneNumberTypeDescriptor": "uri://ed-fi.org/TelephoneNumberTypeDescriptor#Home",
+        "orderOfPriority": 1
+      },
+      {
+        "telephoneNumber": "(950) 708 2926",
+        "telephoneNumberTypeDescriptor": "uri://ed-fi.org/TelephoneNumberTypeDescriptor#Mobile"
+      }
+    ],
+    "tribalAffiliations": []
+  }


### PR DESCRIPTION
The "single table" design effectively supports both referential integrity and the outbox pattern for simplified streaming data out. This facilitates the use of streaming data for populating other data stores, such as a search database or a data lake. This design also forces creation of searchable indexes somewhere other than on the single table - for example, in an OpenSearch database.

But some organizations do not want these features. They add unnecessary complexity and cost for their installations. Instead, they would prefer to have a traditional relational database structure, with fully indexing capability in the relational tables.

This code is a quick-and-dirty POC for parsing nested JSON and saving into a relational structure similar to the `EdFi_ODS` database used by the Ed-Fi ODS/API. 90% of the code was written by GitHub Copilot using two detailed prompts; the prompts are included in the branch, along with a sample JSON file for upload. 

Some light editing was required to fix compilation errors; for example, in both classes, Copilot tried to use a `BeginTransactionAsync` method that returns a `DbTransaction` instead of a `SqlTransaction` - and in fact, I cannot find documentation of this class. Copilot also is interfering with VS Code's ability to follow source code references, so I cannot use the normal F12 to try to look up the decompiled reference. There were also a couple of null handling bugs. Even writing the null error checks was primarily done by Copilot, although it used the semantically incorrect `ArgumentNullException` instead of `InvalidOperationException`.

Imagine combining these simple classes with the JsonSchema, which would provide more detailed information about what should be indexed (for example) or about data limits. Data limits (for example, string length) aren't strictly necessary at the database level any more, thanks to that JSON validation, so long as people do not bypass the API by inserting directly into the database. The code would need to be modified to ignore reference tables: do not create them (they should already exist) and do not insert records into them. There would also need to be an understanding of dependency order when creating the tables in the first place, or a two-pass process where foreign keys are not created until after all of the tables have been created.

Here are a few screenshots of the actual output.

![image](https://github.com/user-attachments/assets/bf7904b5-5a53-4c11-bab3-a1772f0d6c23)

![image](https://github.com/user-attachments/assets/326e6e01-0b59-4860-a457-1ed4d859d897)
