### PR TITLE
[DMS-749] Configure SRI for swagger-ui dependencies

### DIFF
--- a/eng/docker-compose/custom-swagger-ui/index.html
+++ b/eng/docker-compose/custom-swagger-ui/index.html
@@ -11,15 +11,18 @@ See the LICENSE and NOTICES files in the project root for more information.
 <head>
     <meta charset="UTF-8">
     <title>Ed-Fi DMS API Documentation</title>
-    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.25.2/swagger-ui.css"
+          integrity="sha384-S+iZGxcLHU1ByODKehPIOcS0UkxgKTWKdT/VtKStv2S430eyGsmjt/NeSxrQq6Ke" crossorigin="anonymous" />
 </head>
 <body>
     <div id="swagger-ui"></div>
     <script>
         window.DMS_HTTP_PORTS = "8080";
     </script>
-    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.25.2/swagger-ui-bundle.js"
+            integrity="sha384-KEGL4N19rkwSP4jpdwT9SRy2bQXc+8sp22obIqN/I3lt9NP0ILVxPDacFjDnl0/F" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.25.2/swagger-ui-standalone-preset.js"
+            integrity="sha384-Zc0myuwGRY+wF+Mppj70Hoq/w2OticNP92nkFTlghzBS/OxDNlYummEqqmcOCyAX" crossorigin="anonymous"></script>
     <script src="swagger-initializer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
To update packages

1. Navigate to https://unpkg.com/swagger-ui-dist/ and identify the latest version
2. Go to https://www.srihash.org and get the integrity hash