### PR TITLE
[DMS-593] Fix School Year Data Load in Published Docker Image

### DIFF
--- a/src/dms/Nuget.Dockerfile
+++ b/src/dms/Nuget.Dockerfile
@@ -32,9 +32,6 @@ RUN echo "Tag Version:" $VERSION
 RUN wget -O /app/EdFi.DataManagementService.zip "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.DataManagementService/versions/${VERSION}/content" && \
     unzip /app/EdFi.DataManagementService.zip -d /app/ && \
     cp -r /app/DataManagementService/. /app/ && \
-    cp -r /app/Installer/. /app/. && \
-    cp -r /app/ApiSchemaDownloader/. /app/. && \
-    cp -r /app/SchoolYearLoader/. /app/. && \
     rm -f /app/EdFi.DataManagementService.zip && \
     rm -r /app/DataManagementService
 


### PR DESCRIPTION
This additional copy logic here overwrites some of the libraries in the core dms and causes runtime errors