### PR TITLE
[DMS-616] Contact Authorization: Contact-securable Document GET by ID/DELETE in DMS Core

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlAuthorizationRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlAuthorizationRepository.cs
@@ -30,6 +30,23 @@ public class PostgresqlAuthorizationRepository(NpgsqlDataSource _dataSource, ISq
         return organizationIds.Distinct().ToArray();
     }
 
+    public async Task<long[]> GetEducationOrganizationsForContact(string contactUniqueId)
+    {
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
+        JsonElement? response = await sqlAction.GetContactStudentSchoolAuthorizationEducationOrganizationIds(
+            contactUniqueId,
+            connection,
+            transaction
+        );
+        if (response == null)
+        {
+            return [];
+        }
+        long[] edOrgIds = JsonSerializer.Deserialize<long[]>(response.Value) ?? [];
+        return edOrgIds;
+    }
+
     public async Task<long[]> GetEducationOrganizationsForStudent(string studentUniqueId)
     {
         await using var connection = await _dataSource.OpenConnectionAsync();

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IAuthorizationRepository.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IAuthorizationRepository.cs
@@ -13,4 +13,5 @@ public interface IAuthorizationRepository
     public Task<long[]> GetAncestorEducationOrganizationIds(long[] educationOrganizationIds);
     public Task<long[]> GetEducationOrganizationsForStudent(string studentUniqueId);
     public Task<long[]> GetEducationOrganizationsForStaff(string staffUniqueId);
+    public Task<long[]> GetEducationOrganizationsForContact(string contactUniqueId);
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
@@ -25,6 +25,8 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         _validator = new RelationshipsWithEdOrgsAndPeopleValidator(_authorizationRepository);
     }
 
+    // Student authorization tests
+
     [TestFixture]
     public class Given_Request_Has_No_Student_Info : RelationshipsWithEdOrgsAndPeopleValidatorTests
     {
@@ -158,43 +160,6 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
     }
 
     [TestFixture]
-    public class Given_Resource_Is_Not_Student_Securable : RelationshipsWithEdOrgsAndPeopleValidatorTests
-    {
-        private ResourceAuthorizationResult? _expectedResult;
-
-        [SetUp]
-        public async Task Setup()
-        {
-            var securityElements = new DocumentSecurityElements(
-                [],
-                [],
-                [new StudentUniqueId("12345")],
-                [],
-                []
-            );
-
-            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
-
-            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForStudent("12345"))
-                .Returns([255901L]);
-
-            _expectedResult = await _validator.ValidateAuthorization(
-                securityElements,
-                authorizationFilters,
-                [],
-                OperationType.Get
-            );
-        }
-
-        [Test]
-        public void Should_Return_Expected_AuthorizationResult()
-        {
-            _expectedResult.Should().NotBeNull();
-            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.Authorized));
-        }
-    }
-
-    [TestFixture]
     public class Given_Resource_With_Student_Reference_Has_No_Matching_EdOrg
         : RelationshipsWithEdOrgsAndPeopleValidatorTests
     {
@@ -241,6 +206,358 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                     .Should()
                     .Be(
                         "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                    );
+            }
+        }
+    }
+
+    // Contact authorization tests
+    [TestFixture]
+    public class Given_Request_Has_No_Contact_Info : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [], []);
+            var authorizationFilters = Array.Empty<AuthorizationFilter>();
+            var authorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+            _expectedResult = await _validator!.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [authorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.NotAuthorized));
+            if (_expectedResult is ResourceAuthorizationResult.NotAuthorized notAuthorized)
+            {
+                notAuthorized!.ErrorMessages.Should().HaveCount(1);
+                notAuthorized!
+                    .ErrorMessages[0]
+                    .Should()
+                    .Be(
+                        "No 'Contact' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?"
+                    );
+            }
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_With_Contact_Reference_Has_No_Associated_EdOrgs
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            var authorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("12345")).Returns([]);
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [authorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.NotAuthorized));
+            if (_expectedResult is ResourceAuthorizationResult.NotAuthorized notAuthorized)
+            {
+                notAuthorized!.ErrorMessages.Should().HaveCount(1);
+                notAuthorized!
+                    .ErrorMessages[0]
+                    .Should()
+                    .Be(
+                        "No relationships have been established between the caller's education organization id claims ('255901') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'."
+                    );
+            }
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_With_Contact_Reference_Has_Matching_EdOrg
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            var authorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("12345"))
+                .Returns([255901L]);
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [authorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.Authorized));
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_With_Contact_Reference_Has_No_Matching_EdOrg
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255903") };
+
+            var authorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("12345"))
+                .Returns([255901L]);
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [authorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.NotAuthorized));
+            if (_expectedResult is ResourceAuthorizationResult.NotAuthorized notAuthorized)
+            {
+                notAuthorized!.ErrorMessages.Should().HaveCount(1);
+                notAuthorized!
+                    .ErrorMessages[0]
+                    .Should()
+                    .Be(
+                        "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'."
+                    );
+            }
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_Is_Not_Student_Or_Contact_Securable
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [new StudentUniqueId("12345")],
+                [new ContactUniqueId("89898")]
+            );
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForStudent("12345"))
+                .Returns([255901L]);
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.Authorized));
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_Is_Student_And_Contact_Securable
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [new StudentUniqueId("12345")],
+                [new ContactUniqueId("89898")]
+            );
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForStudent("12345"))
+                .Returns([255901L]);
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("89898"))
+                .Returns([255901L]);
+
+            var studentAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.StudentUniqueId
+            );
+            var contactAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [studentAuthorizationSecurableInfo, contactAuthorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.Authorized));
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_Is_Student_And_Contact_Securable_Missing_Student_Info
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("89898")]);
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForStudent("12345"))
+                .Returns([255901L]);
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("89898"))
+                .Returns([255901L]);
+
+            var studentAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.StudentUniqueId
+            );
+            var contactAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [studentAuthorizationSecurableInfo, contactAuthorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.NotAuthorized));
+            if (_expectedResult is ResourceAuthorizationResult.NotAuthorized notAuthorized)
+            {
+                notAuthorized!.ErrorMessages.Should().HaveCount(1);
+                notAuthorized!
+                    .ErrorMessages[0]
+                    .Should()
+                    .Be(
+                        "No 'Student' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?"
+                    );
+            }
+        }
+    }
+
+    [TestFixture]
+    public class Given_Resource_Is_Student_And_Contact_Securable_Missing_Contact_Info
+        : RelationshipsWithEdOrgsAndPeopleValidatorTests
+    {
+        private ResourceAuthorizationResult? _expectedResult;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var securityElements = new DocumentSecurityElements([], [], [new StudentUniqueId("12345")], []);
+
+            var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
+
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForStudent("12345"))
+                .Returns([255901L]);
+            A.CallTo(() => _authorizationRepository.GetEducationOrganizationsForContact("89898"))
+                .Returns([255901L]);
+
+            var studentAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.StudentUniqueId
+            );
+            var contactAuthorizationSecurableInfo = new AuthorizationSecurableInfo(
+                SecurityElementNameConstants.ContactUniqueId
+            );
+
+            _expectedResult = await _validator.ValidateAuthorization(
+                securityElements,
+                authorizationFilters,
+                [studentAuthorizationSecurableInfo, contactAuthorizationSecurableInfo],
+                OperationType.Get
+            );
+        }
+
+        [Test]
+        public void Should_Return_Expected_AuthorizationResult()
+        {
+            _expectedResult.Should().NotBeNull();
+            _expectedResult!.GetType().Should().Be(typeof(ResourceAuthorizationResult.NotAuthorized));
+            if (_expectedResult is ResourceAuthorizationResult.NotAuthorized notAuthorized)
+            {
+                notAuthorized!.ErrorMessages.Should().HaveCount(1);
+                notAuthorized!
+                    .ErrorMessages[0]
+                    .Should()
+                    .Be(
+                        "No 'Contact' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?"
                     );
             }
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
@@ -111,7 +111,7 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                     .ErrorMessages[0]
                     .Should()
                     .Be(
-                        "No relationships have been established between the caller's education organization id claims ('255901') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                        "No relationships have been established between the caller's education organization id claims ('255901') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                     );
             }
         }
@@ -205,7 +205,7 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                     .ErrorMessages[0]
                     .Should()
                     .Be(
-                        "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                        "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                     );
             }
         }
@@ -296,7 +296,7 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                     .ErrorMessages[0]
                     .Should()
                     .Be(
-                        "No relationships have been established between the caller's education organization id claims ('255901') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'."
+                        "No relationships have been established between the caller's education organization id claims ('255901') and one or more of the following properties of the resource item: 'ContactUniqueId'."
                     );
             }
         }
@@ -390,7 +390,7 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                     .ErrorMessages[0]
                     .Should()
                     .Be(
-                        "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'."
+                        "No relationships have been established between the caller's education organization id claims ('255903') and one or more of the following properties of the resource item: 'ContactUniqueId'."
                     );
             }
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidatorTests.cs
@@ -220,7 +220,7 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [], []);
+            var securityElements = new DocumentSecurityElements([], [], [], [], []);
             var authorizationFilters = Array.Empty<AuthorizationFilter>();
             var authorizationSecurableInfo = new AuthorizationSecurableInfo(
                 SecurityElementNameConstants.ContactUniqueId
@@ -260,7 +260,13 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [],
+                [new ContactUniqueId("12345")],
+                []
+            );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
 
@@ -305,7 +311,13 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [],
+                [new ContactUniqueId("12345")],
+                []
+            );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
 
@@ -341,7 +353,13 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("12345")]);
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [],
+                [new ContactUniqueId("12345")],
+                []
+            );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255903") };
 
@@ -391,7 +409,8 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                 [],
                 [],
                 [new StudentUniqueId("12345")],
-                [new ContactUniqueId("89898")]
+                [new ContactUniqueId("89898")],
+                []
             );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
@@ -428,7 +447,8 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
                 [],
                 [],
                 [new StudentUniqueId("12345")],
-                [new ContactUniqueId("89898")]
+                [new ContactUniqueId("89898")],
+                []
             );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
@@ -470,7 +490,13 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [], [new ContactUniqueId("89898")]);
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [],
+                [new ContactUniqueId("89898")],
+                []
+            );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
 
@@ -521,7 +547,13 @@ public class RelationshipsWithEdOrgsAndPeopleValidatorTests
         [SetUp]
         public async Task Setup()
         {
-            var securityElements = new DocumentSecurityElements([], [], [new StudentUniqueId("12345")], []);
+            var securityElements = new DocumentSecurityElements(
+                [],
+                [],
+                [new StudentUniqueId("12345")],
+                [],
+                []
+            );
 
             var authorizationFilters = new[] { new AuthorizationFilter("EducationOrganization", "255901") };
 

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -55,9 +55,11 @@ public static class DmsCoreServiceExtensions
             .AddTransient<NamespaceBasedValidator>()
             .AddTransient<RelationshipsWithEdOrgsOnlyValidator>()
             .AddTransient<RelationshipsWithEdOrgsAndPeopleValidator>()
+            .AddTransient<RelationshipsWithStudentsOnlyValidator>()
             .AddTransient<RelationshipsWithEdOrgsOnlyFiltersProvider>()
             .AddTransient<RelationshipsWithEdOrgsAndPeopleFiltersProvider>()
             .AddTransient<NoFurtherAuthorizationRequiredFiltersProvider>()
+            .AddTransient<RelationshipsWithStudentsOnlyFiltersProvider>()
             .AddTransient<NamespaceBasedFiltersProvider>()
             .AddResiliencePipeline("backendResiliencePipeline", backendResiliencePipeline);
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsFiltersProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsFiltersProvider.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Security.AuthorizationFilters;
+
+/// <summary>
+/// Provides authorization filters for various authorization strategies
+/// </summary>
+public static class RelationshipsFiltersProvider
+{
+    public static AuthorizationStrategyEvaluator GetFilters(
+        ClientAuthorizations authorizations,
+        string authorizationStrategyName
+    )
+    {
+        var filters = new List<AuthorizationFilter>();
+        var edOrgIdsFromClaim = authorizations
+            .EducationOrganizationIds.Select(e => e.Value.ToString())
+            .ToList();
+        if (edOrgIdsFromClaim.Count == 0)
+        {
+            string noRequiredClaimError =
+                $"The API client has been given permissions on a resource that uses the '{authorizationStrategyName}' authorization strategy but the client doesn't have any education organizations assigned.";
+            throw new AuthorizationException(noRequiredClaimError);
+        }
+        foreach (var edOrgId in edOrgIdsFromClaim)
+        {
+            filters.Add(new AuthorizationFilter(SecurityElementNameConstants.EducationOrganization, edOrgId));
+        }
+
+        return new AuthorizationStrategyEvaluator(authorizationStrategyName, [.. filters], FilterOperator.Or);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsWithEdOrgsOnlyFiltersProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsWithEdOrgsOnlyFiltersProvider.cs
@@ -3,7 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 
 namespace EdFi.DataManagementService.Core.Security.AuthorizationFilters;
@@ -18,21 +17,6 @@ public class RelationshipsWithEdOrgsOnlyFiltersProvider : IAuthorizationFiltersP
 
     public AuthorizationStrategyEvaluator GetFilters(ClientAuthorizations authorizations)
     {
-        var filters = new List<AuthorizationFilter>();
-        var edOrgIdsFromClaim = authorizations
-            .EducationOrganizationIds.Select(e => e.Value.ToString())
-            .ToList();
-        if (edOrgIdsFromClaim.Count == 0)
-        {
-            string noRequiredClaimError =
-                $"The API client has been given permissions on a resource that uses the '{AuthorizationStrategyName}' authorization strategy but the client doesn't have any education organizations assigned.";
-            throw new AuthorizationException(noRequiredClaimError);
-        }
-        foreach (var edOrgId in edOrgIdsFromClaim)
-        {
-            filters.Add(new AuthorizationFilter(SecurityElementNameConstants.EducationOrganization, edOrgId));
-        }
-
-        return new AuthorizationStrategyEvaluator(AuthorizationStrategyName, [.. filters], FilterOperator.Or);
+        return RelationshipsFiltersProvider.GetFilters(authorizations, AuthorizationStrategyName);
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsWithStudentsOnlyFiltersProvider.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationFilters/RelationshipsWithStudentsOnlyFiltersProvider.cs
@@ -3,18 +3,17 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 
 namespace EdFi.DataManagementService.Core.Security.AuthorizationFilters;
 
 /// <summary>
-/// Provides authorization filters for RelationshipsWithEdOrgsAndPeople authorization strategy
+/// Provides authorization filters for RelationshipsWithStudentsOnly authorization strategy
 /// </summary>
 [AuthorizationStrategyName(AuthorizationStrategyName)]
-public class RelationshipsWithEdOrgsAndPeopleFiltersProvider : IAuthorizationFiltersProvider
+public class RelationshipsWithStudentsOnlyFiltersProvider : IAuthorizationFiltersProvider
 {
-    private const string AuthorizationStrategyName = "RelationshipsWithEdOrgsAndPeople";
+    private const string AuthorizationStrategyName = "RelationshipsWithStudentsOnly";
 
     public AuthorizationStrategyEvaluator GetFilters(ClientAuthorizations authorizations)
     {

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsBasedAuthorizationHelper.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsBasedAuthorizationHelper.cs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Security.AuthorizationValidation;
+
+public static class RelationshipsBasedAuthorizationHelper
+{
+    private const string NoPropertyFoundErrorMessage =
+        "No '{PropertyName}' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?";
+
+    public static bool HasSecurable(AuthorizationSecurableInfo[] securableInfos, string securableKey)
+    {
+        return securableInfos.AsEnumerable().Any(x => x.SecurableKey == securableKey);
+    }
+
+    private static bool IsAuthorized(AuthorizationFilter[] authorizationFilters, long[]? educationOrgIds)
+    {
+        var authorizedEdOrgIds = authorizationFilters
+            .Select(f => long.TryParse(f.Value, out var id) ? (long?)id : null)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value);
+
+        return educationOrgIds != null
+            && educationOrgIds.Length > 0
+            && authorizedEdOrgIds.Any(id => educationOrgIds.Contains(id));
+    }
+
+    public static async Task<ResourceAuthorizationResult> ValidateStudentAuthorization(
+        IAuthorizationRepository authorizationRepository,
+        DocumentSecurityElements securityElements,
+        AuthorizationFilter[] authorizationFilters
+    )
+    {
+        if (securityElements.Student.Length == 0)
+        {
+            string error = NoPropertyFoundErrorMessage.Replace("{PropertyName}", "Student");
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+
+        var studentUniqueId = securityElements.Student[0].Value;
+
+        var educationOrgIds = await authorizationRepository.GetEducationOrganizationsForStudent(
+            studentUniqueId
+        );
+
+        bool isAuthorized = IsAuthorized(authorizationFilters, educationOrgIds);
+
+        if (!isAuthorized)
+        {
+            string edOrgIdsFromFilters = string.Join(", ", authorizationFilters.Select(x => $"'{x.Value}'"));
+            string error =
+                $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'StudentUniqueId'.";
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+
+        return new ResourceAuthorizationResult.Authorized();
+    }
+
+    public static async Task<ResourceAuthorizationResult> ValidateContactAuthorization(
+        IAuthorizationRepository authorizationRepository,
+        DocumentSecurityElements securityElements,
+        AuthorizationFilter[] authorizationFilters
+    )
+    {
+        if (securityElements.Contact.Length == 0)
+        {
+            string error = NoPropertyFoundErrorMessage.Replace("{PropertyName}", "Contact");
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+        var contactUniqueId = securityElements.Contact[0].Value;
+
+        var educationOrgIds = await authorizationRepository.GetEducationOrganizationsForContact(
+            contactUniqueId
+        );
+
+        bool isAuthorized = IsAuthorized(authorizationFilters, educationOrgIds);
+
+        if (!isAuthorized)
+        {
+            string edOrgIdsFromFilters = string.Join(", ", authorizationFilters.Select(x => $"'{x.Value}'"));
+            string error =
+                $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'ContactUniqueId'.";
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+
+        return new ResourceAuthorizationResult.Authorized();
+    }
+
+    public static async Task<ResourceAuthorizationResult> ValidateStaffAuthorization(
+        IAuthorizationRepository authorizationRepository,
+        DocumentSecurityElements securityElements,
+        AuthorizationFilter[] authorizationFilters
+    )
+    {
+        if (securityElements.Staff.Length == 0)
+        {
+            string error = NoPropertyFoundErrorMessage.Replace("{PropertyName}", "Staff");
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+        var staffUniqueId = securityElements.Staff[0].Value;
+        var educationOrgIds = await authorizationRepository.GetEducationOrganizationsForStaff(staffUniqueId);
+        bool isAuthorized = IsAuthorized(authorizationFilters, educationOrgIds);
+        if (!isAuthorized)
+        {
+            string edOrgIdsFromFilters = string.Join(", ", authorizationFilters.Select(x => $"'{x.Value}'"));
+            string error =
+                $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'StaffUniqueId'.";
+            return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+        return new ResourceAuthorizationResult.Authorized();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidator.cs
@@ -26,132 +26,66 @@ public class RelationshipsWithEdOrgsAndPeopleValidator(IAuthorizationRepository 
         OperationType operationType
     )
     {
-        bool isStudentSecurable = authorizationSecurableInfos
-            .AsEnumerable()
-            .Any(x => x.SecurableKey == SecurityElementNameConstants.StudentUniqueId);
+        var errorMessages = new List<string>();
 
-        bool isContactSecurable = authorizationSecurableInfos
-            .AsEnumerable()
-            .Any(x => x.SecurableKey == SecurityElementNameConstants.ContactUniqueId);
-
-        if (isStudentSecurable)
+        if (
+            RelationshipsBasedAuthorizationHelper.HasSecurable(
+                authorizationSecurableInfos,
+                SecurityElementNameConstants.StudentUniqueId
+            )
+        )
         {
-            return await ValidateStudentAuthorization(securityElements, authorizationFilters);
-        }
-
-        bool isStaffSecurable = authorizationSecurableInfos
-            .AsEnumerable()
-            .Any(x => x.SecurableKey == SecurityElementNameConstants.StaffUniqueId);
-
-        if (isStaffSecurable)
-        {
-            return await ValidateStaffAuthorization(securityElements, authorizationFilters);
-        }
-
-        return new ResourceAuthorizationResult.Authorized();
-    }
-
-    private async Task<ResourceAuthorizationResult> ValidateStudentAuthorization(
-        DocumentSecurityElements securityElements,
-        AuthorizationFilter[] authorizationFilters
-    )
-    {
-        if (securityElements.Student.Length == 0)
-        {
-            string error =
-                "No 'Student' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?";
-            return new ResourceAuthorizationResult.NotAuthorized([error]);
-        }
-
-        string studentUniqueId = securityElements.Student[0].Value;
-
-        long[] educationOrgIds = await authorizationRepository.GetEducationOrganizationsForStudent(
-            studentUniqueId
-        );
-
-        var authorizedEdOrgIds = authorizationFilters
-            .Select(f => long.TryParse(f.Value, out long id) ? (long?)id : null)
-            .WhereNotNull()
-            .ToHashSet();
-
-        bool isAuthorized =
-            educationOrgIds.Length > 0 && authorizedEdOrgIds.Any(id => educationOrgIds.Contains(id));
-
-        if (!isAuthorized)
-        {
-            string edOrgIdsFromFilters = string.Join(", ", authorizationFilters.Select(x => $"'{x.Value}'"));
-            string error =
-                $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'.";
-            return new ResourceAuthorizationResult.NotAuthorized([error]);
-        }
-
-        return new ResourceAuthorizationResult.Authorized();
-    }
-
-    private async Task<ResourceAuthorizationResult> ValidateStaffAuthorization(
-        DocumentSecurityElements securityElements,
-        AuthorizationFilter[] authorizationFilters
-    )
-    {
-        if (securityElements.Staff.Length == 0)
-        {
-            string error =
-                "No 'Staff' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?";
-            return new ResourceAuthorizationResult.NotAuthorized([error]);
-        }
-
-        string staffUniqueId = securityElements.Staff[0].Value;
-
-        long[] educationOrgIds = await authorizationRepository.GetEducationOrganizationsForStaff(
-            staffUniqueId
-        );
-
-        var authorizedEdOrgIds = authorizationFilters
-            .Select(f => long.TryParse(f.Value, out long id) ? (long?)id : null)
-            .WhereNotNull()
-            .ToHashSet();
-
-        bool isAuthorized =
-            educationOrgIds.Length > 0 && authorizedEdOrgIds.Any(id => educationOrgIds.Contains(id));
-
-        if (!isAuthorized)
-        {
-            string edOrgIdsFromFilters = string.Join(", ", authorizationFilters.Select(x => $"'{x.Value}'"));
-            string error =
-                $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StaffUniqueId'.";
-            return new ResourceAuthorizationResult.NotAuthorized([error]);
-        }
-
-        if (isContactSecurable)
-        {
-            if (securityElements.Contact.Length == 0)
-            {
-                string error =
-                    "No 'Contact' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?";
-                return new ResourceAuthorizationResult.NotAuthorized([error]);
-            }
-            var contactUniqueId = securityElements.Contact[0].Value;
-            var educationOrgIds = await authorizationRepository.GetEducationOrganizationsForContact(
-                contactUniqueId
+            var studentResult = await RelationshipsBasedAuthorizationHelper.ValidateStudentAuthorization(
+                authorizationRepository,
+                securityElements,
+                authorizationFilters
             );
-            var authorizedEdOrgIds = authorizationFilters
-                .Select(f => long.TryParse(f.Value, out var id) ? (long?)id : null)
-                .Where(id => id.HasValue)
-                .Select(id => id!.Value);
-            bool isAuthorized =
-                educationOrgIds != null
-                && educationOrgIds.Length > 0
-                && authorizedEdOrgIds.Any(id => educationOrgIds.Contains(id));
-            if (!isAuthorized)
+            if (studentResult is ResourceAuthorizationResult.NotAuthorized notAuthorizedStudent)
             {
-                string edOrgIdsFromFilters = string.Join(
-                    ", ",
-                    authorizationFilters.Select(x => $"'{x.Value}'")
-                );
-                string error =
-                    $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'.";
-                return new ResourceAuthorizationResult.NotAuthorized([error]);
+                errorMessages.AddRange(notAuthorizedStudent.ErrorMessages);
             }
+        }
+
+        if (
+            RelationshipsBasedAuthorizationHelper.HasSecurable(
+                authorizationSecurableInfos,
+                SecurityElementNameConstants.StaffUniqueId
+            )
+        )
+        {
+            var staffResult = await RelationshipsBasedAuthorizationHelper.ValidateStaffAuthorization(
+                authorizationRepository,
+                securityElements,
+                authorizationFilters
+            );
+            if (staffResult is ResourceAuthorizationResult.NotAuthorized notAuthorizedStaff)
+            {
+                errorMessages.AddRange(notAuthorizedStaff.ErrorMessages);
+            }
+        }
+
+        if (
+            RelationshipsBasedAuthorizationHelper.HasSecurable(
+                authorizationSecurableInfos,
+                SecurityElementNameConstants.ContactUniqueId
+            )
+        )
+        {
+            var contactResult = await RelationshipsBasedAuthorizationHelper.ValidateContactAuthorization(
+                authorizationRepository,
+                securityElements,
+                authorizationFilters
+            );
+            if (contactResult is ResourceAuthorizationResult.NotAuthorized notAuthorizedContact)
+            {
+                errorMessages.AddRange(notAuthorizedContact.ErrorMessages);
+            }
+        }
+
+        // Return consolidated result
+        if (errorMessages.Count > 0)
+        {
+            return new ResourceAuthorizationResult.NotAuthorized([.. errorMessages]);
         }
 
         return new ResourceAuthorizationResult.Authorized();

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithEdOrgsAndPeopleValidator.cs
@@ -30,6 +30,10 @@ public class RelationshipsWithEdOrgsAndPeopleValidator(IAuthorizationRepository 
             .AsEnumerable()
             .Any(x => x.SecurableKey == SecurityElementNameConstants.StudentUniqueId);
 
+        bool isContactSecurable = authorizationSecurableInfos
+            .AsEnumerable()
+            .Any(x => x.SecurableKey == SecurityElementNameConstants.ContactUniqueId);
+
         if (isStudentSecurable)
         {
             return await ValidateStudentAuthorization(securityElements, authorizationFilters);
@@ -116,6 +120,38 @@ public class RelationshipsWithEdOrgsAndPeopleValidator(IAuthorizationRepository 
             string error =
                 $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StaffUniqueId'.";
             return new ResourceAuthorizationResult.NotAuthorized([error]);
+        }
+
+        if (isContactSecurable)
+        {
+            if (securityElements.Contact.Length == 0)
+            {
+                string error =
+                    "No 'Contact' property could be found on the resource in order to perform authorization. Should a different authorization strategy be used?";
+                return new ResourceAuthorizationResult.NotAuthorized([error]);
+            }
+            var contactUniqueId = securityElements.Contact[0].Value;
+            var educationOrgIds = await authorizationRepository.GetEducationOrganizationsForContact(
+                contactUniqueId
+            );
+            var authorizedEdOrgIds = authorizationFilters
+                .Select(f => long.TryParse(f.Value, out var id) ? (long?)id : null)
+                .Where(id => id.HasValue)
+                .Select(id => id!.Value);
+            bool isAuthorized =
+                educationOrgIds != null
+                && educationOrgIds.Length > 0
+                && authorizedEdOrgIds.Any(id => educationOrgIds.Contains(id));
+            if (!isAuthorized)
+            {
+                string edOrgIdsFromFilters = string.Join(
+                    ", ",
+                    authorizationFilters.Select(x => $"'{x.Value}'")
+                );
+                string error =
+                    $"No relationships have been established between the caller's education organization id claims ({edOrgIdsFromFilters}) and one or more of the following properties of the resource item: 'EducationOrganizationId', 'ContactUniqueId'.";
+                return new ResourceAuthorizationResult.NotAuthorized([error]);
+            }
         }
 
         return new ResourceAuthorizationResult.Authorized();

--- a/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithStudentsOnlyValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Security/AuthorizationValidation/RelationshipsWithStudentsOnlyValidator.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Security.AuthorizationValidation;
+
+/// <summary>
+/// Validates whether a client is authorized to access a resource based on relationships
+/// with students.
+/// </summary>
+[AuthorizationStrategyName(AuthorizationStrategyName)]
+public class RelationshipsWithStudentsOnlyValidator(IAuthorizationRepository authorizationRepository)
+    : IAuthorizationValidator
+{
+    private const string AuthorizationStrategyName = "RelationshipsWithStudentsOnly";
+
+    public async Task<ResourceAuthorizationResult> ValidateAuthorization(
+        DocumentSecurityElements securityElements,
+        AuthorizationFilter[] authorizationFilters,
+        AuthorizationSecurableInfo[] authorizationSecurableInfos,
+        OperationType operationType
+    )
+    {
+        if (
+            RelationshipsBasedAuthorizationHelper.HasSecurable(
+                authorizationSecurableInfos,
+                SecurityElementNameConstants.StudentUniqueId
+            )
+        )
+        {
+            return await RelationshipsBasedAuthorizationHelper.ValidateStudentAuthorization(
+                authorizationRepository,
+                securityElements,
+                authorizationFilters
+            );
+        }
+        return new ResourceAuthorizationResult.Authorized();
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStudents.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStudents.feature
@@ -1238,7 +1238,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   "status": 403,
                   "validationErrors": {},
                   "errors": [
-                    "No relationships have been established between the caller's education organization id claims ('255901001', '244901') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                    "No relationships have been established between the caller's education organization id claims ('255901001', '244901') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                   ]
                   }
                   """
@@ -1288,7 +1288,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                       "status": 403,
                       "validationErrors": {},
                       "errors": [
-                      "No relationships have been established between the caller's education organization id claims ('255901001', '244901') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                      "No relationships have been established between the caller's education organization id claims ('255901001', '244901') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                       ]
                   }
                   """
@@ -1357,7 +1357,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                          "status": 403,
                          "validationErrors": {},
                          "errors": [
-                              "No relationships have been established between the caller's education organization id claims ('3', '301') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                              "No relationships have been established between the caller's education organization id claims ('3', '301') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                           ]
                         }
                   """
@@ -1372,7 +1372,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                         "status": 403,
                         "validationErrors": {},
                         "errors": [
-                          "No relationships have been established between the caller's education organization id claims ('3', '301') and one or more of the following properties of the resource item: 'EducationOrganizationId', 'StudentUniqueId'."
+                          "No relationships have been established between the caller's education organization id claims ('3', '301') and one or more of the following properties of the resource item: 'StudentUniqueId'."
                         ]
                       }
                   """

--- a/src/dms/tests/RestClient/test.studentContactAssociation.http
+++ b/src/dms/tests/RestClient/test.studentContactAssociation.http
@@ -304,7 +304,7 @@ Authorization: bearer {{dmsToken}}
      }
  }
 
-### GET Contact
+### GET student contact association
 # @name getStudentContactAssociation2
 GET {{createStudentContactAssociation2.response.headers.location}}
 Authorization: bearer {{dmsToken}}
@@ -380,7 +380,122 @@ grant_type=client_credentials
 ###
 @sandboxToken={{sandboxTokenRequest.response.body.access_token}}
 
-### Query Contacts - should return no records with this token
+### Get Contacts
 ###
 GET {{dataApi}}/ed-fi/contacts
 Authorization: bearer {{sandboxToken}}
+
+### Create a new application with EdFiSandbox claim set
+# @name createApplication3
+POST http://localhost:{{configPort}}/v2/applications
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+    "vendorId": {{vendorId}},
+    "applicationName": "Demo application 3",
+    "claimSetName": "EdFiSandbox",
+    "educationOrganizationIds": [6001011]
+}
+
+###
+@clientKey3={{createApplication3.response.body.key}}
+@clientSecret3={{createApplication3.response.body.secret}}
+
+### Create a DMS token
+# @name sandboxTokenResponse
+POST {{tokenUrl}}
+Authorization: basic {{clientKey3}}:{{clientSecret3}}
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+
+###
+@EdFiSandboxToken={{sandboxTokenResponse.response.body.access_token}}
+
+### Create contact
+# @name createContact
+POST {{dataApi}}/ed-fi/contacts
+Authorization: bearer {{EdFiSandboxToken}}
+
+ {
+     "contactUniqueId": "77777",
+     "firstName": "contactfirstname",
+     "lastSurname": "contactlastname"
+ }
+
+### Create second student contact association with same contact
+# @name createStudentContactAssociation3
+POST {{dataApi}}/ed-fi/studentcontactassociations
+Authorization: bearer {{EdFiSandboxToken}}
+
+{
+      "studentReference": {
+       "studentUniqueId": "604824"
+     },
+     "contactReference": {
+       "contactUniqueId": "77777"
+     }
+}
+
+
+### GET contact
+# @name getContact
+GET {{createContact.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+
+###
+@contactId={{getContact.response.body.id}}
+
+### Update contact
+# @name updateContact
+PUT {{createContact.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+
+{
+    "id": "{{contactId}}",
+    "contactUniqueId": "77777",
+    "firstName": "contactfirstname-update",
+    "lastSurname": "contactlastname-update"
+}
+
+### Get student contact association
+# @name getStudentContactAssociation3
+GET {{createStudentContactAssociation3.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+
+###
+@studentContactAssociationId3={{getStudentContactAssociation3.response.body.id}}
+
+### Update StudentContactAssociation
+# @name updateStudentContactAssociation3
+PUT {{createStudentContactAssociation3.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+
+{
+    "id": "{{studentContactAssociationId3}}",
+    "studentReference": {
+       "studentUniqueId": "604824"
+     },
+     "contactReference": {
+       "contactUniqueId": "77777"
+     },
+     "contactPriority": 1
+}
+
+### Get Contacts should return 2 records
+GET {{dataApi}}/ed-fi/contacts
+Authorization: bearer {{EdFiSandboxToken}}
+
+### Delete student contact association (604824->77777)
+DELETE {{createStudentContactAssociation3.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+
+### Get Contacts should return 1 record
+GET {{dataApi}}/ed-fi/contacts
+Authorization: bearer {{EdFiSandboxToken}}
+
+### No student school association, should be able to delete contact 77777
+DELETE {{createContact.response.headers.location}}
+Authorization: bearer {{EdFiSandboxToken}}
+


### PR DESCRIPTION
E2E tests will be covered by https://edfi.atlassian.net/browse/DMS-620.
Added tests with EdFiSAndbox claim set on test.studentContactAssociation.http file.