### PR TITLE
[DMS-709] Grant access to Contacts after their StudentSchoolAssociation is recreated

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
@@ -29,8 +29,8 @@ public class ContactStudentSchoolAuthorization
     public long StudentContactAssociationId { get; set; }
     public short StudentContactAssociationPartitionKey { get; set; }
 
-    public long StudentSchoolAssociationId { get; set; }
-    public short StudentSchoolAssociationPartitionKey { get; set; }
+    public long? StudentSchoolAssociationId { get; set; }
+    public short? StudentSchoolAssociationPartitionKey { get; set; }
 }
 
 public class StudentSecurableDocument
@@ -418,8 +418,14 @@ public class DatabaseIntegrationTestHelper : DatabaseTest
                 StudentContactAssociationId = (long)reader["StudentContactAssociationId"],
                 StudentContactAssociationPartitionKey = (short)
                     reader["StudentContactAssociationPartitionKey"],
-                StudentSchoolAssociationId = (long)reader["StudentSchoolAssociationId"],
-                StudentSchoolAssociationPartitionKey = (short)reader["StudentSchoolAssociationPartitionKey"],
+                StudentSchoolAssociationId =
+                    reader["StudentSchoolAssociationId"] == DBNull.Value
+                        ? null
+                        : (long?)reader["StudentSchoolAssociationId"],
+                StudentSchoolAssociationPartitionKey =
+                    reader["StudentSchoolAssociationPartitionKey"] == DBNull.Value
+                        ? null
+                        : (short?)reader["StudentSchoolAssociationPartitionKey"],
             };
             results.Add(authorization);
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1001_Create_ContactStudentSchoolAuthorization_Table.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1001_Create_ContactStudentSchoolAuthorization_Table.sql
@@ -10,13 +10,13 @@ CREATE TABLE dms.ContactStudentSchoolAuthorization(
     ContactStudentSchoolAuthorizationEducationOrganizationIds JSONB NOT NULL,
     StudentContactAssociationId BIGINT NOT NULL,
     StudentContactAssociationPartitionKey SMALLINT NOT NULL,
-    StudentSchoolAssociationId BIGINT NOT NULL,
-    StudentSchoolAssociationPartitionKey SMALLINT NOT NULL,
+    StudentSchoolAssociationId BIGINT,
+    StudentSchoolAssociationPartitionKey SMALLINT,
     CONSTRAINT FK_ContactStudentSchoolAuthorization_SSA_Document FOREIGN KEY (StudentSchoolAssociationId, StudentSchoolAssociationPartitionKey)
-        REFERENCES dms.Document(Id, DocumentPartitionKey) ON DELETE CASCADE,
+        REFERENCES dms.Document(Id, DocumentPartitionKey) ON DELETE SET NULL,
 
     CONSTRAINT FK_ContactStudentSchoolAuthorization_SCA_Document FOREIGN KEY (StudentContactAssociationId, StudentContactAssociationPartitionKey)
-        REFERENCES dms.Document(Id, DocumentPartitionKey) ON DELETE CASCADE
+        REFERENCES dms.Document(Id, DocumentPartitionKey) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX IX_ContactStudentSchoolAuthorization_ContactUniqueId

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
@@ -1149,8 +1149,6 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     ]
                   """
 
-        # Re-enable when DMS-709 is done
-        @ignore
         Scenario: 52 Ensure client can retrieve a Contact after the SSA has been recreated
             # Change to use long EdOrgIds when DMS-706 is done
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1455901001"


### PR DESCRIPTION
Why the issue happened:

```
               School                                  
                 │                                     
                 ▼                                     
StudentSchoolAssociationAuthorization ─┐               
                 │                     │               
                 ▼                     │               
        StudentSchoolAssociation ──────┤ Cascade delete
                 │                     │               
                 ▼                     │               
               Student                 │               
                 │                     │               
                 ▼                     │               
    ContactStudentSchoolAuthorization ─┘               
                 │                                     
                 ▼                                     
        StudentContactAssociation                      
                 │                                     
                 ▼                                     
               Contact                                 
```
When we delete a `StudentSchoolAssociation`, the cascade delete also deletes the related `StudentSchoolAssociationAuthorization` and `ContactStudentSchoolAuthorization`.
When we recreate the `StudentSchoolAssociation`, the trigger doesn't grant access to the Contacts because the `ContactStudentSchoolAuthorizations` don't exist anymore, so there's no way to get to the `StudentContactAssociations`.

To fix it, I changed the `ON DELETE CASCADE` to `ON DELETE SET NULL`, which keeps the `ContactStudentSchoolAuthorizations` after the `StudentSchoolAssociation` is deleted.
This brings the side effect that when the same `StudentSchoolAssociation` gets deleted multiple times, we end up with many `ContactStudentSchoolAuthorizations` with empty EdOrgIds (garbage). We could consider cleaning them up in an asynchronous recurrent process.

I recommend revisiting this implementation after the RC release, we might consider the next options:
- Add a table similar to `ContactStudentSchoolAuthorization` with the only purpose of having an index toward the `StudentContactAssociation` (by Student Id).
- Investigating if we can add an index directly to the Documents table for the `StudentContactAssociation` StudentId ([see jsonb indexing](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)).