### PR TITLE
[DMS-90] Redact EDFiDocs from polly logs

### DIFF
--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -34,7 +34,8 @@ public static class WebApplicationBuilderExtensions
         webAppBuilder
             .Services.AddDmsDefaultConfiguration(
                 logger,
-                webAppBuilder.Configuration.GetSection("CircuitBreaker")
+                webAppBuilder.Configuration.GetSection("CircuitBreaker"),
+                webAppBuilder.Configuration.GetSection("AppSettings").GetValue<bool>("MaskRequestBodyInLogs")
             )
             .AddTransient<IAssemblyLoader, ApiSchemaAssemblyLoader>()
             .AddTransient<IContentProvider, ContentProvider>()


### PR DESCRIPTION
Polly is logging response messages, including successful ones. For reads (GET/QUERY) these responses will have EdFiDoc. The change here will use the existing app config setting `maskRequestBodyInLogs` to redact the body when set. 

Sample logs here:

```
INF Execution attempt. Source: 'backendResiliencePipeline/(null)/Retry', Operation Key: 'null', Result: 'QuerySuccess { EdfiDocs = [
2025-06-04 14:56:35   "[REDACTED]"
2025-06-04 14:56:35 ], TotalCount = 1 }', Handled: 'False', Attempt: '0', Execution Time: 992.7237ms

2025-06-04 14:56:12 2025-06-04 19:56:12.243 INF Execution attempt. Source: 'backendResiliencePipeline/(null)/Retry', Operation Key: 'null', Result: 'GetSuccess { DocumentUuid = DocumentUuid { Value = 715b17a3-455c-4d9b-93b5-2ff96b7d94af }, EdfiDoc = [REDACTED], LastModifiedDate = 06/04/2025 19:55:30, LastModifiedTraceId = 0HND3K70OF1S8:00000001 }', Handled: 'False', Attempt: '0', Execution Time: 16.8119ms
```