### PR TITLE
[DMS-1064] Enumerate all DS 5.2 resources with multi-hop Person authorization join paths

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Ds52FixtureHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Ds52FixtureHelper.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+/// <summary>
+/// Shared helper for tests that compile the authoritative DS 5.2 schema
+/// into a DerivedRelationalModelSet and MappingSet.
+/// </summary>
+internal static class Ds52FixtureHelper
+{
+    public const string FixturePath =
+        "../Fixtures/authoritative/ds-5.2/inputs/ds-5.2-api-schema-authoritative.json";
+
+    /// <summary>
+    /// Builds the derived relational model and compiles the mapping set for the
+    /// authoritative DS 5.2 schema. Defaults to PostgreSQL but supports MSSQL
+    /// for dialect-specific tests (e.g. column name truncation, quoting rules).
+    /// </summary>
+    public static (DerivedRelationalModelSet ModelSet, MappingSet MappingSet) BuildAndCompile(
+        SqlDialect dialect = SqlDialect.Pgsql
+    )
+    {
+        var modelSet = RuntimePlanFixtureModelSetBuilder.Build(FixturePath, dialect);
+        var compiler = new MappingSetCompiler();
+        var mappingSet = compiler.Compile(modelSet);
+        return (modelSet, mappingSet);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths-mssql.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths-mssql.json
@@ -12,7 +12,7 @@
       },
       {
         "sourceTable": "edfi.StudentAssessmentRegistration",
-        "sourceColumn": "ScheduledStudentEducationOrganizationAssessmentAccom_8a1ccd30ea",
+        "sourceColumn": "ScheduledStudentEducationOrganizationAssessmentAccommodation_DocumentId",
         "targetTable": "edfi.StudentEducationOrganizationAssessmentAccommodation",
         "targetColumn": "DocumentId"
       },

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths-pgsql.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths-pgsql.json
@@ -1,0 +1,108 @@
+[
+  {
+    "resourceName": "StudentAssessmentRegistrationBatteryPartAssociation",
+    "personType": "Student",
+    "securableElementJsonPath": "$.studentAssessmentRegistrationReference.studentUniqueId",
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistrationBatteryPartAssociation",
+        "sourceColumn": "StudentAssessmentRegistration_DocumentId",
+        "targetTable": "edfi.StudentAssessmentRegistration",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistration",
+        "sourceColumn": "ScheduledStudentEducationOrganizationAssessmentAccom_8a1ccd30ea",
+        "targetTable": "edfi.StudentEducationOrganizationAssessmentAccommodation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentEducationOrganizationAssessmentAccommodation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 3
+  },
+  {
+    "resourceName": "CourseTranscript",
+    "personType": "Student",
+    "securableElementJsonPath": "$.studentAcademicRecordReference.studentUniqueId",
+    "joinPath": [
+      {
+        "sourceTable": "edfi.CourseTranscript",
+        "sourceColumn": "StudentAcademicRecord_DocumentId",
+        "targetTable": "edfi.StudentAcademicRecord",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAcademicRecord",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "Grade",
+    "personType": "Student",
+    "securableElementJsonPath": "$.studentSectionAssociationReference.studentUniqueId",
+    "joinPath": [
+      {
+        "sourceTable": "edfi.Grade",
+        "sourceColumn": "StudentSectionAssociation_DocumentId",
+        "targetTable": "edfi.StudentSectionAssociation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentSectionAssociation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "StudentAssessmentEducationOrganizationAssociation",
+    "personType": "Student",
+    "securableElementJsonPath": "$.studentAssessmentReference.studentUniqueId",
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentEducationOrganizationAssociation",
+        "sourceColumn": "StudentAssessment_DocumentId",
+        "targetTable": "edfi.StudentAssessment",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAssessment",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "StudentAssessmentRegistration",
+    "personType": "Student",
+    "securableElementJsonPath": "$.studentEducationOrganizationAssociationReference.studentUniqueId",
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistration",
+        "sourceColumn": "StudentEducationOrganizationAssociation_DocumentId",
+        "targetTable": "edfi.StudentEducationOrganizationAssociation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentEducationOrganizationAssociation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  }
+]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths.json
@@ -1,0 +1,118 @@
+[
+  {
+    "resourceName": "StudentAssessmentRegistrationBatteryPartAssociation",
+    "personType": "Student",
+    "securableElementJsonPaths": [
+      "$.studentAssessmentRegistrationReference.studentUniqueId"
+    ],
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistrationBatteryPartAssociation",
+        "sourceColumn": "StudentAssessmentRegistration_DocumentId",
+        "targetTable": "edfi.StudentAssessmentRegistration",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistration",
+        "sourceColumn": "ScheduledStudentEducationOrganizationAssessmentAccom_8a1ccd30ea",
+        "targetTable": "edfi.StudentEducationOrganizationAssessmentAccommodation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentEducationOrganizationAssessmentAccommodation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 3
+  },
+  {
+    "resourceName": "CourseTranscript",
+    "personType": "Student",
+    "securableElementJsonPaths": [
+      "$.studentAcademicRecordReference.studentUniqueId"
+    ],
+    "joinPath": [
+      {
+        "sourceTable": "edfi.CourseTranscript",
+        "sourceColumn": "StudentAcademicRecord_DocumentId",
+        "targetTable": "edfi.StudentAcademicRecord",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAcademicRecord",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "Grade",
+    "personType": "Student",
+    "securableElementJsonPaths": [
+      "$.studentSectionAssociationReference.studentUniqueId"
+    ],
+    "joinPath": [
+      {
+        "sourceTable": "edfi.Grade",
+        "sourceColumn": "StudentSectionAssociation_DocumentId",
+        "targetTable": "edfi.StudentSectionAssociation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentSectionAssociation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "StudentAssessmentEducationOrganizationAssociation",
+    "personType": "Student",
+    "securableElementJsonPaths": [
+      "$.studentAssessmentReference.studentUniqueId"
+    ],
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentEducationOrganizationAssociation",
+        "sourceColumn": "StudentAssessment_DocumentId",
+        "targetTable": "edfi.StudentAssessment",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentAssessment",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  },
+  {
+    "resourceName": "StudentAssessmentRegistration",
+    "personType": "Student",
+    "securableElementJsonPaths": [
+      "$.studentEducationOrganizationAssociationReference.studentUniqueId"
+    ],
+    "joinPath": [
+      {
+        "sourceTable": "edfi.StudentAssessmentRegistration",
+        "sourceColumn": "StudentEducationOrganizationAssociation_DocumentId",
+        "targetTable": "edfi.StudentEducationOrganizationAssociation",
+        "targetColumn": "DocumentId"
+      },
+      {
+        "sourceTable": "edfi.StudentEducationOrganizationAssociation",
+        "sourceColumn": "Student_DocumentId",
+        "targetTable": "edfi.Student",
+        "targetColumn": "DocumentId"
+      }
+    ],
+    "hopCount": 2
+  }
+]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/multi-hop-person-auth-paths.json
@@ -2,9 +2,7 @@
   {
     "resourceName": "StudentAssessmentRegistrationBatteryPartAssociation",
     "personType": "Student",
-    "securableElementJsonPaths": [
-      "$.studentAssessmentRegistrationReference.studentUniqueId"
-    ],
+    "securableElementJsonPath": "$.studentAssessmentRegistrationReference.studentUniqueId",
     "joinPath": [
       {
         "sourceTable": "edfi.StudentAssessmentRegistrationBatteryPartAssociation",
@@ -30,9 +28,7 @@
   {
     "resourceName": "CourseTranscript",
     "personType": "Student",
-    "securableElementJsonPaths": [
-      "$.studentAcademicRecordReference.studentUniqueId"
-    ],
+    "securableElementJsonPath": "$.studentAcademicRecordReference.studentUniqueId",
     "joinPath": [
       {
         "sourceTable": "edfi.CourseTranscript",
@@ -52,9 +48,7 @@
   {
     "resourceName": "Grade",
     "personType": "Student",
-    "securableElementJsonPaths": [
-      "$.studentSectionAssociationReference.studentUniqueId"
-    ],
+    "securableElementJsonPath": "$.studentSectionAssociationReference.studentUniqueId",
     "joinPath": [
       {
         "sourceTable": "edfi.Grade",
@@ -74,9 +68,7 @@
   {
     "resourceName": "StudentAssessmentEducationOrganizationAssociation",
     "personType": "Student",
-    "securableElementJsonPaths": [
-      "$.studentAssessmentReference.studentUniqueId"
-    ],
+    "securableElementJsonPath": "$.studentAssessmentReference.studentUniqueId",
     "joinPath": [
       {
         "sourceTable": "edfi.StudentAssessmentEducationOrganizationAssociation",
@@ -96,9 +88,7 @@
   {
     "resourceName": "StudentAssessmentRegistration",
     "personType": "Student",
-    "securableElementJsonPaths": [
-      "$.studentEducationOrganizationAssociationReference.studentUniqueId"
-    ],
+    "securableElementJsonPath": "$.studentEducationOrganizationAssociationReference.studentUniqueId",
     "joinPath": [
       {
         "sourceTable": "edfi.StudentAssessmentRegistration",

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -270,10 +270,13 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration(SqlDialect dialect)
     {
         // Person resources (Student, Contact, Staff) have securable elements but
         // don't produce mapping entries because they ARE the authorization anchor.
-        var personResourceNames = new HashSet<string>(
-            ["Student", "Contact", "Staff"],
-            StringComparer.Ordinal
-        );
+        // Use fully-qualified names to match production's homograph-safe comparison.
+        var personResources = new HashSet<QualifiedResourceName>
+        {
+            new("Ed-Fi", "Student"),
+            new("Ed-Fi", "Contact"),
+            new("Ed-Fi", "Staff"),
+        };
 
         var resourcesWithPersonSecurableElements = _modelSet
             .ConcreteResourcesInNameOrder.Where(r =>
@@ -282,7 +285,7 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration(SqlDialect dialect)
                 || r.SecurableElements.Staff.Count > 0
             )
             .Select(r => r.RelationalModel.Resource)
-            .Where(r => !personResourceNames.Contains(r.ResourceName))
+            .Where(r => !personResources.Contains(r))
             .ToHashSet();
 
         var resourcesInMapping = _mappingSet.SecurableElementColumnPathsByResource.Keys.ToHashSet();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -6,6 +6,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
 using FluentAssertions;
 using NUnit.Framework;
 
@@ -18,8 +19,16 @@ namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
 [TestFixture]
 public class Given_MultiHop_Person_Auth_Path_Enumeration
 {
-    private const string Ds52FixturePath =
-        "../Fixtures/authoritative/ds-5.2/inputs/ds-5.2-api-schema-authoritative.json";
+    private const string ProjectFileName = "EdFi.DataManagementService.Backend.Plans.Tests.Unit.csproj";
+
+    private const string GoldenFileName = "multi-hop-person-auth-paths.json";
+
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
 
     private static readonly SecurableElementKind[] _personKinds =
     [
@@ -35,9 +44,7 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     [OneTimeSetUp]
     public void Setup()
     {
-        _modelSet = RuntimePlanFixtureModelSetBuilder.Build(Ds52FixturePath, SqlDialect.Pgsql);
-        var compiler = new MappingSetCompiler();
-        _mappingSet = compiler.Compile(_modelSet);
+        (_modelSet, _mappingSet) = Ds52FixtureHelper.BuildAndCompile();
         _multiHopEntries = BuildMultiHopEntries();
     }
 
@@ -71,9 +78,6 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
                     continue;
                 }
 
-                // The resolver produces one shortest join chain per (resource, kind),
-                // so we aggregate all JSON paths for the kind here. This is accurate for
-                // DS 5.2 where no resource has divergent join chains for same-kind person elements.
                 var jsonPaths = resolvedPath.Kind switch
                 {
                     SecurableElementKind.Student => concreteResource.SecurableElements.Student,
@@ -129,107 +133,101 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     }
 
     [Test]
-    public void It_should_enumerate_all_expected_multi_hop_resources()
+    public void It_should_match_golden_report_json()
     {
-        var expectedResources = new[]
+        var actualJson = JsonSerializer.Serialize(_multiHopEntries, _jsonOptions);
+
+        var projectRoot = GoldenFixtureTestHelpers.FindProjectRoot(
+            TestContext.CurrentContext.TestDirectory,
+            ProjectFileName
+        );
+        var expectedPath = Path.Combine(
+            projectRoot,
+            "Fixtures",
+            "authoritative",
+            "ds-5.2",
+            "expected",
+            GoldenFileName
+        );
+
+        var actualPath = Path.Combine(
+            TestContext.CurrentContext.WorkDirectory,
+            "authoritative",
+            "ds-5.2",
+            "actual",
+            GoldenFileName
+        );
+        Directory.CreateDirectory(Path.GetDirectoryName(actualPath)!);
+        File.WriteAllText(actualPath, actualJson);
+
+        if (GoldenFixtureTestHelpers.ShouldUpdateGoldens())
         {
-            "CourseTranscript",
-            "Grade",
-            "StudentAssessmentEducationOrganizationAssociation",
-            "StudentAssessmentRegistration",
-            "StudentAssessmentRegistrationBatteryPartAssociation",
-        };
+            Directory.CreateDirectory(Path.GetDirectoryName(expectedPath)!);
+            File.WriteAllText(expectedPath, actualJson);
+        }
 
-        var actualResources = _multiHopEntries.Select(e => e.ResourceName).Distinct().Order().ToArray();
-
-        actualResources
+        File.Exists(expectedPath)
             .Should()
-            .BeEquivalentTo(
-                expectedResources,
-                "the full set of DS 5.2 resources with multi-hop Person paths must be locked in"
+            .BeTrue($"golden file missing at {expectedPath}. Set UPDATE_GOLDENS=1 to generate.");
+
+        var diffOutput = GoldenFixtureTestHelpers.RunGitDiff(expectedPath, actualPath);
+
+        diffOutput
+            .Should()
+            .BeEmpty(
+                "the multi-hop person auth path report must match the golden file. "
+                    + "If the change is intentional, set UPDATE_GOLDENS=1 and re-run."
             );
     }
 
     [Test]
-    public void It_should_generate_multi_hop_report_json()
+    public void It_should_have_at_most_one_resolved_path_per_person_kind_per_resource()
     {
-        var options = new JsonSerializerOptions
+        foreach (var (resource, resolvedPaths) in _mappingSet.SecurableElementColumnPathsByResource)
         {
-            WriteIndented = true,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
-        };
+            var personPathsByKind = resolvedPaths
+                .Where(p => _personKinds.Contains(p.Kind))
+                .GroupBy(p => p.Kind);
 
-        var json = JsonSerializer.Serialize(_multiHopEntries, options);
-
-        TestContext.Out.WriteLine($"Total multi-hop entries: {_multiHopEntries.Count}");
-        TestContext.Out.WriteLine();
-        TestContext.Out.WriteLine(json);
+            foreach (var group in personPathsByKind)
+            {
+                group
+                    .Should()
+                    .HaveCount(
+                        1,
+                        $"resource '{resource.ResourceName}' should have exactly one resolved "
+                            + $"path for {group.Key}, but found {group.Count()}"
+                    );
+            }
+        }
     }
 
     [Test]
-    public void It_should_find_CourseTranscript_Student_two_hop_path()
+    public void It_should_process_all_concrete_resources_with_securable_elements()
     {
-        var entry = _multiHopEntries.Find(e =>
-            e.ResourceName == "CourseTranscript" && e.PersonType == "Student"
+        // Person resources (Student, Contact, Staff) have securable elements but
+        // don't produce mapping entries because they ARE the authorization anchor.
+        var personResourceNames = new HashSet<string>(
+            ["Student", "Contact", "Staff"],
+            StringComparer.Ordinal
         );
 
-        entry.Should().NotBeNull("CourseTranscript should have a multi-hop Student path");
+        var resourcesWithSecurableElements = _modelSet
+            .ConcreteResourcesInNameOrder.Where(r => r.SecurableElements.HasAny)
+            .Select(r => r.RelationalModel.Resource)
+            .Where(r => !personResourceNames.Contains(r.ResourceName))
+            .ToHashSet();
 
-        entry!.HopCount.Should().Be(2);
-        entry.SecurableElementJsonPaths.Should().Contain("$.studentAcademicRecordReference.studentUniqueId");
+        var resourcesInMapping = _mappingSet.SecurableElementColumnPathsByResource.Keys.ToHashSet();
 
-        entry.JoinPath.Should().HaveCount(2);
-
-        entry.JoinPath[0].SourceTable.Should().Be("edfi.CourseTranscript");
-        entry.JoinPath[0].SourceColumn.Should().Be("StudentAcademicRecord_DocumentId");
-        entry.JoinPath[0].TargetTable.Should().Be("edfi.StudentAcademicRecord");
-        entry.JoinPath[0].TargetColumn.Should().Be("DocumentId");
-
-        entry.JoinPath[1].SourceTable.Should().Be("edfi.StudentAcademicRecord");
-        entry.JoinPath[1].SourceColumn.Should().Be("Student_DocumentId");
-        entry.JoinPath[1].TargetTable.Should().Be("edfi.Student");
-        entry.JoinPath[1].TargetColumn.Should().Be("DocumentId");
-    }
-
-    [Test]
-    public void It_should_find_StudentAssessmentRegistrationBatteryPartAssociation_Student_three_hop_path()
-    {
-        var entry = _multiHopEntries.Find(e =>
-            e.ResourceName == "StudentAssessmentRegistrationBatteryPartAssociation"
-            && e.PersonType == "Student"
-        );
-
-        entry
+        resourcesWithSecurableElements
             .Should()
-            .NotBeNull(
-                "StudentAssessmentRegistrationBatteryPartAssociation should have a multi-hop Student path"
+            .BeSubsetOf(
+                resourcesInMapping,
+                "every concrete resource with securable elements (excluding person "
+                    + "resources that are their own authorization anchor) should have "
+                    + "a resolved entry in the mapping set"
             );
-
-        entry!.HopCount.Should().Be(3);
-        entry
-            .SecurableElementJsonPaths.Should()
-            .Contain("$.studentAssessmentRegistrationReference.studentUniqueId");
-
-        entry.JoinPath.Should().HaveCount(3);
-
-        entry.JoinPath[0].SourceTable.Should().Be("edfi.StudentAssessmentRegistrationBatteryPartAssociation");
-        entry.JoinPath[0].SourceColumn.Should().Be("StudentAssessmentRegistration_DocumentId");
-        entry.JoinPath[0].TargetTable.Should().Be("edfi.StudentAssessmentRegistration");
-        entry.JoinPath[0].TargetColumn.Should().Be("DocumentId");
-
-        entry.JoinPath[1].SourceTable.Should().Be("edfi.StudentAssessmentRegistration");
-        entry
-            .JoinPath[1]
-            .SourceColumn.Should()
-            .Be("ScheduledStudentEducationOrganizationAssessmentAccom_8a1ccd30ea");
-        entry.JoinPath[1].TargetTable.Should().Be("edfi.StudentEducationOrganizationAssessmentAccommodation");
-        entry.JoinPath[1].TargetColumn.Should().Be("DocumentId");
-
-        entry.JoinPath[2].SourceTable.Should().Be("edfi.StudentEducationOrganizationAssessmentAccommodation");
-        entry.JoinPath[2].SourceColumn.Should().Be("Student_DocumentId");
-        entry.JoinPath[2].TargetTable.Should().Be("edfi.Student");
-        entry.JoinPath[2].TargetColumn.Should().Be("DocumentId");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -86,36 +86,41 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
                     _ => [],
                 };
 
-                entries.Add(
-                    new MultiHopEntry(
-                        ResourceName: resource.ResourceName,
-                        PersonType: resolvedPath.Kind.ToString(),
-                        SecurableElementJsonPaths: jsonPaths.ToArray(),
-                        JoinPath: resolvedPath
-                            .Steps.Select(step =>
-                            {
-                                var targetTable =
-                                    step.TargetTable
-                                    ?? throw new InvalidOperationException(
-                                        $"Multi-hop step for {resource.ResourceName} has null TargetTable"
-                                    );
-                                var targetColumn =
-                                    step.TargetColumnName
-                                    ?? throw new InvalidOperationException(
-                                        $"Multi-hop step for {resource.ResourceName} has null TargetColumnName"
-                                    );
+                var joinSteps = resolvedPath
+                    .Steps.Select(step =>
+                    {
+                        var targetTable =
+                            step.TargetTable
+                            ?? throw new InvalidOperationException(
+                                $"Multi-hop step for {resource.ResourceName} has null TargetTable"
+                            );
+                        var targetColumn =
+                            step.TargetColumnName
+                            ?? throw new InvalidOperationException(
+                                $"Multi-hop step for {resource.ResourceName} has null TargetColumnName"
+                            );
 
-                                return new JoinStep(
-                                    SourceTable: step.SourceTable.ToString(),
-                                    SourceColumn: step.SourceColumnName.Value,
-                                    TargetTable: targetTable.ToString(),
-                                    TargetColumn: targetColumn.Value
-                                );
-                            })
-                            .ToArray(),
-                        HopCount: resolvedPath.Steps.Count
-                    )
-                );
+                        return new JoinStep(
+                            SourceTable: step.SourceTable.ToString(),
+                            SourceColumn: step.SourceColumnName.Value,
+                            TargetTable: targetTable.ToString(),
+                            TargetColumn: targetColumn.Value
+                        );
+                    })
+                    .ToArray();
+
+                foreach (var jsonPath in jsonPaths)
+                {
+                    entries.Add(
+                        new MultiHopEntry(
+                            ResourceName: resource.ResourceName,
+                            PersonType: resolvedPath.Kind.ToString(),
+                            SecurableElementJsonPath: jsonPath,
+                            JoinPath: joinSteps,
+                            HopCount: resolvedPath.Steps.Count
+                        )
+                    );
+                }
             }
         }
 
@@ -203,7 +208,57 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     }
 
     [Test]
-    public void It_should_process_all_concrete_resources_with_securable_elements()
+    public void It_should_resolve_every_person_kind_present_in_securable_elements()
+    {
+        foreach (var concreteResource in _modelSet.ConcreteResourcesInNameOrder)
+        {
+            var resource = concreteResource.RelationalModel.Resource;
+            var elements = concreteResource.SecurableElements;
+
+            if (
+                !_mappingSet.SecurableElementColumnPathsByResource.TryGetValue(
+                    resource,
+                    out var resolvedPaths
+                )
+            )
+            {
+                continue;
+            }
+
+            var resolvedPersonKinds = resolvedPaths
+                .Where(p => _personKinds.Contains(p.Kind))
+                .Select(p => p.Kind)
+                .ToHashSet();
+
+            var expectedPersonKinds = new List<SecurableElementKind>();
+            if (elements.Student.Count > 0)
+            {
+                expectedPersonKinds.Add(SecurableElementKind.Student);
+            }
+            if (elements.Contact.Count > 0)
+            {
+                expectedPersonKinds.Add(SecurableElementKind.Contact);
+            }
+            if (elements.Staff.Count > 0)
+            {
+                expectedPersonKinds.Add(SecurableElementKind.Staff);
+            }
+
+            foreach (var expectedKind in expectedPersonKinds)
+            {
+                resolvedPersonKinds
+                    .Should()
+                    .Contain(
+                        expectedKind,
+                        $"resource '{resource.ResourceName}' has {expectedKind} securable elements "
+                            + "but no resolved column path for that kind"
+                    );
+            }
+        }
+    }
+
+    [Test]
+    public void It_should_process_all_concrete_resources_with_person_securable_elements()
     {
         // Person resources (Student, Contact, Staff) have securable elements but
         // don't produce mapping entries because they ARE the authorization anchor.
@@ -212,21 +267,25 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
             StringComparer.Ordinal
         );
 
-        var resourcesWithSecurableElements = _modelSet
-            .ConcreteResourcesInNameOrder.Where(r => r.SecurableElements.HasAny)
+        var resourcesWithPersonSecurableElements = _modelSet
+            .ConcreteResourcesInNameOrder.Where(r =>
+                r.SecurableElements.Student.Count > 0
+                || r.SecurableElements.Contact.Count > 0
+                || r.SecurableElements.Staff.Count > 0
+            )
             .Select(r => r.RelationalModel.Resource)
             .Where(r => !personResourceNames.Contains(r.ResourceName))
             .ToHashSet();
 
         var resourcesInMapping = _mappingSet.SecurableElementColumnPathsByResource.Keys.ToHashSet();
 
-        resourcesWithSecurableElements
+        resourcesWithPersonSecurableElements
             .Should()
             .BeSubsetOf(
                 resourcesInMapping,
-                "every concrete resource with securable elements (excluding person "
-                    + "resources that are their own authorization anchor) should have "
-                    + "a resolved entry in the mapping set"
+                "every concrete resource with person securable elements (excluding "
+                    + "person resources that are their own authorization anchor) should "
+                    + "have a resolved entry in the mapping set"
             );
     }
 
@@ -277,7 +336,7 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     private sealed record MultiHopEntry(
         string ResourceName,
         string PersonType,
-        string[] SecurableElementJsonPaths,
+        string SecurableElementJsonPath,
         JoinStep[] JoinPath,
         int HopCount
     );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -71,6 +71,9 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
                     continue;
                 }
 
+                // The resolver produces one shortest join chain per (resource, kind),
+                // so we aggregate all JSON paths for the kind here. This is accurate for
+                // DS 5.2 where no resource has divergent join chains for same-kind person elements.
                 var jsonPaths = resolvedPath.Kind switch
                 {
                     SecurableElementKind.Student => concreteResource.SecurableElements.Student,
@@ -126,10 +129,30 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     }
 
     [Test]
+    public void It_should_enumerate_all_expected_multi_hop_resources()
+    {
+        var expectedResources = new[]
+        {
+            "CourseTranscript",
+            "Grade",
+            "StudentAssessmentEducationOrganizationAssociation",
+            "StudentAssessmentRegistration",
+            "StudentAssessmentRegistrationBatteryPartAssociation",
+        };
+
+        var actualResources = _multiHopEntries.Select(e => e.ResourceName).Distinct().Order().ToArray();
+
+        actualResources
+            .Should()
+            .BeEquivalentTo(
+                expectedResources,
+                "the full set of DS 5.2 resources with multi-hop Person paths must be locked in"
+            );
+    }
+
+    [Test]
     public void It_should_generate_multi_hop_report_json()
     {
-        _multiHopEntries.Should().NotBeEmpty("there should be at least one multi-hop Person path in DS 5.2");
-
         var options = new JsonSerializerOptions
         {
             WriteIndented = true,
@@ -139,13 +162,6 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
 
         var json = JsonSerializer.Serialize(_multiHopEntries, options);
 
-        var outputPath = Path.Combine(
-            TestContext.CurrentContext.TestDirectory,
-            "multi-hop-person-auth-paths.json"
-        );
-        File.WriteAllText(outputPath, json);
-
-        TestContext.Out.WriteLine($"Report written to: {outputPath}");
         TestContext.Out.WriteLine($"Total multi-hop entries: {_multiHopEntries.Count}");
         TestContext.Out.WriteLine();
         TestContext.Out.WriteLine(json);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -177,6 +177,46 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     }
 
     [Test]
+    public void It_should_find_StudentAssessmentRegistrationBatteryPartAssociation_Student_three_hop_path()
+    {
+        var entry = _multiHopEntries.Find(e =>
+            e.ResourceName == "StudentAssessmentRegistrationBatteryPartAssociation"
+            && e.PersonType == "Student"
+        );
+
+        entry
+            .Should()
+            .NotBeNull(
+                "StudentAssessmentRegistrationBatteryPartAssociation should have a multi-hop Student path"
+            );
+
+        entry!.HopCount.Should().Be(3);
+        entry
+            .SecurableElementJsonPaths.Should()
+            .Contain("$.studentAssessmentRegistrationReference.studentUniqueId");
+
+        entry.JoinPath.Should().HaveCount(3);
+
+        entry.JoinPath[0].SourceTable.Should().Be("edfi.StudentAssessmentRegistrationBatteryPartAssociation");
+        entry.JoinPath[0].SourceColumn.Should().Be("StudentAssessmentRegistration_DocumentId");
+        entry.JoinPath[0].TargetTable.Should().Be("edfi.StudentAssessmentRegistration");
+        entry.JoinPath[0].TargetColumn.Should().Be("DocumentId");
+
+        entry.JoinPath[1].SourceTable.Should().Be("edfi.StudentAssessmentRegistration");
+        entry
+            .JoinPath[1]
+            .SourceColumn.Should()
+            .Be("ScheduledStudentEducationOrganizationAssessmentAccom_8a1ccd30ea");
+        entry.JoinPath[1].TargetTable.Should().Be("edfi.StudentEducationOrganizationAssessmentAccommodation");
+        entry.JoinPath[1].TargetColumn.Should().Be("DocumentId");
+
+        entry.JoinPath[2].SourceTable.Should().Be("edfi.StudentEducationOrganizationAssessmentAccommodation");
+        entry.JoinPath[2].SourceColumn.Should().Be("Student_DocumentId");
+        entry.JoinPath[2].TargetTable.Should().Be("edfi.Student");
+        entry.JoinPath[2].TargetColumn.Should().Be("DocumentId");
+    }
+
+    [Test]
     public void It_should_exclude_single_hop_paths()
     {
         _multiHopEntries.Should().OnlyContain(e => e.HopCount > 1);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -85,12 +85,26 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
                         PersonType: resolvedPath.Kind.ToString(),
                         SecurableElementJsonPaths: jsonPaths.ToArray(),
                         JoinPath: resolvedPath
-                            .Steps.Select(step => new JoinStep(
-                                SourceTable: step.SourceTable.ToString(),
-                                SourceColumn: step.SourceColumnName.Value,
-                                TargetTable: step.TargetTable?.ToString() ?? "",
-                                TargetColumn: step.TargetColumnName?.Value ?? ""
-                            ))
+                            .Steps.Select(step =>
+                            {
+                                var targetTable =
+                                    step.TargetTable
+                                    ?? throw new InvalidOperationException(
+                                        $"Multi-hop step for {resource.ResourceName} has null TargetTable"
+                                    );
+                                var targetColumn =
+                                    step.TargetColumnName
+                                    ?? throw new InvalidOperationException(
+                                        $"Multi-hop step for {resource.ResourceName} has null TargetColumnName"
+                                    );
+
+                                return new JoinStep(
+                                    SourceTable: step.SourceTable.ToString(),
+                                    SourceColumn: step.SourceColumnName.Value,
+                                    TargetTable: targetTable.ToString(),
+                                    TargetColumn: targetColumn.Value
+                                );
+                            })
                             .ToArray(),
                         HopCount: resolvedPath.Steps.Count
                     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+/// <summary>
+/// Enumerates all DS 5.2 resources with multi-hop Person authorization join paths
+/// and produces a JSON report for the DMS-1064 ticket.
+/// </summary>
+[TestFixture]
+public class Given_MultiHop_Person_Auth_Path_Enumeration
+{
+    private const string Ds52FixturePath =
+        "../Fixtures/authoritative/ds-5.2/inputs/ds-5.2-api-schema-authoritative.json";
+
+    private static readonly SecurableElementKind[] _personKinds =
+    [
+        SecurableElementKind.Student,
+        SecurableElementKind.Contact,
+        SecurableElementKind.Staff,
+    ];
+
+    private DerivedRelationalModelSet _modelSet = null!;
+    private MappingSet _mappingSet = null!;
+    private List<MultiHopEntry> _multiHopEntries = null!;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        _modelSet = RuntimePlanFixtureModelSetBuilder.Build(Ds52FixturePath, SqlDialect.Pgsql);
+        var compiler = new MappingSetCompiler();
+        _mappingSet = compiler.Compile(_modelSet);
+        _multiHopEntries = BuildMultiHopEntries();
+    }
+
+    private List<MultiHopEntry> BuildMultiHopEntries()
+    {
+        var entries = new List<MultiHopEntry>();
+
+        foreach (var concreteResource in _modelSet.ConcreteResourcesInNameOrder)
+        {
+            var resource = concreteResource.RelationalModel.Resource;
+
+            if (
+                !_mappingSet.SecurableElementColumnPathsByResource.TryGetValue(
+                    resource,
+                    out var resolvedPaths
+                )
+            )
+            {
+                continue;
+            }
+
+            foreach (var resolvedPath in resolvedPaths)
+            {
+                if (!_personKinds.Contains(resolvedPath.Kind))
+                {
+                    continue;
+                }
+
+                if (resolvedPath.Steps.Count <= 1)
+                {
+                    continue;
+                }
+
+                var jsonPaths = resolvedPath.Kind switch
+                {
+                    SecurableElementKind.Student => concreteResource.SecurableElements.Student,
+                    SecurableElementKind.Contact => concreteResource.SecurableElements.Contact,
+                    SecurableElementKind.Staff => concreteResource.SecurableElements.Staff,
+                    _ => [],
+                };
+
+                entries.Add(
+                    new MultiHopEntry(
+                        ResourceName: resource.ResourceName,
+                        PersonType: resolvedPath.Kind.ToString(),
+                        SecurableElementJsonPaths: jsonPaths.ToArray(),
+                        JoinPath: resolvedPath
+                            .Steps.Select(step => new JoinStep(
+                                SourceTable: step.SourceTable.ToString(),
+                                SourceColumn: step.SourceColumnName.Value,
+                                TargetTable: step.TargetTable?.ToString() ?? "",
+                                TargetColumn: step.TargetColumnName?.Value ?? ""
+                            ))
+                            .ToArray(),
+                        HopCount: resolvedPath.Steps.Count
+                    )
+                );
+            }
+        }
+
+        entries.Sort(
+            (a, b) =>
+            {
+                int cmp = b.HopCount.CompareTo(a.HopCount);
+                return cmp != 0
+                    ? cmp
+                    : string.Compare(a.ResourceName, b.ResourceName, StringComparison.Ordinal);
+            }
+        );
+
+        return entries;
+    }
+
+    [Test]
+    public void It_should_generate_multi_hop_report_json()
+    {
+        _multiHopEntries.Should().NotBeEmpty("there should be at least one multi-hop Person path in DS 5.2");
+
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        };
+
+        var json = JsonSerializer.Serialize(_multiHopEntries, options);
+
+        var outputPath = Path.Combine(
+            TestContext.CurrentContext.TestDirectory,
+            "multi-hop-person-auth-paths.json"
+        );
+        File.WriteAllText(outputPath, json);
+
+        TestContext.Out.WriteLine($"Report written to: {outputPath}");
+        TestContext.Out.WriteLine($"Total multi-hop entries: {_multiHopEntries.Count}");
+        TestContext.Out.WriteLine();
+        TestContext.Out.WriteLine(json);
+    }
+
+    [Test]
+    public void It_should_find_CourseTranscript_Student_two_hop_path()
+    {
+        var entry = _multiHopEntries.Find(e =>
+            e.ResourceName == "CourseTranscript" && e.PersonType == "Student"
+        );
+
+        entry.Should().NotBeNull("CourseTranscript should have a multi-hop Student path");
+
+        entry!.HopCount.Should().Be(2);
+        entry.SecurableElementJsonPaths.Should().Contain("$.studentAcademicRecordReference.studentUniqueId");
+
+        entry.JoinPath.Should().HaveCount(2);
+
+        entry.JoinPath[0].SourceTable.Should().Be("edfi.CourseTranscript");
+        entry.JoinPath[0].SourceColumn.Should().Be("StudentAcademicRecord_DocumentId");
+        entry.JoinPath[0].TargetTable.Should().Be("edfi.StudentAcademicRecord");
+        entry.JoinPath[0].TargetColumn.Should().Be("DocumentId");
+
+        entry.JoinPath[1].SourceTable.Should().Be("edfi.StudentAcademicRecord");
+        entry.JoinPath[1].SourceColumn.Should().Be("Student_DocumentId");
+        entry.JoinPath[1].TargetTable.Should().Be("edfi.Student");
+        entry.JoinPath[1].TargetColumn.Should().Be("DocumentId");
+    }
+
+    [Test]
+    public void It_should_exclude_single_hop_paths()
+    {
+        _multiHopEntries.Should().OnlyContain(e => e.HopCount > 1);
+    }
+
+    [Test]
+    public void It_should_only_include_Person_kinds()
+    {
+        var allowedTypes = new[] { "Student", "Contact", "Staff" };
+        _multiHopEntries.Select(e => e.PersonType).Should().OnlyContain(t => allowedTypes.Contains(t));
+    }
+
+    [Test]
+    public void It_should_sort_by_longest_path_first()
+    {
+        for (int i = 1; i < _multiHopEntries.Count; i++)
+        {
+            var prev = _multiHopEntries[i - 1];
+            var curr = _multiHopEntries[i];
+
+            if (prev.HopCount == curr.HopCount)
+            {
+                string.Compare(prev.ResourceName, curr.ResourceName, StringComparison.Ordinal)
+                    .Should()
+                    .BeLessThanOrEqualTo(
+                        0,
+                        $"entries with equal hop count should be sorted by resource name: "
+                            + $"'{prev.ResourceName}' should come before or equal to '{curr.ResourceName}'"
+                    );
+            }
+            else
+            {
+                prev.HopCount.Should()
+                    .BeGreaterThan(
+                        curr.HopCount,
+                        $"entries should be sorted by descending hop count: "
+                            + $"'{prev.ResourceName}' ({prev.HopCount}) should come before "
+                            + $"'{curr.ResourceName}' ({curr.HopCount})"
+                    );
+            }
+        }
+    }
+
+    private sealed record MultiHopEntry(
+        string ResourceName,
+        string PersonType,
+        string[] SecurableElementJsonPaths,
+        JoinStep[] JoinPath,
+        int HopCount
+    );
+
+    private sealed record JoinStep(
+        string SourceTable,
+        string SourceColumn,
+        string TargetTable,
+        string TargetColumn
+    );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MultiHopPersonAuthPathEnumerationTests.cs
@@ -16,12 +16,14 @@ namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
 /// Enumerates all DS 5.2 resources with multi-hop Person authorization join paths
 /// and produces a JSON report for the DMS-1064 ticket.
 /// </summary>
-[TestFixture]
-public class Given_MultiHop_Person_Auth_Path_Enumeration
+[TestFixture(SqlDialect.Pgsql)]
+[TestFixture(SqlDialect.Mssql)]
+public class Given_MultiHop_Person_Auth_Path_Enumeration(SqlDialect dialect)
 {
     private const string ProjectFileName = "EdFi.DataManagementService.Backend.Plans.Tests.Unit.csproj";
 
-    private const string GoldenFileName = "multi-hop-person-auth-paths.json";
+    private string GoldenFileName { get; } =
+        $"multi-hop-person-auth-paths-{dialect.ToString().ToLowerInvariant()}.json";
 
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -44,7 +46,7 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
     [OneTimeSetUp]
     public void Setup()
     {
-        (_modelSet, _mappingSet) = Ds52FixtureHelper.BuildAndCompile();
+        (_modelSet, _mappingSet) = Ds52FixtureHelper.BuildAndCompile(dialect);
         _multiHopEntries = BuildMultiHopEntries();
     }
 
@@ -185,6 +187,12 @@ public class Given_MultiHop_Person_Auth_Path_Enumeration
             );
     }
 
+    /// <summary>
+    /// Validates the resolver's BFS shortest-path contract: each person kind should
+    /// produce exactly one resolved column path per resource. A failure here in a
+    /// future schema version is an expected early warning that the resolver's
+    /// one-path-per-kind assumption no longer holds, not necessarily a bug.
+    /// </summary>
     [Test]
     public void It_should_have_at_most_one_resolved_path_per_person_kind_per_resource()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SecurableElementColumnPathResolverDs52Tests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/SecurableElementColumnPathResolverDs52Tests.cs
@@ -16,18 +16,13 @@ namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
 [TestFixture]
 public class Given_SecurableElementColumnPathResolver_with_DS52_schema
 {
-    private const string Ds52FixturePath =
-        "../Fixtures/authoritative/ds-5.2/inputs/ds-5.2-api-schema-authoritative.json";
-
     private DerivedRelationalModelSet _modelSet = null!;
     private MappingSet _mappingSet = null!;
 
     [OneTimeSetUp]
     public void Setup()
     {
-        _modelSet = RuntimePlanFixtureModelSetBuilder.Build(Ds52FixturePath, SqlDialect.Pgsql);
-        var compiler = new MappingSetCompiler();
-        _mappingSet = compiler.Compile(_modelSet);
+        (_modelSet, _mappingSet) = Ds52FixtureHelper.BuildAndCompile();
     }
 
     private ConcreteResourceModel FindResource(string resourceName)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                               
- Add test-based enumeration of all Data Standard 5.2 resources that require multi-hop joins to resolve Person authorization (Student, Contact, Staff securable elements reached through intermediate resources rather than directly)                                                                                                                              
- Produce a JSON report of multi-hop paths sorted by longest path first, including resource name, person type, securable element JSON paths, and the full join chain — output is written to the test directory for upload to the DMS-1064 Jira ticket
- Validate known multi-hop examples: 
CourseTranscript → StudentAcademicRecord → Student (2 hops) and 
StudentAssessmentRegistrationBatteryPartAssociation → StudentAssessmentRegistration → StudentEducationOrganizationAssessmentAccommodation → Student (3 hops)

## Test plan
- Run dotnet test on EdFi.DataManagementService.Backend.Plans.Tests.Unit and verify all 6 new tests pass (It_should_generate_multi_hop_report_json, It_should_find_CourseTranscript_Student_two_hop_path, It_should_find_StudentAssessmentRegistrationBatteryPartAssociation_Student_three_hop_path, It_should_exclude_single_hop_paths, It_should_only_include_Person_kinds, It_should_sort_by_longest_path_first)
- Verify the generated multi-hop-person-auth-paths.json report is non-empty and contains only Person types (Student, Contact, Staff) — no EducationOrganization or Namespace entries
- Confirm all entries in the report have hopCount > 1 (no single-hop paths)
- Confirm entries are sorted by descending hop count, then alphabetically by resource name within the same hop count
- Verify the CourseTranscript → Student join path matches the expected 2-hop chain through StudentAcademicRecord
- Upload the generated JSON report to the DMS-1064 Jira ticket as required by the acceptance criteria