### PR TITLE
[DMS-706] LONG edOrgId support in kafka

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/Configuration.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/Configuration.cs
@@ -7,7 +7,7 @@
 using System.Data;
 using Microsoft.Extensions.Configuration;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration
 {
     public static class Configuration
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
@@ -780,9 +780,12 @@ public class DatabaseIntegrationTestHelper : DatabaseTest
 
     public static long[] ParseEducationOrganizationIds(string ids)
     {
-        return ids.Trim('[', ']')
-            .Split(',', StringSplitOptions.RemoveEmptyEntries)
-            .Select(long.Parse)
-            .ToArray();
+        if (string.IsNullOrWhiteSpace(ids) || ids == "[]")
+        {
+            return Array.Empty<long>();
+        }
+
+        return System.Text.Json.JsonSerializer.Deserialize<string[]>(ids)?.Select(long.Parse).ToArray()
+            ?? Array.Empty<long>();
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseIntegrationTestHelper.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Transactions;
-using EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using Npgsql;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseTest.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseTest.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Npgsql;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public abstract class DatabaseTest : DatabaseTestBase
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseTestBase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseTestBase.cs
@@ -8,7 +8,7 @@ using Npgsql;
 using NUnit.Framework;
 using Respawn;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 // A database test base class that creates a datasource and manages table truncation
 public abstract class DatabaseTestBase

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DeleteTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DeleteTests.cs
@@ -8,7 +8,7 @@ using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public class DeleteTests : DatabaseTest
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EducationOrganizationHierarchyTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EducationOrganizationHierarchyTests.cs
@@ -7,7 +7,7 @@ using EdFi.DataManagementService.Core.External.Backend;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public class EducationOrganizationHierarchyTests : DatabaseTest
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetTests.cs
@@ -8,7 +8,7 @@ using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public class GetTests : DatabaseTest
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/QueryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/QueryTests.cs
@@ -9,7 +9,7 @@ using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 [TestFixture]
 public class QueryTests : DatabaseTest

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/UpdateTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/UpdateTests.cs
@@ -4,16 +4,14 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Globalization;
-using System.Net;
 using EdFi.DataManagementService.Backend.Postgresql.Model;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;
-using QuickGraph;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public class UpdateTests : DatabaseTest
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/UpsertTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/UpsertTests.cs
@@ -8,7 +8,7 @@ using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Test.Integration;
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 
 public class UpsertTests : DatabaseTest
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0103_Create_StudentSchoolAssociationAuthorization_Triggers.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0103_Create_StudentSchoolAssociationAuthorization_Triggers.sql
@@ -59,7 +59,7 @@ BEGIN
     school_id := NEW.EdfiDoc->'schoolReference'->>'schoolId';
 
     -- Calculate Ed Org IDs once and store in variable
-    SELECT jsonb_agg(EducationOrganizationId)
+    SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
     FROM dms.GetEducationOrganizationAncestors(school_id)
     INTO ancestor_ed_org_ids;
 
@@ -79,7 +79,7 @@ BEGIN
     );
 
     -- Update all student-securable documents for this student
-    ed_org_ids := dms.GetStudentEdOrgIds(student_id);   
+    ed_org_ids := dms.GetStudentEdOrgIds(student_id);
     PERFORM dms.SetEdOrgIdsToStudentSecurables(ed_org_ids, student_id);
 
     -- Manually update the newly inserted StudentSchoolAssociation because it's not a
@@ -148,7 +148,7 @@ BEGIN
     FOR contact_id IN
         SELECT DISTINCT ContactUniqueId
         FROM dms.ContactStudentSchoolAuthorization
-        WHERE         
+        WHERE
             StudentUniqueId = old_student_id AND
             StudentSchoolAssociationId IS NULL AND
             StudentSchoolAssociationPartitionKey IS NULL
@@ -184,9 +184,9 @@ BEGIN
 
     -- DELETE logic
     PERFORM dms.SetEdOrgIdsToStudentSecurables(NULL, old_student_id);
-    
+
     -- INSERT logic
-    SELECT jsonb_agg(EducationOrganizationId)
+    SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
     FROM dms.GetEducationOrganizationAncestors(new_school_id)
     INTO ancestor_ed_org_ids;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0104_Create_EducationOrganizationHierarchyStudentSchoolAuthorization_Triggers.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/0104_Create_EducationOrganizationHierarchyStudentSchoolAuthorization_Triggers.sql
@@ -39,7 +39,7 @@ BEGIN
         -- Update each affected record with the new hierarchy information
         UPDATE dms.StudentSchoolAssociationAuthorization
         SET StudentSchoolAuthorizationEducationOrganizationIds = (
-            SELECT jsonb_agg(EducationOrganizationId)
+            SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
             FROM dms.GetEducationOrganizationAncestors(affected_record.HierarchySchoolId)
         )
         WHERE
@@ -61,7 +61,7 @@ BEGIN
             EducationOrganizationId = affected_school_id
 
         UNION ALL
-        
+
         -- Find all descendants of the affected school
         SELECT
             child.Id,
@@ -74,7 +74,7 @@ BEGIN
     )
     UPDATE dms.StudentSchoolAssociationAuthorization ssa
     SET StudentSchoolAuthorizationEducationOrganizationIds = (
-        SELECT jsonb_agg(EducationOrganizationId)
+        SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
         FROM dms.GetEducationOrganizationAncestors(ssa.HierarchySchoolId)
     )
     FROM SchoolsInChangedHierarchy sch

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1007_Create_StaffEducationOrganizationAuthorization_Triggers.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1007_Create_StaffEducationOrganizationAuthorization_Triggers.sql
@@ -58,7 +58,7 @@ BEGIN
     staff_id := NEW.EdfiDoc->'staffReference'->>'staffUniqueId';
 
     -- Calculate Ed Org IDs once and store in variable
-    SELECT jsonb_agg(EducationOrganizationId)
+    SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
     FROM dms.GetEducationOrganizationAncestors((NEW.EdfiDoc->'educationOrganizationReference'->>'educationOrganizationId')::BIGINT)
     INTO ed_org_ids;
 
@@ -131,14 +131,14 @@ BEGIN
     END IF;
 
     -- DELETE logic
-    SELECT jsonb_agg(EducationOrganizationId)
+    SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
     FROM dms.GetEducationOrganizationAncestors(old_ed_org_id)
     INTO ed_org_ids;
 
     PERFORM dms.RemoveStaffEducationOrganizationAuthorizationEdOrgIds(old_staff_id, ed_org_ids);
 
     -- INSERT logic
-    SELECT jsonb_agg(EducationOrganizationId)
+    SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
     FROM dms.GetEducationOrganizationAncestors(new_ed_org_id)
     INTO ed_org_ids;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1008_Create_EducationOrganizationHierarchyStaffEdOrgAuthorization_Triggers.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Deploy/Scripts/1008_Create_EducationOrganizationHierarchyStaffEdOrgAuthorization_Triggers.sql
@@ -39,7 +39,7 @@ BEGIN
         -- Update each affected record with the new hierarchy information
         UPDATE dms.StaffEducationOrganizationAuthorization
         SET StaffEducationOrganizationAuthorizationEdOrgIds = (
-            SELECT jsonb_agg(EducationOrganizationId)
+            SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
             FROM dms.GetEducationOrganizationAncestors(affected_record.HierarchyEdOrgId)
         )
         WHERE
@@ -74,7 +74,7 @@ BEGIN
     )
     UPDATE dms.StaffEducationOrganizationAuthorization ssoa
     SET StaffEducationOrganizationAuthorizationEdOrgIds = (
-        SELECT jsonb_agg(EducationOrganizationId)
+        SELECT jsonb_agg(to_jsonb(EducationOrganizationId::text))
         FROM dms.GetEducationOrganizationAncestors(ssoa.HierarchyEdOrgId)
     )
     FROM EdOrgsInChangedHierarchy edorg

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlAuthorizationRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlAuthorizationRepository.cs
@@ -43,7 +43,8 @@ public class PostgresqlAuthorizationRepository(NpgsqlDataSource _dataSource, ISq
         {
             return [];
         }
-        long[] edOrgIds = JsonSerializer.Deserialize<long[]>(response.Value) ?? [];
+        string[] stringIds = JsonSerializer.Deserialize<string[]>(response.Value) ?? [];
+        long[] edOrgIds = stringIds.Select(long.Parse).ToArray();
         return edOrgIds;
     }
 
@@ -60,7 +61,8 @@ public class PostgresqlAuthorizationRepository(NpgsqlDataSource _dataSource, ISq
         {
             return [];
         }
-        long[] edOrgIds = JsonSerializer.Deserialize<long[]>(response.Value) ?? [];
+        string[] stringIds = JsonSerializer.Deserialize<string[]>(response.Value) ?? [];
+        long[] edOrgIds = stringIds.Select(long.Parse).ToArray();
         return edOrgIds;
     }
 
@@ -77,7 +79,8 @@ public class PostgresqlAuthorizationRepository(NpgsqlDataSource _dataSource, ISq
         {
             return [];
         }
-        long[] edOrgIds = JsonSerializer.Deserialize<long[]>(response.Value) ?? [];
+        string[] stringIds = JsonSerializer.Deserialize<string[]>(response.Value) ?? [];
+        long[] edOrgIds = stringIds.Select(long.Parse).ToArray();
         return edOrgIds;
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
@@ -1,16 +1,16 @@
 Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
         Background:
-            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901901, 255901902"
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901901, 25590190200000"
               And the system has these descriptors
                   | descriptorValue                                                |
                   | uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade               |
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school |
                   | uri://ed-fi.org/SexDescriptor#Female                           |
               And the system has these "schools"
-                  | schoolId  | nameOfInstitution   | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
-                  | 255901901 | Authorized school   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
-                  | 255901902 | Authorized school 2 | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
+                  | schoolId       | nameOfInstitution   | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
+                  | 255901901      | Authorized school   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
+                  | 25590190200000 | Authorized school 2 | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
               And the system has these "students"
                   | studentUniqueId | firstName            | lastSurname | birthDate  |
                   | "S91111"        | Authorized student   | student-ln  | 2008-01-01 |
@@ -20,9 +20,9 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   | "C91111"        | Authorized contact | contact-ln  |
                   | "C91112"        | Authorized contact | contact-ln  |
               And the system has these "studentSchoolAssociations"
-                  | schoolReference           | studentReference                | entryGradeLevelDescriptor                          | entryDate  |
-                  | { "schoolId": 255901901 } | { "studentUniqueId": "S91111" } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
-                  | { "schoolId": 255901902 } | { "studentUniqueId": "S91112" } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
+                  | schoolReference                | studentReference                | entryGradeLevelDescriptor                          | entryDate  |
+                  | { "schoolId": 255901901 }      | { "studentUniqueId": "S91111" } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
+                  | { "schoolId": 25590190200000 } | { "studentUniqueId": "S91112" } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
 
     Rule: StudentContactAssociation CRUD is properly authorized
 
@@ -291,7 +291,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         Scenario: 10 Ensure client get the required validation error when studentContactAssociations is created with empty contactReference
-            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901902"
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "25590190200000"
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
                   {
@@ -369,7 +369,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       "status": 403,
                       "validationErrors": {},
                       "errors": [
-                            "No relationships have been established between the caller's education organization id claims ('255901901', '255901902') and the resource item's ContactUniqueId value."
+                            "No relationships have been established between the caller's education organization id claims ('255901901', '25590190200000') and the resource item's ContactUniqueId value."
                           ]
                      }
                   """
@@ -419,7 +419,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       "status": 403,
                       "validationErrors": {},
                       "errors": [
-                            "No relationships have been established between the caller's education organization id claims ('255901901', '255901902') and the resource item's ContactUniqueId value."
+                            "No relationships have been established between the caller's education organization id claims ('255901901', '25590190200000') and the resource item's ContactUniqueId value."
                           ]
                     }
                   """
@@ -556,7 +556,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       "status": 403,
                       "validationErrors": {},
                       "errors": [
-                            "No relationships have been established between the caller's education organization id claims ('255901901', '255901902') and the resource item's ContactUniqueId value."
+                            "No relationships have been established between the caller's education organization id claims ('255901901', '25590190200000') and the resource item's ContactUniqueId value."
                           ]
                     }
                   """
@@ -711,7 +711,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       "status": 403,
                       "validationErrors": {},
                       "errors": [
-                            "No relationships have been established between the caller's education organization id claims ('255901901', '255901902') and the resource item's StudentUniqueId value."
+                            "No relationships have been established between the caller's education organization id claims ('255901901', '25590190200000') and the resource item's StudentUniqueId value."
                           ]
                     }
                   """
@@ -756,7 +756,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   }
                   """
              Then it should respond with 201 or 200
-            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901902"
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "25590190200000"
              When a GET request is made to "/ed-fi/contacts?contactUniqueId=C81127"
              Then it should respond with 200
               And the response body is
@@ -796,7 +796,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
               And the system has these "studentSchoolAssociations"
                   | schoolReference           | studentReference                | entryGradeLevelDescriptor                          | entryDate  |
                   | { "schoolId": 255901904 } | { "studentUniqueId": "S91114" } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
-              
+
         Scenario: 22 Ensure client can retrieve only the associated contacts using student's edorg id
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -1097,7 +1097,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
             Given the token gets switched to the one in the "EdFiSandbox_full_access" variable
              When a DELETE request is made to "/ed-fi/studentSchoolAssociations/{StudentSchoolAssociationId}"
              Then it should respond with 204
-        
+
             # Assert that token with '1355901001' access continues to be able to retrieve a Contact
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1355901001"
              When a GET request is made to "/ed-fi/contacts/{ContactId}"
@@ -1562,7 +1562,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       }
                     ]
                   """
-                  
+
             # Assert that token with '1755901002' access can retrieve a Contact
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1755901002"
              When a GET request is made to "/ed-fi/contacts/{ContactId}"
@@ -1618,7 +1618,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   [
                   ]
                   """
-                  
+
             # Assert that token with '1755901002' access can no longer retrieve a Contact
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1755901002"
              When a GET request is made to "/ed-fi/contacts/{ContactId}"
@@ -1650,7 +1650,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       }
                   ]
                   """
-    
+
             # Recreate SCA for School '1755901001', and '1755901002'
             Given the token gets switched to the one in the "EdFiSandbox_full_access" variable
 
@@ -1685,7 +1685,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                       }
                     ]
                   """
-                  
+
             # Assert that token with '1755901002' access can retrieve a Contact
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1755901002"
              When a GET request is made to "/ed-fi/contacts/{ContactId}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -1669,7 +1669,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                         "studentReference": {
                           "studentUniqueId": "151"
                         },
-                        "termDescriptor": "uri://ed-fi.org/TermDescriptor#Fall Semester"                        
+                        "termDescriptor": "uri://ed-fi.org/TermDescriptor#Fall Semester"
                       }
                   ]
                   """
@@ -1722,7 +1722,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | _storeResultingIdInVariable  | studentReference             | schoolReference            | entryGradeLevelDescriptor                          | entryDate  |
                   | StudentASchool1AssociationId | { "studentUniqueId": "111" } | { "schoolId": 1155901001 } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
                   | StudentASchool2AssociationId | { "studentUniqueId": "111" } | { "schoolId": 1155902001 } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
-            
+
         Scenario: 46 Ensure client with access to both schools can query multiple student school associations
              When a GET request is made to "/ed-fi/StudentSchoolAssociations?studentUniqueId=111&offset=0&limit=10"
              Then it should respond with 200
@@ -2164,7 +2164,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                     }
                   ]
                   """
-        
+
         Scenario: 53 Ensure client can retrieve a Student-securable after the SSA has been updated to a new Student
             # Change to use long EdOrgIds when DMS-706 is done
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "1455901001"
@@ -2308,4 +2308,37 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                       "eventDate": "2023-09-15"
                     }
                   ]
+                  """
+        Scenario: 54 Ensure client can query a Student associated to a School with a long ID
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "3, 301, 30101999999"
+              And the system has these "stateEducationAgencies"
+                  | stateEducationAgencyId | nameOfInstitution | categories                                                                                                       |
+                  | 3                      | Test state        | [{ "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#State" }] |
+              And the system has these "localEducationAgencies"
+                  | localEducationAgencyId | nameOfInstitution | stateEducationAgencyReference   | categories                                                                                                          | localEducationAgencyCategoryDescriptor                       |
+                  | 301                    | Test LEA          | { "stateEducationAgencyId": 3 } | [{ "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#District" }] | "uri://ed-fi.org/localEducationAgencyCategoryDescriptor#ABC" |
+              And the system has these "schools"
+                  | schoolId    | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   | localEducationAgencyReference    |
+                  | 30101999999 | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] | { "localEducationAgencyId": 301} |
+              And the system has these "students"
+                  | studentUniqueId | firstName  | lastSurname | birthDate  |
+                  | "91"            | student-fn | student-ln  | 2008-01-01 |
+              And the system has these "studentSchoolAssociations"
+                  | studentReference            | schoolReference             | entryGradeLevelDescriptor                          | entryDate  |
+                  | { "studentUniqueId": "91" } | { "schoolId": 30101999999 } | "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" | 2023-08-01 |
+
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "3"
+             When a GET request is made to "/ed-fi/students?studentUniqueId=91"
+             Then it should respond with 200
+              And the response body is
+                  """
+                    [
+                      {
+                        "id": "{id}",
+                        "firstName": "student-fn",
+                        "studentUniqueId": "91",
+                        "birthDate": "2008-01-01",
+                        "lastSurname": "student-ln"
+                      }
+                    ]
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -1,17 +1,17 @@
 Feature: RelationshipsWithEdOrgsAndStaff Authorization
 
         Background:
-            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901,255901001"
+            Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901,25590100100000"
               And the system has these descriptors
-                  | descriptorValue                                                                |
-                  | uri://ed-fi.org/ProgramAssignmentDescriptor#Regular Education                  |
+                  | descriptorValue                                               |
+                  | uri://ed-fi.org/ProgramAssignmentDescriptor#Regular Education |
 
               And the system has these "localEducationAgencies"
                   | localEducationAgencyId | categories                                                                                                                         | localEducationAgencyCategoryDescriptor                         | nameOfInstitution |
                   | 255901                 | [ { "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency"} ] | uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#Charter | LEA-100001        |
               And the system has these "schools"
-                  | schoolId  | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   | localEducationAgencyReference       |
-                  | 255901001 | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] | { "localEducationAgencyId": 255901} |
+                  | schoolId       | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   | localEducationAgencyReference       |
+                  | 25590100100000 | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] | { "localEducationAgencyId": 255901} |
               And the system has these "people"
                   | personId | sourceSystemDescriptor                      |
                   | p001     | uri://ed-fi.org/SourceSystemDescriptor#Pass |
@@ -23,11 +23,11 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   | s0004         | Adam      | Buck        |
                   | s0005         | Francis   | Buck        |
               And the system has these "staffEducationOrganizationAssignmentAssociations"
-                  | beginDate  | staffClassificationDescriptor                         | educationOrganizationReference           | staffReference                 |
-                  | 10/10/2020 | uri://ed-fi.org/StaffClassificationDescriptor#Teacher | { "educationOrganizationId": 255901001 } | {  "staffUniqueId": "s0001"  } |
+                  | beginDate  | staffClassificationDescriptor                         | educationOrganizationReference                | staffReference                 |
+                  | 10/10/2020 | uri://ed-fi.org/StaffClassificationDescriptor#Teacher | { "educationOrganizationId": 25590100100000 } | {  "staffUniqueId": "s0001"  } |
               And the system has these "staffEducationOrganizationEmploymentAssociations"
-                  | hireDate   | employmentStatusDescriptor                         | educationOrganizationReference           | staffReference                 |
-                  | 10/10/2020 | uri://ed-fi.org/employmentStatusDescriptor#Teacher | { "educationOrganizationId": 255901001 } | {  "staffUniqueId": "s0004"  } |
+                  | hireDate   | employmentStatusDescriptor                         | educationOrganizationReference                | staffReference                 |
+                  | 10/10/2020 | uri://ed-fi.org/employmentStatusDescriptor#Teacher | { "educationOrganizationId": 25590100100000 } | {  "staffUniqueId": "s0004"  } |
 
     Rule: staffEducationOrganizationAssignmentAssociations CRUD is properly authorized
 
@@ -37,7 +37,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                      {
                         "schoolReference": {
-                            "schoolId": 255901001
+                            "schoolId": 25590100100000
                         },
                         "staffReference": {
                             "staffUniqueId": "s0001"
@@ -53,7 +53,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                      {
                         "schoolReference": {
-                            "schoolId": 255901001
+                            "schoolId": 25590100100000
                         },
                         "staffReference": {
                             "staffUniqueId": "s0002"
@@ -72,7 +72,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                       "correlationId": "0HNCJPIJKHR7A:00000019",
                       "validationErrors": {},
                       "errors": [
-                        "No relationships have been established between the caller's education organization id claims ('255901', '255901001') and the resource item's StaffUniqueId value."
+                        "No relationships have been established between the caller's education organization id claims ('255901', '25590100100000') and the resource item's StaffUniqueId value."
                       ]
                     }
                   """
@@ -84,7 +84,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                       {
                       "schoolReference": {
-                          "schoolId": 255901001
+                          "schoolId": 25590100100000
                       },
                       "staffReference": {
                           "staffUniqueId": "s0001"
@@ -99,7 +99,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                       {
                       "id":"{id}",
                       "schoolReference": {
-                          "schoolId": 255901001
+                          "schoolId": 25590100100000
                       },
                       "staffReference": {
                           "staffUniqueId": "s0002"
@@ -118,31 +118,31 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                           "correlationId": "0HNCJPIJKHR7K:0000001A",
                           "validationErrors": {},
                           "errors": [
-                          "No relationships have been established between the caller's education organization id claims ('255901', '255901001') and the resource item's StaffUniqueId value."
+                          "No relationships have been established between the caller's education organization id claims ('255901', '25590100100000') and the resource item's StaffUniqueId value."
                           ]
                       }
                   """
 
         Scenario: 04 Ensure client can Search staffEducationOrganizationAssignmentAssociations
 
-                     When a GET request is made to "/ed-fi/staffEducationOrganizationAssignmentAssociations"
-                     Then it should respond with 200
-                      And the response body is
-                          """
-                            [
-                              {
-                                "beginDate": "2020-10-10",
-                                "educationOrganizationReference": {
-                                  "educationOrganizationId": 255901001
-                                },
-                                "staffReference": {
-                                  "staffUniqueId": "s0001"
-                                },
-                                "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                                "id": "{id}"
-                              }
-                            ]
-                          """
+             When a GET request is made to "/ed-fi/staffEducationOrganizationAssignmentAssociations"
+             Then it should respond with 200
+              And the response body is
+                  """
+                    [
+                      {
+                        "beginDate": "2020-10-10",
+                        "educationOrganizationReference": {
+                          "educationOrganizationId": 25590100100000
+                        },
+                        "staffReference": {
+                          "staffUniqueId": "s0001"
+                        },
+                        "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
+                        "id": "{id}"
+                      }
+                    ]
+                  """
 
         Scenario: 05 Ensure client can POST staffEducationOrganizationAssignmentAssociations
 
@@ -150,7 +150,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -166,7 +166,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0001"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -186,7 +186,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                         },
                         "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
                         "educationOrganizationReference": {
-                          "educationOrganizationId": 255901001
+                          "educationOrganizationId": 25590100100000
                         }
                       }
                   """
@@ -199,7 +199,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0001"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -211,7 +211,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                     {
                        "id":"{id}",
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0001"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Science Teacher"
@@ -225,7 +225,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0001"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -241,7 +241,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -268,7 +268,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -297,7 +297,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -317,7 +317,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -330,7 +330,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                     {
                        "id":"{id}",
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Science Teacher"
@@ -356,7 +356,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "staffClassificationDescriptor": "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0002"  },
                       "beginDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -388,7 +388,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                      {
                         "schoolReference": {
-                            "schoolId": 255901001
+                            "schoolId": 25590100100000
                         },
                         "staffReference": {
                             "staffUniqueId": "s0004"
@@ -404,7 +404,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                       {
                       "schoolReference": {
-                          "schoolId": 255901001
+                          "schoolId": 25590100100000
                       },
                       "staffReference": {
                           "staffUniqueId": "s0004"
@@ -419,7 +419,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                       {
                       "id":"{id}",
                       "schoolReference": {
-                          "schoolId": 255901001
+                          "schoolId": 25590100100000
                       },
                       "staffReference": {
                           "staffUniqueId": "s0005"
@@ -438,7 +438,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                           "correlationId": "0HNCJPIJKHR7K:0000001A",
                           "validationErrors": {},
                           "errors": [
-                          "No relationships have been established between the caller's education organization id claims ('255901', '255901001') and the resource item's StaffUniqueId value."
+                          "No relationships have been established between the caller's education organization id claims ('255901', '25590100100000') and the resource item's StaffUniqueId value."
                           ]
                       }
                   """
@@ -454,7 +454,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                         "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
                         "hireDate": "2020-10-10",
                         "educationOrganizationReference": {
-                          "educationOrganizationId": 255901001
+                          "educationOrganizationId": 25590100100000
                         },
                         "staffReference": {
                           "staffUniqueId": "s0004"
@@ -470,7 +470,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -484,7 +484,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -503,7 +503,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                       },
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
                       "educationOrganizationReference": {
-                        "educationOrganizationId": 255901001
+                        "educationOrganizationId": 25590100100000
                       }
                     }
                   """
@@ -514,7 +514,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -526,7 +526,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                     {
                        "id":"{id}",
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Science Teacher"
@@ -540,7 +540,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -556,7 +556,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -583,7 +583,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -612,7 +612,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -632,7 +632,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"
@@ -645,7 +645,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                     {
                        "id":"{id}",
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Science Teacher"
@@ -671,7 +671,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
                     {
                       "employmentStatusDescriptor": "uri://ed-fi.org/employmentStatusDescriptor#Teacher",
-                      "educationOrganizationReference": { "educationOrganizationId": 255901001 },
+                      "educationOrganizationReference": { "educationOrganizationId": 25590100100000 },
                       "staffReference": {  "staffUniqueId": "s0005"  },
                       "hireDate": "2018-08-20",
                       "positionTitle": "Math Teacher"


### PR DESCRIPTION
Jsonb columns holding simple arrays cannot mix int32 and int64, no matter the sort order or else kafka will error and the data will not make it to opensearch. The fix here is to make them arrays of strings always. 