### PR TITLE
[DMS-816] Fix Incorrect HTTP Status Code Returned for Invalid Endpoint in DMS API

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateEndpointMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateEndpointMiddleware.cs
@@ -37,8 +37,12 @@ internal class ValidateEndpointMiddleware(ILogger _logger) : IPipelineStep
             );
             requestInfo.FrontendResponse = new FrontendResponse(
                 StatusCode: 404,
-                Body: $"Invalid resource '{requestInfo.PathComponents.EndpointName}'.",
-                Headers: []
+                Body: ForNotFound(
+                    "The specified data could not be found.",
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
             );
             return;
         }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -491,3 +491,140 @@ Feature: Validation of the structure of the URLs
                         "Total-Count": 1
                     }
                   """
+
+        @DMS-816
+        Scenario: 18 Ensure clients get 404 for completely invalid path with prefix before data model
+             When a POST request is made to "/notExisting/ed-fi/gradeLevelDescriptors" with
+                  """
+                  {
+                      "namespace": "uri://ed-fi.org/GradeLevelDescriptor",
+                      "codeValue": "Test",
+                      "shortDescription": "Test",
+                      "description": "Test"
+                  }
+                  """
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """
+
+        @DMS-816
+        Scenario: 19 Ensure clients get 404 for misspelled resource endpoint
+             When a POST request is made to "/ed-fi/gradeLevelDescriptorz" with
+                  """
+                  {
+                      "namespace": "uri://ed-fi.org/GradeLevelDescriptor",
+                      "codeValue": "Test",
+                      "shortDescription": "Test",
+                      "description": "Test"
+                  }
+                  """
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """
+
+        @DMS-816
+        Scenario: 20 Ensure clients get 404 for arbitrary non-existent path
+             When a GET request is made to "/foo/bar/baz"
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """
+
+        @DMS-816
+        Scenario: 21 Ensure clients get 404 for DELETE on non-existent path
+             When a DELETE request is made to "/nonexistent/endpoint"
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """
+
+        @DMS-816
+        Scenario: 22 Ensure clients get 404 for PUT on non-existent path with ID
+             When a PUT request is made to "/invalid/path/00000000-0000-4000-a000-000000000000" with
+                  """
+                  {
+                      "id": "00000000-0000-4000-a000-000000000000",
+                      "test": "value"
+                  }
+                  """
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """


### PR DESCRIPTION
This pull request improves how the service handles requests to invalid or non-existent endpoints by standardizing 404 Not Found responses across the application. It ensures that all unmatched routes and invalid resource requests consistently return a problem+json response with detailed error information, and adds comprehensive end-to-end test coverage for these scenarios.

**Error handling improvements:**

* Added a catch-all fallback in `Program.cs` to return a standardized 404 response with a `application/problem+json` content type and a structured error body for any unmatched route.
* Updated `ValidateEndpointMiddleware` to return the same standardized 404 problem+json response for invalid resource endpoints.

**Testing enhancements:**

* Added several end-to-end test scenarios to `URLValidation.feature` that verify the new 404 response format for various invalid paths and methods, ensuring correct error body and headers.