### PR TITLE
[DMS-710] Fix Keycloak throwing many warnings per second

### DIFF
--- a/eng/docker-compose/keycloak.yml
+++ b/eng/docker-compose/keycloak.yml
@@ -14,6 +14,7 @@ services:
       KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
       KC_HOSTNAME: http://localhost:${KEYCLOAK_PORT:-8045}
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: true
+      KC_LOG_CONSOLE_LEVEL: error
     ports:
       - '127.0.0.1:${KEYCLOAK_PORT:-8045}:8080'
     networks:


### PR DESCRIPTION
- Keycloak console log level up to Error
- The log level is the same in the container creation process.
![image](https://github.com/user-attachments/assets/72890882-74ba-4745-9296-0ffddd4086c4)

After running all the e2e test the log console remains the same.