### PR TITLE
[DMS-992] Project Descriptor URIs from dms.Descriptor

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionDescriptorProjectionTests.cs
@@ -1,0 +1,544 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Shared schema, model, and data constants for MSSQL integration tests that cover
+/// descriptor FK projection on a child (collection-item) table.
+/// The resource model is a "School" with a child "SchoolAddress" table
+/// that has an <c>AddressType_DescriptorId</c> nullable descriptor FK column.
+/// </summary>
+internal static class MssqlCollectionDescriptorProjectionFixture
+{
+    internal const string TestSchema = "colldescrprojmssqltest";
+    internal const long SchoolDocumentId1 = 820L;
+    internal const long AddressCollectionItemId1 = 5001L;
+    internal const long AddressCollectionItemId2 = 5002L;
+    internal const long DescriptorId920 = 920L;
+    internal const long DescriptorId921 = 921L;
+    internal const string Uri920 = "uri://ed-fi.org/AddressTypeDescriptor#Physical";
+    internal const string Uri921 = "uri://ed-fi.org/AddressTypeDescriptor#Mailing";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName RootTableName = new(Schema, "School");
+    internal static readonly DbTableName ChildTableName = new(Schema, "SchoolAddress");
+
+    internal static readonly JsonPathExpression AddressTypeDescriptorPath = new(
+        "$.addresses[*].addressTypeDescriptor",
+        [
+            new JsonPathSegment.Property("addresses"),
+            new JsonPathSegment.AnyArrayElement(),
+            new JsonPathSegment.Property("addressTypeDescriptor"),
+        ]
+    );
+
+    internal static readonly QualifiedResourceName AddressTypeDescriptorResource = new(
+        "Ed-Fi",
+        "AddressTypeDescriptor"
+    );
+
+    internal static readonly DbColumnName AddressTypeFkColumn = new("AddressType_DescriptorId");
+
+    internal static DbTableModel BuildRootTableModel() =>
+        new(
+            Table: RootTableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                $"PK_{TestSchema}_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("SchoolId"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32),
+                    IsNullable: false,
+                    SourceJsonPath: new JsonPathExpression(
+                        "$.schoolId",
+                        [new JsonPathSegment.Property("schoolId")]
+                    ),
+                    TargetResource: null
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static DbTableModel BuildChildTableModel() =>
+        new(
+            Table: ChildTableName,
+            JsonScope: new JsonPathExpression(
+                "$.addresses[*]",
+                [new JsonPathSegment.Property("addresses"), new JsonPathSegment.AnyArrayElement()]
+            ),
+            Key: new TableKey(
+                $"PK_{TestSchema}_SchoolAddress",
+                [
+                    new DbKeyColumn(new DbColumnName("School_DocumentId"), ColumnKind.ParentKeyPart),
+                    new DbKeyColumn(new DbColumnName("Ordinal"), ColumnKind.Ordinal),
+                ]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("CollectionItemId"),
+                    Kind: ColumnKind.CollectionKey,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("School_DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Ordinal"),
+                    Kind: ColumnKind.Ordinal,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("City"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 100),
+                    IsNullable: false,
+                    SourceJsonPath: new JsonPathExpression(
+                        "$.addresses[*].city",
+                        [
+                            new JsonPathSegment.Property("addresses"),
+                            new JsonPathSegment.AnyArrayElement(),
+                            new JsonPathSegment.Property("city"),
+                        ]
+                    ),
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: AddressTypeFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: AddressTypeDescriptorPath,
+                    TargetResource: AddressTypeDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Collection,
+                PhysicalRowIdentityColumns: [new DbColumnName("CollectionItemId")],
+                RootScopeLocatorColumns: [new DbColumnName("School_DocumentId")],
+                ImmediateParentScopeLocatorColumns: [new DbColumnName("School_DocumentId")],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var rootTable = BuildRootTableModel();
+        var childTable = BuildChildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "School"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable, childTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: AddressTypeDescriptorPath,
+                    Table: ChildTableName,
+                    FkColumn: AddressTypeFkColumn,
+                    DescriptorResource: AddressTypeDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static async Task ProvisionSchemaAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{TestSchema}') EXEC('CREATE SCHEMA [{TestSchema}]');
+
+            CREATE TABLE [dms].[Document] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DocumentUuid] uniqueidentifier NOT NULL,
+                [ResourceKeyId] smallint NOT NULL DEFAULT 0,
+                [ContentVersion] bigint NOT NULL DEFAULT 1,
+                [IdentityVersion] bigint NOT NULL DEFAULT 1,
+                [ContentLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [IdentityLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [CreatedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            CREATE TABLE [dms].[Descriptor] (
+                [DocumentId] bigint PRIMARY KEY,
+                [Namespace] varchar(255) NOT NULL DEFAULT '',
+                [CodeValue] varchar(50) NOT NULL DEFAULT '',
+                [ShortDescription] varchar(75) NOT NULL DEFAULT '',
+                [Description] varchar(1024) NULL,
+                [EffectiveBeginDate] date NULL,
+                [EffectiveEndDate] date NULL,
+                [Discriminator] varchar(128) NOT NULL DEFAULT '',
+                [Uri] varchar(306) NOT NULL
+            );
+
+            CREATE TABLE [{TestSchema}].[School] (
+                [DocumentId] bigint PRIMARY KEY,
+                [SchoolId] int NOT NULL
+            );
+
+            CREATE TABLE [{TestSchema}].[SchoolAddress] (
+                [CollectionItemId] bigint PRIMARY KEY,
+                [School_DocumentId] bigint NOT NULL,
+                [Ordinal] int NOT NULL,
+                [City] varchar(100) NOT NULL,
+                [AddressType_DescriptorId] bigint NULL
+            );
+            """
+        );
+    }
+
+    internal static async Task InsertTestDataAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            INSERT INTO [dms].[Document] ([DocumentId], [DocumentUuid], [ResourceKeyId], [ContentVersion], [IdentityVersion]) VALUES
+                ({SchoolDocumentId1}, '82000000-0000-0000-0000-000000000820', 0, 1, 1);
+
+            INSERT INTO [dms].[Descriptor] ([DocumentId], [Namespace], [CodeValue], [ShortDescription], [Discriminator], [Uri]) VALUES
+                ({DescriptorId920}, 'uri://ed-fi.org/AddressTypeDescriptor', 'Physical', 'Physical', 'edfi.AddressTypeDescriptor', '{Uri920}'),
+                ({DescriptorId921}, 'uri://ed-fi.org/AddressTypeDescriptor', 'Mailing', 'Mailing', 'edfi.AddressTypeDescriptor', '{Uri921}');
+            """
+        );
+    }
+
+    private static async Task ExecuteSqlAsync(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Verifies that a descriptor FK on a collection-item (child table) row is resolved to a URI
+/// and projected into the reconstituted JSON document at the correct array-element path,
+/// exercising the full database-backed hydrate + project + reconstitute pipeline against SQL Server.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Collection_Item_Descriptor_FK_Resolves_To_URI_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlCollectionDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlCollectionDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Insert root document
+        await using var insertRootCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlCollectionDescriptorProjectionFixture.TestSchema}].[School]
+                ([DocumentId], [SchoolId])
+            VALUES
+                ({MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 255901);
+            """,
+            setupConn
+        );
+        await insertRootCmd.ExecuteNonQueryAsync();
+
+        // Insert two collection items with descriptor FKs
+        await using var insertChildCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlCollectionDescriptorProjectionFixture.TestSchema}].[SchoolAddress]
+                ([CollectionItemId], [School_DocumentId], [Ordinal], [City], [AddressType_DescriptorId])
+            VALUES
+                ({MssqlCollectionDescriptorProjectionFixture.AddressCollectionItemId1},
+                 {MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 0, 'Grand Bend',
+                 {MssqlCollectionDescriptorProjectionFixture.DescriptorId920}),
+                ({MssqlCollectionDescriptorProjectionFixture.AddressCollectionItemId2},
+                 {MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 1, 'Austin',
+                 {MssqlCollectionDescriptorProjectionFixture.DescriptorId921});
+            """,
+            setupConn
+        );
+        await insertChildCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlCollectionDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlCollectionDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_emits_the_addresses_array()
+    {
+        _reconstitutedDocument["addresses"].Should().NotBeNull();
+        _reconstitutedDocument["addresses"]!.AsArray().Should().HaveCount(2);
+    }
+
+    [Test]
+    public void It_emits_the_first_address_descriptor_uri()
+    {
+        _reconstitutedDocument["addresses"]![0]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlCollectionDescriptorProjectionFixture.Uri920);
+    }
+
+    [Test]
+    public void It_emits_the_second_address_descriptor_uri()
+    {
+        _reconstitutedDocument["addresses"]![1]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlCollectionDescriptorProjectionFixture.Uri921);
+    }
+
+    [Test]
+    public void It_emits_the_scalar_city_on_the_first_address()
+    {
+        _reconstitutedDocument["addresses"]![0]!["city"]!.GetValue<string>().Should().Be("Grand Bend");
+    }
+
+    [Test]
+    public void It_does_not_expose_the_raw_descriptor_fk_column()
+    {
+        _reconstitutedDocument["addresses"]![0]!["AddressType_DescriptorId"].Should().BeNull();
+        _reconstitutedDocument["addresses"]![1]!["AddressType_DescriptorId"].Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that a null descriptor FK on a collection-item row causes the descriptor property
+/// to be omitted from that array element in the reconstituted JSON against SQL Server.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Collection_Item_Null_Descriptor_FK_Omits_Property_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlCollectionDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlCollectionDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertRootCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlCollectionDescriptorProjectionFixture.TestSchema}].[School]
+                ([DocumentId], [SchoolId])
+            VALUES
+                ({MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 255901);
+            """,
+            setupConn
+        );
+        await insertRootCmd.ExecuteNonQueryAsync();
+
+        // Insert one collection item with a non-null descriptor and one with NULL
+        await using var insertChildCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlCollectionDescriptorProjectionFixture.TestSchema}].[SchoolAddress]
+                ([CollectionItemId], [School_DocumentId], [Ordinal], [City], [AddressType_DescriptorId])
+            VALUES
+                ({MssqlCollectionDescriptorProjectionFixture.AddressCollectionItemId1},
+                 {MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 0, 'Grand Bend',
+                 {MssqlCollectionDescriptorProjectionFixture.DescriptorId920}),
+                ({MssqlCollectionDescriptorProjectionFixture.AddressCollectionItemId2},
+                 {MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1}, 1, 'Austin',
+                 NULL);
+            """,
+            setupConn
+        );
+        await insertChildCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlCollectionDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlCollectionDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            MssqlCollectionDescriptorProjectionFixture.SchoolDocumentId1,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_emits_the_descriptor_uri_on_the_non_null_collection_item()
+    {
+        _reconstitutedDocument["addresses"]![0]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlCollectionDescriptorProjectionFixture.Uri920);
+    }
+
+    [Test]
+    public void It_omits_the_descriptor_property_on_the_null_collection_item()
+    {
+        _reconstitutedDocument["addresses"]![1]!["addressTypeDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_still_emits_the_scalar_city_on_both_items()
+    {
+        _reconstitutedDocument["addresses"]![0]!["city"]!.GetValue<string>().Should().Be("Grand Bend");
+        _reconstitutedDocument["addresses"]![1]!["city"]!.GetValue<string>().Should().Be("Austin");
+    }
+}
+
+file static class MssqlCollectionDescriptorProjectionTestHelper
+{
+    internal static IReadOnlyDictionary<long, string> BuildDescriptorUriLookup(
+        IReadOnlyList<HydratedDescriptorRows> descriptorRowsInPlanOrder
+    )
+    {
+        Dictionary<long, string> lookup = [];
+
+        foreach (var descriptorRows in descriptorRowsInPlanOrder)
+        {
+            foreach (var row in descriptorRows.Rows)
+            {
+                lookup.TryAdd(row.DescriptorId, row.Uri);
+            }
+        }
+
+        return lookup;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionPipelineTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionPipelineTests.cs
@@ -1,0 +1,432 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Shared schema, model, and data constants for SQL Server descriptor projection integration tests
+/// that cover a resource with both required and optional descriptor foreign keys.
+/// </summary>
+internal static class MssqlDescriptorProjectionPipelineFixture
+{
+    internal const string TestSchema = "descprojpipelinemssqltest";
+    internal const long DocumentId810 = 810L;
+    internal const long DocumentId811 = 811L;
+    internal const long DescriptorId910 = 910L;
+    internal const long DescriptorId911 = 911L;
+    internal const string Uri910 = "uri://ed-fi.org/AcademicSubjectDescriptor#English Language Arts";
+    internal const string Uri911 = "uri://ed-fi.org/InstructionLanguageDescriptor#English";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName TableName = new(Schema, "CourseOffering");
+
+    internal static readonly JsonPathExpression AcademicSubjectDescriptorPath = new(
+        "$.academicSubjectDescriptor",
+        [new JsonPathSegment.Property("academicSubjectDescriptor")]
+    );
+
+    internal static readonly JsonPathExpression InstructionLanguageDescriptorPath = new(
+        "$.instructionLanguageDescriptor",
+        [new JsonPathSegment.Property("instructionLanguageDescriptor")]
+    );
+
+    internal static readonly QualifiedResourceName AcademicSubjectDescriptorResource = new(
+        "Ed-Fi",
+        "AcademicSubjectDescriptor"
+    );
+
+    internal static readonly QualifiedResourceName InstructionLanguageDescriptorResource = new(
+        "Ed-Fi",
+        "InstructionLanguageDescriptor"
+    );
+
+    internal static readonly DbColumnName AcademicSubjectFkColumn = new(
+        "AcademicSubjectDescriptor_DescriptorId"
+    );
+
+    internal static readonly DbColumnName InstructionLanguageFkColumn = new(
+        "InstructionLanguageDescriptor_DescriptorId"
+    );
+
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var tableModel = BuildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "CourseOffering"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: tableModel,
+            TablesInDependencyOrder: [tableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: AcademicSubjectDescriptorPath,
+                    Table: TableName,
+                    FkColumn: AcademicSubjectFkColumn,
+                    DescriptorResource: AcademicSubjectDescriptorResource
+                ),
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: InstructionLanguageDescriptorPath,
+                    Table: TableName,
+                    FkColumn: InstructionLanguageFkColumn,
+                    DescriptorResource: InstructionLanguageDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static DbTableModel BuildTableModel() =>
+        new(
+            Table: TableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                "PK_descprojpipelinemssqltest_CourseOffering",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: AcademicSubjectFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: AcademicSubjectDescriptorPath,
+                    TargetResource: AcademicSubjectDescriptorResource
+                ),
+                new DbColumnModel(
+                    ColumnName: InstructionLanguageFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: InstructionLanguageDescriptorPath,
+                    TargetResource: InstructionLanguageDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static async Task ProvisionSchemaAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{TestSchema}') EXEC('CREATE SCHEMA [{TestSchema}]');
+
+            CREATE TABLE [dms].[Document] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DocumentUuid] uniqueidentifier NOT NULL,
+                [ResourceKeyId] smallint NOT NULL DEFAULT 0,
+                [ContentVersion] bigint NOT NULL DEFAULT 1,
+                [IdentityVersion] bigint NOT NULL DEFAULT 1,
+                [ContentLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [IdentityLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [CreatedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            CREATE TABLE [dms].[Descriptor] (
+                [DocumentId] bigint PRIMARY KEY,
+                [Namespace] varchar(255) NOT NULL DEFAULT '',
+                [CodeValue] varchar(50) NOT NULL DEFAULT '',
+                [ShortDescription] varchar(75) NOT NULL DEFAULT '',
+                [Description] varchar(1024) NULL,
+                [EffectiveBeginDate] date NULL,
+                [EffectiveEndDate] date NULL,
+                [Discriminator] varchar(128) NOT NULL DEFAULT '',
+                [Uri] varchar(306) NOT NULL
+            );
+
+            CREATE TABLE [{TestSchema}].[CourseOffering] (
+                [DocumentId] bigint PRIMARY KEY,
+                [AcademicSubjectDescriptor_DescriptorId] bigint NOT NULL,
+                [InstructionLanguageDescriptor_DescriptorId] bigint NULL
+            );
+            """
+        );
+    }
+
+    internal static async Task InsertTestDataAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            INSERT INTO [dms].[Document] ([DocumentId], [DocumentUuid], [ResourceKeyId], [ContentVersion], [IdentityVersion]) VALUES
+                (810, '81000000-0000-0000-0000-000000000810', 0, 1, 1),
+                (811, '81100000-0000-0000-0000-000000000811', 0, 1, 1);
+
+            INSERT INTO [dms].[Descriptor] ([DocumentId], [Namespace], [CodeValue], [ShortDescription], [Discriminator], [Uri]) VALUES
+                (910, 'uri://ed-fi.org/AcademicSubjectDescriptor', 'English Language Arts', 'English Language Arts', 'edfi.AcademicSubjectDescriptor', '{Uri910}'),
+                (911, 'uri://ed-fi.org/InstructionLanguageDescriptor', 'English', 'English', 'edfi.InstructionLanguageDescriptor', '{Uri911}');
+            """
+        );
+    }
+
+    private static async Task ExecuteSqlAsync(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Mssql_Reconstitution_With_Both_Descriptor_Fks_Set
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionPipelineFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionPipelineFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionPipelineFixture.TestSchema}].[CourseOffering]
+                ([DocumentId], [AcademicSubjectDescriptor_DescriptorId], [InstructionLanguageDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionPipelineFixture.DocumentId810},
+                 {MssqlDescriptorProjectionPipelineFixture.DescriptorId910},
+                 {MssqlDescriptorProjectionPipelineFixture.DescriptorId911});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionPipelineFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(MssqlDescriptorProjectionPipelineFixture.DocumentId810),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlDescriptorProjectionPipelineTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            MssqlDescriptorProjectionPipelineFixture.DocumentId810,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_document()
+    {
+        _reconstitutedDocument.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_emits_the_required_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["academicSubjectDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlDescriptorProjectionPipelineFixture.Uri910);
+    }
+
+    [Test]
+    public void It_emits_the_optional_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["instructionLanguageDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlDescriptorProjectionPipelineFixture.Uri911);
+    }
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Mssql_Reconstitution_With_Optional_Descriptor_Fk_Null
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionPipelineFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionPipelineFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionPipelineFixture.TestSchema}].[CourseOffering]
+                ([DocumentId], [AcademicSubjectDescriptor_DescriptorId], [InstructionLanguageDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionPipelineFixture.DocumentId811},
+                 {MssqlDescriptorProjectionPipelineFixture.DescriptorId910},
+                 NULL);
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionPipelineFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(MssqlDescriptorProjectionPipelineFixture.DocumentId811),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlDescriptorProjectionPipelineTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            MssqlDescriptorProjectionPipelineFixture.DocumentId811,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_document()
+    {
+        _reconstitutedDocument.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_emits_the_required_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["academicSubjectDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(MssqlDescriptorProjectionPipelineFixture.Uri910);
+    }
+
+    [Test]
+    public void It_does_not_emit_the_optional_descriptor_property_key()
+    {
+        _reconstitutedDocument.AsObject()["instructionLanguageDescriptor"].Should().BeNull();
+    }
+}
+
+file static class MssqlDescriptorProjectionPipelineTestHelper
+{
+    internal static IReadOnlyDictionary<long, string> BuildDescriptorUriLookup(
+        IReadOnlyList<HydratedDescriptorRows> descriptorRowsInPlanOrder
+    )
+    {
+        Dictionary<long, string> lookup = [];
+
+        foreach (var descriptorRows in descriptorRowsInPlanOrder)
+        {
+            foreach (var row in descriptorRows.Rows)
+            {
+                lookup.TryAdd(row.DescriptorId, row.Uri);
+            }
+        }
+
+        return lookup;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionTests.cs
@@ -1,0 +1,831 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Integration tests for descriptor projection SQL execution against a live SQL Server database.
+/// All test fixtures use the schema <c>"descprojtest"</c> with a minimal
+/// <c>"StudentSchoolAssociation"</c> table that has one nullable descriptor FK column.
+/// </summary>
+/// <remarks>
+/// DocumentIds 700–703 and DescriptorIds 901–903 are reserved for these fixtures.
+/// Each fixture provisions its own isolated MSSQL database.
+/// </remarks>
+internal static class MssqlDescriptorProjectionFixture
+{
+    internal const string TestSchema = "descprojtest";
+    internal const long DocumentId700 = 700L;
+    internal const long DocumentId701 = 701L;
+    internal const long DocumentId702 = 702L;
+    internal const long DocumentId703 = 703L;
+    internal const long DescriptorId901 = 901L;
+    internal const long DescriptorId902 = 902L;
+    internal const long DescriptorId903 = 903L;
+    internal const string Uri901 = "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade";
+    internal const string Uri902 = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+    internal const string Uri903 = "uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName TableName = new(Schema, "StudentSchoolAssociation");
+
+    internal static readonly JsonPathExpression GradeLevelDescriptorPath = new(
+        "$.gradeLevelDescriptor",
+        [new JsonPathSegment.Property("gradeLevelDescriptor")]
+    );
+
+    internal static readonly QualifiedResourceName GradeLevelDescriptorResource = new(
+        "Ed-Fi",
+        "GradeLevelDescriptor"
+    );
+
+    internal static readonly DbColumnName FkColumnName = new("GradeLevelDescriptor_DescriptorId");
+
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var tableModel = BuildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "StudentSchoolAssociation"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: tableModel,
+            TablesInDependencyOrder: [tableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: GradeLevelDescriptorPath,
+                    Table: TableName,
+                    FkColumn: FkColumnName,
+                    DescriptorResource: GradeLevelDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static DbTableModel BuildTableModel() =>
+        new(
+            Table: TableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                "PK_descprojtest_StudentSchoolAssociation",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: FkColumnName,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: GradeLevelDescriptorPath,
+                    TargetResource: GradeLevelDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    /// <summary>
+    /// Provisions the dms schema, Document and Descriptor tables, and the test resource table.
+    /// Each invocation is idempotent within a freshly-created database.
+    /// </summary>
+    internal static async Task ProvisionSchemaAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{TestSchema}') EXEC('CREATE SCHEMA [{TestSchema}]');
+
+            CREATE TABLE [dms].[Document] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DocumentUuid] uniqueidentifier NOT NULL,
+                [ResourceKeyId] smallint NOT NULL DEFAULT 0,
+                [ContentVersion] bigint NOT NULL DEFAULT 1,
+                [IdentityVersion] bigint NOT NULL DEFAULT 1,
+                [ContentLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [IdentityLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [CreatedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            CREATE TABLE [dms].[Descriptor] (
+                [DocumentId] bigint PRIMARY KEY,
+                [Namespace] varchar(255) NOT NULL DEFAULT '',
+                [CodeValue] varchar(50) NOT NULL DEFAULT '',
+                [ShortDescription] varchar(75) NOT NULL DEFAULT '',
+                [Description] varchar(1024) NULL,
+                [EffectiveBeginDate] date NULL,
+                [EffectiveEndDate] date NULL,
+                [Discriminator] varchar(128) NOT NULL DEFAULT '',
+                [Uri] varchar(306) NOT NULL
+            );
+
+            CREATE TABLE [{TestSchema}].[StudentSchoolAssociation] (
+                [DocumentId] bigint PRIMARY KEY,
+                [GradeLevelDescriptor_DescriptorId] bigint NULL
+            );
+            """
+        );
+    }
+
+    internal static async Task InsertTestDataAsync(SqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            INSERT INTO [dms].[Document] ([DocumentId], [DocumentUuid], [ResourceKeyId], [ContentVersion], [IdentityVersion]) VALUES
+                (700, '70000000-0000-0000-0000-000000000700', 0, 1, 1),
+                (701, '70100000-0000-0000-0000-000000000701', 0, 1, 1),
+                (702, '70200000-0000-0000-0000-000000000702', 0, 1, 1),
+                (703, '70300000-0000-0000-0000-000000000703', 0, 1, 1);
+
+            INSERT INTO [dms].[Descriptor] ([DocumentId], [Namespace], [CodeValue], [ShortDescription], [Discriminator], [Uri]) VALUES
+                (901, 'uri://ed-fi.org/GradeLevelDescriptor', 'Ninth grade', 'Ninth grade', 'edfi.GradeLevelDescriptor', '{Uri901}'),
+                (902, 'uri://ed-fi.org/GradeLevelDescriptor', 'Tenth grade', 'Tenth grade', 'edfi.GradeLevelDescriptor', '{Uri902}'),
+                (903, 'uri://ed-fi.org/GradeLevelDescriptor', 'Eleventh grade', 'Eleventh grade', 'edfi.GradeLevelDescriptor', '{Uri903}');
+            """
+        );
+    }
+
+    /// <summary>
+    /// Creates the <c>#page</c> keyset temp table and inserts the supplied document IDs.
+    /// The temp table persists for the session so subsequent commands can JOIN it.
+    /// </summary>
+    internal static async Task CreatePageTableAsync(SqlConnection connection, params long[] documentIds)
+    {
+        var valuesClause = string.Join(", ", documentIds.Select(id => $"({id})"));
+
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            IF OBJECT_ID('tempdb..[#page]') IS NOT NULL
+                DROP TABLE [#page];
+            CREATE TABLE [#page] ([DocumentId] bigint PRIMARY KEY);
+            INSERT INTO [#page] ([DocumentId]) VALUES {valuesClause};
+            """
+        );
+    }
+
+    private static async Task ExecuteSqlAsync(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows return the correct URI string for a non-null
+/// required descriptor FK column against SQL Server.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Required_Descriptor_FK_Resolves_To_URI_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId700}, {MssqlDescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(MssqlDescriptorProjectionFixture.DocumentId700),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+        _lookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_non_empty_lookup()
+    {
+        _lookup.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_the_descriptor_id_to_the_correct_uri()
+    {
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri901);
+    }
+
+    [Test]
+    public void It_stores_the_uri_exactly_as_in_dms_Descriptor()
+    {
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be("uri://ed-fi.org/GradeLevelDescriptor#Ninth grade");
+    }
+
+    [Test]
+    public void It_uses_mssql_dialect_quoting_in_the_compiled_plan_sql()
+    {
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        readPlan.DescriptorProjectionPlansInOrder.Should().HaveCount(1);
+        var sql = readPlan.DescriptorProjectionPlansInOrder[0].SelectByKeysetSql;
+
+        // Validate MSSQL-dialect bracketed identifier quoting
+        sql.Should().Contain("[#page]");
+        sql.Should().Contain($"[{MssqlDescriptorProjectionFixture.TestSchema}]");
+        sql.Should().Contain("[dms]");
+
+        // Must NOT contain PostgreSQL double-quote syntax
+        sql.Should().NotContain("\"#page\"");
+        sql.Should().NotContain("\"page\"");
+    }
+}
+
+/// <summary>
+/// Verifies that a null descriptor FK causes the descriptor property to be absent from the
+/// reconstituted JSON document when executing the full hydrate + project + reconstitute pipeline
+/// against SQL Server.
+/// Mirrors Task 3 (PostgreSQL null FK omission) for the MSSQL dialect.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Null_Descriptor_FK_Omits_Property_From_Reconstituted_Document_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Document 701 has NULL descriptor FK
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId701}, NULL);
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+        var keyset = new PageKeysetSpec.Single(MssqlDescriptorProjectionFixture.DocumentId701);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        // Step 1: Hydrate — HydrationExecutor creates [#page] as part of its batch
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        // Step 3: Reconstitute (pure in-memory)
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            documentId: MssqlDescriptorProjectionFixture.DocumentId701,
+            tableRowsInDependencyOrder: hydratedPage.TableRowsInDependencyOrder,
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup: descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_does_not_emit_the_descriptor_property_key()
+    {
+        _reconstitutedDocument["gradeLevelDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_does_not_emit_json_null_at_the_descriptor_path()
+    {
+        var gradeLevelDescriptor = _reconstitutedDocument["gradeLevelDescriptor"];
+        gradeLevelDescriptor.Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows return all distinct descriptor URIs for a page
+/// containing multiple documents and still deduplicate shared descriptors.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Page_With_Multiple_Documents_And_Distinct_Descriptors_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+    private IReadOnlyDictionary<long, string> _sharedDescriptorLookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Three documents each referencing a distinct descriptor
+        await using var insertDistinctCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId700}, {MssqlDescriptorProjectionFixture.DescriptorId901}),
+                ({MssqlDescriptorProjectionFixture.DocumentId701}, {MssqlDescriptorProjectionFixture.DescriptorId902}),
+                ({MssqlDescriptorProjectionFixture.DocumentId702}, {MssqlDescriptorProjectionFixture.DescriptorId903});
+            """,
+            setupConn
+        );
+        await insertDistinctCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        await using var distinctConn = new SqlConnection(_connectionString);
+        await distinctConn.OpenAsync();
+        var distinctHydratedPage = await HydrationExecutor.ExecuteAsync(
+            distinctConn,
+            readPlan,
+            MssqlDescriptorProjectionPageKeysetHelper.CreatePageKeyset(
+                MssqlDescriptorProjectionFixture.TestSchema,
+                MssqlDescriptorProjectionFixture.DocumentId700,
+                MssqlDescriptorProjectionFixture.DocumentId701,
+                MssqlDescriptorProjectionFixture.DocumentId702
+            ),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+        _lookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            distinctHydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        // --- shared descriptor run: 703 and 700 both reference descriptor 901 ---
+        await using var insertSharedCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId703}, {MssqlDescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertSharedCmd.ExecuteNonQueryAsync();
+
+        await using var sharedConn = new SqlConnection(_connectionString);
+        await sharedConn.OpenAsync();
+        var sharedHydratedPage = await HydrationExecutor.ExecuteAsync(
+            sharedConn,
+            readPlan,
+            MssqlDescriptorProjectionPageKeysetHelper.CreatePageKeyset(
+                MssqlDescriptorProjectionFixture.TestSchema,
+                MssqlDescriptorProjectionFixture.DocumentId700,
+                MssqlDescriptorProjectionFixture.DocumentId703
+            ),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+        _sharedDescriptorLookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            sharedHydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_one_entry_per_distinct_descriptor_id()
+    {
+        _lookup.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void It_contains_all_expected_descriptor_uris()
+    {
+        _lookup
+            .Values.Should()
+            .Contain(MssqlDescriptorProjectionFixture.Uri901)
+            .And.Contain(MssqlDescriptorProjectionFixture.Uri902)
+            .And.Contain(MssqlDescriptorProjectionFixture.Uri903);
+    }
+
+    [Test]
+    public void It_maps_each_descriptor_id_to_the_correct_uri()
+    {
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri901);
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId902]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri902);
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId903]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri903);
+    }
+
+    [Test]
+    public void It_deduplicates_a_shared_descriptor_to_a_single_lookup_entry()
+    {
+        // Documents 700 and 703 both reference DescriptorId 901
+        _sharedDescriptorLookup.Should().HaveCount(1);
+        _sharedDescriptorLookup[MssqlDescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri901);
+    }
+}
+
+/// <summary>
+/// Verifies that reconstituting a document whose descriptor FK was first set to a non-null value
+/// and then cleared to NULL correctly omits the descriptor property from the output.
+/// This specifically exercises the update-to-null path, which is distinct from an FK that
+/// was never populated.
+/// Task 3 (cleared-to-null acceptance case): MSSQL dialect mirror.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Descriptor_FK_Cleared_To_Null_Omits_Property_From_Reconstituted_Document_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Insert document 702 with a non-null descriptor FK first
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId702}, {MssqlDescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        // Simulate an update that clears the descriptor FK to NULL
+        await using var updateCmd = new SqlCommand(
+            $"""
+            UPDATE [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+            SET [GradeLevelDescriptor_DescriptorId] = NULL
+            WHERE [DocumentId] = {MssqlDescriptorProjectionFixture.DocumentId702};
+            """,
+            setupConn
+        );
+        await updateCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+        var keyset = new PageKeysetSpec.Single(MssqlDescriptorProjectionFixture.DocumentId702);
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            documentId: MssqlDescriptorProjectionFixture.DocumentId702,
+            tableRowsInDependencyOrder: hydratedPage.TableRowsInDependencyOrder,
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup: descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_does_not_emit_the_descriptor_property_key()
+    {
+        _reconstitutedDocument["gradeLevelDescriptor"].Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows correctly resolve all descriptor URIs when the page is
+/// materialized from a real <see cref="PageKeysetSpec.Query"/> via <see cref="HydrationExecutor"/>.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[NonParallelizable]
+public class Given_Multi_Document_Page_Created_Via_Query_Keyset_Returns_All_Descriptor_URIs_Mssql
+{
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("SQL Server integration tests require a MssqlAdmin connection string.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var setupConn = new SqlConnection(_connectionString);
+        await setupConn.OpenAsync();
+
+        await MssqlDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await MssqlDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Three documents each referencing a distinct descriptor
+        await using var insertCmd = new SqlCommand(
+            $"""
+            INSERT INTO [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation]
+                ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES
+                ({MssqlDescriptorProjectionFixture.DocumentId700}, {MssqlDescriptorProjectionFixture.DescriptorId901}),
+                ({MssqlDescriptorProjectionFixture.DocumentId701}, {MssqlDescriptorProjectionFixture.DescriptorId902}),
+                ({MssqlDescriptorProjectionFixture.DocumentId702}, {MssqlDescriptorProjectionFixture.DescriptorId903});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = MssqlDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(resourceModel);
+
+        // Use a real query keyset so HydrationExecutor materializes [#page] from the query.
+        var keyset = new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: $"""
+                SELECT r.[DocumentId]
+                FROM [{MssqlDescriptorProjectionFixture.TestSchema}].[StudentSchoolAssociation] r
+                ORDER BY r.[DocumentId]
+                OFFSET @offset ROWS FETCH NEXT @limit ROWS ONLY
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                    new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?> { ["offset"] = 0L, ["limit"] = 25L }
+        );
+
+        await using var execConn = new SqlConnection(_connectionString);
+        await execConn.OpenAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+        _lookup = MssqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null && MssqlTestDatabaseHelper.IsConfigured())
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_one_entry_per_distinct_descriptor_id_across_the_page()
+    {
+        _lookup.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void It_resolves_all_three_descriptor_uris()
+    {
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri901);
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId902]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri902);
+        _lookup[MssqlDescriptorProjectionFixture.DescriptorId903]
+            .Should()
+            .Be(MssqlDescriptorProjectionFixture.Uri903);
+    }
+}
+
+file static class MssqlDescriptorProjectionTestHelper
+{
+    internal static IReadOnlyDictionary<long, string> BuildDescriptorUriLookup(
+        IReadOnlyList<HydratedDescriptorRows> descriptorRowsInPlanOrder
+    )
+    {
+        Dictionary<long, string> lookup = [];
+
+        foreach (var descriptorRows in descriptorRowsInPlanOrder)
+        {
+            foreach (var row in descriptorRows.Rows)
+            {
+                lookup.TryAdd(row.DescriptorId, row.Uri);
+            }
+        }
+
+        return lookup;
+    }
+}
+
+file static class MssqlDescriptorProjectionPageKeysetHelper
+{
+    internal static PageKeysetSpec.Query CreatePageKeyset(string schemaName, params long[] documentIds)
+    {
+        return new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: $"""
+                SELECT r.[DocumentId]
+                FROM [{schemaName}].[StudentSchoolAssociation] r
+                WHERE r.[DocumentId] IN ({string.Join(", ", documentIds)})
+                ORDER BY r.[DocumentId]
+                OFFSET 0 ROWS
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder: [],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?>()
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
@@ -3937,6 +3937,214 @@ public class Given_DocumentReconstituter_With_Empty_Collection_Extension_Scope
 }
 
 [TestFixture]
+public class Given_DocumentReconstituter_With_Descriptor_On_Collection_Item
+{
+    private JsonNode _result = null!;
+
+    private static readonly DbSchemaName _schema = new("edfi");
+    private static readonly DbTableName _rootTableName = new(_schema, "School");
+    private static readonly DbTableName _addressTableName = new(_schema, "SchoolAddress");
+
+    private static readonly JsonPathExpression _rootScope = new("$", []);
+
+    private static readonly JsonPathExpression _addressesScope = new(
+        "$.addresses[*]",
+        [new JsonPathSegment.Property("addresses"), new JsonPathSegment.AnyArrayElement()]
+    );
+
+    private static readonly JsonPathExpression _schoolIdPath = new(
+        "$.schoolId",
+        [new JsonPathSegment.Property("schoolId")]
+    );
+
+    private static readonly JsonPathExpression _cityPath = new(
+        "$.addresses[*].city",
+        [
+            new JsonPathSegment.Property("addresses"),
+            new JsonPathSegment.AnyArrayElement(),
+            new JsonPathSegment.Property("city"),
+        ]
+    );
+
+    private static readonly JsonPathExpression _addressTypeDescriptorPath = new(
+        "$.addresses[*].addressTypeDescriptor",
+        [
+            new JsonPathSegment.Property("addresses"),
+            new JsonPathSegment.AnyArrayElement(),
+            new JsonPathSegment.Property("addressTypeDescriptor"),
+        ]
+    );
+
+    private static readonly QualifiedResourceName _addressTypeDescriptorResource = new(
+        "Ed-Fi",
+        "AddressTypeDescriptor"
+    );
+
+    [SetUp]
+    public void SetUp()
+    {
+        var rootTableModel = new DbTableModel(
+            Table: _rootTableName,
+            JsonScope: _rootScope,
+            Key: new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("SchoolId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    _schoolIdPath,
+                    null
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        var addressTableModel = new DbTableModel(
+            Table: _addressTableName,
+            JsonScope: _addressesScope,
+            Key: new TableKey(
+                "PK_SchoolAddress",
+                [new DbKeyColumn(new DbColumnName("CollectionItemId"), ColumnKind.CollectionKey)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    new DbColumnName("CollectionItemId"),
+                    ColumnKind.CollectionKey,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("School_DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Ordinal"),
+                    ColumnKind.Ordinal,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("City"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 30),
+                    false,
+                    _cityPath,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("AddressType_DescriptorId"),
+                    ColumnKind.DescriptorFk,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    true,
+                    null,
+                    _addressTypeDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Collection,
+                [new DbColumnName("CollectionItemId")],
+                [new DbColumnName("School_DocumentId")],
+                [new DbColumnName("School_DocumentId")],
+                []
+            ),
+        };
+
+        var descriptorSource = new DescriptorEdgeSource(
+            IsIdentityComponent: false,
+            DescriptorValuePath: _addressTypeDescriptorPath,
+            Table: _addressTableName,
+            FkColumn: new DbColumnName("AddressType_DescriptorId"),
+            DescriptorResource: _addressTypeDescriptorResource
+        );
+
+        object?[] rootRow = [1L, 255901];
+        object?[] addressRow = [10L, 1L, 0, "Grand Bend", 100L];
+
+        _result = DocumentReconstituter.Reconstitute(
+            documentId: 1L,
+            tableRowsInDependencyOrder:
+            [
+                new HydratedTableRows(rootTableModel, [rootRow]),
+                new HydratedTableRows(addressTableModel, [addressRow]),
+            ],
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: [descriptorSource],
+            descriptorUriLookup: new Dictionary<long, string>
+            {
+                [100L] = "uri://ed-fi.org/AddressTypeDescriptor#Physical",
+            }
+        );
+    }
+
+    [Test]
+    public void It_should_return_a_json_object()
+    {
+        _result.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_should_emit_addresses_array_with_one_item()
+    {
+        _result["addresses"]!.AsArray().Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_should_emit_city_on_the_address_item()
+    {
+        _result["addresses"]![0]!["city"]!.GetValue<string>().Should().Be("Grand Bend");
+    }
+
+    [Test]
+    public void It_should_emit_addressTypeDescriptor_uri_on_the_collection_item()
+    {
+        _result["addresses"]![0]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be("uri://ed-fi.org/AddressTypeDescriptor#Physical");
+    }
+
+    [Test]
+    public void It_should_not_emit_the_descriptor_fk_column_on_the_collection_item()
+    {
+        _result["addresses"]![0]!["AddressType_DescriptorId"].Should().BeNull();
+    }
+}
+
+[TestFixture]
 public class Given_DocumentReconstituter_PropertyOrderNode_Empty_Sentinel
 {
     private Exception _exception = null!;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationDescriptorResultTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationDescriptorResultTests.cs
@@ -118,6 +118,79 @@ public class Given_HydrationExecutor_With_Descriptor_Result_Sets
     }
 
     [Test]
+    public async Task It_executes_descriptor_projection_as_part_of_the_single_hydration_batch()
+    {
+        var descriptorPlans = new[]
+        {
+            new DescriptorProjectionPlan(
+                SelectByKeysetSql: "SELECT descriptor rows FROM root_descriptor;",
+                ResultShape: new DescriptorProjectionResultShape(DescriptorIdOrdinal: 0, UriOrdinal: 1),
+                SourcesInOrder: []
+            ),
+            new DescriptorProjectionPlan(
+                SelectByKeysetSql: "SELECT descriptor rows FROM child_descriptor;",
+                ResultShape: new DescriptorProjectionResultShape(DescriptorIdOrdinal: 0, UriOrdinal: 1),
+                SourcesInOrder: []
+            ),
+        };
+
+        var command = new RecordingDbCommand(
+            HydrationDescriptorResultTestHelper.CreateReader(
+                CreateDocumentMetadataTable(
+                    (
+                        42L,
+                        Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"),
+                        44L,
+                        45L,
+                        new DateTimeOffset(2026, 4, 2, 12, 0, 0, TimeSpan.Zero),
+                        new DateTimeOffset(2026, 4, 2, 12, 1, 0, TimeSpan.Zero)
+                    )
+                ),
+                CreateRootTableRows((42L, 255901)),
+                CreateChildTableRows((100L, 42L, 0, "Springfield")),
+                CreateDescriptorRowsTableWithDescriptorIdFirst(
+                    (301L, "uri://ed-fi.org/SchoolTypeDescriptor#Charter")
+                ),
+                CreateDescriptorRowsTableWithDescriptorIdFirst(
+                    (401L, "uri://ed-fi.org/AddressTypeDescriptor#Home")
+                )
+            )
+        );
+
+        var connection = new RecordingDbConnection(command);
+
+        await HydrationExecutor.ExecuteAsync(
+            connection,
+            BuildTestReadPlan(SqlDialect.Pgsql, descriptorPlans),
+            new PageKeysetSpec.Single(42L),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        command.ExecuteReaderCount.Should().Be(1);
+
+        var commandText = command.CommandText;
+        var rootTableIndex = commandText.IndexOf("SELECT root columns FROM root;", StringComparison.Ordinal);
+        var childTableIndex = commandText.IndexOf(
+            "SELECT child columns FROM child;",
+            StringComparison.Ordinal
+        );
+        var rootDescriptorIndex = commandText.IndexOf(
+            "SELECT descriptor rows FROM root_descriptor;",
+            StringComparison.Ordinal
+        );
+        var childDescriptorIndex = commandText.IndexOf(
+            "SELECT descriptor rows FROM child_descriptor;",
+            StringComparison.Ordinal
+        );
+
+        rootTableIndex.Should().BePositive();
+        childTableIndex.Should().BeGreaterThan(rootTableIndex);
+        rootDescriptorIndex.Should().BeGreaterThan(childTableIndex);
+        childDescriptorIndex.Should().BeGreaterThan(rootDescriptorIndex);
+    }
+
+    [Test]
     public async Task It_can_skip_descriptor_result_sets_when_projection_is_disabled()
     {
         var descriptorPlans = new[]
@@ -289,6 +362,8 @@ internal sealed class RecordingDbCommand(DbDataReader reader) : DbCommand
     private readonly DbDataReader _reader = reader ?? throw new ArgumentNullException(nameof(reader));
     private readonly RecordingDbParameterCollection _parameters = [];
 
+    public int ExecuteReaderCount { get; private set; }
+
     [AllowNull]
     public override string CommandText { get; set; } = string.Empty;
 
@@ -322,7 +397,11 @@ internal sealed class RecordingDbCommand(DbDataReader reader) : DbCommand
 
     protected override DbParameter CreateDbParameter() => new RecordingDbParameter();
 
-    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior) => _reader;
+    protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+    {
+        ExecuteReaderCount++;
+        return _reader;
+    }
 
     protected override Task<DbDataReader> ExecuteDbDataReaderAsync(
         CommandBehavior behavior,
@@ -330,6 +409,7 @@ internal sealed class RecordingDbCommand(DbDataReader reader) : DbCommand
     )
     {
         cancellationToken.ThrowIfCancellationRequested();
+        ExecuteReaderCount++;
         return Task.FromResult(_reader);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCollectionDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCollectionDescriptorProjectionTests.cs
@@ -1,0 +1,517 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Shared schema, model, and data constants for PostgreSQL integration tests that cover
+/// descriptor FK projection on a child (collection-item) table.
+/// The resource model is a "School" with a child "SchoolAddress" table
+/// that has an <c>AddressType_DescriptorId</c> nullable descriptor FK column.
+/// </summary>
+internal static class CollectionDescriptorProjectionFixture
+{
+    internal const string TestSchema = "colldescrprojtest";
+    internal const long SchoolDocumentId1 = 820L;
+    internal const long AddressCollectionItemId1 = 5001L;
+    internal const long AddressCollectionItemId2 = 5002L;
+    internal const long DescriptorId920 = 920L;
+    internal const long DescriptorId921 = 921L;
+    internal const string Uri920 = "uri://ed-fi.org/AddressTypeDescriptor#Physical";
+    internal const string Uri921 = "uri://ed-fi.org/AddressTypeDescriptor#Mailing";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName RootTableName = new(Schema, "School");
+    internal static readonly DbTableName ChildTableName = new(Schema, "SchoolAddress");
+
+    internal static readonly JsonPathExpression AddressTypeDescriptorPath = new(
+        "$.addresses[*].addressTypeDescriptor",
+        [
+            new JsonPathSegment.Property("addresses"),
+            new JsonPathSegment.AnyArrayElement(),
+            new JsonPathSegment.Property("addressTypeDescriptor"),
+        ]
+    );
+
+    internal static readonly QualifiedResourceName AddressTypeDescriptorResource = new(
+        "Ed-Fi",
+        "AddressTypeDescriptor"
+    );
+
+    internal static readonly DbColumnName AddressTypeFkColumn = new("AddressType_DescriptorId");
+
+    internal static DbTableModel BuildRootTableModel() =>
+        new(
+            Table: RootTableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                $"PK_{TestSchema}_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("SchoolId"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32),
+                    IsNullable: false,
+                    SourceJsonPath: new JsonPathExpression(
+                        "$.schoolId",
+                        [new JsonPathSegment.Property("schoolId")]
+                    ),
+                    TargetResource: null
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static DbTableModel BuildChildTableModel() =>
+        new(
+            Table: ChildTableName,
+            JsonScope: new JsonPathExpression(
+                "$.addresses[*]",
+                [new JsonPathSegment.Property("addresses"), new JsonPathSegment.AnyArrayElement()]
+            ),
+            Key: new TableKey(
+                $"PK_{TestSchema}_SchoolAddress",
+                [
+                    new DbKeyColumn(new DbColumnName("School_DocumentId"), ColumnKind.ParentKeyPart),
+                    new DbKeyColumn(new DbColumnName("Ordinal"), ColumnKind.Ordinal),
+                ]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("CollectionItemId"),
+                    Kind: ColumnKind.CollectionKey,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("School_DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Ordinal"),
+                    Kind: ColumnKind.Ordinal,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("City"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 100),
+                    IsNullable: false,
+                    SourceJsonPath: new JsonPathExpression(
+                        "$.addresses[*].city",
+                        [
+                            new JsonPathSegment.Property("addresses"),
+                            new JsonPathSegment.AnyArrayElement(),
+                            new JsonPathSegment.Property("city"),
+                        ]
+                    ),
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: AddressTypeFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: AddressTypeDescriptorPath,
+                    TargetResource: AddressTypeDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Collection,
+                PhysicalRowIdentityColumns: [new DbColumnName("CollectionItemId")],
+                RootScopeLocatorColumns: [new DbColumnName("School_DocumentId")],
+                ImmediateParentScopeLocatorColumns: [new DbColumnName("School_DocumentId")],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var rootTable = BuildRootTableModel();
+        var childTable = BuildChildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "School"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable, childTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: AddressTypeDescriptorPath,
+                    Table: ChildTableName,
+                    FkColumn: AddressTypeFkColumn,
+                    DescriptorResource: AddressTypeDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static async Task ProvisionSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            CREATE SCHEMA IF NOT EXISTS dms;
+            DROP SCHEMA IF EXISTS "{TestSchema}" CASCADE;
+            CREATE SCHEMA "{TestSchema}";
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE "{TestSchema}"."School" (
+                "DocumentId" bigint PRIMARY KEY,
+                "SchoolId" int NOT NULL
+            );
+
+            CREATE TABLE "{TestSchema}"."SchoolAddress" (
+                "CollectionItemId" bigint PRIMARY KEY,
+                "School_DocumentId" bigint NOT NULL,
+                "Ordinal" int NOT NULL,
+                "City" varchar(100) NOT NULL,
+                "AddressType_DescriptorId" bigint NULL
+            );
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task InsertTestDataAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" IN ({DescriptorId920}, {DescriptorId921});
+            DELETE FROM dms."Document" WHERE "DocumentId" IN ({SchoolDocumentId1});
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId", "ContentVersion", "IdentityVersion") VALUES
+                ({SchoolDocumentId1}, '82000000-0000-0000-0000-000000000820', 0, 1, 1);
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Namespace", "CodeValue", "ShortDescription", "Discriminator", "Uri") VALUES
+                ({DescriptorId920}, 'uri://ed-fi.org/AddressTypeDescriptor', 'Physical', 'Physical', 'edfi.AddressTypeDescriptor', '{Uri920}'),
+                ({DescriptorId921}, 'uri://ed-fi.org/AddressTypeDescriptor', 'Mailing', 'Mailing', 'edfi.AddressTypeDescriptor', '{Uri921}');
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task DropSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DROP SCHEMA IF EXISTS "{TestSchema}" CASCADE;
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" IN ({DescriptorId920}, {DescriptorId921});
+            DELETE FROM dms."Document" WHERE "DocumentId" IN ({SchoolDocumentId1});
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Verifies that a descriptor FK on a collection-item (child table) row is resolved to a URI
+/// and projected into the reconstituted JSON document at the correct array-element path,
+/// exercising the full database-backed hydrate + project + reconstitute pipeline.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Collection_Item_Descriptor_FK_Resolves_To_URI_Postgresql
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await CollectionDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await CollectionDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Insert root document
+        await using var insertRootCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{CollectionDescriptorProjectionFixture.TestSchema}"."School"
+                ("DocumentId", "SchoolId")
+            VALUES
+                ({CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 255901);
+            """,
+            setupConn
+        );
+        await insertRootCmd.ExecuteNonQueryAsync();
+
+        // Insert two collection items with descriptor FKs
+        await using var insertChildCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{CollectionDescriptorProjectionFixture.TestSchema}"."SchoolAddress"
+                ("CollectionItemId", "School_DocumentId", "Ordinal", "City", "AddressType_DescriptorId")
+            VALUES
+                ({CollectionDescriptorProjectionFixture.AddressCollectionItemId1},
+                 {CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 0, 'Grand Bend',
+                 {CollectionDescriptorProjectionFixture.DescriptorId920}),
+                ({CollectionDescriptorProjectionFixture.AddressCollectionItemId2},
+                 {CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 1, 'Austin',
+                 {CollectionDescriptorProjectionFixture.DescriptorId921});
+            """,
+            setupConn
+        );
+        await insertChildCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = CollectionDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(CollectionDescriptorProjectionFixture.SchoolDocumentId1),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            CollectionDescriptorProjectionFixture.SchoolDocumentId1,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await CollectionDescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_emits_the_addresses_array()
+    {
+        _reconstitutedDocument["addresses"].Should().NotBeNull();
+        _reconstitutedDocument["addresses"]!.AsArray().Should().HaveCount(2);
+    }
+
+    [Test]
+    public void It_emits_the_first_address_descriptor_uri()
+    {
+        _reconstitutedDocument["addresses"]![0]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(CollectionDescriptorProjectionFixture.Uri920);
+    }
+
+    [Test]
+    public void It_emits_the_second_address_descriptor_uri()
+    {
+        _reconstitutedDocument["addresses"]![1]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(CollectionDescriptorProjectionFixture.Uri921);
+    }
+
+    [Test]
+    public void It_emits_the_scalar_city_on_the_first_address()
+    {
+        _reconstitutedDocument["addresses"]![0]!["city"]!.GetValue<string>().Should().Be("Grand Bend");
+    }
+
+    [Test]
+    public void It_does_not_expose_the_raw_descriptor_fk_column()
+    {
+        _reconstitutedDocument["addresses"]![0]!["AddressType_DescriptorId"].Should().BeNull();
+        _reconstitutedDocument["addresses"]![1]!["AddressType_DescriptorId"].Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that a null descriptor FK on a collection-item row causes the descriptor property
+/// to be omitted from that array element in the reconstituted JSON.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Collection_Item_Null_Descriptor_FK_Omits_Property_Postgresql
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await CollectionDescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await CollectionDescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertRootCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{CollectionDescriptorProjectionFixture.TestSchema}"."School"
+                ("DocumentId", "SchoolId")
+            VALUES
+                ({CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 255901);
+            """,
+            setupConn
+        );
+        await insertRootCmd.ExecuteNonQueryAsync();
+
+        // Insert one collection item with a non-null descriptor and one with NULL
+        await using var insertChildCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{CollectionDescriptorProjectionFixture.TestSchema}"."SchoolAddress"
+                ("CollectionItemId", "School_DocumentId", "Ordinal", "City", "AddressType_DescriptorId")
+            VALUES
+                ({CollectionDescriptorProjectionFixture.AddressCollectionItemId1},
+                 {CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 0, 'Grand Bend',
+                 {CollectionDescriptorProjectionFixture.DescriptorId920}),
+                ({CollectionDescriptorProjectionFixture.AddressCollectionItemId2},
+                 {CollectionDescriptorProjectionFixture.SchoolDocumentId1}, 1, 'Austin',
+                 NULL);
+            """,
+            setupConn
+        );
+        await insertChildCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = CollectionDescriptorProjectionFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(CollectionDescriptorProjectionFixture.SchoolDocumentId1),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            CollectionDescriptorProjectionFixture.SchoolDocumentId1,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await CollectionDescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_emits_the_descriptor_uri_on_the_non_null_collection_item()
+    {
+        _reconstitutedDocument["addresses"]![0]!["addressTypeDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(CollectionDescriptorProjectionFixture.Uri920);
+    }
+
+    [Test]
+    public void It_omits_the_descriptor_property_on_the_null_collection_item()
+    {
+        _reconstitutedDocument["addresses"]![1]!["addressTypeDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_still_emits_the_scalar_city_on_both_items()
+    {
+        _reconstitutedDocument["addresses"]![0]!["city"]!.GetValue<string>().Should().Be("Grand Bend");
+        _reconstitutedDocument["addresses"]![1]!["city"]!.GetValue<string>().Should().Be("Austin");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionAliasTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionAliasTests.cs
@@ -1,0 +1,450 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Shared schema, model, and data constants for the key-unified descriptor alias projection tests.
+/// </summary>
+/// <remarks>
+/// Uses schema <c>"descprojaliasinttest"</c>, table <c>"UnifiedAliasResource"</c> with:
+/// <list type="bullet">
+/// <item><c>DocumentId bigint PRIMARY KEY</c></item>
+/// <item><c>Canonical_DescriptorId bigint NULL</c> — physical storage column (no SourceJsonPath)</item>
+/// <item><c>Alias1_DescriptorId bigint GENERATED ALWAYS AS ("Canonical_DescriptorId") STORED</c> — first alias ($.subject1Descriptor)</item>
+/// <item><c>Alias2_DescriptorId bigint GENERATED ALWAYS AS ("Canonical_DescriptorId") STORED</c> — second alias ($.subject2Descriptor)</item>
+/// </list>
+/// DocumentIds 820–821 and DescriptorId 920 are reserved for these fixtures.
+/// </remarks>
+internal static class DescriptorProjectionAliasFixture
+{
+    internal const string TestSchema = "descprojaliasinttest";
+    internal const long DocumentId820 = 820L;
+    internal const long DocumentId821 = 821L;
+    internal const long DescriptorId920 = 920L;
+    internal const string Uri920 = "uri://ed-fi.org/SubjectDescriptor#Mathematics";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName TableName = new(Schema, "UnifiedAliasResource");
+
+    internal static readonly DbColumnName CanonicalFkColumn = new("Canonical_DescriptorId");
+    internal static readonly DbColumnName Alias1FkColumn = new("Alias1_DescriptorId");
+    internal static readonly DbColumnName Alias2FkColumn = new("Alias2_DescriptorId");
+
+    internal static readonly JsonPathExpression Subject1DescriptorPath = new(
+        "$.subject1Descriptor",
+        [new JsonPathSegment.Property("subject1Descriptor")]
+    );
+
+    internal static readonly JsonPathExpression Subject2DescriptorPath = new(
+        "$.subject2Descriptor",
+        [new JsonPathSegment.Property("subject2Descriptor")]
+    );
+
+    internal static readonly QualifiedResourceName SubjectDescriptorResource = new(
+        "Ed-Fi",
+        "SubjectDescriptor"
+    );
+
+    /// <summary>
+    /// Builds a <see cref="DbTableModel"/> where the descriptor FK column is a
+    /// <see cref="ColumnStorage.UnifiedAlias"/> pointing to a canonical storage column.
+    /// Column layout (ordinals):
+    /// <list type="number">
+    /// <item>0: DocumentId (ParentKeyPart, Stored)</item>
+    /// <item>1: Canonical_DescriptorId (DescriptorFk, Stored, no SourceJsonPath)</item>
+    /// <item>2: Alias1_DescriptorId (DescriptorFk, UnifiedAlias → Canonical, SourceJsonPath=$.subject1Descriptor)</item>
+    /// <item>3: Alias2_DescriptorId (DescriptorFk, UnifiedAlias → Canonical, SourceJsonPath=$.subject2Descriptor)</item>
+    /// </list>
+    /// </summary>
+    internal static DbTableModel BuildTableModel() =>
+        new(
+            Table: TableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                "PK_descprojaliasinttest_UnifiedAliasResource",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: CanonicalFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: null,
+                    TargetResource: SubjectDescriptorResource
+                ),
+                new DbColumnModel(
+                    ColumnName: Alias1FkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: Subject1DescriptorPath,
+                    TargetResource: SubjectDescriptorResource,
+                    Storage: new ColumnStorage.UnifiedAlias(CanonicalFkColumn, PresenceColumn: null)
+                ),
+                new DbColumnModel(
+                    ColumnName: Alias2FkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: Subject2DescriptorPath,
+                    TargetResource: SubjectDescriptorResource,
+                    Storage: new ColumnStorage.UnifiedAlias(CanonicalFkColumn, PresenceColumn: null)
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    /// <summary>
+    /// Builds a <see cref="RelationalResourceModel"/> with two <see cref="DescriptorEdgeSource"/>
+    /// entries, both resolving through <see cref="ColumnStorage.UnifiedAlias"/> to the same
+    /// canonical storage column.
+    /// </summary>
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var tableModel = BuildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "UnifiedAliasResource"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: tableModel,
+            TablesInDependencyOrder: [tableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: Subject1DescriptorPath,
+                    Table: TableName,
+                    FkColumn: Alias1FkColumn,
+                    DescriptorResource: SubjectDescriptorResource
+                ),
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: Subject2DescriptorPath,
+                    Table: TableName,
+                    FkColumn: Alias2FkColumn,
+                    DescriptorResource: SubjectDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static async Task ProvisionSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DROP SCHEMA IF EXISTS {TestSchema} CASCADE;
+            CREATE SCHEMA {TestSchema};
+            CREATE SCHEMA IF NOT EXISTS dms;
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {TestSchema}."UnifiedAliasResource" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Canonical_DescriptorId" bigint NULL,
+                "Alias1_DescriptorId" bigint GENERATED ALWAYS AS ("Canonical_DescriptorId") STORED,
+                "Alias2_DescriptorId" bigint GENERATED ALWAYS AS ("Canonical_DescriptorId") STORED
+            );
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task InsertSharedDescriptorDataAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" = 920;
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (820, 821);
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId", "ContentVersion", "IdentityVersion") VALUES
+                (820, '82000000-0000-0000-0000-000000000820', 0, 1, 1),
+                (821, '82100000-0000-0000-0000-000000000821', 0, 1, 1);
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Namespace", "CodeValue", "ShortDescription", "Discriminator", "Uri") VALUES
+                (920, 'uri://ed-fi.org/SubjectDescriptor', 'Mathematics', 'Mathematics', 'edfi.SubjectDescriptor', '{Uri920}');
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task DropSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DROP SCHEMA IF EXISTS {TestSchema} CASCADE;
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" = 920;
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (820, 821);
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows for a plan whose SQL targets the canonical storage column
+/// return the correct descriptor URI, even though data was written through the alias FK column path.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Key_Unified_Alias_Descriptor_FK_Executor_Returns_URI_From_Canonical_Column
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionAliasFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionAliasFixture.InsertSharedDescriptorDataAsync(setupConn);
+
+        // Insert DocumentId=820 referencing Canonical_DescriptorId=920.
+        // Alias columns are GENERATED ALWAYS AS and will automatically carry 920.
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionAliasFixture.TestSchema}."UnifiedAliasResource"
+                ("DocumentId", "Canonical_DescriptorId")
+            VALUES
+                ({DescriptorProjectionAliasFixture.DocumentId820}, {DescriptorProjectionAliasFixture.DescriptorId920});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        // Compile a real plan using ReadPlanCompiler so the SQL targets the canonical column.
+        var resourceModel = DescriptorProjectionAliasFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionAliasFixture.DocumentId820),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        _lookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionAliasFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_non_empty_lookup()
+    {
+        _lookup.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_the_canonical_descriptor_id_to_the_correct_uri()
+    {
+        _lookup[DescriptorProjectionAliasFixture.DescriptorId920]
+            .Should()
+            .Be(DescriptorProjectionAliasFixture.Uri920);
+    }
+
+    [Test]
+    public void It_contains_exactly_one_entry_for_the_single_canonical_descriptor()
+    {
+        _lookup.Should().HaveCount(1);
+    }
+}
+
+/// <summary>
+/// Verifies that the full hydrate + descriptor reconstitution pipeline correctly emits URI
+/// strings at both alias descriptor JSON paths when the canonical FK column is set, and
+/// omits both paths when the canonical FK column is NULL.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Key_Unified_Alias_Descriptor_FK_Full_Pipeline_Emits_URIs_At_Alias_Paths
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedWithDescriptor = null!;
+    private JsonNode _reconstitutedWithNullDescriptor = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionAliasFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionAliasFixture.InsertSharedDescriptorDataAsync(setupConn);
+
+        // DocumentId=820: Canonical_DescriptorId=920 → aliases get 920 via GENERATED.
+        // DocumentId=821: Canonical_DescriptorId=NULL → aliases get NULL via GENERATED.
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionAliasFixture.TestSchema}."UnifiedAliasResource"
+                ("DocumentId", "Canonical_DescriptorId")
+            VALUES
+                ({DescriptorProjectionAliasFixture.DocumentId820}, {DescriptorProjectionAliasFixture.DescriptorId920}),
+                ({DescriptorProjectionAliasFixture.DocumentId821}, NULL);
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = DescriptorProjectionAliasFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        _reconstitutedWithDescriptor = await RunPipelineAsync(
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionAliasFixture.DocumentId820),
+            DescriptorProjectionAliasFixture.DocumentId820
+        );
+
+        _reconstitutedWithNullDescriptor = await RunPipelineAsync(
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionAliasFixture.DocumentId821),
+            DescriptorProjectionAliasFixture.DocumentId821
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionAliasFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_emits_subject1Descriptor_uri_at_alias1_path_when_canonical_is_set()
+    {
+        _reconstitutedWithDescriptor["subject1Descriptor"]
+            ?.GetValue<string>()
+            .Should()
+            .Be(DescriptorProjectionAliasFixture.Uri920);
+    }
+
+    [Test]
+    public void It_emits_subject2Descriptor_uri_at_alias2_path_when_canonical_is_set()
+    {
+        _reconstitutedWithDescriptor["subject2Descriptor"]
+            ?.GetValue<string>()
+            .Should()
+            .Be(DescriptorProjectionAliasFixture.Uri920);
+    }
+
+    [Test]
+    public void It_omits_subject1Descriptor_path_when_canonical_is_null()
+    {
+        _reconstitutedWithNullDescriptor["subject1Descriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_omits_subject2Descriptor_path_when_canonical_is_null()
+    {
+        _reconstitutedWithNullDescriptor["subject2Descriptor"].Should().BeNull();
+    }
+
+    private async Task<JsonNode> RunPipelineAsync(
+        ResourceReadPlan readPlan,
+        PageKeysetSpec keyset,
+        long documentId
+    )
+    {
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        await using var tx = await execConn.BeginTransactionAsync();
+
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Pgsql,
+            tx,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        var reconstituted = DocumentReconstituter.Reconstitute(
+            documentId: documentId,
+            tableRowsInDependencyOrder: hydratedPage.TableRowsInDependencyOrder,
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup: descriptorUriLookup
+        );
+
+        await tx.RollbackAsync();
+        return reconstituted;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionPipelineTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionPipelineTests.cs
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Shared schema, model, and data constants for PostgreSQL descriptor projection integration tests
+/// that cover a resource with both required and optional descriptor foreign keys.
+/// </summary>
+internal static class DescriptorProjectionPipelineFixture
+{
+    internal const string TestSchema = "descprojpipelinetest";
+    internal const long DocumentId810 = 810L;
+    internal const long DocumentId811 = 811L;
+    internal const long DescriptorId910 = 910L;
+    internal const long DescriptorId911 = 911L;
+    internal const string Uri910 = "uri://ed-fi.org/AcademicSubjectDescriptor#English Language Arts";
+    internal const string Uri911 = "uri://ed-fi.org/InstructionLanguageDescriptor#English";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName TableName = new(Schema, "CourseOffering");
+
+    internal static readonly JsonPathExpression AcademicSubjectDescriptorPath = new(
+        "$.academicSubjectDescriptor",
+        [new JsonPathSegment.Property("academicSubjectDescriptor")]
+    );
+
+    internal static readonly JsonPathExpression InstructionLanguageDescriptorPath = new(
+        "$.instructionLanguageDescriptor",
+        [new JsonPathSegment.Property("instructionLanguageDescriptor")]
+    );
+
+    internal static readonly QualifiedResourceName AcademicSubjectDescriptorResource = new(
+        "Ed-Fi",
+        "AcademicSubjectDescriptor"
+    );
+
+    internal static readonly QualifiedResourceName InstructionLanguageDescriptorResource = new(
+        "Ed-Fi",
+        "InstructionLanguageDescriptor"
+    );
+
+    internal static readonly DbColumnName AcademicSubjectFkColumn = new(
+        "AcademicSubjectDescriptor_DescriptorId"
+    );
+
+    internal static readonly DbColumnName InstructionLanguageFkColumn = new(
+        "InstructionLanguageDescriptor_DescriptorId"
+    );
+
+    internal static RelationalResourceModel BuildResourceModel()
+    {
+        var tableModel = BuildTableModel();
+        return new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "CourseOffering"),
+            PhysicalSchema: Schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: tableModel,
+            TablesInDependencyOrder: [tableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: AcademicSubjectDescriptorPath,
+                    Table: TableName,
+                    FkColumn: AcademicSubjectFkColumn,
+                    DescriptorResource: AcademicSubjectDescriptorResource
+                ),
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: InstructionLanguageDescriptorPath,
+                    Table: TableName,
+                    FkColumn: InstructionLanguageFkColumn,
+                    DescriptorResource: InstructionLanguageDescriptorResource
+                ),
+            ]
+        );
+    }
+
+    internal static DbTableModel BuildTableModel() =>
+        new(
+            Table: TableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                "PK_descprojpipelinetest_CourseOffering",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: AcademicSubjectFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: AcademicSubjectDescriptorPath,
+                    TargetResource: AcademicSubjectDescriptorResource
+                ),
+                new DbColumnModel(
+                    ColumnName: InstructionLanguageFkColumn,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: InstructionLanguageDescriptorPath,
+                    TargetResource: InstructionLanguageDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static async Task ProvisionSchemaAsync(NpgsqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            CREATE SCHEMA IF NOT EXISTS dms;
+            DROP SCHEMA IF EXISTS "{TestSchema}" CASCADE;
+            CREATE SCHEMA IF NOT EXISTS "{TestSchema}";
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE "{TestSchema}"."CourseOffering" (
+                "DocumentId" bigint PRIMARY KEY,
+                "AcademicSubjectDescriptor_DescriptorId" bigint NOT NULL,
+                "InstructionLanguageDescriptor_DescriptorId" bigint NULL
+            );
+            """
+        );
+    }
+
+    internal static async Task DropSchemaAsync(NpgsqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            DROP SCHEMA IF EXISTS "{TestSchema}" CASCADE;
+
+            DELETE FROM dms."Descriptor"
+            WHERE "DocumentId" IN ({DescriptorId910}, {DescriptorId911});
+
+            DELETE FROM dms."Document"
+            WHERE "DocumentId" IN ({DocumentId810}, {DocumentId811});
+            """
+        );
+    }
+
+    internal static async Task InsertTestDataAsync(NpgsqlConnection connection)
+    {
+        await ExecuteSqlAsync(
+            connection,
+            $"""
+            DELETE FROM dms."Descriptor"
+            WHERE "DocumentId" IN ({DescriptorId910}, {DescriptorId911});
+
+            DELETE FROM dms."Document"
+            WHERE "DocumentId" IN ({DocumentId810}, {DocumentId811});
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId", "ContentVersion", "IdentityVersion") VALUES
+                ({DocumentId810}, '81000000-0000-0000-0000-000000000810', 0, 1, 1),
+                ({DocumentId811}, '81100000-0000-0000-0000-000000000811', 0, 1, 1);
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Namespace", "CodeValue", "ShortDescription", "Discriminator", "Uri") VALUES
+                ({DescriptorId910}, 'uri://ed-fi.org/AcademicSubjectDescriptor', 'English Language Arts', 'English Language Arts', 'edfi.AcademicSubjectDescriptor', '{Uri910}'),
+                ({DescriptorId911}, 'uri://ed-fi.org/InstructionLanguageDescriptor', 'English', 'English', 'edfi.InstructionLanguageDescriptor', '{Uri911}');
+            """
+        );
+    }
+
+    private static async Task ExecuteSqlAsync(NpgsqlConnection connection, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Postgresql_Reconstitution_With_Both_Descriptor_Fks_Set
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionPipelineFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionPipelineFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{DescriptorProjectionPipelineFixture.TestSchema}"."CourseOffering"
+                ("DocumentId", "AcademicSubjectDescriptor_DescriptorId", "InstructionLanguageDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionPipelineFixture.DocumentId810},
+                 {DescriptorProjectionPipelineFixture.DescriptorId910},
+                 {DescriptorProjectionPipelineFixture.DescriptorId911});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = DescriptorProjectionPipelineFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionPipelineFixture.DocumentId810),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            DescriptorProjectionPipelineFixture.DocumentId810,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionPipelineFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_document()
+    {
+        _reconstitutedDocument.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_emits_the_required_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["academicSubjectDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(DescriptorProjectionPipelineFixture.Uri910);
+    }
+
+    [Test]
+    public void It_emits_the_optional_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["instructionLanguageDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(DescriptorProjectionPipelineFixture.Uri911);
+    }
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Postgresql_Reconstitution_With_Optional_Descriptor_Fk_Null
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionPipelineFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionPipelineFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO "{DescriptorProjectionPipelineFixture.TestSchema}"."CourseOffering"
+                ("DocumentId", "AcademicSubjectDescriptor_DescriptorId", "InstructionLanguageDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionPipelineFixture.DocumentId811},
+                 {DescriptorProjectionPipelineFixture.DescriptorId910},
+                 NULL);
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var resourceModel = DescriptorProjectionPipelineFixture.BuildResourceModel();
+        var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(resourceModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionPipelineFixture.DocumentId811),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            DescriptorProjectionPipelineFixture.DocumentId811,
+            hydratedPage.TableRowsInDependencyOrder,
+            readPlan.ReferenceIdentityProjectionPlansInDependencyOrder,
+            readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionPipelineFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_document()
+    {
+        _reconstitutedDocument.Should().NotBeNull();
+    }
+
+    [Test]
+    public void It_emits_the_required_descriptor_uri_at_the_correct_json_path()
+    {
+        var doc = _reconstitutedDocument.AsObject();
+        doc["academicSubjectDescriptor"]
+            .Should()
+            .NotBeNull()
+            .And.Subject.As<JsonValue>()
+            .GetValue<string>()
+            .Should()
+            .Be(DescriptorProjectionPipelineFixture.Uri910);
+    }
+
+    [Test]
+    public void It_does_not_emit_the_optional_descriptor_property_key()
+    {
+        _reconstitutedDocument.AsObject()["instructionLanguageDescriptor"].Should().BeNull();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorProjectionTests.cs
@@ -1,0 +1,775 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Integration tests for descriptor projection SQL execution against a live PostgreSQL database.
+/// All test fixtures share a common schema <c>"descprojtest"</c> with a minimal
+/// <c>"StudentSchoolAssociation"</c> table that has one nullable descriptor FK column.
+/// </summary>
+/// <remarks>
+/// DocumentIds 700–703 and DescriptorIds 901–903 are reserved for these fixtures.
+/// The dms."Descriptor" table is expected to exist (created by DatabaseSetupFixture or DDL migration).
+/// </remarks>
+internal static class DescriptorProjectionFixture
+{
+    internal const string TestSchema = "descprojtest";
+    internal const long DocumentId700 = 700L;
+    internal const long DocumentId701 = 701L;
+    internal const long DocumentId702 = 702L;
+    internal const long DocumentId703 = 703L;
+    internal const long DescriptorId901 = 901L;
+    internal const long DescriptorId902 = 902L;
+    internal const long DescriptorId903 = 903L;
+    internal const string Uri901 = "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade";
+    internal const string Uri902 = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+    internal const string Uri903 = "uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade";
+
+    internal static readonly DbSchemaName Schema = new(TestSchema);
+    internal static readonly DbTableName TableName = new(Schema, "StudentSchoolAssociation");
+
+    internal static readonly JsonPathExpression GradeLevelDescriptorPath = new(
+        "$.gradeLevelDescriptor",
+        [new JsonPathSegment.Property("gradeLevelDescriptor")]
+    );
+
+    internal static readonly QualifiedResourceName GradeLevelDescriptorResource = new(
+        "Ed-Fi",
+        "GradeLevelDescriptor"
+    );
+
+    internal static readonly DbColumnName FkColumnName = new("GradeLevelDescriptor_DescriptorId");
+
+    /// <summary>
+    /// Builds the descriptor projection plan SQL for the test schema.
+    /// The SQL uses the "page" keyset temp table (Postgresql dialect).
+    /// </summary>
+    internal static DescriptorProjectionPlan BuildDescriptorProjectionPlan() =>
+        new(
+            SelectByKeysetSql: $"""
+            SELECT
+                p."DescriptorId",
+                d."Uri"
+            FROM
+                (
+                    SELECT DISTINCT t0."{FkColumnName.Value}" AS "DescriptorId"
+                    FROM "{TestSchema}"."StudentSchoolAssociation" t0
+                    INNER JOIN "page" k ON t0."DocumentId" = k."DocumentId"
+                    WHERE t0."{FkColumnName.Value}" IS NOT NULL
+                ) p
+            INNER JOIN "dms"."Descriptor" d ON d."DocumentId" = p."DescriptorId"
+            ORDER BY
+                p."DescriptorId" ASC
+            ;
+
+            """,
+            ResultShape: new DescriptorProjectionResultShape(DescriptorIdOrdinal: 0, UriOrdinal: 1),
+            SourcesInOrder:
+            [
+                new DescriptorProjectionSource(
+                    DescriptorValuePath: GradeLevelDescriptorPath,
+                    Table: TableName,
+                    DescriptorResource: GradeLevelDescriptorResource,
+                    DescriptorIdColumnOrdinal: 1
+                ),
+            ]
+        );
+
+    internal static DbTableModel BuildTableModel() =>
+        new(
+            Table: TableName,
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                "PK_descprojtest_StudentSchoolAssociation",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: FkColumnName,
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: GradeLevelDescriptorPath,
+                    TargetResource: GradeLevelDescriptorResource
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    internal static ResourceReadPlan BuildReadPlan(DbTableModel tableModel) =>
+        new(
+            Model: new RelationalResourceModel(
+                Resource: new QualifiedResourceName("Ed-Fi", "StudentSchoolAssociation"),
+                PhysicalSchema: Schema,
+                StorageKind: ResourceStorageKind.RelationalTables,
+                Root: tableModel,
+                TablesInDependencyOrder: [tableModel],
+                DocumentReferenceBindings: [],
+                DescriptorEdgeSources:
+                [
+                    new DescriptorEdgeSource(
+                        IsIdentityComponent: false,
+                        DescriptorValuePath: GradeLevelDescriptorPath,
+                        Table: TableName,
+                        FkColumn: FkColumnName,
+                        DescriptorResource: GradeLevelDescriptorResource
+                    ),
+                ]
+            ),
+            KeysetTable: KeysetTableConventions.GetKeysetTableContract(SqlDialect.Pgsql),
+            TablePlansInDependencyOrder:
+            [
+                new TableReadPlan(
+                    TableModel: tableModel,
+                    SelectByKeysetSql: $"""
+                    SELECT
+                        r."DocumentId",
+                        r."{FkColumnName.Value}"
+                    FROM "{TestSchema}"."StudentSchoolAssociation" r
+                    INNER JOIN "page" k ON r."DocumentId" = k."DocumentId"
+                    ORDER BY
+                        r."DocumentId" ASC
+                    ;
+
+                    """
+                ),
+            ],
+            ReferenceIdentityProjectionPlansInDependencyOrder: [],
+            DescriptorProjectionPlansInOrder: [BuildDescriptorProjectionPlan()]
+        );
+
+    internal static async Task ProvisionSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DROP SCHEMA IF EXISTS {TestSchema} CASCADE;
+            CREATE SCHEMA {TestSchema};
+            CREATE SCHEMA IF NOT EXISTS dms;
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {TestSchema}."StudentSchoolAssociation" (
+                "DocumentId" bigint PRIMARY KEY,
+                "GradeLevelDescriptor_DescriptorId" bigint NULL
+            );
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task InsertTestDataAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" IN (901, 902, 903);
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (700, 701, 702, 703);
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId", "ContentVersion", "IdentityVersion") VALUES
+                (700, '70000000-0000-0000-0000-000000000700', 0, 1, 1),
+                (701, '70100000-0000-0000-0000-000000000701', 0, 1, 1),
+                (702, '70200000-0000-0000-0000-000000000702', 0, 1, 1),
+                (703, '70300000-0000-0000-0000-000000000703', 0, 1, 1);
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Namespace", "CodeValue", "ShortDescription", "Discriminator", "Uri") VALUES
+                (901, 'uri://ed-fi.org/GradeLevelDescriptor', 'Ninth grade', 'Ninth grade', 'edfi.GradeLevelDescriptor', '{Uri901}'),
+                (902, 'uri://ed-fi.org/GradeLevelDescriptor', 'Tenth grade', 'Tenth grade', 'edfi.GradeLevelDescriptor', '{Uri902}'),
+                (903, 'uri://ed-fi.org/GradeLevelDescriptor', 'Eleventh grade', 'Eleventh grade', 'edfi.GradeLevelDescriptor', '{Uri903}');
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task DropSchemaAsync(NpgsqlConnection connection)
+    {
+        await using var cmd = new NpgsqlCommand(
+            $"""
+            DROP SCHEMA IF EXISTS {TestSchema} CASCADE;
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" IN (901, 902, 903);
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (700, 701, 702, 703);
+            """,
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows return the correct URI string for a non-null
+/// required descriptor FK column.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Required_Descriptor_FK_Resolves_To_URI
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId700}, {DescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var tableModel = DescriptorProjectionFixture.BuildTableModel();
+        var readPlan = DescriptorProjectionFixture.BuildReadPlan(tableModel);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            new PageKeysetSpec.Single(DescriptorProjectionFixture.DocumentId700),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        _lookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_non_empty_lookup()
+    {
+        _lookup.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public void It_resolves_the_descriptor_id_to_the_correct_uri()
+    {
+        _lookup[DescriptorProjectionFixture.DescriptorId901].Should().Be(DescriptorProjectionFixture.Uri901);
+    }
+
+    [Test]
+    public void It_stores_the_uri_exactly_as_in_dms_Descriptor()
+    {
+        _lookup[DescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be("uri://ed-fi.org/GradeLevelDescriptor#Ninth grade");
+    }
+}
+
+/// <summary>
+/// Verifies that a null descriptor FK causes the descriptor property to be absent from the
+/// reconstituted JSON document (no JSON null emitted, no missing-URI exception).
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Null_Descriptor_FK_Omits_Property_From_Reconstituted_Document
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Document 701 has a NULL descriptor FK
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId701}, NULL);
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var tableModel = DescriptorProjectionFixture.BuildTableModel();
+        var readPlan = DescriptorProjectionFixture.BuildReadPlan(tableModel);
+        var keyset = new PageKeysetSpec.Single(DescriptorProjectionFixture.DocumentId701);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            documentId: DescriptorProjectionFixture.DocumentId701,
+            tableRowsInDependencyOrder: hydratedPage.TableRowsInDependencyOrder,
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup: descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_does_not_emit_the_descriptor_property_key()
+    {
+        _reconstitutedDocument["gradeLevelDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_does_not_emit_json_null_at_the_descriptor_path()
+    {
+        var gradeLevelDescriptor = _reconstitutedDocument["gradeLevelDescriptor"];
+        gradeLevelDescriptor.Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows return all distinct descriptor URIs for a page
+/// containing multiple documents and still deduplicate shared descriptors.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Page_With_Multiple_Documents_And_Distinct_Descriptors
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+    private IReadOnlyDictionary<long, string> _sharedDescriptorLookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Three documents each referencing a distinct descriptor
+        await using var insertDistinctCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId700}, {DescriptorProjectionFixture.DescriptorId901}),
+                ({DescriptorProjectionFixture.DocumentId701}, {DescriptorProjectionFixture.DescriptorId902}),
+                ({DescriptorProjectionFixture.DocumentId702}, {DescriptorProjectionFixture.DescriptorId903});
+            """,
+            setupConn
+        );
+        await insertDistinctCmd.ExecuteNonQueryAsync();
+
+        var tableModel = DescriptorProjectionFixture.BuildTableModel();
+        var readPlan = DescriptorProjectionFixture.BuildReadPlan(tableModel);
+
+        await using var distinctConn = await _dataSource.OpenConnectionAsync();
+        var distinctHydratedPage = await HydrationExecutor.ExecuteAsync(
+            distinctConn,
+            readPlan,
+            PostgresqlDescriptorProjectionPageKeysetHelper.CreatePageKeyset(
+                DescriptorProjectionFixture.TestSchema,
+                DescriptorProjectionFixture.DocumentId700,
+                DescriptorProjectionFixture.DocumentId701,
+                DescriptorProjectionFixture.DocumentId702
+            ),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        _lookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            distinctHydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        // --- shared descriptor run: 703 and 700 both reference descriptor 901 ---
+        await using var insertSharedCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId703}, {DescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertSharedCmd.ExecuteNonQueryAsync();
+
+        await using var sharedConn = await _dataSource.OpenConnectionAsync();
+        var sharedHydratedPage = await HydrationExecutor.ExecuteAsync(
+            sharedConn,
+            readPlan,
+            PostgresqlDescriptorProjectionPageKeysetHelper.CreatePageKeyset(
+                DescriptorProjectionFixture.TestSchema,
+                DescriptorProjectionFixture.DocumentId700,
+                DescriptorProjectionFixture.DocumentId703
+            ),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        _sharedDescriptorLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            sharedHydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_one_entry_per_distinct_descriptor_id_across_the_page()
+    {
+        _lookup.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void It_resolves_all_distinct_descriptor_uris()
+    {
+        _lookup[DescriptorProjectionFixture.DescriptorId901].Should().Be(DescriptorProjectionFixture.Uri901);
+        _lookup[DescriptorProjectionFixture.DescriptorId902].Should().Be(DescriptorProjectionFixture.Uri902);
+        _lookup[DescriptorProjectionFixture.DescriptorId903].Should().Be(DescriptorProjectionFixture.Uri903);
+    }
+
+    [Test]
+    public void It_deduplicates_to_one_entry_when_two_documents_share_the_same_descriptor()
+    {
+        _sharedDescriptorLookup.Should().HaveCount(1);
+        _sharedDescriptorLookup[DescriptorProjectionFixture.DescriptorId901]
+            .Should()
+            .Be(DescriptorProjectionFixture.Uri901);
+    }
+}
+
+/// <summary>
+/// Verifies that reconstituting a document whose descriptor FK was first set to a non-null value
+/// and then cleared to NULL correctly omits the descriptor property from the output.
+/// This specifically exercises the update-to-null path, which is distinct from an FK that
+/// was never populated.
+/// Task 3 (cleared-to-null acceptance case): PostgreSQL full pipeline.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Descriptor_FK_Cleared_To_Null_Omits_Property_From_Reconstituted_Document
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private JsonNode _reconstitutedDocument = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Insert document 702 with a non-null descriptor FK first
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId702}, {DescriptorProjectionFixture.DescriptorId901});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        // Simulate an update that clears the descriptor FK to NULL
+        await using var updateCmd = new NpgsqlCommand(
+            $"""
+            UPDATE {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+            SET "GradeLevelDescriptor_DescriptorId" = NULL
+            WHERE "DocumentId" = {DescriptorProjectionFixture.DocumentId702};
+            """,
+            setupConn
+        );
+        await updateCmd.ExecuteNonQueryAsync();
+
+        var tableModel = DescriptorProjectionFixture.BuildTableModel();
+        var readPlan = DescriptorProjectionFixture.BuildReadPlan(tableModel);
+        var keyset = new PageKeysetSpec.Single(DescriptorProjectionFixture.DocumentId702);
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        var descriptorUriLookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+
+        _reconstitutedDocument = DocumentReconstituter.Reconstitute(
+            documentId: DescriptorProjectionFixture.DocumentId702,
+            tableRowsInDependencyOrder: hydratedPage.TableRowsInDependencyOrder,
+            referenceProjectionPlans: [],
+            descriptorProjectionSources: readPlan.Model.DescriptorEdgeSources,
+            descriptorUriLookup: descriptorUriLookup
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_a_reconstituted_json_object()
+    {
+        _reconstitutedDocument.Should().BeOfType<JsonObject>();
+    }
+
+    [Test]
+    public void It_does_not_emit_the_descriptor_property_key()
+    {
+        _reconstitutedDocument["gradeLevelDescriptor"].Should().BeNull();
+    }
+}
+
+/// <summary>
+/// Verifies that hydrated descriptor rows correctly resolve all descriptor URIs when the page is
+/// materialized from a real <see cref="PageKeysetSpec.Query"/> via <see cref="HydrationExecutor"/>.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[NonParallelizable]
+public class Given_Multi_Document_Page_Created_Via_Query_Keyset_Returns_All_Descriptor_URIs
+{
+    private NpgsqlDataSource _dataSource = null!;
+    private IReadOnlyDictionary<long, string> _lookup = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var setupConn = await _dataSource.OpenConnectionAsync();
+        await DescriptorProjectionFixture.ProvisionSchemaAsync(setupConn);
+        await DescriptorProjectionFixture.InsertTestDataAsync(setupConn);
+
+        // Three documents each referencing a distinct descriptor
+        await using var insertCmd = new NpgsqlCommand(
+            $"""
+            INSERT INTO {DescriptorProjectionFixture.TestSchema}."StudentSchoolAssociation"
+                ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES
+                ({DescriptorProjectionFixture.DocumentId700}, {DescriptorProjectionFixture.DescriptorId901}),
+                ({DescriptorProjectionFixture.DocumentId701}, {DescriptorProjectionFixture.DescriptorId902}),
+                ({DescriptorProjectionFixture.DocumentId702}, {DescriptorProjectionFixture.DescriptorId903});
+            """,
+            setupConn
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        var tableModel = DescriptorProjectionFixture.BuildTableModel();
+        var readPlan = DescriptorProjectionFixture.BuildReadPlan(tableModel);
+
+        // Use a real query keyset so HydrationExecutor materializes the page from the query,
+        // not from a single-document INSERT.
+        var keyset = new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: $"""
+                SELECT r."DocumentId"
+                FROM "{DescriptorProjectionFixture.TestSchema}"."StudentSchoolAssociation" r
+                ORDER BY r."DocumentId"
+                LIMIT @limit OFFSET @offset
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                    new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?> { ["offset"] = 0L, ["limit"] = 25L }
+        );
+
+        await using var execConn = await _dataSource.OpenConnectionAsync();
+        var hydratedPage = await HydrationExecutor.ExecuteAsync(
+            execConn,
+            readPlan,
+            keyset,
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+        _lookup = PostgresqlDescriptorProjectionTestHelper.BuildDescriptorUriLookup(
+            hydratedPage.DescriptorRowsInPlanOrder
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var conn = await _dataSource.OpenConnectionAsync();
+            await DescriptorProjectionFixture.DropSchemaAsync(conn);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_one_entry_per_distinct_descriptor_id_across_the_page()
+    {
+        _lookup.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void It_resolves_all_three_descriptor_uris()
+    {
+        _lookup[DescriptorProjectionFixture.DescriptorId901].Should().Be(DescriptorProjectionFixture.Uri901);
+        _lookup[DescriptorProjectionFixture.DescriptorId902].Should().Be(DescriptorProjectionFixture.Uri902);
+        _lookup[DescriptorProjectionFixture.DescriptorId903].Should().Be(DescriptorProjectionFixture.Uri903);
+    }
+}
+
+internal static class PostgresqlDescriptorProjectionTestHelper
+{
+    internal static IReadOnlyDictionary<long, string> BuildDescriptorUriLookup(
+        IReadOnlyList<HydratedDescriptorRows> descriptorRowsInPlanOrder
+    )
+    {
+        Dictionary<long, string> lookup = [];
+
+        foreach (var descriptorRows in descriptorRowsInPlanOrder)
+        {
+            foreach (var row in descriptorRows.Rows)
+            {
+                lookup.TryAdd(row.DescriptorId, row.Uri);
+            }
+        }
+
+        return lookup;
+    }
+}
+
+internal static class PostgresqlDescriptorProjectionPageKeysetHelper
+{
+    internal static PageKeysetSpec.Query CreatePageKeyset(string schemaName, params long[] documentIds)
+    {
+        return new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: $"""
+                SELECT r."DocumentId"
+                FROM "{schemaName}"."StudentSchoolAssociation" r
+                WHERE r."DocumentId" IN ({string.Join(", ", documentIds)})
+                ORDER BY r."DocumentId"
+                """,
+                TotalCountSql: null,
+                PageParametersInOrder: [],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?>()
+        );
+    }
+}


### PR DESCRIPTION
**Note: The implementation of the Project Descriptor code was handled under DMS‑990.**

This pull request adds a comprehensive new test fixture to the `DocumentReconstituterTests.cs` file. The new tests specifically cover the scenario where a descriptor is present on a collection item, ensuring that JSON reconstitution correctly handles descriptor values and related fields for collection elements.

The most important changes are:

**New test coverage for descriptors on collection items:**

* Added the `Given_DocumentReconstituter_With_Descriptor_On_Collection_Item` test fixture, which sets up a scenario with a `School` root entity and a related `addresses` collection, including a descriptor reference (`addressTypeDescriptor`).
* Tests that the reconstituted JSON object:
  * Is of type `JsonObject`.
  * Emits an `addresses` array with one item.
  * Includes the correct `city` value on the address item.
  * Emits the correct `addressTypeDescriptor` URI on the collection item.
  * Does not emit the underlying descriptor foreign key column (`AddressType_DescriptorId`) on the collection item.