### PR TITLE
Update OAuth URL in .env.example

### DIFF
--- a/eng/docker-compose/.env.example
+++ b/eng/docker-compose/.env.example
@@ -48,7 +48,7 @@ KEYCLOAK_PORT=8045
 # DMS
 # ---
 DMS_HTTP_PORTS=8080
-OAUTH_TOKEN_ENDPOINT=http://dms-keycloak:8080/realms/edfi/protocol/openid-connect/token
+OAUTH_TOKEN_ENDPOINT=http://localhost:${KEYCLOAK_PORT}/realms/edfi/protocol/openid-connect/token
 NEED_DATABASE_SETUP=true
 BYPASS_STRING_COERCION=false
 MAXIMUM_PAGE_SIZE=500


### PR DESCRIPTION
Someone accidentally copied the e2e setting into the example, which is not appropriate for anyone interacting with the containers from outside of the Docker network.