### PR TITLE
[DMS-766] Handle the Sdk namespace as a parameter in SmokeTest Utility for DMS SDK

### DIFF
--- a/.github/workflows/Pkg EdFi.DmsApi.Sdk.yml
+++ b/.github/workflows/Pkg EdFi.DmsApi.Sdk.yml
@@ -43,13 +43,13 @@ jobs:
 
       - name: Generate Core SDK
         run: |
-          ./build-sdk.ps1 BuildAndGenerateSdk -PackageName "EdFi.OdsApi.Sdk"
+          ./build-sdk.ps1 BuildAndGenerateSdk -PackageName "EdFi.DmsApi.Sdk"
 
       - name: Package Core SDK
         run: |
           $packageVersion = "${{ steps.versions.outputs.dms-semver }}" -replace "dms-v", ""
 
-          ./build-sdk.ps1 Package -SDKVersion $packageVersion  -PackageName "EdFi.OdsApi.Sdk"
+          ./build-sdk.ps1 Package -SDKVersion $packageVersion  -PackageName "EdFi.DmsApi.Sdk"
 
       - name: Upload Core SDK Packages as Artifacts
         if: success()

--- a/.github/workflows/Pkg EdFi.DmsApi.TestSdk.yml
+++ b/.github/workflows/Pkg EdFi.DmsApi.TestSdk.yml
@@ -43,13 +43,13 @@ jobs:
 
       - name: Generate Test SDK
         run: |
-          ./build-sdk.ps1  BuildAndGenerateSdk -PackageName  "EdFi.OdsApi.TestSdk"
+          ./build-sdk.ps1  BuildAndGenerateSdk -PackageName  "EdFi.DmsApi.TestSdk"
 
       - name: Package Test SDK
         run: |
           $packageVersion = "${{ steps.versions.outputs.dms-semver }}" -replace "dms-v", ""
 
-          ./build-sdk.ps1 Package -SDKVersion $packageVersion -PackageName  "EdFi.OdsApi.TestSdk"
+          ./build-sdk.ps1 Package -SDKVersion $packageVersion -PackageName  "EdFi.DmsApi.TestSdk"
 
       - name: Upload Test SDK Packages as Artifacts
         if: success()

--- a/build-sdk.ps1
+++ b/build-sdk.ps1
@@ -68,8 +68,8 @@ param(
 
     # Package name for the NuGet package
     [string]
-    [ValidateSet("EdFi.OdsApi.Sdk", "EdFi.OdsApi.TestSdk")]
-    $PackageName = "EdFi.OdsApi.Sdk",
+    [ValidateSet("EdFi.DmsApi.Sdk", "EdFi.DmsApi.TestSdk")]
+    $PackageName = "EdFi.DmsApi.Sdk",
 
     [string]
     $StandardVersion = "5.2.0"
@@ -198,10 +198,10 @@ function PushPackage {
 function Invoke-BuildAndGenerateSdk {
     Invoke-Step { DownloadCodeGen }
 
-    if ($PackageName -eq "EdFi.OdsApi.TestSdk") {
+    if ($PackageName -eq "EdFi.DmsApi.TestSdk") {
         Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
         Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" }
-    } elseif ($PackageName -eq "EdFi.OdsApi.Sdk") {
+    } elseif ($PackageName -eq "EdFi.DmsApi.Sdk") {
         Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
         Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" }
     } else {

--- a/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>EdFi.OdsApi.Sdk</id>
+    <id>EdFi.DmsApi.Sdk</id>
     <version>$version$</version>
-    <title>EdFi.OdsApi.Sdk</title>
+    <title>EdFi.DmsApi.Sdk</title>
     <authors>Ed-Fi Alliance</authors>
     <owners>Ed-Fi Alliance</owners>
     <projectUrl>https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service</projectUrl>
@@ -23,6 +23,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.OdsApi.Sdk\bin\Release\net8.0\EdFi.OdsApi.Sdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.Sdk\bin\Release\net8.0\EdFi.DmsApi.Sdk.dll" target="lib\net8.0" />
   </files>
 </package>

--- a/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>EdFi.OdsApi.TestSdk</id>
+    <id>EdFi.DmsApi.TestSdk</id>
     <version>$version$</version>
-    <title>EdFi.OdsApi.TestSdk</title>
+    <title>EdFi.DmsApi.TestSdk</title>
     <authors>Ed-Fi Alliance</authors>
     <owners>Ed-Fi Alliance</owners>
     <projectUrl>https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service</projectUrl>
@@ -23,6 +23,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.OdsApi.TestSdk\bin\Release\net8.0\EdFi.OdsApi.TestSdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.TestSdk\bin\Release\net8.0\EdFi.DmsApi.TestSdk.dll" target="lib\net8.0" />
   </files>
 </package>


### PR DESCRIPTION

[dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.OdsApi.Sdk.Standard.5.2.0/overview/0.5.1-alpha.0.42](https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.OdsApi.Sdk.Standard.5.2.0/overview/0.5.1-alpha.0.42)

https://dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_artifacts/feed/EdFi/NuGet/EdFi.OdsApi.TestSdk.Standard.5.2.0/overview/0.5.1-alpha.0.42