### PR TITLE
[DMS-768] Missing query fields on descriptors 

### DIFF
--- a/eng/docker-compose/.env.e2e
+++ b/eng/docker-compose/.env.e2e
@@ -100,23 +100,23 @@ CACHE_EXPIRATION_MINUTES=10
 
 SCHEMA_PACKAGES='[
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.DataStandard52.ApiSchema"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.TPDM.ApiSchema"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.Sample.ApiSchema",
     "extensionName": "Sample"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.Homograph.ApiSchema",
     "extensionName": "Homograph"

--- a/eng/docker-compose/.env.example
+++ b/eng/docker-compose/.env.example
@@ -105,23 +105,23 @@ CACHE_EXPIRATION_MINUTES=10
 
 SCHEMA_PACKAGES='[
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.DataStandard52.ApiSchema"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.TPDM.ApiSchema"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.Sample.ApiSchema",
     "extensionName": "Sample"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.Homograph.ApiSchema",
     "extensionName": "Homograph"

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -143,12 +143,12 @@ USE_API_SCHEMA_PATH and API_SCHEMA_PATH environment variables.
  API_SCHEMA_PATH=/app/ApiSchema
  SCHEMA_PACKAGES='[
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.DataStandard52.ApiSchema"
   },
   {
-    "version": "1.0.225",
+    "version": "1.0.253",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.Sample.ApiSchema",
     "extensionName": "Sample"

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,10 +12,10 @@
         <PackageVersion Include="Dapper" Version="2.1.35" />
         <PackageVersion Include="dbup-core" Version="5.0.87" />
         <PackageVersion Include="dbup-postgresql" Version="5.0.40" />
-        <PackageVersion Include="EdFi.DataStandard52.ApiSchema" Version="1.0.225" />
-        <PackageVersion Include="EdFi.Homograph.ApiSchema" Version="1.0.225" />
-        <PackageVersion Include="EdFi.Sample.ApiSchema" Version="1.0.225" />
-        <PackageVersion Include="EdFi.TPDM.ApiSchema" Version="1.0.225" />
+        <PackageVersion Include="EdFi.DataStandard52.ApiSchema" Version="1.0.253" />
+        <PackageVersion Include="EdFi.Homograph.ApiSchema" Version="1.0.253" />
+        <PackageVersion Include="EdFi.Sample.ApiSchema" Version="1.0.253" />
+        <PackageVersion Include="EdFi.TPDM.ApiSchema" Version="1.0.253" />
         <PackageVersion Include="Keycloak.Net.Core" Version="1.0.29" />
         <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
         <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration/ApiSchemaDownloaderTests.cs
+++ b/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration/ApiSchemaDownloaderTests.cs
@@ -86,7 +86,7 @@ namespace EdFi.DataManagementService.ApiSchemaDownloader.Tests.Unit
             {
                 // Arrange
                 string packageId = "EdFi.DataStandard52.ApiSchema";
-                string packageVersion = "1.0.225";
+                string packageVersion = "1.0.253";
                 string feedUrl =
                     "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json";
 

--- a/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader/Properties/launchSettings.json
+++ b/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader/Properties/launchSettings.json
@@ -2,7 +2,7 @@
     "profiles": {
         "EdFi.DataManagementService.ApiSchemaDownloader": {
             "commandName": "Project",
-            "commandLineArgs": "--packageId \"EdFi.DataStandard52.ApiSchema\"  --apiSchemaFolder \"$(ProjectDir)\\..\\..\\EdFi.DataStandard52.ApiSchema\" --packageVersion \"1.0.225\" --feedUrl \"https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json\""
+            "commandLineArgs": "--packageId \"EdFi.DataStandard52.ApiSchema\"  --apiSchemaFolder \"$(ProjectDir)\\..\\..\\EdFi.DataStandard52.ApiSchema\" --packageVersion \"1.0.253\" --feedUrl \"https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json\""
         }
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/DescriptorQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/DescriptorQueriesQueryString.feature
@@ -7,6 +7,9 @@ Feature: Query String handling for GET requests for Descriptor Queries
             Given the system has these descriptors
                   | descriptorValue                                           |
                   | uri://ed-fi.org/AbsenceEventCategoryDescriptor#Sick Leave |
+              And the system has these "calendarEventDescriptors"
+                  | codeValue | description | namespace                               | shortDescription | effectiveBeginDate | effectiveEndDate |
+                  | Fake      | Fake        | uri://ed-fi.org/CalendarEventDescriptor | Fake             | 2020-01-01         | 2020-12-31       |
 
         @API-115
         Scenario: 01 Verify existing descriptors can be retrieved successfully
@@ -75,4 +78,45 @@ Feature: Query String handling for GET requests for Descriptor Queries
               And the response body is
                   """
                   []
+                  """
+
+        Scenario: 09 Ensure clients can query by effectiveBeginDate and effectiveEndDate
+             When a GET request is made to "/ed-fi/calendarEventDescriptors?effectiveBeginDate=2020-01-01"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  [
+                    {
+                        "id": "{id}",
+                        "codeValue": "Fake",
+                        "description": "Fake",
+                        "namespace": "uri://ed-fi.org/CalendarEventDescriptor",
+                        "shortDescription": "Fake",
+                        "effectiveBeginDate": "2020-01-01",
+                        "effectiveEndDate": "2020-12-31"
+                    }
+                  ]
+                  """
+             When a GET request is made to "/ed-fi/calendarEventDescriptors?effectiveEndDate=2020-12-31"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  [
+                    {
+                        "id": "{id}",
+                        "codeValue": "Fake",
+                        "description": "Fake",
+                        "namespace": "uri://ed-fi.org/CalendarEventDescriptor",
+                        "shortDescription": "Fake",
+                        "effectiveBeginDate": "2020-01-01",
+                        "effectiveEndDate": "2020-12-31"
+                    }
+                  ]
+                  """
+             When a GET request is made to "/ed-fi/calendarEventDescriptors?effectiveEndDate=1920-12-31"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  [
+                  ]
                   """


### PR DESCRIPTION
Package update fixes missing `effectiveBegindate` and `effictaveEndDate` query fields on descriptors. E2E test verifies. 