### PR TITLE
[DMS-1004] Serve `_etag`, `_lastModifiedDate`, and `ChangeVersion` from Stored Stamps

### DIFF
--- a/reference/design/backend-redesign/epics/10-update-tracking-change-queries/02-derived-metadata.md
+++ b/reference/design/backend-redesign/epics/10-update-tracking-change-queries/02-derived-metadata.md
@@ -9,9 +9,11 @@ jira_url: https://edfi.atlassian.net/browse/DMS-1004
 
 Implement serving of update-tracking metadata per `reference/design/backend-redesign/design-docs/update-tracking.md`:
 
-- `_etag` is derived from the stored representation stamp (`dms.Document.ContentVersion`).
+- `_etag` is derived from the canonical JSON form of the served response document:
+  remove `id`, `_etag`, and `_lastModifiedDate`, canonicalize object properties using ordinal ordering
+  while preserving array order, serialize as minified UTF-8, compute `SHA-256`, and encode as base64.
 - `_lastModifiedDate` is served from `dms.Document.ContentLastModifiedAt`.
-- `ChangeVersion` is served from `dms.Document.ContentVersion`.
+- `ChangeVersion` is established from `dms.Document.ContentVersion` for Change Query responses.
 
 This design performs no dependency enumeration at read time; indirect impacts are materialized as FK cascade updates that trigger normal stamping.
 
@@ -19,10 +21,12 @@ This design performs no dependency enumeration at read time; indirect impacts ar
 
 - `_etag` changes when the served representation changes (direct content changes or indirect reference-identity changes).
 - `_lastModifiedDate` changes when the served representation changes.
-- `ChangeVersion` matches the served representation stamp.
+- `ChangeVersion` matches the served representation stamp when surfaced by Change Query responses.
 - Reads do not perform dependency token expansion.
 
 ## Tasks
 
-1. Implement mapping from `dms.Document` stamps to API fields (`_etag`, `_lastModifiedDate`, `ChangeVersion`).
-2. Add integration tests covering indirect representation changes (a referenced identity change cascades into a referrer and bumps the referrer’s stamps).
+1. Implement mapping from `dms.Document` stamps to API metadata semantics:
+   `_lastModifiedDate` served from `ContentLastModifiedAt`, `ChangeVersion` sourced from `ContentVersion`,
+   and `_etag` recomputed from the served representation.
+2. Add integration tests covering indirect representation changes (a referenced identity change cascades into a referrer and bumps the referrer's stamps).

--- a/reference/design/backend-redesign/epics/10-update-tracking-change-queries/03-if-match.md
+++ b/reference/design/backend-redesign/epics/10-update-tracking-change-queries/03-if-match.md
@@ -9,7 +9,9 @@ jira_url: https://edfi.atlassian.net/browse/DMS-1005
 
 Implement optimistic concurrency checks using stored representation stamps:
 
-- For update operations that support `If-Match`, compare the client-provided `_etag` to the current `_etag` served from `dms.Document.ContentVersion`.
+- For update operations that support `If-Match`, compare the client-provided `_etag` to the current `_etag`
+  computed from the canonical JSON form of the current served representation, as defined by
+  `reference/design/backend-redesign/design-docs/update-tracking.md`.
 - No dependency locking is required because indirect impacts are materialized as local updates that bump the same stamp.
 - `DMS-984` introduces the internal `ContentVersion` freshness recheck for the shared guarded no-op fast path, and `DMS-1124` reuses that result for profiled no-op outcomes; this story owns HTTP `If-Match` comparison and `412` mapping for both changed-write and stale-no-op outcomes.
 
@@ -22,7 +24,7 @@ Implement optimistic concurrency checks using stored representation stamps:
 
 ## Tasks
 
-1. Implement a “read current stored `_etag`” path usable by update handlers prior to write.
+1. Implement a "read current document and compute `_etag` from its served representation" path usable by update handlers prior to write.
 2. Implement `If-Match` comparison and stale-no-op handling paths usable by both changed writes and guarded no-op handlers, consuming the internal freshness result produced by the shared `DMS-984` executor path and reused by `DMS-1124`.
 3. Add tests for:
    1. match success,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlBaselineDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlBaselineDatabase.cs
@@ -344,21 +344,15 @@ internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
             var fileId = reader.GetInt32(0);
             var logicalName = reader.GetString(1);
             var physicalName = reader.GetString(2);
+            var snapshotFileName = $"{databaseName}_baseline_{fileId}_{SanitizeFileName(logicalName)}.ss";
             var directoryPath =
                 Path.GetDirectoryName(physicalName)
                 ?? throw new InvalidOperationException(
                     $"Could not determine the data file directory for database '{databaseName}'."
                 );
+            var snapshotPath = Path.Combine(directoryPath, snapshotFileName);
 
-            files.Add(
-                new(
-                    LogicalName: logicalName,
-                    SnapshotPath: Path.Combine(
-                        directoryPath,
-                        $"{databaseName}_baseline_{fileId}_{SanitizeFileName(logicalName)}.ss"
-                    )
-                )
-            );
+            files.Add(new(LogicalName: logicalName, SnapshotPath: snapshotPath));
         }
 
         return files.Count != 0

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeDs52SurveySmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeDs52SurveySmokeTests.cs
@@ -369,18 +369,86 @@ public class Given_A_Mssql_Relational_Write_Propagated_Reference_Identity_Runtim
     public async Task It_should_keep_runtime_written_rows_participating_in_identity_propagation_trigger_fallback()
     {
         var beforeCascade = await ReadPersistedStateAsync(SurveyDocumentUuid.Value);
+        var metadataBeforeCascade = await ReadDocumentMetadataAsync(SurveyDocumentUuid.Value);
+        var getResultBeforeCascade = await ExecuteGetByIdAsync(
+            SurveyDocumentUuid,
+            "mssql-propagated-reference-identity-runtime-get-before-cascade"
+        );
 
         beforeCascade.Should().Be(_stateAfterChangedUpdate);
 
         await UpdateSessionNameAsync(_seedData.SpringSessionDocumentId, UpdatedSpringSessionName);
 
         var afterCascade = await ReadPersistedStateAsync(SurveyDocumentUuid.Value);
+        var metadataAfterCascade = await ReadDocumentMetadataAsync(SurveyDocumentUuid.Value);
+        var getResultAfterCascade = await ExecuteGetByIdAsync(
+            SurveyDocumentUuid,
+            "mssql-propagated-reference-identity-runtime-get-after-cascade"
+        );
 
         afterCascade
             .Should()
             .Be(_stateAfterChangedUpdate with { SessionSessionName = UpdatedSpringSessionName });
         afterCascade.SessionSessionName.Should().NotBe(beforeCascade.SessionSessionName);
         afterCascade.SessionDocumentId.Should().Be(beforeCascade.SessionDocumentId);
+        metadataAfterCascade.ContentVersion.Should().BeGreaterThan(metadataBeforeCascade.ContentVersion);
+        metadataAfterCascade
+            .ContentLastModifiedAt.Should()
+            .BeAfter(metadataBeforeCascade.ContentLastModifiedAt);
+
+        getResultBeforeCascade.Should().BeOfType<GetResult.GetSuccess>();
+        getResultAfterCascade.Should().BeOfType<GetResult.GetSuccess>();
+
+        var successBeforeCascade = (GetResult.GetSuccess)getResultBeforeCascade;
+        var successAfterCascade = (GetResult.GetSuccess)getResultAfterCascade;
+        var expectedDocument =
+            JsonNode.Parse(ChangedUpdateRequestBodyJson)?.AsObject()
+            ?? throw new InvalidOperationException("Expected changed update request body to parse.");
+        var expectedSessionReference =
+            expectedDocument["sessionReference"] as JsonObject
+            ?? throw new InvalidOperationException(
+                "Expected changed update request body to contain sessionReference."
+            );
+
+        expectedSessionReference["sessionName"] = UpdatedSpringSessionName;
+
+        var expectedExternalResponse = RelationalGetIntegrationTestHelper.CreateExpectedExternalResponse(
+            expectedDocument.ToJsonString(),
+            _resourceInfo,
+            _mappingSet,
+            SurveyDocumentUuid.Value,
+            metadataAfterCascade.ContentLastModifiedAt
+        );
+
+        successAfterCascade.DocumentUuid.Should().Be(SurveyDocumentUuid);
+        successAfterCascade.LastModifiedTraceId.Should().BeNull();
+        successAfterCascade
+            .LastModifiedDate.Should()
+            .Be(metadataAfterCascade.ContentLastModifiedAt.UtcDateTime);
+        successAfterCascade.EdfiDoc["sessionReference"]!["sessionName"]!
+            .GetValue<string>()
+            .Should()
+            .Be(UpdatedSpringSessionName);
+        successAfterCascade.EdfiDoc["_etag"]!
+            .GetValue<string>()
+            .Should()
+            .Be(expectedExternalResponse["_etag"]!.GetValue<string>());
+        successAfterCascade.EdfiDoc["_etag"]!
+            .GetValue<string>()
+            .Should()
+            .NotBe(successBeforeCascade.EdfiDoc["_etag"]!.GetValue<string>());
+        successAfterCascade.EdfiDoc["_lastModifiedDate"]!
+            .GetValue<string>()
+            .Should()
+            .Be(
+                RelationalGetIntegrationTestHelper.FormatExternalLastModifiedDate(
+                    metadataAfterCascade.ContentLastModifiedAt
+                )
+            );
+        RelationalGetIntegrationTestHelper
+            .CanonicalizeJson(successAfterCascade.EdfiDoc)
+            .Should()
+            .Be(RelationalGetIntegrationTestHelper.CanonicalizeJson(expectedExternalResponse));
     }
 
     private async Task<UpsertResult> ExecuteCreateAsync(
@@ -445,6 +513,24 @@ public class Given_A_Mssql_Relational_Write_Propagated_Reference_Identity_Runtim
         return await scope
             .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
             .UpdateDocumentById(request);
+    }
+
+    private async Task<GetResult> ExecuteGetByIdAsync(DocumentUuid documentUuid, string traceId)
+    {
+        await using var scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        var request = new IntegrationRelationalGetRequest(
+            DocumentUuid: documentUuid,
+            ResourceInfo: _resourceInfo,
+            MappingSet: _mappingSet,
+            ResourceAuthorizationHandler: new MssqlSurveyRuntimeAllowAllResourceAuthorizationHandler(),
+            TraceId: new TraceId(traceId)
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .GetDocumentById(request);
     }
 
     private void SetSelectedInstance(IServiceProvider serviceProvider)
@@ -627,6 +713,27 @@ public class Given_A_Mssql_Relational_Write_Propagated_Reference_Identity_Runtim
             Namespace: ReadRequiredString(row["Namespace"]),
             SurveyIdentifier: ReadRequiredString(row["SurveyIdentifier"]),
             SurveyTitle: ReadRequiredString(row["SurveyTitle"])
+        );
+    }
+
+    private async Task<(long ContentVersion, DateTimeOffset ContentLastModifiedAt)> ReadDocumentMetadataAsync(
+        Guid documentUuid
+    )
+    {
+        var row = (
+            await _database.QueryRowsAsync(
+                """
+                SELECT [ContentVersion], [ContentLastModifiedAt]
+                FROM [dms].[Document]
+                WHERE [DocumentUuid] = @documentUuid;
+                """,
+                new SqlParameter("@documentUuid", documentUuid)
+            )
+        ).Single();
+
+        return (
+            Convert.ToInt64(row["ContentVersion"], CultureInfo.InvariantCulture),
+            ReadRequiredDateTimeOffset(row["ContentLastModifiedAt"])
         );
     }
 
@@ -851,4 +958,12 @@ public class Given_A_Mssql_Relational_Write_Propagated_Reference_Identity_Runtim
 
     private static string ReadRequiredString(object? value) =>
         value as string ?? throw new InvalidOperationException("Expected a non-null string value.");
+
+    private static DateTimeOffset ReadRequiredDateTimeOffset(object? value) =>
+        value switch
+        {
+            DateTimeOffset dateTimeOffset => dateTimeOffset,
+            DateTime dateTime => new(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc), TimeSpan.Zero),
+            _ => throw new InvalidOperationException("Expected a non-null DateTimeOffset-compatible value."),
+        };
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
@@ -338,7 +338,10 @@ file static class MssqlStudentSchoolAssociationIntegrationTestSupport
     }
 }
 
-internal sealed record MssqlStudentSchoolAssociationSeedData(long GraduationPlanTypeDescriptorId);
+internal sealed record MssqlStudentSchoolAssociationSeedData(
+    long StudentDocumentId,
+    long GraduationPlanTypeDescriptorId
+);
 
 internal sealed record MssqlStudentSchoolAssociationDocumentMetadata(
     Guid DocumentUuid,
@@ -405,7 +408,6 @@ public class Given_A_Mssql_Relational_Write_Then_Read_Smoke_With_The_Authoritati
         "uri://ed-fi.org/EducationPlanDescriptor#Intervention";
     private const string ResidentMembershipTypeDescriptorUri =
         "uri://sample.org/MembershipTypeDescriptor#Resident";
-
     private const string CreateRequestBodyJson = """
         {
           "entryDate": "2024-08-20",
@@ -1105,7 +1107,7 @@ public class Given_A_Mssql_Relational_Write_Then_Read_Smoke_With_The_Authoritati
             graduationPlanResourceKeyId
         );
 
-        return new(graduationPlanTypeDescriptorId);
+        return new(studentDocumentId, graduationPlanTypeDescriptorId);
     }
 
     private async Task DisableStudentSchoolAssociationReferentialIdentityTriggerAsync()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderTests.cs
@@ -83,6 +83,29 @@ public class Given_HydrationBatchBuilder_With_Single_Keyset
     }
 
     [Test]
+    public void It_should_emit_document_metadata_columns_in_fixed_reader_ordinal_order()
+    {
+        AssertAppearsInOrder(
+            _pgsqlBatch,
+            "d.\"DocumentId\"",
+            "d.\"DocumentUuid\"",
+            "d.\"ContentVersion\"",
+            "d.\"IdentityVersion\"",
+            "d.\"ContentLastModifiedAt\"",
+            "d.\"IdentityLastModifiedAt\""
+        );
+        AssertAppearsInOrder(
+            _mssqlBatch,
+            "d.[DocumentId]",
+            "d.[DocumentUuid]",
+            "d.[ContentVersion]",
+            "d.[IdentityVersion]",
+            "d.[ContentLastModifiedAt]",
+            "d.[IdentityLastModifiedAt]"
+        );
+    }
+
+    [Test]
     public void It_should_emit_deterministic_order_by_on_document_metadata()
     {
         _pgsqlBatch.Should().Contain("ORDER BY d.\"DocumentId\"");
@@ -552,5 +575,17 @@ internal static class HydrationBatchBuilderTestHelper
             ReferenceIdentityProjectionPlansInDependencyOrder: [],
             DescriptorProjectionPlansInOrder: descriptorProjectionPlans ?? []
         );
+    }
+
+    internal static void AssertAppearsInOrder(string text, params string[] values)
+    {
+        var previousIndex = -1;
+
+        foreach (var value in values)
+        {
+            var currentIndex = text.IndexOf(value, StringComparison.Ordinal);
+            currentIndex.Should().BeGreaterThan(previousIndex, $"expected '{value}' in ordinal order");
+            previousIndex = currentIndex;
+        }
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationReaderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationReaderTests.cs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+public class Given_HydrationReader_With_Document_Metadata_Result_Sets
+{
+    [Test]
+    public async Task It_reads_document_metadata_rows_using_the_fixed_ordinal_contract()
+    {
+        DateTimeOffset firstContentLastModifiedAt = new(2026, 4, 3, 14, 10, 11, TimeSpan.Zero);
+        DateTimeOffset firstIdentityLastModifiedAt = new(2026, 4, 3, 14, 12, 13, TimeSpan.Zero);
+        DateTimeOffset secondContentLastModifiedAt = new(2026, 4, 4, 8, 9, 10, TimeSpan.Zero);
+        DateTimeOffset secondIdentityLastModifiedAt = new(2026, 4, 4, 8, 11, 12, TimeSpan.Zero);
+
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(
+            CreateDocumentMetadataTable(
+                (
+                    42L,
+                    Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"),
+                    101L,
+                    201L,
+                    firstContentLastModifiedAt,
+                    firstIdentityLastModifiedAt
+                ),
+                (
+                    84L,
+                    Guid.Parse("cccccccc-4444-5555-6666-dddddddddddd"),
+                    102L,
+                    202L,
+                    secondContentLastModifiedAt,
+                    secondIdentityLastModifiedAt
+                )
+            )
+        );
+
+        var result = await HydrationReader.ReadDocumentMetadataAsync(reader, CancellationToken.None);
+
+        result
+            .Should()
+            .Equal(
+                new DocumentMetadataRow(
+                    DocumentId: 42L,
+                    DocumentUuid: Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"),
+                    ContentVersion: 101L,
+                    IdentityVersion: 201L,
+                    ContentLastModifiedAt: firstContentLastModifiedAt,
+                    IdentityLastModifiedAt: firstIdentityLastModifiedAt
+                ),
+                new DocumentMetadataRow(
+                    DocumentId: 84L,
+                    DocumentUuid: Guid.Parse("cccccccc-4444-5555-6666-dddddddddddd"),
+                    ContentVersion: 102L,
+                    IdentityVersion: 202L,
+                    ContentLastModifiedAt: secondContentLastModifiedAt,
+                    IdentityLastModifiedAt: secondIdentityLastModifiedAt
+                )
+            );
+    }
+
+    [Test]
+    public async Task It_rejects_document_metadata_result_sets_with_an_unexpected_column_count()
+    {
+        using var reader = HydrationDescriptorResultTestHelper.CreateReader(
+            CreateIncompleteDocumentMetadataTable(
+                (
+                    42L,
+                    Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"),
+                    101L,
+                    201L,
+                    new DateTimeOffset(2026, 4, 3, 14, 10, 11, TimeSpan.Zero)
+                )
+            )
+        );
+
+        var act = () => HydrationReader.ReadDocumentMetadataAsync(reader, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+        exception.Which.Message.Should().StartWith("Document metadata result set has 5 columns but expected");
+    }
+
+    private static DataTable CreateDocumentMetadataTable(
+        params (
+            long DocumentId,
+            Guid DocumentUuid,
+            long ContentVersion,
+            long IdentityVersion,
+            DateTimeOffset ContentLastModifiedAt,
+            DateTimeOffset IdentityLastModifiedAt
+        )[] rows
+    )
+    {
+        DataTable table = new();
+        table.Columns.Add("DocumentId", typeof(long));
+        table.Columns.Add("DocumentUuid", typeof(Guid));
+        table.Columns.Add("ContentVersion", typeof(long));
+        table.Columns.Add("IdentityVersion", typeof(long));
+        table.Columns.Add("ContentLastModifiedAt", typeof(DateTimeOffset));
+        table.Columns.Add("IdentityLastModifiedAt", typeof(DateTimeOffset));
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(
+                row.DocumentId,
+                row.DocumentUuid,
+                row.ContentVersion,
+                row.IdentityVersion,
+                row.ContentLastModifiedAt,
+                row.IdentityLastModifiedAt
+            );
+        }
+
+        return table;
+    }
+
+    private static DataTable CreateIncompleteDocumentMetadataTable(
+        params (
+            long DocumentId,
+            Guid DocumentUuid,
+            long ContentVersion,
+            long IdentityVersion,
+            DateTimeOffset ContentLastModifiedAt
+        )[] rows
+    )
+    {
+        DataTable table = new();
+        table.Columns.Add("DocumentId", typeof(long));
+        table.Columns.Add("DocumentUuid", typeof(Guid));
+        table.Columns.Add("ContentVersion", typeof(long));
+        table.Columns.Add("IdentityVersion", typeof(long));
+        table.Columns.Add("ContentLastModifiedAt", typeof(DateTimeOffset));
+
+        foreach (var row in rows)
+        {
+            table.Rows.Add(
+                row.DocumentId,
+                row.DocumentUuid,
+                row.ContentVersion,
+                row.IdentityVersion,
+                row.ContentLastModifiedAt
+            );
+        }
+
+        return table;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSmokeTests.cs
@@ -1838,8 +1838,10 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
     private ResourceSchema _extensionResourceSchema = null!;
     private PropagatedReferenceIdentityCascadeSeedData _seedData = null!;
     private UpsertResult _createResult = null!;
+    private GetResult _getResultAfterCreate = null!;
     private PropagatedReferenceIdentityCascadePersistedState _stateAfterCreate = null!;
     private PropagatedReferenceIdentityCascadeReferenceShape _shapeAfterCreate = null!;
+    private DateTimeOffset _lastModifiedAtAfterCreate;
 
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
@@ -1888,6 +1890,11 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
         _createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
         _stateAfterCreate = await ReadPersistedStateAsync(AssociationDocumentUuid.Value);
         _shapeAfterCreate = await ReadReferenceShapeAsync(_stateAfterCreate.Document.DocumentId);
+        _lastModifiedAtAfterCreate = await ReadContentLastModifiedAtAsync(AssociationDocumentUuid.Value);
+        _getResultAfterCreate = await ExecuteGetByIdAsync(
+            AssociationDocumentUuid,
+            "pg-propagated-reference-identity-cascade-get-after-create"
+        );
     }
 
     [OneTimeTearDown]
@@ -1946,6 +1953,11 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
 
         var stateAfterCascade = await ReadPersistedStateAsync(AssociationDocumentUuid.Value);
         var shapeAfterCascade = await ReadReferenceShapeAsync(stateAfterCascade.Document.DocumentId);
+        var lastModifiedAtAfterCascade = await ReadContentLastModifiedAtAsync(AssociationDocumentUuid.Value);
+        var getResultAfterCascade = await ExecuteGetByIdAsync(
+            AssociationDocumentUuid,
+            "pg-propagated-reference-identity-cascade-get-after-cascade"
+        );
 
         stateAfterCascade
             .Association.Should()
@@ -1956,6 +1968,60 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
                 }
             );
         shapeAfterCascade.Should().Be(_shapeAfterCreate);
+        stateAfterCascade
+            .Document.ContentVersion.Should()
+            .BeGreaterThan(_stateAfterCreate.Document.ContentVersion);
+        lastModifiedAtAfterCascade.Should().BeAfter(_lastModifiedAtAfterCreate);
+
+        _getResultAfterCreate.Should().BeOfType<GetResult.GetSuccess>();
+        getResultAfterCascade.Should().BeOfType<GetResult.GetSuccess>();
+
+        var successAfterCreate = (GetResult.GetSuccess)_getResultAfterCreate;
+        var successAfterCascade = (GetResult.GetSuccess)getResultAfterCascade;
+        var expectedDocument =
+            JsonNode.Parse(CreateRequestBodyJson)?.AsObject()
+            ?? throw new InvalidOperationException("Expected create request body to parse.");
+        var expectedEducationOrganizationReference =
+            expectedDocument["educationOrganizationReference"] as JsonObject
+            ?? throw new InvalidOperationException(
+                "Expected create request body to contain educationOrganizationReference."
+            );
+
+        expectedEducationOrganizationReference["educationOrganizationId"] = UpdatedEducationOrganizationId;
+
+        var expectedExternalResponse = RelationalGetIntegrationTestHelper.CreateExpectedExternalResponse(
+            expectedDocument.ToJsonString(),
+            _resourceInfo,
+            _mappingSet,
+            AssociationDocumentUuid.Value,
+            lastModifiedAtAfterCascade
+        );
+
+        successAfterCascade.DocumentUuid.Should().Be(AssociationDocumentUuid);
+        successAfterCascade.LastModifiedTraceId.Should().BeNull();
+        successAfterCascade.LastModifiedDate.Should().Be(lastModifiedAtAfterCascade.UtcDateTime);
+        successAfterCascade.EdfiDoc["educationOrganizationReference"]!["educationOrganizationId"]!
+            .GetValue<long>()
+            .Should()
+            .Be(UpdatedEducationOrganizationId);
+        successAfterCascade.EdfiDoc["_etag"]!
+            .GetValue<string>()
+            .Should()
+            .Be(expectedExternalResponse["_etag"]!.GetValue<string>());
+        successAfterCascade.EdfiDoc["_etag"]!
+            .GetValue<string>()
+            .Should()
+            .NotBe(successAfterCreate.EdfiDoc["_etag"]!.GetValue<string>());
+        successAfterCascade.EdfiDoc["_lastModifiedDate"]!
+            .GetValue<string>()
+            .Should()
+            .Be(
+                RelationalGetIntegrationTestHelper.FormatExternalLastModifiedDate(lastModifiedAtAfterCascade)
+            );
+        RelationalGetIntegrationTestHelper
+            .CanonicalizeJson(successAfterCascade.EdfiDoc)
+            .Should()
+            .Be(RelationalGetIntegrationTestHelper.CanonicalizeJson(expectedExternalResponse));
     }
 
     private async Task<UpsertResult> ExecuteCreateAsync()
@@ -1989,6 +2055,24 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
         return await scope
             .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
             .UpsertDocument(request);
+    }
+
+    private async Task<GetResult> ExecuteGetByIdAsync(DocumentUuid documentUuid, string traceId)
+    {
+        await using var scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        var request = new IntegrationRelationalGetRequest(
+            DocumentUuid: documentUuid,
+            ResourceInfo: _resourceInfo,
+            MappingSet: _mappingSet,
+            ResourceAuthorizationHandler: new AuthoritativeSampleWriteAllowAllResourceAuthorizationHandler(),
+            TraceId: new TraceId(traceId)
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .GetDocumentById(request);
     }
 
     private void SetSelectedInstance(IServiceProvider serviceProvider)
@@ -2127,6 +2211,34 @@ public class Given_A_Postgresql_Relational_Write_Propagated_Reference_Identity_C
             new NpgsqlParameter("documentId", documentId),
             new NpgsqlParameter("resourceKeyId", resourceKeyId)
         );
+    }
+
+    private async Task<DateTimeOffset> ReadContentLastModifiedAtAsync(Guid documentUuid)
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT "ContentLastModifiedAt"
+            FROM "dms"."Document"
+            WHERE "DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", documentUuid)
+        );
+
+        return rows.Count == 1
+            ? rows[0]["ContentLastModifiedAt"] switch
+            {
+                DateTimeOffset value => value,
+                DateTime value => new DateTimeOffset(
+                    DateTime.SpecifyKind(value, DateTimeKind.Utc),
+                    TimeSpan.Zero
+                ),
+                _ => throw new InvalidOperationException(
+                    "Expected ContentLastModifiedAt to be a DateTimeOffset-compatible value."
+                ),
+            }
+            : throw new InvalidOperationException(
+                $"Expected exactly one document metadata row for '{documentUuid}', but found {rows.Count}."
+            );
     }
 
     private static ReferentialId CreateReferentialId(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
@@ -507,7 +507,6 @@ public class Given_A_Postgresql_Relational_Write_Smoke_With_The_Authoritative_Sa
         "uri://sample.org/MembershipTypeDescriptor#Resident";
     private const string TransferMembershipTypeDescriptorUri =
         "uri://sample.org/MembershipTypeDescriptor#Transfer";
-
     private const string CreateRequestBodyJson = """
         {
           "entryDate": "2024-08-20",
@@ -634,6 +633,7 @@ public class Given_A_Postgresql_Relational_Write_Smoke_With_The_Authoritative_Sa
     private AuthoritativeSampleStudentSchoolAssociationPersistedState _stateAfterChangedUpdate = null!;
     private AuthoritativeSampleStudentSchoolAssociationPersistedState _stateAfterNoOpUpdate = null!;
     private DateTimeOffset _lastModifiedAtAfterCreate;
+    private DateTimeOffset _lastModifiedAtAfterNoOpUpdate;
 
     [OneTimeSetUp]
     public async Task OneTimeSetUp()
@@ -721,6 +721,9 @@ public class Given_A_Postgresql_Relational_Write_Smoke_With_The_Authoritative_Sa
 
         _noOpUpdateResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
         _stateAfterNoOpUpdate = await ReadPersistedStateAsync(StudentSchoolAssociationDocumentUuid.Value);
+        _lastModifiedAtAfterNoOpUpdate = await ReadContentLastModifiedAtAsync(
+            StudentSchoolAssociationDocumentUuid.Value
+        );
         _getResultAfterNoOpUpdate = await ExecuteGetByIdAsync(
             StudentSchoolAssociationDocumentUuid,
             "pg-authoritative-sample-student-school-association-get-after-no-op-update"
@@ -1075,21 +1078,18 @@ public class Given_A_Postgresql_Relational_Write_Smoke_With_The_Authoritative_Sa
     [Test]
     public async Task It_reads_back_the_written_document_via_relational_get_by_id_with_semantic_json_equivalence_and_metadata()
     {
-        var expectedLastModifiedAt = await ReadContentLastModifiedAtAsync(
-            StudentSchoolAssociationDocumentUuid.Value
-        );
         var expectedDocument = RelationalGetIntegrationTestHelper.CreateExpectedExternalResponse(
             ChangedUpdateRequestBodyJson,
             _resourceInfo,
             _mappingSet,
             _stateAfterNoOpUpdate.Document.DocumentUuid,
-            expectedLastModifiedAt
+            _lastModifiedAtAfterNoOpUpdate
         );
 
         RelationalGetIntegrationTestHelper.AssertStudentSchoolAssociationExternalResponse(
             _getResultAfterNoOpUpdate,
             StudentSchoolAssociationDocumentUuid,
-            expectedLastModifiedAt,
+            _lastModifiedAtAfterNoOpUpdate,
             expectedDocument,
             [EndorsementGraduationSchoolYear, StemGraduationSchoolYear],
             [InterventionEducationPlanDescriptorUri, CareerEducationPlanDescriptorUri]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerResponseEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerResponseEtagTests.cs
@@ -19,9 +19,10 @@ namespace EdFi.DataManagementService.Backend.Tests.Unit;
 public class Given_Descriptor_Write_Response_Etags
 {
     private static readonly QualifiedResourceName _descriptorResource = new("Ed-Fi", "SchoolTypeDescriptor");
+    private const string StampStyleEtagPattern = "^\"\\d+\"$";
 
     [Test]
-    public async Task It_returns_the_legacy_opaque_etag_for_descriptor_post_creates()
+    public async Task It_returns_the_canonical_hash_etag_for_descriptor_post_creates()
     {
         var targetLookupService = new StubRelationalWriteTargetLookupService
         {
@@ -40,7 +41,14 @@ public class Given_Descriptor_Write_Response_Etags
 
         result
             .Should()
-            .BeEquivalentTo(new UpsertResult.InsertSuccess(request.DocumentUuid, ExpectedEtag(request)));
+            .BeEquivalentTo(
+                new UpsertResult.InsertSuccess(request.DocumentUuid, ExpectedCanonicalHashEtag(request))
+            );
+        result
+            .Should()
+            .BeOfType<UpsertResult.InsertSuccess>()
+            .Which.ETag.Should()
+            .NotMatchRegex(StampStyleEtagPattern);
         targetLookupService.ResolveForPostCallCount.Should().Be(1);
         targetLookupService.ResolveForPutCallCount.Should().Be(0);
         commandExecutor.Commands.Should().ContainSingle();
@@ -74,11 +82,13 @@ public class Given_Descriptor_Write_Response_Etags
 
         result
             .Should()
-            .BeEquivalentTo(new UpsertResult.InsertSuccess(request.DocumentUuid, ExpectedEtag(request)));
+            .BeEquivalentTo(
+                new UpsertResult.InsertSuccess(request.DocumentUuid, ExpectedCanonicalHashEtag(request))
+            );
     }
 
     [Test]
-    public async Task It_returns_the_legacy_opaque_etag_for_descriptor_post_as_update()
+    public async Task It_returns_the_canonical_hash_etag_for_descriptor_post_as_update()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
         var targetLookupService = new StubRelationalWriteTargetLookupService
@@ -91,7 +101,14 @@ public class Given_Descriptor_Write_Response_Etags
 
         var result = await sut.HandlePostAsync(request);
 
-        result.Should().BeEquivalentTo(new UpsertResult.UpdateSuccess(documentUuid, ExpectedEtag(request)));
+        result
+            .Should()
+            .BeEquivalentTo(new UpsertResult.UpdateSuccess(documentUuid, ExpectedCanonicalHashEtag(request)));
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpdateSuccess>()
+            .Which.ETag.Should()
+            .NotMatchRegex(StampStyleEtagPattern);
         targetLookupService.ResolveForPostCallCount.Should().Be(1);
         targetLookupService.ResolveForPutCallCount.Should().Be(0);
         commandExecutor.Commands.Should().ContainSingle();
@@ -99,7 +116,7 @@ public class Given_Descriptor_Write_Response_Etags
     }
 
     [Test]
-    public async Task It_returns_the_legacy_opaque_etag_for_descriptor_put_no_ops_without_an_update_command()
+    public async Task It_returns_the_canonical_hash_etag_for_descriptor_put_no_ops_without_an_update_command()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
         var targetLookupService = new StubRelationalWriteTargetLookupService
@@ -124,13 +141,20 @@ public class Given_Descriptor_Write_Response_Etags
 
         var result = await sut.HandlePutAsync(request);
 
-        result.Should().BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, ExpectedEtag(request)));
+        result
+            .Should()
+            .BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, ExpectedCanonicalHashEtag(request)));
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateSuccess>()
+            .Which.ETag.Should()
+            .NotMatchRegex(StampStyleEtagPattern);
         targetLookupService.ResolveForPutCallCount.Should().Be(1);
         commandExecutor.Commands.Should().ContainSingle();
     }
 
     [Test]
-    public async Task It_returns_the_legacy_opaque_etag_for_descriptor_put_updates()
+    public async Task It_returns_the_canonical_hash_etag_for_descriptor_put_updates()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
         var targetLookupService = new StubRelationalWriteTargetLookupService
@@ -159,13 +183,20 @@ public class Given_Descriptor_Write_Response_Etags
 
         var result = await sut.HandlePutAsync(request);
 
-        result.Should().BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, ExpectedEtag(request)));
+        result
+            .Should()
+            .BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, ExpectedCanonicalHashEtag(request)));
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateSuccess>()
+            .Which.ETag.Should()
+            .NotMatchRegex(StampStyleEtagPattern);
         targetLookupService.ResolveForPutCallCount.Should().Be(1);
         commandExecutor.Commands.Should().HaveCount(2);
         commandExecutor.Commands[1].CommandText.Should().NotContain("SELECT document.\"ContentVersion\"");
     }
 
-    private static string ExpectedEtag(DescriptorWriteRequest request) =>
+    private static string ExpectedCanonicalHashEtag(DescriptorWriteRequest request) =>
         RelationalApiMetadataFormatter.FormatEtag(
             DescriptorWriteBodyExtractor.Extract(request.RequestBody, request.Resource)
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalApiMetadataFormatterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalApiMetadataFormatterTests.cs
@@ -77,4 +77,27 @@ public class Given_RelationalApiMetadataFormatter
         RelationalApiMetadataFormatter.FormatEtag(document).Should().Be(expectedHash);
         RelationalApiMetadataFormatter.FormatEtag(document).Should().NotBe(legacySerializerHash);
     }
+
+    [Test]
+    public void It_refreshes_etag_from_the_projected_document_shape_without_mutating_other_metadata()
+    {
+        var projectedDocument = JsonNode.Parse(
+            """
+            {
+              "id": "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb",
+              "_etag": "stale",
+              "_lastModifiedDate": "2026-04-13T12:00:00Z",
+              "schoolId": 255901,
+              "nameOfInstitution": "Lincoln High"
+            }
+            """
+        )!;
+        var expectedHash = RelationalApiMetadataFormatter.FormatEtag(projectedDocument);
+
+        RelationalApiMetadataFormatter.RefreshEtag(projectedDocument);
+
+        projectedDocument["id"]!.GetValue<string>().Should().Be("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
+        projectedDocument["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-04-13T12:00:00Z");
+        projectedDocument["_etag"]!.GetValue<string>().Should().Be(expectedHash);
+    }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -21,6 +21,7 @@ namespace EdFi.DataManagementService.Backend.Tests.Unit;
 public class Given_RelationalDocumentStoreRepositoryTests
 {
     private static readonly ResourceInfo _schoolResourceInfo = CreateResourceInfo("School");
+    private const string StampStyleEtagPattern = "^\"\\d+\"$";
     private static readonly BaseResourceInfo _localEducationAgencyResourceInfo = new(
         new ProjectName("Ed-Fi"),
         new ResourceName("LocalEducationAgency"),
@@ -224,7 +225,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_applies_readable_profile_projection_after_external_materialization()
+    public async Task It_recomputes_etag_after_readable_profile_projection_while_preserving_other_metadata()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
         var mappingSet = CreateProfileProjectionOrderSensitiveMappingSet(_schoolResourceInfo);
@@ -319,8 +320,12 @@ public class Given_RelationalDocumentStoreRepositoryTests
         result.Should().BeOfType<GetResult.GetSuccess>();
         var success = (GetResult.GetSuccess)result;
         success.EdfiDoc.Should().BeSameAs(projectedDocument);
+        success.LastModifiedDate.Should().Be(new DateTime(2026, 4, 11, 17, 30, 45, DateTimeKind.Utc));
+        success.EdfiDoc["id"]!.GetValue<string>().Should().Be(documentUuid.Value.ToString());
+        success.EdfiDoc["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-04-11T17:30:45Z");
         success.EdfiDoc["_etag"]!.GetValue<string>().Should().Be(expectedProjectedEtag);
         success.EdfiDoc["_etag"]!.GetValue<string>().Should().NotBe("\"93\"");
+        success.EdfiDoc["ChangeVersion"].Should().BeNull();
         A.CallTo(() =>
                 _readableProfileProjector.Project(
                     materializedDocument,
@@ -476,7 +481,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     [Test]
     public async Task It_routes_post_requests_through_the_executor_with_reference_resolution_inputs()
     {
-        const string committedEtag = "\"91\"";
+        var committedEtag = CreateCommittedReadbackEtag("Lincoln High");
         var documentReference = CreateDocumentReference(
             _localEducationAgencyResourceInfo,
             "$.localEducationAgencyReference"
@@ -520,6 +525,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         result.Should().BeEquivalentTo(new UpsertResult.InsertSuccess(documentUuid, committedEtag));
         ((UpsertResult.InsertSuccess)result).ETag.Should().NotBe(requestBody["_etag"]!.GetValue<string>());
+        ((UpsertResult.InsertSuccess)result).ETag.Should().NotMatchRegex(StampStyleEtagPattern);
         _capturedExecutorRequest.MappingSet.Should().BeSameAs(mappingSet);
         _capturedExecutorRequest.OperationKind.Should().Be(RelationalWriteOperationKind.Post);
         _capturedExecutorRequest
@@ -556,7 +562,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     [Test]
     public async Task It_routes_post_as_update_requests_through_the_executor_with_a_read_plan()
     {
-        const string committedEtag = "\"92\"";
+        var committedEtag = CreateCommittedReadbackEtag("Post As Update High");
         var traceId = new TraceId("post-update-trace");
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var requestBody = CreateRequestBody("Post As Update High");
@@ -597,6 +603,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         result.Should().BeEquivalentTo(new UpsertResult.UpdateSuccess(documentUuid, committedEtag));
         ((UpsertResult.UpdateSuccess)result).ETag.Should().NotBe(requestBody["_etag"]!.GetValue<string>());
+        ((UpsertResult.UpdateSuccess)result).ETag.Should().NotMatchRegex(StampStyleEtagPattern);
         _capturedExecutorRequest.OperationKind.Should().Be(RelationalWriteOperationKind.Post);
         _capturedExecutorRequest
             .TargetRequest.Should()
@@ -615,7 +622,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     [Test]
     public async Task It_routes_put_requests_through_the_executor_with_reference_resolution_inputs()
     {
-        const string committedEtag = "\"93\"";
+        var committedEtag = CreateCommittedReadbackEtag("Roosevelt High");
         var documentReference = CreateDocumentReference(
             _localEducationAgencyResourceInfo,
             "$.localEducationAgencyReference"
@@ -660,6 +667,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         result.Should().BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, committedEtag));
         ((UpdateResult.UpdateSuccess)result).ETag.Should().NotBe(requestBody["_etag"]!.GetValue<string>());
+        ((UpdateResult.UpdateSuccess)result).ETag.Should().NotMatchRegex(StampStyleEtagPattern);
         _capturedExecutorRequest.MappingSet.Should().BeSameAs(mappingSet);
         _capturedExecutorRequest.OperationKind.Should().Be(RelationalWriteOperationKind.Put);
         _capturedExecutorRequest
@@ -1168,8 +1176,10 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
 
         var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var requestBody = CreateDescriptorRequestBody();
+        var descriptorResponseEtag = CreateDescriptorResponseEtag(requestBody);
         A.CallTo(() => descriptorHandler.HandlePostAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
-            .Returns(new UpsertResult.InsertSuccess(documentUuid, "\"71\""));
+            .Returns(new UpsertResult.InsertSuccess(documentUuid, descriptorResponseEtag));
 
         var upsertRequest = A.Fake<IRelationalUpsertRequest>();
         A.CallTo(() => upsertRequest.ResourceInfo).Returns(_descriptorResourceInfo);
@@ -1177,11 +1187,12 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Returns(CreateDescriptorOnlyMappingSet(_descriptorResourceInfo));
         A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
         A.CallTo(() => upsertRequest.DocumentUuid).Returns(documentUuid);
-        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody());
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(requestBody);
 
         var result = await _sut.UpsertDocument(upsertRequest);
 
-        result.Should().BeEquivalentTo(new UpsertResult.InsertSuccess(documentUuid, "\"71\""));
+        result.Should().BeEquivalentTo(new UpsertResult.InsertSuccess(documentUuid, descriptorResponseEtag));
+        ((UpsertResult.InsertSuccess)result).ETag.Should().NotMatchRegex(StampStyleEtagPattern);
         _targetLookupService.ResolveForPostCallCount.Should().Be(0);
         _targetLookupService.ResolveForPutCallCount.Should().Be(0);
         A.CallTo(() => descriptorHandler.HandlePostAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
@@ -1204,8 +1215,10 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
 
         var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var requestBody = CreateDescriptorRequestBody("Updated Charter");
+        var descriptorResponseEtag = CreateDescriptorResponseEtag(requestBody);
         A.CallTo(() => descriptorHandler.HandlePutAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
-            .Returns(new UpdateResult.UpdateSuccess(documentUuid, "\"72\""));
+            .Returns(new UpdateResult.UpdateSuccess(documentUuid, descriptorResponseEtag));
 
         var updateRequest = A.Fake<IRelationalUpdateRequest>();
         A.CallTo(() => updateRequest.ResourceInfo).Returns(_descriptorResourceInfo);
@@ -1213,11 +1226,12 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Returns(CreateDescriptorOnlyMappingSet(_descriptorResourceInfo));
         A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
         A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
-        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody());
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(requestBody);
 
         var result = await _sut.UpdateDocumentById(updateRequest);
 
-        result.Should().BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, "\"72\""));
+        result.Should().BeEquivalentTo(new UpdateResult.UpdateSuccess(documentUuid, descriptorResponseEtag));
+        ((UpdateResult.UpdateSuccess)result).ETag.Should().NotMatchRegex(StampStyleEtagPattern);
         _targetLookupService.ResolveForPostCallCount.Should().Be(0);
         _targetLookupService.ResolveForPutCallCount.Should().Be(0);
         A.CallTo(() => descriptorHandler.HandlePutAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
@@ -1556,6 +1570,38 @@ public class Given_RelationalDocumentStoreRepositoryTests
     private static JsonNode CreateRequestBody(string name = "Lincoln High")
     {
         return JsonNode.Parse($$"""{"name":"{{name}}"}""")!;
+    }
+
+    private static JsonNode CreateDescriptorRequestBody(string description = "Charter")
+    {
+        return JsonNode.Parse(
+            $$"""
+            {
+              "namespace": "uri://ed-fi.org/SchoolTypeDescriptor",
+              "codeValue": "Charter",
+              "shortDescription": "Charter",
+              "description": "{{description}}",
+              "effectiveBeginDate": "2024-01-01"
+            }
+            """
+        )!;
+    }
+
+    private static string CreateCommittedReadbackEtag(string name, int schoolId = 255901)
+    {
+        return RelationalApiMetadataFormatter.FormatEtag(
+            JsonNode.Parse($$"""{"schoolId":{{schoolId}},"name":"{{name}}"}""")!
+        );
+    }
+
+    private static string CreateDescriptorResponseEtag(JsonNode requestBody)
+    {
+        return RelationalApiMetadataFormatter.FormatEtag(
+            DescriptorWriteBodyExtractor.Extract(
+                requestBody,
+                new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor")
+            )
+        );
     }
 
     private static DocumentReference CreateDocumentReference(BaseResourceInfo targetResource, string path)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
@@ -18,7 +18,7 @@ public class Given_RelationalReadMaterializer
     private static readonly Guid _documentUuid = Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
 
     [Test]
-    public void It_injects_api_metadata_for_external_response_reads()
+    public void It_injects_a_canonical_etag_and_stored_last_modified_date_for_external_response_reads()
     {
         var sut = new RelationalReadMaterializer();
         var readPlan = CreateReadPlan();
@@ -44,6 +44,42 @@ public class Given_RelationalReadMaterializer
             .Should()
             .Be(RelationalApiMetadataFormatter.FormatEtag(JsonNode.Parse("""{"name":"Lincoln High"}""")!));
         result["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-04-03T14:10:11Z");
+    }
+
+    [Test]
+    public void It_does_not_derive_the_external_etag_or_a_public_change_version_from_content_version()
+    {
+        var sut = new RelationalReadMaterializer();
+        var readPlan = CreateReadPlan();
+
+        var firstResult = sut.Materialize(
+            new RelationalReadMaterializationRequest(
+                readPlan,
+                CreateDocumentMetadataRow(
+                    contentVersion: 91L,
+                    contentLastModifiedAt: new DateTimeOffset(2026, 4, 3, 14, 10, 11, TimeSpan.Zero)
+                ),
+                CreateHydratedTableRows(readPlan, (345L, "Lincoln High")),
+                [],
+                RelationalGetRequestReadMode.ExternalResponse
+            )
+        );
+        var secondResult = sut.Materialize(
+            new RelationalReadMaterializationRequest(
+                readPlan,
+                CreateDocumentMetadataRow(
+                    contentVersion: 907L,
+                    contentLastModifiedAt: new DateTimeOffset(2026, 4, 3, 14, 10, 11, TimeSpan.Zero)
+                ),
+                CreateHydratedTableRows(readPlan, (345L, "Lincoln High")),
+                [],
+                RelationalGetRequestReadMode.ExternalResponse
+            )
+        );
+
+        firstResult["_etag"]!.GetValue<string>().Should().Be(secondResult["_etag"]!.GetValue<string>());
+        firstResult["ChangeVersion"].Should().BeNull();
+        secondResult["ChangeVersion"].Should().BeNull();
     }
 
     [Test]


### PR DESCRIPTION
Add unit and integration coverage for the DMS-1004 derived metadata contract.

- lock canonical hash-based _etag generation and readable-profile refresh behavior
- cover relational GET, committed write response, and descriptor response metadata parity
- verify indirect metadata changes after identity propagation and update MSSQL baseline test expectations