### PR TITLE
[DMS-758] Use int32 instead of int16 for the TotalCount result

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Operation/SqlAction.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/Operation/SqlAction.cs
@@ -438,7 +438,7 @@ public partial class SqlAction() : ISqlAction
         }
 
         await reader.ReadAsync();
-        return reader.GetInt16(reader.GetOrdinal("Total"));
+        return reader.GetInt32(reader.GetOrdinal("Total"));
     }
 
     /// <summary>


### PR DESCRIPTION
When using PostgreSQL as the QueryHandler, this failed when the TotalCount overflowed the int16.