### PR TITLE
[DMS-717] Disable geoip downloading in search

### DIFF
--- a/eng/docker-compose/kafka-elasticsearch.yml
+++ b/eng/docker-compose/kafka-elasticsearch.yml
@@ -16,6 +16,7 @@ services:
       xpack.security.enabled: false
       xpack.security.transport.ssl.enabled: false
       xpack.security.http.ssl.enabled: false
+      ingest.geoip.downloader.enabled: false
     ports:
       - '127.0.0.1:${ELASTICSEARCH_ANALYZER_PORT:-9300}:9300'
       - '127.0.0.1:${ELASTICSEARCH_HTTP_PORT:-9200}:9200'

--- a/eng/docker-compose/kafka-opensearch.yml
+++ b/eng/docker-compose/kafka-opensearch.yml
@@ -98,6 +98,7 @@ services:
       DISABLE_INSTALL_DEMO_CONFIG: true
       # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
       DISABLE_SECURITY_PLUGIN: true
+      OPENSEARCH_INGEST_GEOIP_DOWNLOADER_ENABLED: false
     ports:
       - '127.0.0.1:${OPENSEARCH_ANALYZER_PORT:-9600}:9600' # required for Performance Analyzer
       - '127.0.0.1:${OPENSEARCH_HTTP_PORT:-9200}:9200'


### PR DESCRIPTION
Verified these are the correct environment variables for each search engine by running `start-local-dms` with each and searching `dms-search` logs for `geoip`. 