### PR TITLE
[DMS-1124] Slice 2 root-table-only baseline

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/FixtureRunnerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/FixtureRunnerTests.cs
@@ -68,6 +68,13 @@ public class Given_FixtureRunner_With_ReferentialIdentity_Fixture : DdlGoldenFix
 }
 
 [TestFixture]
+public class Given_FixtureRunner_With_ProfileRootOnlyMerge_Fixture : DdlGoldenFixtureTestBase
+{
+    protected override string ResolveFixtureDirectory(string projectRoot) =>
+        Path.Combine(projectRoot, "Fixtures", "small", "profile-root-only-merge");
+}
+
+[TestFixture]
 public class Given_FixtureRunner_With_EmitDdlManifest_False : DdlGoldenFixtureTestBase
 {
     protected override string ResolveFixtureDirectory(string projectRoot) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/ddl.manifest.json
@@ -1,0 +1,16 @@
+{
+  "effective_schema_hash": "5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10",
+  "relational_mapping_version": "v1",
+  "ddl": [
+    {
+      "dialect": "mssql",
+      "normalized_sql_sha256": "4cab4727ad01a9eec0909ebddf95fa6e823f96cb79d8c030cc5af01b3e50758e",
+      "statement_count": 88
+    },
+    {
+      "dialect": "pgsql",
+      "normalized_sql_sha256": "81d32ac2441ef21a6699e16b16c29727a0c79a4d9b872e5256a18583e723e099",
+      "statement_count": 70
+    }
+  ]
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/effective-schema.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/effective-schema.manifest.json
@@ -1,0 +1,36 @@
+{
+  "api_schema_format_version": "1.0.0",
+  "relational_mapping_version": "v1",
+  "effective_schema_hash": "5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10",
+  "resource_key_count": 3,
+  "resource_key_seed_hash": "a72b6d85b70e1147001e9503787a2f7173c575ddbed1dfd867aafecc5acd13d9",
+  "schema_components": [
+    {
+      "project_endpoint_name": "ed-fi",
+      "project_name": "Ed-Fi",
+      "project_version": "5.0.0",
+      "is_extension_project": false,
+      "project_hash": "e6189a041e2cd6e7275d29a0be45aed76e506cf4550e58233f68287c97ca04ab"
+    }
+  ],
+  "resource_keys": [
+    {
+      "resource_key_id": 1,
+      "project_name": "Ed-Fi",
+      "resource_name": "ProfileRootOnlyMergeItem",
+      "resource_version": "5.0.0"
+    },
+    {
+      "resource_key_id": 2,
+      "project_name": "Ed-Fi",
+      "resource_name": "SchoolTypeDescriptor",
+      "resource_version": "5.0.0"
+    },
+    {
+      "resource_key_id": 3,
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "resource_version": "5.0.0"
+    }
+  ]
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/mssql.sql
@@ -1,0 +1,805 @@
+-- ==========================================================
+-- Phase 0: Preflight (fail fast on schema hash mismatch)
+-- ==========================================================
+
+-- Preflight: fail fast if database is provisioned for a different schema hash
+DECLARE @preflight_stored_hash nvarchar(200);
+
+IF OBJECT_ID(N'dms.EffectiveSchema', N'U') IS NOT NULL
+BEGIN
+    SELECT @preflight_stored_hash = [EffectiveSchemaHash] FROM [dms].[EffectiveSchema]
+    WHERE [EffectiveSchemaSingletonId] = 1;
+    IF @preflight_stored_hash IS NOT NULL AND @preflight_stored_hash <> N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10'
+    BEGIN
+        DECLARE @preflight_msg nvarchar(500) = CONCAT(N'EffectiveSchemaHash mismatch: database has ''', @preflight_stored_hash, N''' but expected ''', N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10', N'''');
+        THROW 50000, @preflight_msg, 1;
+    END
+END
+
+-- ==========================================================
+-- Phase 1: Schemas
+-- ==========================================================
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'dms')
+    EXEC('CREATE SCHEMA [dms]');
+
+-- ==========================================================
+-- Phase 3: Sequences
+-- ==========================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.sequences s
+    JOIN sys.schemas sch ON s.schema_id = sch.schema_id
+    WHERE sch.name = N'dms' AND s.name = N'ChangeVersionSequence'
+)
+CREATE SEQUENCE [dms].[ChangeVersionSequence] START WITH 1;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.sequences s
+    JOIN sys.schemas sch ON s.schema_id = sch.schema_id
+    WHERE sch.name = N'dms' AND s.name = N'CollectionItemIdSequence'
+)
+CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
+
+-- ==========================================================
+-- Phase 4: Functions and Types
+-- ==========================================================
+
+GO
+CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
+RETURNS uniqueidentifier
+WITH SCHEMABINDING
+AS
+BEGIN
+    DECLARE @ns_bytes varbinary(16) = CAST(@namespace_uuid AS varbinary(16));
+
+    -- Convert SQL Server mixed-endian to RFC 4122 big-endian for hashing
+    DECLARE @ns_be varbinary(16) =
+        SUBSTRING(@ns_bytes, 4, 1) + SUBSTRING(@ns_bytes, 3, 1)
+        + SUBSTRING(@ns_bytes, 2, 1) + SUBSTRING(@ns_bytes, 1, 1)
+        + SUBSTRING(@ns_bytes, 6, 1) + SUBSTRING(@ns_bytes, 5, 1)
+        + SUBSTRING(@ns_bytes, 8, 1) + SUBSTRING(@ns_bytes, 7, 1)
+        + SUBSTRING(@ns_bytes, 9, 8);
+
+    -- Apply UTF-8 collation to the nvarchar source before casting to varchar so the
+    -- conversion uses code page 65001 directly, matching Core (Encoding.UTF8) and
+    -- PostgreSQL (convert_to ... 'UTF8') for non-ASCII characters.
+    DECLARE @name_bytes varbinary(max) = CAST(CAST(@name_text COLLATE Latin1_General_100_CI_AS_SC_UTF8 AS varchar(max)) AS varbinary(max));
+
+    DECLARE @hash varbinary(20) = HASHBYTES('SHA1', @ns_be + @name_bytes);
+
+    -- Take first 16 bytes and set version/variant bits
+    DECLARE @result varbinary(16) = SUBSTRING(@hash, 1, 16);
+
+    DECLARE @byte6 int = CAST(SUBSTRING(@result, 7, 1) AS int);
+    SET @result = SUBSTRING(@result, 1, 6)
+        + CAST((@byte6 & 0x0F) | 0x50 AS binary(1))
+        + SUBSTRING(@result, 8, 9);
+
+    DECLARE @byte8 int = CAST(SUBSTRING(@result, 9, 1) AS int);
+    SET @result = SUBSTRING(@result, 1, 8)
+        + CAST((@byte8 & 0x3F) | 0x80 AS binary(1))
+        + SUBSTRING(@result, 10, 7);
+
+    -- Convert big-endian result back to SQL Server mixed-endian
+    RETURN CAST(
+        SUBSTRING(@result, 4, 1) + SUBSTRING(@result, 3, 1)
+        + SUBSTRING(@result, 2, 1) + SUBSTRING(@result, 1, 1)
+        + SUBSTRING(@result, 6, 1) + SUBSTRING(@result, 5, 1)
+        + SUBSTRING(@result, 8, 1) + SUBSTRING(@result, 7, 1)
+        + SUBSTRING(@result, 9, 8)
+        AS uniqueidentifier);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.types t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms'
+      AND t.name = N'BigIntTable'
+      AND t.is_table_type = 1
+)
+CREATE TYPE [dms].[BigIntTable] AS TABLE(
+    [Id] bigint NOT NULL
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.types t
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms'
+      AND t.name = N'UniqueIdentifierTable'
+      AND t.is_table_type = 1
+)
+CREATE TYPE [dms].[UniqueIdentifierTable] AS TABLE(
+    [Id] uniqueidentifier NOT NULL
+);
+
+-- ==========================================================
+-- Phase 5: Tables (PK/UNIQUE/CHECK only, no cross-table FKs)
+-- ==========================================================
+
+IF OBJECT_ID(N'dms.Descriptor', N'U') IS NULL
+CREATE TABLE [dms].[Descriptor]
+(
+    [DocumentId] bigint NOT NULL,
+    [Namespace] nvarchar(255) NOT NULL,
+    [CodeValue] nvarchar(50) NOT NULL,
+    [ShortDescription] nvarchar(75) NOT NULL,
+    [Description] nvarchar(1024) NULL,
+    [EffectiveBeginDate] date NULL,
+    [EffectiveEndDate] date NULL,
+    [Discriminator] nvarchar(128) NOT NULL,
+    [Uri] nvarchar(306) NOT NULL,
+    CONSTRAINT [PK_Descriptor] PRIMARY KEY CLUSTERED ([DocumentId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = N'UX_Descriptor_Uri_Discriminator' AND type = 'UQ' AND parent_object_id = OBJECT_ID(N'dms.Descriptor')
+)
+ALTER TABLE [dms].[Descriptor]
+ADD CONSTRAINT [UX_Descriptor_Uri_Discriminator] UNIQUE ([Uri], [Discriminator]);
+
+IF OBJECT_ID(N'dms.Document', N'U') IS NULL
+CREATE TABLE [dms].[Document]
+(
+    [DocumentId] bigint IDENTITY(1,1) NOT NULL,
+    [DocumentUuid] uniqueidentifier NOT NULL,
+    [ResourceKeyId] smallint NOT NULL,
+    [ContentVersion] bigint NOT NULL CONSTRAINT [DF_Document_ContentVersion] DEFAULT (NEXT VALUE FOR [dms].[ChangeVersionSequence]),
+    [IdentityVersion] bigint NOT NULL CONSTRAINT [DF_Document_IdentityVersion] DEFAULT (NEXT VALUE FOR [dms].[ChangeVersionSequence]),
+    [ContentLastModifiedAt] datetime2(7) NOT NULL CONSTRAINT [DF_Document_ContentLastModifiedAt] DEFAULT (sysutcdatetime()),
+    [IdentityLastModifiedAt] datetime2(7) NOT NULL CONSTRAINT [DF_Document_IdentityLastModifiedAt] DEFAULT (sysutcdatetime()),
+    [CreatedAt] datetime2(7) NOT NULL CONSTRAINT [DF_Document_CreatedAt] DEFAULT (sysutcdatetime()),
+    CONSTRAINT [PK_Document] PRIMARY KEY CLUSTERED ([DocumentId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = N'UX_Document_DocumentUuid' AND type = 'UQ' AND parent_object_id = OBJECT_ID(N'dms.Document')
+)
+ALTER TABLE [dms].[Document]
+ADD CONSTRAINT [UX_Document_DocumentUuid] UNIQUE ([DocumentUuid]);
+
+IF OBJECT_ID(N'dms.DocumentCache', N'U') IS NULL
+CREATE TABLE [dms].[DocumentCache]
+(
+    [DocumentId] bigint NOT NULL,
+    [DocumentUuid] uniqueidentifier NOT NULL,
+    [ProjectName] nvarchar(256) NOT NULL,
+    [ResourceName] nvarchar(256) NOT NULL,
+    [ResourceVersion] nvarchar(32) NOT NULL,
+    [Etag] nvarchar(64) NOT NULL,
+    [LastModifiedAt] datetime2(7) NOT NULL,
+    [DocumentJson] nvarchar(max) NOT NULL,
+    [ComputedAt] datetime2(7) NOT NULL CONSTRAINT [DF_DocumentCache_ComputedAt] DEFAULT (sysutcdatetime()),
+    CONSTRAINT [PK_DocumentCache] PRIMARY KEY CLUSTERED ([DocumentId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = N'UX_DocumentCache_DocumentUuid' AND type = 'UQ' AND parent_object_id = OBJECT_ID(N'dms.DocumentCache')
+)
+ALTER TABLE [dms].[DocumentCache]
+ADD CONSTRAINT [UX_DocumentCache_DocumentUuid] UNIQUE ([DocumentUuid]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.check_constraints
+    WHERE name = N'CK_DocumentCache_IsJsonObject' AND parent_object_id = OBJECT_ID(N'dms.DocumentCache')
+)
+ALTER TABLE [dms].[DocumentCache]
+ADD CONSTRAINT [CK_DocumentCache_IsJsonObject] CHECK (ISJSON([DocumentJson]) = 1 AND LEFT(LTRIM([DocumentJson]), 1) = '{');
+
+IF OBJECT_ID(N'dms.DocumentChangeEvent', N'U') IS NULL
+CREATE TABLE [dms].[DocumentChangeEvent]
+(
+    [ChangeVersion] bigint NOT NULL,
+    [DocumentId] bigint NOT NULL,
+    [ResourceKeyId] smallint NOT NULL,
+    [CreatedAt] datetime2(7) NOT NULL CONSTRAINT [DF_DocumentChangeEvent_CreatedAt] DEFAULT (sysutcdatetime()),
+    CONSTRAINT [PK_DocumentChangeEvent] PRIMARY KEY CLUSTERED ([ChangeVersion], [DocumentId])
+);
+
+IF OBJECT_ID(N'dms.EffectiveSchema', N'U') IS NULL
+CREATE TABLE [dms].[EffectiveSchema]
+(
+    [EffectiveSchemaSingletonId] smallint NOT NULL,
+    [ApiSchemaFormatVersion] nvarchar(64) NOT NULL,
+    [EffectiveSchemaHash] nvarchar(64) NOT NULL,
+    [ResourceKeyCount] smallint NOT NULL,
+    [ResourceKeySeedHash] binary(32) NOT NULL,
+    [AppliedAt] datetime2(7) NOT NULL CONSTRAINT [DF_EffectiveSchema_AppliedAt] DEFAULT (sysutcdatetime()),
+    CONSTRAINT [PK_EffectiveSchema] PRIMARY KEY CLUSTERED ([EffectiveSchemaSingletonId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.check_constraints
+    WHERE name = N'CK_EffectiveSchema_Singleton' AND parent_object_id = OBJECT_ID(N'dms.EffectiveSchema')
+)
+ALTER TABLE [dms].[EffectiveSchema]
+ADD CONSTRAINT [CK_EffectiveSchema_Singleton] CHECK ([EffectiveSchemaSingletonId] = 1);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.check_constraints
+    WHERE name = N'CK_EffectiveSchema_ApiSchemaFormatVersion_NotBlank' AND parent_object_id = OBJECT_ID(N'dms.EffectiveSchema')
+)
+ALTER TABLE [dms].[EffectiveSchema]
+ADD CONSTRAINT [CK_EffectiveSchema_ApiSchemaFormatVersion_NotBlank] CHECK (LEN(LTRIM(RTRIM([ApiSchemaFormatVersion]))) > 0);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = N'UX_EffectiveSchema_EffectiveSchemaHash' AND type = 'UQ' AND parent_object_id = OBJECT_ID(N'dms.EffectiveSchema')
+)
+ALTER TABLE [dms].[EffectiveSchema]
+ADD CONSTRAINT [UX_EffectiveSchema_EffectiveSchemaHash] UNIQUE ([EffectiveSchemaHash]);
+
+IF OBJECT_ID(N'dms.ReferentialIdentity', N'U') IS NULL
+CREATE TABLE [dms].[ReferentialIdentity]
+(
+    [ReferentialId] uniqueidentifier NOT NULL,
+    [DocumentId] bigint NOT NULL,
+    [ResourceKeyId] smallint NOT NULL,
+    CONSTRAINT [PK_ReferentialIdentity] PRIMARY KEY NONCLUSTERED ([ReferentialId]),
+    CONSTRAINT [UX_ReferentialIdentity_DocumentId_ResourceKeyId] UNIQUE CLUSTERED ([DocumentId], [ResourceKeyId])
+);
+
+IF OBJECT_ID(N'dms.ResourceKey', N'U') IS NULL
+CREATE TABLE [dms].[ResourceKey]
+(
+    [ResourceKeyId] smallint NOT NULL,
+    [ProjectName] nvarchar(256) NOT NULL,
+    [ResourceName] nvarchar(256) NOT NULL,
+    [ResourceVersion] nvarchar(32) NOT NULL,
+    CONSTRAINT [PK_ResourceKey] PRIMARY KEY CLUSTERED ([ResourceKeyId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.key_constraints
+    WHERE name = N'UX_ResourceKey_ProjectName_ResourceName' AND type = 'UQ' AND parent_object_id = OBJECT_ID(N'dms.ResourceKey')
+)
+ALTER TABLE [dms].[ResourceKey]
+ADD CONSTRAINT [UX_ResourceKey_ProjectName_ResourceName] UNIQUE ([ProjectName], [ResourceName]);
+
+IF OBJECT_ID(N'dms.SchemaComponent', N'U') IS NULL
+CREATE TABLE [dms].[SchemaComponent]
+(
+    [EffectiveSchemaHash] nvarchar(64) NOT NULL,
+    [ProjectEndpointName] nvarchar(128) NOT NULL,
+    [ProjectName] nvarchar(256) NOT NULL,
+    [ProjectVersion] nvarchar(32) NOT NULL,
+    [IsExtensionProject] bit NOT NULL,
+    CONSTRAINT [PK_SchemaComponent] PRIMARY KEY CLUSTERED ([EffectiveSchemaHash], [ProjectEndpointName])
+);
+
+-- ==========================================================
+-- Phase 6: Foreign Keys
+-- ==========================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_Descriptor_Document' AND parent_object_id = OBJECT_ID(N'dms.Descriptor')
+)
+ALTER TABLE [dms].[Descriptor]
+ADD CONSTRAINT [FK_Descriptor_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_Document_ResourceKey' AND parent_object_id = OBJECT_ID(N'dms.Document')
+)
+ALTER TABLE [dms].[Document]
+ADD CONSTRAINT [FK_Document_ResourceKey]
+FOREIGN KEY ([ResourceKeyId])
+REFERENCES [dms].[ResourceKey] ([ResourceKeyId])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DocumentCache_Document' AND parent_object_id = OBJECT_ID(N'dms.DocumentCache')
+)
+ALTER TABLE [dms].[DocumentCache]
+ADD CONSTRAINT [FK_DocumentCache_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DocumentChangeEvent_Document' AND parent_object_id = OBJECT_ID(N'dms.DocumentChangeEvent')
+)
+ALTER TABLE [dms].[DocumentChangeEvent]
+ADD CONSTRAINT [FK_DocumentChangeEvent_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DocumentChangeEvent_ResourceKey' AND parent_object_id = OBJECT_ID(N'dms.DocumentChangeEvent')
+)
+ALTER TABLE [dms].[DocumentChangeEvent]
+ADD CONSTRAINT [FK_DocumentChangeEvent_ResourceKey]
+FOREIGN KEY ([ResourceKeyId])
+REFERENCES [dms].[ResourceKey] ([ResourceKeyId])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_ReferentialIdentity_Document' AND parent_object_id = OBJECT_ID(N'dms.ReferentialIdentity')
+)
+ALTER TABLE [dms].[ReferentialIdentity]
+ADD CONSTRAINT [FK_ReferentialIdentity_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_ReferentialIdentity_ResourceKey' AND parent_object_id = OBJECT_ID(N'dms.ReferentialIdentity')
+)
+ALTER TABLE [dms].[ReferentialIdentity]
+ADD CONSTRAINT [FK_ReferentialIdentity_ResourceKey]
+FOREIGN KEY ([ResourceKeyId])
+REFERENCES [dms].[ResourceKey] ([ResourceKeyId])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_SchemaComponent_EffectiveSchemaHash' AND parent_object_id = OBJECT_ID(N'dms.SchemaComponent')
+)
+ALTER TABLE [dms].[SchemaComponent]
+ADD CONSTRAINT [FK_SchemaComponent_EffectiveSchemaHash]
+FOREIGN KEY ([EffectiveSchemaHash])
+REFERENCES [dms].[EffectiveSchema] ([EffectiveSchemaHash])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+-- ==========================================================
+-- Phase 7: Indexes
+-- ==========================================================
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'Descriptor' AND i.name = N'IX_Descriptor_Uri_Discriminator'
+)
+CREATE INDEX [IX_Descriptor_Uri_Discriminator] ON [dms].[Descriptor] ([Uri], [Discriminator]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'Document' AND i.name = N'IX_Document_ResourceKeyId_DocumentId'
+)
+CREATE INDEX [IX_Document_ResourceKeyId_DocumentId] ON [dms].[Document] ([ResourceKeyId], [DocumentId]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'DocumentCache' AND i.name = N'IX_DocumentCache_ProjectName_ResourceName_LastModifiedAt'
+)
+CREATE INDEX [IX_DocumentCache_ProjectName_ResourceName_LastModifiedAt] ON [dms].[DocumentCache] ([ProjectName], [ResourceName], [LastModifiedAt], [DocumentId]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'DocumentChangeEvent' AND i.name = N'IX_DocumentChangeEvent_DocumentId'
+)
+CREATE INDEX [IX_DocumentChangeEvent_DocumentId] ON [dms].[DocumentChangeEvent] ([DocumentId]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'DocumentChangeEvent' AND i.name = N'IX_DocumentChangeEvent_ResourceKeyId_ChangeVersion'
+)
+CREATE INDEX [IX_DocumentChangeEvent_ResourceKeyId_ChangeVersion] ON [dms].[DocumentChangeEvent] ([ResourceKeyId], [ChangeVersion], [DocumentId]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'dms' AND t.name = N'ReferentialIdentity' AND i.name = N'IX_ReferentialIdentity_DocumentId'
+)
+CREATE INDEX [IX_ReferentialIdentity_DocumentId] ON [dms].[ReferentialIdentity] ([DocumentId]);
+
+-- ==========================================================
+-- Phase 8: Triggers
+-- ==========================================================
+
+GO
+CREATE OR ALTER TRIGGER [dms].[TR_Document_Journal]
+ON [dms].[Document]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF UPDATE([ContentVersion]) OR NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        INSERT INTO [dms].[DocumentChangeEvent] ([ChangeVersion], [DocumentId], [ResourceKeyId], [CreatedAt])
+        SELECT i.[ContentVersion], i.[DocumentId], i.[ResourceKeyId], sysutcdatetime()
+        FROM inserted i;
+    END
+END;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'edfi')
+    EXEC('CREATE SCHEMA [edfi]');
+
+IF OBJECT_ID(N'edfi.ProfileRootOnlyMergeItem', N'U') IS NULL
+CREATE TABLE [edfi].[ProfileRootOnlyMergeItem]
+(
+    [DocumentId] bigint NOT NULL,
+    [PrimarySchoolTypeDescriptor_DescriptorId_Present] bit NULL,
+    [PrimarySchoolTypeDescriptor_Unified_DescriptorId] bigint NULL,
+    [SecondarySchoolTypeDescriptor_DescriptorId_Present] bit NULL,
+    [StudentReference_DocumentId] bigint NULL,
+    [StudentReference_StudentUniqueId] nvarchar(32) NULL,
+    [PrimarySchoolTypeDescriptor_DescriptorId] AS (CASE WHEN [PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL THEN NULL ELSE [PrimarySchoolTypeDescriptor_Unified_DescriptorId] END) PERSISTED,
+    [SecondarySchoolTypeDescriptor_DescriptorId] AS (CASE WHEN [SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL THEN NULL ELSE [PrimarySchoolTypeDescriptor_Unified_DescriptorId] END) PERSISTED,
+    [DisplayName] nvarchar(100) NULL,
+    [ProfileRootOnlyMergeItemId] int NOT NULL,
+    [ProfileScopeClearableText] nvarchar(100) NULL,
+    [ProfileScopePreservedText] nvarchar(100) NULL,
+    CONSTRAINT [PK_ProfileRootOnlyMergeItem] PRIMARY KEY ([DocumentId]),
+    CONSTRAINT [UX_ProfileRootOnlyMergeItem_NK] UNIQUE ([ProfileRootOnlyMergeItemId]),
+    CONSTRAINT [CK_ProfileRootOnlyMergeItem_StudentReference_AllNone] CHECK (([StudentReference_DocumentId] IS NULL AND [StudentReference_StudentUniqueId] IS NULL) OR ([StudentReference_DocumentId] IS NOT NULL AND [StudentReference_StudentUniqueId] IS NOT NULL)),
+    CONSTRAINT [CK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_DescriptorId_Present_NullOrTrue] CHECK ([PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL OR [PrimarySchoolTypeDescriptor_DescriptorId_Present] = 1),
+    CONSTRAINT [CK_ProfileRootOnlyMergeItem_SecondarySchoolTypeDescriptor_DescriptorId_Present_NullOrTrue] CHECK ([SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL OR [SecondarySchoolTypeDescriptor_DescriptorId_Present] = 1)
+);
+
+IF OBJECT_ID(N'edfi.Student', N'U') IS NULL
+CREATE TABLE [edfi].[Student]
+(
+    [DocumentId] bigint NOT NULL,
+    [FirstName] nvarchar(75) NOT NULL,
+    [StudentUniqueId] nvarchar(32) NOT NULL,
+    CONSTRAINT [PK_Student] PRIMARY KEY ([DocumentId]),
+    CONSTRAINT [UX_Student_NK] UNIQUE ([StudentUniqueId]),
+    CONSTRAINT [UX_Student_RefKey] UNIQUE ([DocumentId], [StudentUniqueId])
+);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_ProfileRootOnlyMergeItem_Document' AND parent_object_id = OBJECT_ID(N'edfi.ProfileRootOnlyMergeItem')
+)
+ALTER TABLE [edfi].[ProfileRootOnlyMergeItem]
+ADD CONSTRAINT [FK_ProfileRootOnlyMergeItem_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified' AND parent_object_id = OBJECT_ID(N'edfi.ProfileRootOnlyMergeItem')
+)
+ALTER TABLE [edfi].[ProfileRootOnlyMergeItem]
+ADD CONSTRAINT [FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified]
+FOREIGN KEY ([PrimarySchoolTypeDescriptor_Unified_DescriptorId])
+REFERENCES [dms].[Descriptor] ([DocumentId])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_ProfileRootOnlyMergeItem_StudentReference_RefKey' AND parent_object_id = OBJECT_ID(N'edfi.ProfileRootOnlyMergeItem')
+)
+ALTER TABLE [edfi].[ProfileRootOnlyMergeItem]
+ADD CONSTRAINT [FK_ProfileRootOnlyMergeItem_StudentReference_RefKey]
+FOREIGN KEY ([StudentReference_DocumentId], [StudentReference_StudentUniqueId])
+REFERENCES [edfi].[Student] ([DocumentId], [StudentUniqueId])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_Student_Document' AND parent_object_id = OBJECT_ID(N'edfi.Student')
+)
+ALTER TABLE [edfi].[Student]
+ADD CONSTRAINT [FK_Student_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'edfi' AND t.name = N'ProfileRootOnlyMergeItem' AND i.name = N'IX_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified_DescriptorId'
+)
+CREATE INDEX [IX_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified_DescriptorId] ON [edfi].[ProfileRootOnlyMergeItem] ([PrimarySchoolTypeDescriptor_Unified_DescriptorId]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'edfi' AND t.name = N'ProfileRootOnlyMergeItem' AND i.name = N'IX_ProfileRootOnlyMergeItem_StudentReference_DocumentId_StudentReference_StudentUniqueId'
+)
+CREATE INDEX [IX_ProfileRootOnlyMergeItem_StudentReference_DocumentId_StudentReference_StudentUniqueId] ON [edfi].[ProfileRootOnlyMergeItem] ([StudentReference_DocumentId], [StudentReference_StudentUniqueId]);
+
+GO
+CREATE OR ALTER TRIGGER [edfi].[TR_ProfileRootOnlyMergeItem_ReferentialIdentity]
+ON [edfi].[ProfileRootOnlyMergeItem]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 1;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiProfileRootOnlyMergeItem' AS nvarchar(max)) + N'$.profileRootOnlyMergeItemId=' + CAST(i.[ProfileRootOnlyMergeItemId] AS nvarchar(max))), i.[DocumentId], 1
+        FROM inserted i;
+    END
+    ELSE IF (UPDATE([ProfileRootOnlyMergeItemId]))
+    BEGIN
+        DECLARE @changedDocs TABLE ([DocumentId] bigint NOT NULL);
+        INSERT INTO @changedDocs ([DocumentId])
+        SELECT i.[DocumentId]
+        FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
+        WHERE (i.[ProfileRootOnlyMergeItemId] <> d.[ProfileRootOnlyMergeItemId] OR (i.[ProfileRootOnlyMergeItemId] IS NULL AND d.[ProfileRootOnlyMergeItemId] IS NOT NULL) OR (i.[ProfileRootOnlyMergeItemId] IS NOT NULL AND d.[ProfileRootOnlyMergeItemId] IS NULL));
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 1;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiProfileRootOnlyMergeItem' AS nvarchar(max)) + N'$.profileRootOnlyMergeItemId=' + CAST(i.[ProfileRootOnlyMergeItemId] AS nvarchar(max))), i.[DocumentId], 1
+        FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_ProfileRootOnlyMergeItem_Stamp]
+ON [edfi].[ProfileRootOnlyMergeItem]
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    ;WITH affectedDocs AS (
+        SELECT i.[DocumentId]
+        FROM inserted i
+        LEFT JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE del.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] <> del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL AND del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL) OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL AND del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL)) OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] <> del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NULL AND del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NOT NULL) OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NOT NULL AND del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NULL)) OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] <> del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL AND del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL) OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL AND del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL)) OR (i.[StudentReference_DocumentId] <> del.[StudentReference_DocumentId] OR (i.[StudentReference_DocumentId] IS NULL AND del.[StudentReference_DocumentId] IS NOT NULL) OR (i.[StudentReference_DocumentId] IS NOT NULL AND del.[StudentReference_DocumentId] IS NULL)) OR (CAST(i.[StudentReference_StudentUniqueId] AS varbinary(max)) <> CAST(del.[StudentReference_StudentUniqueId] AS varbinary(max)) OR (i.[StudentReference_StudentUniqueId] IS NULL AND del.[StudentReference_StudentUniqueId] IS NOT NULL) OR (i.[StudentReference_StudentUniqueId] IS NOT NULL AND del.[StudentReference_StudentUniqueId] IS NULL)) OR (CAST(i.[DisplayName] AS varbinary(max)) <> CAST(del.[DisplayName] AS varbinary(max)) OR (i.[DisplayName] IS NULL AND del.[DisplayName] IS NOT NULL) OR (i.[DisplayName] IS NOT NULL AND del.[DisplayName] IS NULL)) OR (i.[ProfileRootOnlyMergeItemId] <> del.[ProfileRootOnlyMergeItemId] OR (i.[ProfileRootOnlyMergeItemId] IS NULL AND del.[ProfileRootOnlyMergeItemId] IS NOT NULL) OR (i.[ProfileRootOnlyMergeItemId] IS NOT NULL AND del.[ProfileRootOnlyMergeItemId] IS NULL)) OR (CAST(i.[ProfileScopeClearableText] AS varbinary(max)) <> CAST(del.[ProfileScopeClearableText] AS varbinary(max)) OR (i.[ProfileScopeClearableText] IS NULL AND del.[ProfileScopeClearableText] IS NOT NULL) OR (i.[ProfileScopeClearableText] IS NOT NULL AND del.[ProfileScopeClearableText] IS NULL)) OR (CAST(i.[ProfileScopePreservedText] AS varbinary(max)) <> CAST(del.[ProfileScopePreservedText] AS varbinary(max)) OR (i.[ProfileScopePreservedText] IS NULL AND del.[ProfileScopePreservedText] IS NOT NULL) OR (i.[ProfileScopePreservedText] IS NOT NULL AND del.[ProfileScopePreservedText] IS NULL))
+        UNION
+        SELECT del.[DocumentId]
+        FROM deleted del
+        LEFT JOIN inserted i ON i.[DocumentId] = del.[DocumentId]
+        WHERE i.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] <> del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL AND del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL) OR (i.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL AND del.[PrimarySchoolTypeDescriptor_DescriptorId_Present] IS NULL)) OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] <> del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NULL AND del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NOT NULL) OR (i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NOT NULL AND del.[PrimarySchoolTypeDescriptor_Unified_DescriptorId] IS NULL)) OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] <> del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL AND del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL) OR (i.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NOT NULL AND del.[SecondarySchoolTypeDescriptor_DescriptorId_Present] IS NULL)) OR (i.[StudentReference_DocumentId] <> del.[StudentReference_DocumentId] OR (i.[StudentReference_DocumentId] IS NULL AND del.[StudentReference_DocumentId] IS NOT NULL) OR (i.[StudentReference_DocumentId] IS NOT NULL AND del.[StudentReference_DocumentId] IS NULL)) OR (CAST(i.[StudentReference_StudentUniqueId] AS varbinary(max)) <> CAST(del.[StudentReference_StudentUniqueId] AS varbinary(max)) OR (i.[StudentReference_StudentUniqueId] IS NULL AND del.[StudentReference_StudentUniqueId] IS NOT NULL) OR (i.[StudentReference_StudentUniqueId] IS NOT NULL AND del.[StudentReference_StudentUniqueId] IS NULL)) OR (CAST(i.[DisplayName] AS varbinary(max)) <> CAST(del.[DisplayName] AS varbinary(max)) OR (i.[DisplayName] IS NULL AND del.[DisplayName] IS NOT NULL) OR (i.[DisplayName] IS NOT NULL AND del.[DisplayName] IS NULL)) OR (i.[ProfileRootOnlyMergeItemId] <> del.[ProfileRootOnlyMergeItemId] OR (i.[ProfileRootOnlyMergeItemId] IS NULL AND del.[ProfileRootOnlyMergeItemId] IS NOT NULL) OR (i.[ProfileRootOnlyMergeItemId] IS NOT NULL AND del.[ProfileRootOnlyMergeItemId] IS NULL)) OR (CAST(i.[ProfileScopeClearableText] AS varbinary(max)) <> CAST(del.[ProfileScopeClearableText] AS varbinary(max)) OR (i.[ProfileScopeClearableText] IS NULL AND del.[ProfileScopeClearableText] IS NOT NULL) OR (i.[ProfileScopeClearableText] IS NOT NULL AND del.[ProfileScopeClearableText] IS NULL)) OR (CAST(i.[ProfileScopePreservedText] AS varbinary(max)) <> CAST(del.[ProfileScopePreservedText] AS varbinary(max)) OR (i.[ProfileScopePreservedText] IS NULL AND del.[ProfileScopePreservedText] IS NOT NULL) OR (i.[ProfileScopePreservedText] IS NOT NULL AND del.[ProfileScopePreservedText] IS NULL))
+    )
+    UPDATE d
+    SET d.[ContentVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[ContentLastModifiedAt] = sysutcdatetime()
+    FROM [dms].[Document] d
+    INNER JOIN affectedDocs a ON d.[DocumentId] = a.[DocumentId];
+    IF EXISTS (SELECT 1 FROM deleted) AND (UPDATE([ProfileRootOnlyMergeItemId]))
+    BEGIN
+        UPDATE d
+        SET d.[IdentityVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[IdentityLastModifiedAt] = sysutcdatetime()
+        FROM [dms].[Document] d
+        INNER JOIN inserted i ON d.[DocumentId] = i.[DocumentId]
+        INNER JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE (i.[ProfileRootOnlyMergeItemId] <> del.[ProfileRootOnlyMergeItemId] OR (i.[ProfileRootOnlyMergeItemId] IS NULL AND del.[ProfileRootOnlyMergeItemId] IS NOT NULL) OR (i.[ProfileRootOnlyMergeItemId] IS NOT NULL AND del.[ProfileRootOnlyMergeItemId] IS NULL));
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_Student_ReferentialIdentity]
+ON [edfi].[Student]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 3;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 3
+        FROM inserted i;
+    END
+    ELSE IF (UPDATE([StudentUniqueId]))
+    BEGIN
+        DECLARE @changedDocs TABLE ([DocumentId] bigint NOT NULL);
+        INSERT INTO @changedDocs ([DocumentId])
+        SELECT i.[DocumentId]
+        FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
+        WHERE (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(d.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND d.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND d.[StudentUniqueId] IS NULL));
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 3;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 3
+        FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_Student_Stamp]
+ON [edfi].[Student]
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    ;WITH affectedDocs AS (
+        SELECT i.[DocumentId]
+        FROM inserted i
+        LEFT JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE del.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (CAST(i.[FirstName] AS varbinary(max)) <> CAST(del.[FirstName] AS varbinary(max)) OR (i.[FirstName] IS NULL AND del.[FirstName] IS NOT NULL) OR (i.[FirstName] IS NOT NULL AND del.[FirstName] IS NULL)) OR (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(del.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND del.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND del.[StudentUniqueId] IS NULL))
+        UNION
+        SELECT del.[DocumentId]
+        FROM deleted del
+        LEFT JOIN inserted i ON i.[DocumentId] = del.[DocumentId]
+        WHERE i.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (CAST(i.[FirstName] AS varbinary(max)) <> CAST(del.[FirstName] AS varbinary(max)) OR (i.[FirstName] IS NULL AND del.[FirstName] IS NOT NULL) OR (i.[FirstName] IS NOT NULL AND del.[FirstName] IS NULL)) OR (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(del.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND del.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND del.[StudentUniqueId] IS NULL))
+    )
+    UPDATE d
+    SET d.[ContentVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[ContentLastModifiedAt] = sysutcdatetime()
+    FROM [dms].[Document] d
+    INNER JOIN affectedDocs a ON d.[DocumentId] = a.[DocumentId];
+    IF EXISTS (SELECT 1 FROM deleted) AND (UPDATE([StudentUniqueId]))
+    BEGIN
+        UPDATE d
+        SET d.[IdentityVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[IdentityLastModifiedAt] = sysutcdatetime()
+        FROM [dms].[Document] d
+        INNER JOIN inserted i ON d.[DocumentId] = i.[DocumentId]
+        INNER JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(del.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND del.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND del.[StudentUniqueId] IS NULL));
+    END
+END;
+GO
+
+-- ==========================================================
+-- Phase 7: Seed Data (insert-if-missing + validation)
+-- ==========================================================
+
+-- ResourceKey seed inserts (insert-if-missing)
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 1)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (1, N'Ed-Fi', N'ProfileRootOnlyMergeItem', N'5.0.0');
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 2)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (2, N'Ed-Fi', N'SchoolTypeDescriptor', N'5.0.0');
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 3)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (3, N'Ed-Fi', N'Student', N'5.0.0');
+
+-- ResourceKey full-table validation (count + content)
+DECLARE @actual_count integer;
+DECLARE @mismatched_count integer;
+DECLARE @rk_mismatched_ids nvarchar(max);
+
+SELECT @actual_count = COUNT(*) FROM [dms].[ResourceKey];
+IF @actual_count <> 3
+BEGIN
+    DECLARE @rk_count_msg nvarchar(200) = CONCAT(N'dms.ResourceKey count mismatch: expected 3, found ', CAST(@actual_count AS nvarchar(10)));
+    THROW 50000, @rk_count_msg, 1;
+END
+
+SELECT @mismatched_count = COUNT(*)
+FROM [dms].[ResourceKey] rk
+WHERE NOT EXISTS (
+    SELECT 1 FROM (VALUES
+        (1, N'Ed-Fi', N'ProfileRootOnlyMergeItem', N'5.0.0'),
+        (2, N'Ed-Fi', N'SchoolTypeDescriptor', N'5.0.0'),
+        (3, N'Ed-Fi', N'Student', N'5.0.0')
+    ) AS expected([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    WHERE expected.[ResourceKeyId] = rk.[ResourceKeyId]
+    AND expected.[ProjectName] = rk.[ProjectName]
+    AND expected.[ResourceName] = rk.[ResourceName]
+    AND expected.[ResourceVersion] = rk.[ResourceVersion]
+);
+IF @mismatched_count > 0
+BEGIN
+    SELECT @rk_mismatched_ids = STRING_AGG(sub.[ResourceKeyId], N', ') WITHIN GROUP (ORDER BY sub.[ResourceKeyIdNum])
+    FROM (
+        SELECT TOP 10 CAST(rk.[ResourceKeyId] AS nvarchar(10)) AS [ResourceKeyId], rk.[ResourceKeyId] AS [ResourceKeyIdNum]
+        FROM [dms].[ResourceKey] rk
+        WHERE NOT EXISTS (
+            SELECT 1 FROM (VALUES
+                (1, N'Ed-Fi', N'ProfileRootOnlyMergeItem', N'5.0.0'),
+                (2, N'Ed-Fi', N'SchoolTypeDescriptor', N'5.0.0'),
+                (3, N'Ed-Fi', N'Student', N'5.0.0')
+            ) AS expected([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+            WHERE expected.[ResourceKeyId] = rk.[ResourceKeyId]
+            AND expected.[ProjectName] = rk.[ProjectName]
+            AND expected.[ResourceName] = rk.[ResourceName]
+            AND expected.[ResourceVersion] = rk.[ResourceVersion]
+        )
+        ORDER BY rk.[ResourceKeyId]
+    ) sub;
+    DECLARE @rk_content_msg nvarchar(500) = CONCAT(N'dms.ResourceKey contents mismatch: ', CAST(@mismatched_count AS nvarchar(10)), N' unexpected or modified rows (ResourceKeyIds: ', @rk_mismatched_ids, N'). Run ddl provision for detailed row-level diff.');
+    THROW 50000, @rk_content_msg, 1;
+END
+
+-- EffectiveSchema singleton insert-if-missing
+IF NOT EXISTS (SELECT 1 FROM [dms].[EffectiveSchema] WHERE [EffectiveSchemaSingletonId] = 1)
+    INSERT INTO [dms].[EffectiveSchema] ([EffectiveSchemaSingletonId], [ApiSchemaFormatVersion], [EffectiveSchemaHash], [ResourceKeyCount], [ResourceKeySeedHash])
+    VALUES (1, N'1.0.0', N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10', 3, 0xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9);
+
+-- EffectiveSchema validation (ApiSchemaFormatVersion + ResourceKeyCount + ResourceKeySeedHash)
+DECLARE @es_stored_api_schema_format_version nvarchar(255);
+DECLARE @es_stored_count smallint;
+DECLARE @es_stored_hash varbinary(32);
+
+SELECT @es_stored_api_schema_format_version = [ApiSchemaFormatVersion], @es_stored_count = [ResourceKeyCount], @es_stored_hash = [ResourceKeySeedHash]
+FROM [dms].[EffectiveSchema]
+WHERE [EffectiveSchemaSingletonId] = 1;
+IF @es_stored_count IS NOT NULL
+BEGIN
+    IF @es_stored_api_schema_format_version IS NULL OR LEN(LTRIM(RTRIM(@es_stored_api_schema_format_version))) = 0
+    BEGIN
+        THROW 50000, N'dms.EffectiveSchema.ApiSchemaFormatVersion must not be empty.', 1;
+    END
+    IF @es_stored_count <> 3
+    BEGIN
+        DECLARE @es_count_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeyCount mismatch: expected 3, found ', CAST(@es_stored_count AS nvarchar(10)));
+        THROW 50000, @es_count_msg, 1;
+    END
+    IF @es_stored_hash <> 0xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9
+    BEGIN
+        DECLARE @es_hash_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored ', CONVERT(nvarchar(66), @es_stored_hash, 1), N' but expected ', CONVERT(nvarchar(66), 0xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9, 1));
+        THROW 50000, @es_hash_msg, 1;
+    END
+END
+
+-- SchemaComponent seed inserts (insert-if-missing)
+IF NOT EXISTS (SELECT 1 FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10' AND [ProjectEndpointName] = N'ed-fi')
+    INSERT INTO [dms].[SchemaComponent] ([EffectiveSchemaHash], [ProjectEndpointName], [ProjectName], [ProjectVersion], [IsExtensionProject])
+    VALUES (N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10', N'ed-fi', N'Ed-Fi', N'5.0.0', 0);
+
+-- SchemaComponent exact-match validation (count + content)
+DECLARE @sc_actual_count integer;
+DECLARE @sc_mismatched_count integer;
+DECLARE @sc_mismatched_names nvarchar(max);
+
+SELECT @sc_actual_count = COUNT(*) FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10';
+IF @sc_actual_count <> 1
+BEGIN
+    DECLARE @sc_count_msg nvarchar(200) = CONCAT(N'dms.SchemaComponent count mismatch: expected 1, found ', CAST(@sc_actual_count AS nvarchar(10)));
+    THROW 50000, @sc_count_msg, 1;
+END
+
+SELECT @sc_mismatched_count = COUNT(*)
+FROM [dms].[SchemaComponent] sc
+WHERE sc.[EffectiveSchemaHash] = N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10'
+AND NOT EXISTS (
+    SELECT 1 FROM (VALUES
+        (N'ed-fi', N'Ed-Fi', N'5.0.0', 0)
+    ) AS expected([ProjectEndpointName], [ProjectName], [ProjectVersion], [IsExtensionProject])
+    WHERE expected.[ProjectEndpointName] = sc.[ProjectEndpointName]
+    AND expected.[ProjectName] = sc.[ProjectName]
+    AND expected.[ProjectVersion] = sc.[ProjectVersion]
+    AND expected.[IsExtensionProject] = sc.[IsExtensionProject]
+);
+IF @sc_mismatched_count > 0
+BEGIN
+    SELECT @sc_mismatched_names = STRING_AGG(sub.[ProjectEndpointName], N', ') WITHIN GROUP (ORDER BY sub.[ProjectEndpointName])
+    FROM (
+        SELECT TOP 10 sc.[ProjectEndpointName]
+        FROM [dms].[SchemaComponent] sc
+        WHERE sc.[EffectiveSchemaHash] = N'5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10'
+        AND NOT EXISTS (
+            SELECT 1 FROM (VALUES
+                (N'ed-fi', N'Ed-Fi', N'5.0.0', 0)
+            ) AS expected([ProjectEndpointName], [ProjectName], [ProjectVersion], [IsExtensionProject])
+            WHERE expected.[ProjectEndpointName] = sc.[ProjectEndpointName]
+            AND expected.[ProjectName] = sc.[ProjectName]
+            AND expected.[ProjectVersion] = sc.[ProjectVersion]
+            AND expected.[IsExtensionProject] = sc.[IsExtensionProject]
+        )
+        ORDER BY sc.[ProjectEndpointName]
+    ) sub;
+    DECLARE @sc_content_msg nvarchar(500) = CONCAT(N'dms.SchemaComponent contents mismatch: ', CAST(@sc_mismatched_count AS nvarchar(10)), N' unexpected or modified rows (ProjectEndpointNames: ', @sc_mismatched_names, N'). Run ddl provision for detailed row-level diff.');
+    THROW 50000, @sc_content_msg, 1;
+END
+

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
@@ -1,0 +1,804 @@
+-- ==========================================================
+-- Phase 0: Preflight (fail fast on schema hash mismatch)
+-- ==========================================================
+
+-- Preflight: fail fast if database is provisioned for a different schema hash
+DO $$
+DECLARE
+    _stored_hash text;
+BEGIN
+    IF to_regclass('"dms"."EffectiveSchema"') IS NOT NULL THEN
+        SELECT "EffectiveSchemaHash" INTO _stored_hash FROM "dms"."EffectiveSchema"
+        WHERE "EffectiveSchemaSingletonId" = 1;
+        IF _stored_hash IS NOT NULL AND _stored_hash <> '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10' THEN
+            RAISE EXCEPTION 'EffectiveSchemaHash mismatch: database has ''%'' but expected ''%''', _stored_hash, '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10';
+        END IF;
+    END IF;
+END $$;
+
+-- ==========================================================
+-- Phase 1: Schemas
+-- ==========================================================
+
+CREATE SCHEMA IF NOT EXISTS "dms";
+
+-- ==========================================================
+-- Phase 2: Extensions
+-- ==========================================================
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ==========================================================
+-- Phase 3: Sequences
+-- ==========================================================
+
+CREATE SEQUENCE IF NOT EXISTS "dms"."ChangeVersionSequence" START WITH 1;
+
+CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
+
+-- ==========================================================
+-- Phase 4: Functions and Types
+-- ==========================================================
+
+CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
+RETURNS integer
+LANGUAGE plpgsql
+AS $throw_error$
+BEGIN
+    RAISE EXCEPTION '%', msg USING ERRCODE = code;
+END
+$throw_error$;
+
+CREATE OR REPLACE FUNCTION "dms"."uuidv5"(namespace_uuid uuid, name_text text)
+RETURNS uuid
+LANGUAGE plpgsql
+IMMUTABLE STRICT PARALLEL SAFE
+AS $uuidv5$
+DECLARE
+    hash bytea;
+BEGIN
+    hash := digest(
+        decode(replace(namespace_uuid::text, '-', ''), 'hex')
+        || convert_to(name_text, 'UTF8'),
+        'sha1'
+    );
+    hash := set_byte(hash, 6, (get_byte(hash, 6) & x'0f'::int) | x'50'::int);
+    hash := set_byte(hash, 8, (get_byte(hash, 8) & x'3f'::int) | x'80'::int);
+    RETURN encode(substring(hash from 1 for 16), 'hex')::uuid;
+END
+$uuidv5$;
+
+-- ==========================================================
+-- Phase 5: Tables (PK/UNIQUE/CHECK only, no cross-table FKs)
+-- ==========================================================
+
+CREATE TABLE IF NOT EXISTS "dms"."Descriptor"
+(
+    "DocumentId" bigint NOT NULL,
+    "Namespace" varchar(255) NOT NULL,
+    "CodeValue" varchar(50) NOT NULL,
+    "ShortDescription" varchar(75) NOT NULL,
+    "Description" varchar(1024) NULL,
+    "EffectiveBeginDate" date NULL,
+    "EffectiveEndDate" date NULL,
+    "Discriminator" varchar(128) NOT NULL,
+    "Uri" varchar(306) NOT NULL,
+    CONSTRAINT "PK_Descriptor" PRIMARY KEY ("DocumentId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'UX_Descriptor_Uri_Discriminator'
+        AND conrelid = to_regclass('"dms"."Descriptor"')
+    )
+    THEN
+        ALTER TABLE "dms"."Descriptor"
+        ADD CONSTRAINT "UX_Descriptor_Uri_Discriminator" UNIQUE ("Uri", "Discriminator");
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "dms"."Document"
+(
+    "DocumentId" bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
+    "DocumentUuid" uuid NOT NULL,
+    "ResourceKeyId" smallint NOT NULL,
+    "ContentVersion" bigint NOT NULL DEFAULT nextval('"dms"."ChangeVersionSequence"'),
+    "IdentityVersion" bigint NOT NULL DEFAULT nextval('"dms"."ChangeVersionSequence"'),
+    "ContentLastModifiedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    "IdentityLastModifiedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    "CreatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "PK_Document" PRIMARY KEY ("DocumentId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'UX_Document_DocumentUuid'
+        AND conrelid = to_regclass('"dms"."Document"')
+    )
+    THEN
+        ALTER TABLE "dms"."Document"
+        ADD CONSTRAINT "UX_Document_DocumentUuid" UNIQUE ("DocumentUuid");
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "dms"."DocumentCache"
+(
+    "DocumentId" bigint NOT NULL,
+    "DocumentUuid" uuid NOT NULL,
+    "ProjectName" varchar(256) NOT NULL,
+    "ResourceName" varchar(256) NOT NULL,
+    "ResourceVersion" varchar(32) NOT NULL,
+    "Etag" varchar(64) NOT NULL,
+    "LastModifiedAt" timestamp with time zone NOT NULL,
+    "DocumentJson" jsonb NOT NULL,
+    "ComputedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "PK_DocumentCache" PRIMARY KEY ("DocumentId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'UX_DocumentCache_DocumentUuid'
+        AND conrelid = to_regclass('"dms"."DocumentCache"')
+    )
+    THEN
+        ALTER TABLE "dms"."DocumentCache"
+        ADD CONSTRAINT "UX_DocumentCache_DocumentUuid" UNIQUE ("DocumentUuid");
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'CK_DocumentCache_JsonObject'
+        AND conrelid = to_regclass('"dms"."DocumentCache"')
+    )
+    THEN
+        ALTER TABLE "dms"."DocumentCache"
+        ADD CONSTRAINT "CK_DocumentCache_JsonObject" CHECK (jsonb_typeof("DocumentJson") = 'object');
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "dms"."DocumentChangeEvent"
+(
+    "ChangeVersion" bigint NOT NULL,
+    "DocumentId" bigint NOT NULL,
+    "ResourceKeyId" smallint NOT NULL,
+    "CreatedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "PK_DocumentChangeEvent" PRIMARY KEY ("ChangeVersion", "DocumentId")
+);
+
+CREATE TABLE IF NOT EXISTS "dms"."EffectiveSchema"
+(
+    "EffectiveSchemaSingletonId" smallint NOT NULL,
+    "ApiSchemaFormatVersion" varchar(64) NOT NULL,
+    "EffectiveSchemaHash" varchar(64) NOT NULL,
+    "ResourceKeyCount" smallint NOT NULL,
+    "ResourceKeySeedHash" bytea NOT NULL,
+    "AppliedAt" timestamp with time zone NOT NULL DEFAULT now(),
+    CONSTRAINT "PK_EffectiveSchema" PRIMARY KEY ("EffectiveSchemaSingletonId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'CK_EffectiveSchema_Singleton'
+        AND conrelid = to_regclass('"dms"."EffectiveSchema"')
+    )
+    THEN
+        ALTER TABLE "dms"."EffectiveSchema"
+        ADD CONSTRAINT "CK_EffectiveSchema_Singleton" CHECK ("EffectiveSchemaSingletonId" = 1);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'CK_EffectiveSchema_ApiSchemaFormatVersion_NotBlank'
+        AND conrelid = to_regclass('"dms"."EffectiveSchema"')
+    )
+    THEN
+        ALTER TABLE "dms"."EffectiveSchema"
+        ADD CONSTRAINT "CK_EffectiveSchema_ApiSchemaFormatVersion_NotBlank" CHECK (btrim("ApiSchemaFormatVersion") <> '');
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'CK_EffectiveSchema_ResourceKeySeedHash_Length'
+        AND conrelid = to_regclass('"dms"."EffectiveSchema"')
+    )
+    THEN
+        ALTER TABLE "dms"."EffectiveSchema"
+        ADD CONSTRAINT "CK_EffectiveSchema_ResourceKeySeedHash_Length" CHECK (octet_length("ResourceKeySeedHash") = 32);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'UX_EffectiveSchema_EffectiveSchemaHash'
+        AND conrelid = to_regclass('"dms"."EffectiveSchema"')
+    )
+    THEN
+        ALTER TABLE "dms"."EffectiveSchema"
+        ADD CONSTRAINT "UX_EffectiveSchema_EffectiveSchemaHash" UNIQUE ("EffectiveSchemaHash");
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "dms"."ReferentialIdentity"
+(
+    "ReferentialId" uuid NOT NULL,
+    "DocumentId" bigint NOT NULL,
+    "ResourceKeyId" smallint NOT NULL,
+    CONSTRAINT "PK_ReferentialIdentity" PRIMARY KEY ("ReferentialId"),
+    CONSTRAINT "UX_ReferentialIdentity_DocumentId_ResourceKeyId" UNIQUE ("DocumentId", "ResourceKeyId")
+);
+
+CREATE TABLE IF NOT EXISTS "dms"."ResourceKey"
+(
+    "ResourceKeyId" smallint NOT NULL,
+    "ProjectName" varchar(256) NOT NULL,
+    "ResourceName" varchar(256) NOT NULL,
+    "ResourceVersion" varchar(32) NOT NULL,
+    CONSTRAINT "PK_ResourceKey" PRIMARY KEY ("ResourceKeyId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'UX_ResourceKey_ProjectName_ResourceName'
+        AND conrelid = to_regclass('"dms"."ResourceKey"')
+    )
+    THEN
+        ALTER TABLE "dms"."ResourceKey"
+        ADD CONSTRAINT "UX_ResourceKey_ProjectName_ResourceName" UNIQUE ("ProjectName", "ResourceName");
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "dms"."SchemaComponent"
+(
+    "EffectiveSchemaHash" varchar(64) NOT NULL,
+    "ProjectEndpointName" varchar(128) NOT NULL,
+    "ProjectName" varchar(256) NOT NULL,
+    "ProjectVersion" varchar(32) NOT NULL,
+    "IsExtensionProject" boolean NOT NULL,
+    CONSTRAINT "PK_SchemaComponent" PRIMARY KEY ("EffectiveSchemaHash", "ProjectEndpointName")
+);
+
+-- ==========================================================
+-- Phase 6: Foreign Keys
+-- ==========================================================
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_Descriptor_Document'
+        AND conrelid = to_regclass('"dms"."Descriptor"')
+    )
+    THEN
+        ALTER TABLE "dms"."Descriptor"
+        ADD CONSTRAINT "FK_Descriptor_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_Document_ResourceKey'
+        AND conrelid = to_regclass('"dms"."Document"')
+    )
+    THEN
+        ALTER TABLE "dms"."Document"
+        ADD CONSTRAINT "FK_Document_ResourceKey"
+        FOREIGN KEY ("ResourceKeyId")
+        REFERENCES "dms"."ResourceKey" ("ResourceKeyId")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DocumentCache_Document'
+        AND conrelid = to_regclass('"dms"."DocumentCache"')
+    )
+    THEN
+        ALTER TABLE "dms"."DocumentCache"
+        ADD CONSTRAINT "FK_DocumentCache_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DocumentChangeEvent_Document'
+        AND conrelid = to_regclass('"dms"."DocumentChangeEvent"')
+    )
+    THEN
+        ALTER TABLE "dms"."DocumentChangeEvent"
+        ADD CONSTRAINT "FK_DocumentChangeEvent_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DocumentChangeEvent_ResourceKey'
+        AND conrelid = to_regclass('"dms"."DocumentChangeEvent"')
+    )
+    THEN
+        ALTER TABLE "dms"."DocumentChangeEvent"
+        ADD CONSTRAINT "FK_DocumentChangeEvent_ResourceKey"
+        FOREIGN KEY ("ResourceKeyId")
+        REFERENCES "dms"."ResourceKey" ("ResourceKeyId")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_ReferentialIdentity_Document'
+        AND conrelid = to_regclass('"dms"."ReferentialIdentity"')
+    )
+    THEN
+        ALTER TABLE "dms"."ReferentialIdentity"
+        ADD CONSTRAINT "FK_ReferentialIdentity_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_ReferentialIdentity_ResourceKey'
+        AND conrelid = to_regclass('"dms"."ReferentialIdentity"')
+    )
+    THEN
+        ALTER TABLE "dms"."ReferentialIdentity"
+        ADD CONSTRAINT "FK_ReferentialIdentity_ResourceKey"
+        FOREIGN KEY ("ResourceKeyId")
+        REFERENCES "dms"."ResourceKey" ("ResourceKeyId")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_SchemaComponent_EffectiveSchemaHash'
+        AND conrelid = to_regclass('"dms"."SchemaComponent"')
+    )
+    THEN
+        ALTER TABLE "dms"."SchemaComponent"
+        ADD CONSTRAINT "FK_SchemaComponent_EffectiveSchemaHash"
+        FOREIGN KEY ("EffectiveSchemaHash")
+        REFERENCES "dms"."EffectiveSchema" ("EffectiveSchemaHash")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+-- ==========================================================
+-- Phase 7: Indexes
+-- ==========================================================
+
+CREATE INDEX IF NOT EXISTS "IX_Descriptor_Uri_Discriminator" ON "dms"."Descriptor" ("Uri", "Discriminator");
+
+CREATE INDEX IF NOT EXISTS "IX_Document_ResourceKeyId_DocumentId" ON "dms"."Document" ("ResourceKeyId", "DocumentId");
+
+CREATE INDEX IF NOT EXISTS "IX_DocumentCache_ProjectName_ResourceName_LastModifiedAt" ON "dms"."DocumentCache" ("ProjectName", "ResourceName", "LastModifiedAt", "DocumentId");
+
+CREATE INDEX IF NOT EXISTS "IX_DocumentChangeEvent_DocumentId" ON "dms"."DocumentChangeEvent" ("DocumentId");
+
+CREATE INDEX IF NOT EXISTS "IX_DocumentChangeEvent_ResourceKeyId_ChangeVersion" ON "dms"."DocumentChangeEvent" ("ResourceKeyId", "ChangeVersion", "DocumentId");
+
+CREATE INDEX IF NOT EXISTS "IX_ReferentialIdentity_DocumentId" ON "dms"."ReferentialIdentity" ("DocumentId");
+
+-- ==========================================================
+-- Phase 8: Triggers
+-- ==========================================================
+
+CREATE OR REPLACE FUNCTION "dms"."TF_Document_Journal"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    INSERT INTO "dms"."DocumentChangeEvent" ("ChangeVersion", "DocumentId", "ResourceKeyId", "CreatedAt")
+    VALUES (NEW."ContentVersion", NEW."DocumentId", NEW."ResourceKeyId", now());
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_Document_Journal" ON "dms"."Document";
+CREATE TRIGGER "TR_Document_Journal"
+    AFTER INSERT OR UPDATE OF "ContentVersion" ON "dms"."Document"
+    FOR EACH ROW
+    EXECUTE FUNCTION "dms"."TF_Document_Journal"();
+
+CREATE SCHEMA IF NOT EXISTS "edfi";
+
+CREATE TABLE IF NOT EXISTS "edfi"."ProfileRootOnlyMergeItem"
+(
+    "DocumentId" bigint NOT NULL,
+    "PrimarySchoolTypeDescriptor_DescriptorId_Present" boolean NULL,
+    "PrimarySchoolTypeDescriptor_Unified_DescriptorId" bigint NULL,
+    "SecondarySchoolTypeDescriptor_DescriptorId_Present" boolean NULL,
+    "StudentReference_DocumentId" bigint NULL,
+    "StudentReference_StudentUniqueId" varchar(32) NULL,
+    "PrimarySchoolTypeDescriptor_DescriptorId" bigint GENERATED ALWAYS AS (CASE WHEN "PrimarySchoolTypeDescriptor_DescriptorId_Present" IS NULL THEN NULL ELSE "PrimarySchoolTypeDescriptor_Unified_DescriptorId" END) STORED,
+    "SecondarySchoolTypeDescriptor_DescriptorId" bigint GENERATED ALWAYS AS (CASE WHEN "SecondarySchoolTypeDescriptor_DescriptorId_Present" IS NULL THEN NULL ELSE "PrimarySchoolTypeDescriptor_Unified_DescriptorId" END) STORED,
+    "DisplayName" varchar(100) NULL,
+    "ProfileRootOnlyMergeItemId" integer NOT NULL,
+    "ProfileScopeClearableText" varchar(100) NULL,
+    "ProfileScopePreservedText" varchar(100) NULL,
+    CONSTRAINT "PK_ProfileRootOnlyMergeItem" PRIMARY KEY ("DocumentId"),
+    CONSTRAINT "UX_ProfileRootOnlyMergeItem_NK" UNIQUE ("ProfileRootOnlyMergeItemId"),
+    CONSTRAINT "CK_ProfileRootOnlyMergeItem_StudentReference_AllNone" CHECK (("StudentReference_DocumentId" IS NULL AND "StudentReference_StudentUniqueId" IS NULL) OR ("StudentReference_DocumentId" IS NOT NULL AND "StudentReference_StudentUniqueId" IS NOT NULL)),
+    CONSTRAINT "CK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescrip_61d9cbded7" CHECK ("PrimarySchoolTypeDescriptor_DescriptorId_Present" IS NULL OR "PrimarySchoolTypeDescriptor_DescriptorId_Present" = true),
+    CONSTRAINT "CK_ProfileRootOnlyMergeItem_SecondarySchoolTypeDescr_f2dede0083" CHECK ("SecondarySchoolTypeDescriptor_DescriptorId_Present" IS NULL OR "SecondarySchoolTypeDescriptor_DescriptorId_Present" = true)
+);
+
+CREATE TABLE IF NOT EXISTS "edfi"."Student"
+(
+    "DocumentId" bigint NOT NULL,
+    "FirstName" varchar(75) NOT NULL,
+    "StudentUniqueId" varchar(32) NOT NULL,
+    CONSTRAINT "PK_Student" PRIMARY KEY ("DocumentId"),
+    CONSTRAINT "UX_Student_NK" UNIQUE ("StudentUniqueId"),
+    CONSTRAINT "UX_Student_RefKey" UNIQUE ("DocumentId", "StudentUniqueId")
+);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_ProfileRootOnlyMergeItem_Document'
+        AND conrelid = to_regclass('"edfi"."ProfileRootOnlyMergeItem"')
+    )
+    THEN
+        ALTER TABLE "edfi"."ProfileRootOnlyMergeItem"
+        ADD CONSTRAINT "FK_ProfileRootOnlyMergeItem_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified'
+        AND conrelid = to_regclass('"edfi"."ProfileRootOnlyMergeItem"')
+    )
+    THEN
+        ALTER TABLE "edfi"."ProfileRootOnlyMergeItem"
+        ADD CONSTRAINT "FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified"
+        FOREIGN KEY ("PrimarySchoolTypeDescriptor_Unified_DescriptorId")
+        REFERENCES "dms"."Descriptor" ("DocumentId")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_ProfileRootOnlyMergeItem_StudentReference_RefKey'
+        AND conrelid = to_regclass('"edfi"."ProfileRootOnlyMergeItem"')
+    )
+    THEN
+        ALTER TABLE "edfi"."ProfileRootOnlyMergeItem"
+        ADD CONSTRAINT "FK_ProfileRootOnlyMergeItem_StudentReference_RefKey"
+        FOREIGN KEY ("StudentReference_DocumentId", "StudentReference_StudentUniqueId")
+        REFERENCES "edfi"."Student" ("DocumentId", "StudentUniqueId")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_Student_Document'
+        AND conrelid = to_regclass('"edfi"."Student"')
+    )
+    THEN
+        ALTER TABLE "edfi"."Student"
+        ADD CONSTRAINT "FK_Student_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "IX_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescrip_5313ae7036" ON "edfi"."ProfileRootOnlyMergeItem" ("PrimarySchoolTypeDescriptor_Unified_DescriptorId");
+
+CREATE INDEX IF NOT EXISTS "IX_ProfileRootOnlyMergeItem_StudentReference_Documen_443e258273" ON "edfi"."ProfileRootOnlyMergeItem" ("StudentReference_DocumentId", "StudentReference_StudentUniqueId");
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_ProfileRootOnlyMergeItem_ReferentialIdentity"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'INSERT' OR (OLD."ProfileRootOnlyMergeItemId" IS DISTINCT FROM NEW."ProfileRootOnlyMergeItemId") THEN
+        DELETE FROM "dms"."ReferentialIdentity"
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 1;
+        INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiProfileRootOnlyMergeItem' || '$.profileRootOnlyMergeItemId=' || NEW."ProfileRootOnlyMergeItemId"::text), NEW."DocumentId", 1);
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_ProfileRootOnlyMergeItem_ReferentialIdentity" ON "edfi"."ProfileRootOnlyMergeItem";
+CREATE TRIGGER "TR_ProfileRootOnlyMergeItem_ReferentialIdentity"
+AFTER INSERT OR UPDATE ON "edfi"."ProfileRootOnlyMergeItem"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_ProfileRootOnlyMergeItem_ReferentialIdentity"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_ProfileRootOnlyMergeItem_Stamp"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = OLD."DocumentId";
+        RETURN OLD;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NOT (OLD."DocumentId" IS DISTINCT FROM NEW."DocumentId" OR OLD."PrimarySchoolTypeDescriptor_DescriptorId_Present" IS DISTINCT FROM NEW."PrimarySchoolTypeDescriptor_DescriptorId_Present" OR OLD."PrimarySchoolTypeDescriptor_Unified_DescriptorId" IS DISTINCT FROM NEW."PrimarySchoolTypeDescriptor_Unified_DescriptorId" OR OLD."SecondarySchoolTypeDescriptor_DescriptorId_Present" IS DISTINCT FROM NEW."SecondarySchoolTypeDescriptor_DescriptorId_Present" OR OLD."StudentReference_DocumentId" IS DISTINCT FROM NEW."StudentReference_DocumentId" OR OLD."StudentReference_StudentUniqueId" IS DISTINCT FROM NEW."StudentReference_StudentUniqueId" OR OLD."DisplayName" IS DISTINCT FROM NEW."DisplayName" OR OLD."ProfileRootOnlyMergeItemId" IS DISTINCT FROM NEW."ProfileRootOnlyMergeItemId" OR OLD."ProfileScopeClearableText" IS DISTINCT FROM NEW."ProfileScopeClearableText" OR OLD."ProfileScopePreservedText" IS DISTINCT FROM NEW."ProfileScopePreservedText") THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    IF TG_OP = 'UPDATE' AND (OLD."ProfileRootOnlyMergeItemId" IS DISTINCT FROM NEW."ProfileRootOnlyMergeItemId") THEN
+        UPDATE "dms"."Document"
+        SET "IdentityVersion" = nextval('"dms"."ChangeVersionSequence"'), "IdentityLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_ProfileRootOnlyMergeItem_Stamp" ON "edfi"."ProfileRootOnlyMergeItem";
+CREATE TRIGGER "TR_ProfileRootOnlyMergeItem_Stamp"
+BEFORE INSERT OR UPDATE OR DELETE ON "edfi"."ProfileRootOnlyMergeItem"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_ProfileRootOnlyMergeItem_Stamp"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_Student_ReferentialIdentity"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'INSERT' OR (OLD."StudentUniqueId" IS DISTINCT FROM NEW."StudentUniqueId") THEN
+        DELETE FROM "dms"."ReferentialIdentity"
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 3;
+        INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudent' || '$.studentUniqueId=' || NEW."StudentUniqueId"::text), NEW."DocumentId", 3);
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_Student_ReferentialIdentity" ON "edfi"."Student";
+CREATE TRIGGER "TR_Student_ReferentialIdentity"
+AFTER INSERT OR UPDATE ON "edfi"."Student"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_Student_ReferentialIdentity"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_Student_Stamp"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = OLD."DocumentId";
+        RETURN OLD;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NOT (OLD."DocumentId" IS DISTINCT FROM NEW."DocumentId" OR OLD."FirstName" IS DISTINCT FROM NEW."FirstName" OR OLD."StudentUniqueId" IS DISTINCT FROM NEW."StudentUniqueId") THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    IF TG_OP = 'UPDATE' AND (OLD."StudentUniqueId" IS DISTINCT FROM NEW."StudentUniqueId") THEN
+        UPDATE "dms"."Document"
+        SET "IdentityVersion" = nextval('"dms"."ChangeVersionSequence"'), "IdentityLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_Student_Stamp" ON "edfi"."Student";
+CREATE TRIGGER "TR_Student_Stamp"
+BEFORE INSERT OR UPDATE OR DELETE ON "edfi"."Student"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_Student_Stamp"();
+
+-- ==========================================================
+-- Phase 7: Seed Data (insert-if-missing + validation)
+-- ==========================================================
+
+-- ResourceKey seed inserts (insert-if-missing)
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (1, 'Ed-Fi', 'ProfileRootOnlyMergeItem', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (2, 'Ed-Fi', 'SchoolTypeDescriptor', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (3, 'Ed-Fi', 'Student', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+
+-- ResourceKey full-table validation (count + content)
+DO $$
+DECLARE
+    _actual_count integer;
+    _mismatched_count integer;
+    _mismatched_ids text;
+BEGIN
+    SELECT COUNT(*) INTO _actual_count FROM "dms"."ResourceKey";
+    IF _actual_count <> 3 THEN
+        RAISE EXCEPTION 'dms.ResourceKey count mismatch: expected 3, found %', _actual_count;
+    END IF;
+
+    SELECT COUNT(*) INTO _mismatched_count
+    FROM "dms"."ResourceKey" rk
+    WHERE NOT EXISTS (
+        SELECT 1 FROM (VALUES
+            (1::smallint, 'Ed-Fi', 'ProfileRootOnlyMergeItem', '5.0.0'),
+            (2::smallint, 'Ed-Fi', 'SchoolTypeDescriptor', '5.0.0'),
+            (3::smallint, 'Ed-Fi', 'Student', '5.0.0')
+        ) AS expected("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+        WHERE expected."ResourceKeyId" = rk."ResourceKeyId"
+        AND expected."ProjectName" = rk."ProjectName"
+        AND expected."ResourceName" = rk."ResourceName"
+        AND expected."ResourceVersion" = rk."ResourceVersion"
+    );
+    IF _mismatched_count > 0 THEN
+        SELECT string_agg(sub.id, ', ' ORDER BY sub.id_num) INTO _mismatched_ids
+        FROM (
+            SELECT rk."ResourceKeyId"::text AS id, rk."ResourceKeyId" AS id_num
+            FROM "dms"."ResourceKey" rk
+            WHERE NOT EXISTS (
+                SELECT 1 FROM (VALUES
+                    (1::smallint, 'Ed-Fi', 'ProfileRootOnlyMergeItem', '5.0.0'),
+                    (2::smallint, 'Ed-Fi', 'SchoolTypeDescriptor', '5.0.0'),
+                    (3::smallint, 'Ed-Fi', 'Student', '5.0.0')
+                ) AS expected("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+                WHERE expected."ResourceKeyId" = rk."ResourceKeyId"
+                AND expected."ProjectName" = rk."ProjectName"
+                AND expected."ResourceName" = rk."ResourceName"
+                AND expected."ResourceVersion" = rk."ResourceVersion"
+            )
+            ORDER BY rk."ResourceKeyId"
+            LIMIT 10
+        ) sub;
+        RAISE EXCEPTION 'dms.ResourceKey contents mismatch: % unexpected or modified rows (ResourceKeyIds: %). Run ddl provision for detailed row-level diff.', _mismatched_count, _mismatched_ids;
+    END IF;
+END $$;
+
+-- EffectiveSchema singleton insert-if-missing
+INSERT INTO "dms"."EffectiveSchema" ("EffectiveSchemaSingletonId", "ApiSchemaFormatVersion", "EffectiveSchemaHash", "ResourceKeyCount", "ResourceKeySeedHash")
+VALUES (1, '1.0.0', '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10', 3, '\xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9'::bytea)
+ON CONFLICT ("EffectiveSchemaSingletonId") DO NOTHING;
+
+-- EffectiveSchema validation (ApiSchemaFormatVersion + ResourceKeyCount + ResourceKeySeedHash)
+DO $$
+DECLARE
+    _stored_api_schema_format_version text;
+    _stored_count smallint;
+    _stored_hash bytea;
+BEGIN
+    SELECT "ApiSchemaFormatVersion", "ResourceKeyCount", "ResourceKeySeedHash" INTO _stored_api_schema_format_version, _stored_count, _stored_hash
+    FROM "dms"."EffectiveSchema"
+    WHERE "EffectiveSchemaSingletonId" = 1;
+    IF _stored_count IS NOT NULL THEN
+        IF _stored_api_schema_format_version IS NULL OR btrim(_stored_api_schema_format_version) = '' THEN
+            RAISE EXCEPTION 'dms.EffectiveSchema.ApiSchemaFormatVersion must not be empty.';
+        END IF;
+        IF _stored_count <> 3 THEN
+            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeyCount mismatch: expected 3, found %', _stored_count;
+        END IF;
+        IF _stored_hash <> '\xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9'::bytea THEN
+            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored % but expected %', encode(_stored_hash, 'hex'), encode('\xA72B6D85B70E1147001E9503787A2F7173C575DDBED1DFD867AAFECC5ACD13D9'::bytea, 'hex');
+        END IF;
+    END IF;
+END $$;
+
+-- SchemaComponent seed inserts (insert-if-missing)
+INSERT INTO "dms"."SchemaComponent" ("EffectiveSchemaHash", "ProjectEndpointName", "ProjectName", "ProjectVersion", "IsExtensionProject")
+VALUES ('5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10', 'ed-fi', 'Ed-Fi', '5.0.0', false)
+ON CONFLICT ("EffectiveSchemaHash", "ProjectEndpointName") DO NOTHING;
+
+-- SchemaComponent exact-match validation (count + content)
+DO $$
+DECLARE
+    _actual_count integer;
+    _mismatched_count integer;
+    _mismatched_names text;
+BEGIN
+    SELECT COUNT(*) INTO _actual_count FROM "dms"."SchemaComponent" WHERE "EffectiveSchemaHash" = '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10';
+    IF _actual_count <> 1 THEN
+        RAISE EXCEPTION 'dms.SchemaComponent count mismatch: expected 1, found %', _actual_count;
+    END IF;
+
+    SELECT COUNT(*) INTO _mismatched_count
+    FROM "dms"."SchemaComponent" sc
+    WHERE sc."EffectiveSchemaHash" = '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10'
+    AND NOT EXISTS (
+        SELECT 1 FROM (VALUES
+            ('ed-fi', 'Ed-Fi', '5.0.0', false)
+        ) AS expected("ProjectEndpointName", "ProjectName", "ProjectVersion", "IsExtensionProject")
+        WHERE expected."ProjectEndpointName" = sc."ProjectEndpointName"
+        AND expected."ProjectName" = sc."ProjectName"
+        AND expected."ProjectVersion" = sc."ProjectVersion"
+        AND expected."IsExtensionProject" = sc."IsExtensionProject"
+    );
+    IF _mismatched_count > 0 THEN
+        SELECT string_agg(sub.name, ', ' ORDER BY sub.name) INTO _mismatched_names
+        FROM (
+            SELECT sc."ProjectEndpointName" AS name
+            FROM "dms"."SchemaComponent" sc
+            WHERE sc."EffectiveSchemaHash" = '5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10'
+            AND NOT EXISTS (
+                SELECT 1 FROM (VALUES
+                    ('ed-fi', 'Ed-Fi', '5.0.0', false)
+                ) AS expected("ProjectEndpointName", "ProjectName", "ProjectVersion", "IsExtensionProject")
+                WHERE expected."ProjectEndpointName" = sc."ProjectEndpointName"
+                AND expected."ProjectName" = sc."ProjectName"
+                AND expected."ProjectVersion" = sc."ProjectVersion"
+                AND expected."IsExtensionProject" = sc."IsExtensionProject"
+            )
+            ORDER BY sc."ProjectEndpointName"
+            LIMIT 10
+        ) sub;
+        RAISE EXCEPTION 'dms.SchemaComponent contents mismatch: % unexpected or modified rows (ProjectEndpointNames: %). Run ddl provision for detailed row-level diff.', _mismatched_count, _mismatched_names;
+    END IF;
+END $$;
+

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/relational-model.mssql.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/relational-model.mssql.manifest.json
@@ -1,0 +1,690 @@
+{
+  "dialect": "mssql",
+  "effective_schema_hash": "5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10",
+  "relational_mapping_version": "v1",
+  "projects": [
+    {
+      "project_endpoint_name": "ed-fi",
+      "project_name": "Ed-Fi",
+      "project_version": "5.0.0",
+      "is_extension": false,
+      "physical_schema": "edfi"
+    }
+  ],
+  "resources": [
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "ProfileRootOnlyMergeItem",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "SchoolTypeDescriptor",
+      "storage_kind": "SharedDescriptorTable",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    }
+  ],
+  "abstract_identity_tables": [],
+  "abstract_union_views": [],
+  "indexes": [
+    {
+      "name": "IX_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+      ]
+    },
+    {
+      "name": "IX_ProfileRootOnlyMergeItem_StudentReference_DocumentId_StudentReference_StudentUniqueId",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "StudentReference_DocumentId",
+        "StudentReference_StudentUniqueId"
+      ]
+    },
+    {
+      "name": "PK_ProfileRootOnlyMergeItem",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_ProfileRootOnlyMergeItem_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ]
+    },
+    {
+      "name": "PK_Student",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_Student_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "StudentUniqueId"
+      ]
+    },
+    {
+      "name": "UX_Student_RefKey",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId",
+        "StudentUniqueId"
+      ]
+    }
+  ],
+  "triggers": [
+    {
+      "name": "TR_ProfileRootOnlyMergeItem_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ],
+      "resource_key_id": 1,
+      "project_name": "Ed-Fi",
+      "resource_name": "ProfileRootOnlyMergeItem",
+      "identity_elements": [
+        {
+          "column": "ProfileRootOnlyMergeItemId",
+          "identity_json_path": "$.profileRootOnlyMergeItemId"
+        }
+      ]
+    },
+    {
+      "name": "TR_ProfileRootOnlyMergeItem_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ]
+    },
+    {
+      "name": "TR_Student_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "StudentUniqueId"
+      ],
+      "resource_key_id": 3,
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "identity_elements": [
+        {
+          "column": "StudentUniqueId",
+          "identity_json_path": "$.studentUniqueId"
+        }
+      ]
+    },
+    {
+      "name": "TR_Student_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "StudentUniqueId"
+      ]
+    }
+  ],
+  "resource_details": [
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "ProfileRootOnlyMergeItem"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "ProfileRootOnlyMergeItem",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_DescriptorId_Present",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Boolean"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "SecondarySchoolTypeDescriptor_DescriptorId_Present",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Boolean"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentReference_DocumentId",
+              "kind": "DocumentFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.studentReference",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentReference_StudentUniqueId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 32
+              },
+              "is_nullable": true,
+              "source_path": "$.studentReference.studentUniqueId",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.primarySchoolTypeDescriptor",
+              "storage": {
+                "kind": "UnifiedAlias",
+                "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+                "presence_column": "PrimarySchoolTypeDescriptor_DescriptorId_Present"
+              }
+            },
+            {
+              "name": "SecondarySchoolTypeDescriptor_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.secondarySchoolTypeDescriptor",
+              "storage": {
+                "kind": "UnifiedAlias",
+                "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+                "presence_column": "SecondarySchoolTypeDescriptor_DescriptorId_Present"
+              }
+            },
+            {
+              "name": "DisplayName",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.displayName",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileRootOnlyMergeItemId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Int32"
+              },
+              "is_nullable": false,
+              "source_path": "$.profileRootOnlyMergeItemId",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileScopeClearableText",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.profileScope.clearableText",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileScopePreservedText",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.profileScope.preservedText",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [
+            {
+              "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "member_path_columns": [
+                "PrimarySchoolTypeDescriptor_DescriptorId",
+                "SecondarySchoolTypeDescriptor_DescriptorId"
+              ]
+            }
+          ],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [
+            {
+              "storage_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "binding_columns": [
+                "PrimarySchoolTypeDescriptor_DescriptorId",
+                "SecondarySchoolTypeDescriptor_DescriptorId"
+              ],
+              "constraint_name": "FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified"
+            }
+          ],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_ProfileRootOnlyMergeItem_NK",
+              "columns": [
+                "ProfileRootOnlyMergeItemId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified",
+              "columns": [
+                "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Descriptor"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_StudentReference_RefKey",
+              "columns": [
+                "StudentReference_DocumentId",
+                "StudentReference_StudentUniqueId"
+              ],
+              "target_table": {
+                "schema": "edfi",
+                "name": "Student"
+              },
+              "target_columns": [
+                "DocumentId",
+                "StudentUniqueId"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "AllOrNoneNullability",
+              "name": "CK_ProfileRootOnlyMergeItem_StudentReference_AllNone",
+              "fk_column": "StudentReference_DocumentId",
+              "dependent_columns": [
+                "StudentReference_StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "NullOrTrue",
+              "name": "CK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_DescriptorId_Present_NullOrTrue",
+              "column": "PrimarySchoolTypeDescriptor_DescriptorId_Present"
+            },
+            {
+              "kind": "NullOrTrue",
+              "name": "CK_ProfileRootOnlyMergeItem_SecondarySchoolTypeDescriptor_DescriptorId_Present_NullOrTrue",
+              "column": "SecondarySchoolTypeDescriptor_DescriptorId_Present"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [
+          {
+            "endpoint_a_path": "$.primarySchoolTypeDescriptor",
+            "endpoint_b_path": "$.secondarySchoolTypeDescriptor",
+            "table": {
+              "schema": "edfi",
+              "name": "ProfileRootOnlyMergeItem"
+            },
+            "endpoint_a_column": "PrimarySchoolTypeDescriptor_DescriptorId",
+            "endpoint_b_column": "SecondarySchoolTypeDescriptor_DescriptorId",
+            "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+          }
+        ],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [
+        {
+          "is_identity_component": false,
+          "reference_object_path": "$.studentReference",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "StudentReference_DocumentId",
+          "target_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "Student"
+          },
+          "identity_bindings": [
+            {
+              "identity_json_path": "$.studentUniqueId",
+              "reference_json_path": "$.studentReference.studentUniqueId",
+              "column": "StudentReference_StudentUniqueId"
+            }
+          ]
+        }
+      ],
+      "descriptor_edge_sources": [
+        {
+          "is_identity_component": false,
+          "descriptor_value_path": "$.primarySchoolTypeDescriptor",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "PrimarySchoolTypeDescriptor_DescriptorId",
+          "descriptor_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "SchoolTypeDescriptor"
+          }
+        },
+        {
+          "is_identity_component": false,
+          "descriptor_value_path": "$.secondarySchoolTypeDescriptor",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "SecondarySchoolTypeDescriptor_DescriptorId",
+          "descriptor_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "SchoolTypeDescriptor"
+          }
+        }
+      ],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "SchoolTypeDescriptor"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "SharedDescriptorTable",
+      "tables": [],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "Student"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "Student",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "FirstName",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 75
+              },
+              "is_nullable": false,
+              "source_path": "$.firstName",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentUniqueId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 32
+              },
+              "is_nullable": false,
+              "source_path": "$.studentUniqueId",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_Student_NK",
+              "columns": [
+                "StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "Unique",
+              "name": "UX_Student_RefKey",
+              "columns": [
+                "DocumentId",
+                "StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_Student_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    }
+  ]
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/relational-model.pgsql.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/relational-model.pgsql.manifest.json
@@ -1,0 +1,690 @@
+{
+  "dialect": "pgsql",
+  "effective_schema_hash": "5374395c29d6f67503532983b713b37845dced6bec8f3e86f7a8cca290a1bf10",
+  "relational_mapping_version": "v1",
+  "projects": [
+    {
+      "project_endpoint_name": "ed-fi",
+      "project_name": "Ed-Fi",
+      "project_version": "5.0.0",
+      "is_extension": false,
+      "physical_schema": "edfi"
+    }
+  ],
+  "resources": [
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "ProfileRootOnlyMergeItem",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "SchoolTypeDescriptor",
+      "storage_kind": "SharedDescriptorTable",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    }
+  ],
+  "abstract_identity_tables": [],
+  "abstract_union_views": [],
+  "indexes": [
+    {
+      "name": "IX_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescrip_5313ae7036",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+      ]
+    },
+    {
+      "name": "IX_ProfileRootOnlyMergeItem_StudentReference_Documen_443e258273",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "StudentReference_DocumentId",
+        "StudentReference_StudentUniqueId"
+      ]
+    },
+    {
+      "name": "PK_ProfileRootOnlyMergeItem",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_ProfileRootOnlyMergeItem_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ]
+    },
+    {
+      "name": "PK_Student",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_Student_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "StudentUniqueId"
+      ]
+    },
+    {
+      "name": "UX_Student_RefKey",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId",
+        "StudentUniqueId"
+      ]
+    }
+  ],
+  "triggers": [
+    {
+      "name": "TR_ProfileRootOnlyMergeItem_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ],
+      "resource_key_id": 1,
+      "project_name": "Ed-Fi",
+      "resource_name": "ProfileRootOnlyMergeItem",
+      "identity_elements": [
+        {
+          "column": "ProfileRootOnlyMergeItemId",
+          "identity_json_path": "$.profileRootOnlyMergeItemId"
+        }
+      ]
+    },
+    {
+      "name": "TR_ProfileRootOnlyMergeItem_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "ProfileRootOnlyMergeItem"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "ProfileRootOnlyMergeItemId"
+      ]
+    },
+    {
+      "name": "TR_Student_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "StudentUniqueId"
+      ],
+      "resource_key_id": 3,
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "identity_elements": [
+        {
+          "column": "StudentUniqueId",
+          "identity_json_path": "$.studentUniqueId"
+        }
+      ]
+    },
+    {
+      "name": "TR_Student_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "Student"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "StudentUniqueId"
+      ]
+    }
+  ],
+  "resource_details": [
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "ProfileRootOnlyMergeItem"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "ProfileRootOnlyMergeItem",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_DescriptorId_Present",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Boolean"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "SecondarySchoolTypeDescriptor_DescriptorId_Present",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Boolean"
+              },
+              "is_nullable": true,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentReference_DocumentId",
+              "kind": "DocumentFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.studentReference",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentReference_StudentUniqueId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 32
+              },
+              "is_nullable": true,
+              "source_path": "$.studentReference.studentUniqueId",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "PrimarySchoolTypeDescriptor_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.primarySchoolTypeDescriptor",
+              "storage": {
+                "kind": "UnifiedAlias",
+                "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+                "presence_column": "PrimarySchoolTypeDescriptor_DescriptorId_Present"
+              }
+            },
+            {
+              "name": "SecondarySchoolTypeDescriptor_DescriptorId",
+              "kind": "DescriptorFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": true,
+              "source_path": "$.secondarySchoolTypeDescriptor",
+              "storage": {
+                "kind": "UnifiedAlias",
+                "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+                "presence_column": "SecondarySchoolTypeDescriptor_DescriptorId_Present"
+              }
+            },
+            {
+              "name": "DisplayName",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.displayName",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileRootOnlyMergeItemId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Int32"
+              },
+              "is_nullable": false,
+              "source_path": "$.profileRootOnlyMergeItemId",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileScopeClearableText",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.profileScope.clearableText",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "ProfileScopePreservedText",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 100
+              },
+              "is_nullable": true,
+              "source_path": "$.profileScope.preservedText",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [
+            {
+              "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "member_path_columns": [
+                "PrimarySchoolTypeDescriptor_DescriptorId",
+                "SecondarySchoolTypeDescriptor_DescriptorId"
+              ]
+            }
+          ],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [
+            {
+              "storage_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId",
+              "binding_columns": [
+                "PrimarySchoolTypeDescriptor_DescriptorId",
+                "SecondarySchoolTypeDescriptor_DescriptorId"
+              ],
+              "constraint_name": "FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified"
+            }
+          ],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_ProfileRootOnlyMergeItem_NK",
+              "columns": [
+                "ProfileRootOnlyMergeItemId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescriptor_Unified",
+              "columns": [
+                "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Descriptor"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_ProfileRootOnlyMergeItem_StudentReference_RefKey",
+              "columns": [
+                "StudentReference_DocumentId",
+                "StudentReference_StudentUniqueId"
+              ],
+              "target_table": {
+                "schema": "edfi",
+                "name": "Student"
+              },
+              "target_columns": [
+                "DocumentId",
+                "StudentUniqueId"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "AllOrNoneNullability",
+              "name": "CK_ProfileRootOnlyMergeItem_StudentReference_AllNone",
+              "fk_column": "StudentReference_DocumentId",
+              "dependent_columns": [
+                "StudentReference_StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "NullOrTrue",
+              "name": "CK_ProfileRootOnlyMergeItem_PrimarySchoolTypeDescrip_61d9cbded7",
+              "column": "PrimarySchoolTypeDescriptor_DescriptorId_Present"
+            },
+            {
+              "kind": "NullOrTrue",
+              "name": "CK_ProfileRootOnlyMergeItem_SecondarySchoolTypeDescr_f2dede0083",
+              "column": "SecondarySchoolTypeDescriptor_DescriptorId_Present"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [
+          {
+            "endpoint_a_path": "$.primarySchoolTypeDescriptor",
+            "endpoint_b_path": "$.secondarySchoolTypeDescriptor",
+            "table": {
+              "schema": "edfi",
+              "name": "ProfileRootOnlyMergeItem"
+            },
+            "endpoint_a_column": "PrimarySchoolTypeDescriptor_DescriptorId",
+            "endpoint_b_column": "SecondarySchoolTypeDescriptor_DescriptorId",
+            "canonical_column": "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+          }
+        ],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [
+        {
+          "is_identity_component": false,
+          "reference_object_path": "$.studentReference",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "StudentReference_DocumentId",
+          "target_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "Student"
+          },
+          "identity_bindings": [
+            {
+              "identity_json_path": "$.studentUniqueId",
+              "reference_json_path": "$.studentReference.studentUniqueId",
+              "column": "StudentReference_StudentUniqueId"
+            }
+          ]
+        }
+      ],
+      "descriptor_edge_sources": [
+        {
+          "is_identity_component": false,
+          "descriptor_value_path": "$.primarySchoolTypeDescriptor",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "PrimarySchoolTypeDescriptor_DescriptorId",
+          "descriptor_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "SchoolTypeDescriptor"
+          }
+        },
+        {
+          "is_identity_component": false,
+          "descriptor_value_path": "$.secondarySchoolTypeDescriptor",
+          "table": {
+            "schema": "edfi",
+            "name": "ProfileRootOnlyMergeItem"
+          },
+          "fk_column": "SecondarySchoolTypeDescriptor_DescriptorId",
+          "descriptor_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "SchoolTypeDescriptor"
+          }
+        }
+      ],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "SchoolTypeDescriptor"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "SharedDescriptorTable",
+      "tables": [],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "Student"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "Student",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "FirstName",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 75
+              },
+              "is_nullable": false,
+              "source_path": "$.firstName",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "StudentUniqueId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 32
+              },
+              "is_nullable": false,
+              "source_path": "$.studentUniqueId",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_Student_NK",
+              "columns": [
+                "StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "Unique",
+              "name": "UX_Student_RefKey",
+              "columns": [
+                "DocumentId",
+                "StudentUniqueId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_Student_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    }
+  ]
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/fixture.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/fixture.json
@@ -1,0 +1,4 @@
+{
+  "apiSchemaFiles": ["ApiSchema.json"],
+  "dialects": ["pgsql", "mssql"]
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/inputs/ApiSchema.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/inputs/ApiSchema.json
@@ -1,0 +1,247 @@
+{
+  "apiSchemaVersion": "1.0.0",
+  "projectSchema": {
+    "projectName": "Ed-Fi",
+    "projectEndpointName": "ed-fi",
+    "projectVersion": "5.0.0",
+    "isExtensionProject": false,
+    "description": "Profile root-only merge fixture: exercises inlined nested scope, hidden document reference, hidden descriptor, key-unification hidden contribution/disagreement, and synthetic presence preservation on a single-table resource.",
+    "abstractResources": {},
+    "caseInsensitiveEndpointNameMapping": {
+      "students": "students",
+      "schooltypedescriptors": "schoolTypeDescriptors",
+      "profilerootonlymergeitems": "profileRootOnlyMergeItems"
+    },
+    "educationOrganizationHierarchy": {},
+    "educationOrganizationTypes": [],
+    "resourceNameMapping": {
+      "Student": "students",
+      "SchoolTypeDescriptor": "schoolTypeDescriptors",
+      "ProfileRootOnlyMergeItem": "profileRootOnlyMergeItems"
+    },
+    "resourceSchemas": {
+      "students": {
+        "resourceName": "Student",
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": [
+          "$.studentUniqueId"
+        ],
+        "documentPathsMapping": {
+          "StudentUniqueId": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.studentUniqueId"
+          },
+          "FirstName": {
+            "isReference": false,
+            "isPartOfIdentity": false,
+            "isRequired": true,
+            "path": "$.firstName"
+          }
+        },
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "studentUniqueId": {
+              "type": "string",
+              "maxLength": 32
+            },
+            "firstName": {
+              "type": "string",
+              "maxLength": 75
+            }
+          },
+          "required": [
+            "studentUniqueId",
+            "firstName"
+          ]
+        }
+      },
+      "schoolTypeDescriptors": {
+        "resourceName": "SchoolTypeDescriptor",
+        "isDescriptor": true,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": [
+          "$.namespace",
+          "$.codeValue"
+        ],
+        "documentPathsMapping": {
+          "Namespace": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.namespace"
+          },
+          "CodeValue": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.codeValue"
+          },
+          "ShortDescription": {
+            "isReference": false,
+            "isPartOfIdentity": false,
+            "isRequired": true,
+            "path": "$.shortDescription"
+          }
+        },
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "maxLength": 255
+            },
+            "codeValue": {
+              "type": "string",
+              "maxLength": 50
+            },
+            "shortDescription": {
+              "type": "string",
+              "maxLength": 75
+            }
+          },
+          "required": [
+            "namespace",
+            "codeValue",
+            "shortDescription"
+          ]
+        }
+      },
+      "profileRootOnlyMergeItems": {
+        "resourceName": "ProfileRootOnlyMergeItem",
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [
+          {
+            "sourceJsonPath": "$.primarySchoolTypeDescriptor",
+            "targetJsonPath": "$.secondarySchoolTypeDescriptor"
+          }
+        ],
+        "identityJsonPaths": [
+          "$.profileRootOnlyMergeItemId"
+        ],
+        "documentPathsMapping": {
+          "ProfileRootOnlyMergeItemId": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.profileRootOnlyMergeItemId"
+          },
+          "DisplayName": {
+            "isReference": false,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "path": "$.displayName"
+          },
+          "ProfileScope.ClearableText": {
+            "isReference": false,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "path": "$.profileScope.clearableText"
+          },
+          "ProfileScope.PreservedText": {
+            "isReference": false,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "path": "$.profileScope.preservedText"
+          },
+          "StudentReference": {
+            "isReference": true,
+            "isDescriptor": false,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "projectName": "Ed-Fi",
+            "resourceName": "Student",
+            "referenceJsonPaths": [
+              {
+                "identityJsonPath": "$.studentUniqueId",
+                "referenceJsonPath": "$.studentReference.studentUniqueId"
+              }
+            ]
+          },
+          "PrimarySchoolTypeDescriptor": {
+            "isReference": true,
+            "isDescriptor": true,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "projectName": "Ed-Fi",
+            "resourceName": "SchoolTypeDescriptor",
+            "path": "$.primarySchoolTypeDescriptor"
+          },
+          "SecondarySchoolTypeDescriptor": {
+            "isReference": true,
+            "isDescriptor": true,
+            "isPartOfIdentity": false,
+            "isRequired": false,
+            "projectName": "Ed-Fi",
+            "resourceName": "SchoolTypeDescriptor",
+            "path": "$.secondarySchoolTypeDescriptor"
+          }
+        },
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "profileRootOnlyMergeItemId": {
+              "type": "integer"
+            },
+            "displayName": {
+              "type": "string",
+              "maxLength": 100
+            },
+            "profileScope": {
+              "type": "object",
+              "properties": {
+                "clearableText": {
+                  "type": "string",
+                  "maxLength": 100
+                },
+                "preservedText": {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              }
+            },
+            "studentReference": {
+              "type": "object",
+              "properties": {
+                "studentUniqueId": {
+                  "type": "string",
+                  "maxLength": 32
+                }
+              },
+              "required": ["studentUniqueId"]
+            },
+            "primarySchoolTypeDescriptor": {
+              "type": "string",
+              "maxLength": 306
+            },
+            "secondarySchoolTypeDescriptor": {
+              "type": "string",
+              "maxLength": 306
+            }
+          },
+          "required": [
+            "profileRootOnlyMergeItemId"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
@@ -111,9 +111,19 @@ file static class MssqlProfileRoutingTestSupport
         JsonNode requestBody
     )
     {
+        // Include the $._ext.sample extension scope so the slice-fence classifier returns
+        // SeparateTableNonCollection. Task 6 landed Slice 2 for RootTableOnly shapes, so a
+        // RootTableOnly classification with a multi-table plan now triggers the Slice 2 shape
+        // gate rather than the slice fence; these integration fixtures target the fence for
+        // non-RootTableOnly families, so include the extension scope to guarantee that.
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
         var rootScopeState = new RequestScopeState(
             Address: new ScopeInstanceAddress("$", []),
+            Visibility: ProfileVisibilityKind.VisiblePresent,
+            Creatable: true
+        );
+        var extensionScopeState = new RequestScopeState(
+            Address: new ScopeInstanceAddress("$._ext.sample", []),
             Visibility: ProfileVisibilityKind.VisiblePresent,
             Creatable: true
         );
@@ -122,7 +132,7 @@ file static class MssqlProfileRoutingTestSupport
             Request: new ProfileAppliedWriteRequest(
                 WritableRequestBody: requestBody,
                 RootResourceCreatable: true,
-                RequestScopeStates: [rootScopeState],
+                RequestScopeStates: [rootScopeState, extensionScopeState],
                 VisibleRequestCollectionItems: []
             ),
             ProfileName: "test-profile",
@@ -342,7 +352,7 @@ public class Given_A_Mssql_Profiled_Post_Create_Where_Root_Is_Not_Creatable
 
 /// <summary>
 /// Verifies that a profiled POST that resolves to post-as-update (existing document)
-/// reaches the slice fence and returns a family name like "RootTableOnly",
+/// reaches the slice fence and returns a family name like "SeparateTableNonCollection",
 /// instead of the old broad "DMS-1124 pending" message.
 /// </summary>
 [TestFixture]
@@ -458,7 +468,7 @@ public class Given_A_Mssql_Profiled_Post_As_Update_Reaching_Slice_Fence
         _profiledPostAsUpdateResult
             .As<UpsertResult.UnknownFailure>()
             .FailureMessage.Should()
-            .Contain("RootTableOnly");
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]
@@ -566,7 +576,7 @@ public class Given_A_Mssql_Profiled_Post_As_Update_Reaching_Slice_Fence
 
 /// <summary>
 /// Verifies that a profiled PUT targeting an existing document reaches the slice fence
-/// and returns a family name like "RootTableOnly", instead of the old broad
+/// and returns a family name like "SeparateTableNonCollection", instead of the old broad
 /// "DMS-1124 pending" message.
 /// </summary>
 [TestFixture]
@@ -676,7 +686,10 @@ public class Given_A_Mssql_Profiled_Put_Reaching_Slice_Fence
     public void It_returns_unknown_failure_with_family_name_in_slice_fence()
     {
         _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("RootTableOnly");
+        _profiledPutResult
+            .As<UpdateResult.UnknownFailure>()
+            .FailureMessage.Should()
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
@@ -111,11 +111,9 @@ file static class MssqlProfileRoutingTestSupport
         JsonNode requestBody
     )
     {
-        // Include the $._ext.sample extension scope so the slice-fence classifier returns
-        // SeparateTableNonCollection. Task 6 landed Slice 2 for RootTableOnly shapes, so a
-        // RootTableOnly classification with a multi-table plan now triggers the Slice 2 shape
-        // gate rather than the slice fence; these integration fixtures target the fence for
-        // non-RootTableOnly families, so include the extension scope to guarantee that.
+        // The extension scope below is intentional. Routing fixtures that use this helper
+        // expect the slice-fence family name to appear in the failure message, so the profile
+        // must include a non-root scope that forces a non-root-table-only classification.
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
         var rootScopeState = new RequestScopeState(
             Address: new ScopeInstanceAddress("$", []),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeFixtureTests.cs
@@ -1,0 +1,1247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+// MSSQL mirror of PostgresqlProfileRootTableOnlyMergeFixtureTests. See the pgsql sibling
+// for fixture rationale and the scenario mapping. Column names are identical across the two
+// dialects so only the harness plumbing (MssqlGeneratedDdlTestDatabase, SqlParameter, bracketed
+// identifiers) differs.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+file sealed class MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler
+    : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+/// <summary>
+/// MSSQL-flavored projection invoker; emits the root scope plus the inlined
+/// non-collection scopes used by the ProfileRootOnlyMergeItem fixture:
+/// <c>$.profileScope</c> and <c>$.studentReference</c>.
+/// </summary>
+internal sealed class MssqlProfileRootOnlyFixtureProjectionInvoker : IStoredStateProjectionInvoker
+{
+    private readonly ProfileVisibilityKind _rootVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _rootHiddenMemberPaths;
+    private readonly ProfileVisibilityKind _profileScopeVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _profileScopeHiddenMemberPaths;
+    private readonly bool _emitStudentReferenceScope;
+    private readonly ProfileVisibilityKind _studentReferenceVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _studentReferenceHiddenMemberPaths;
+
+    public MssqlProfileRootOnlyFixtureProjectionInvoker(
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        ProfileVisibilityKind profileScopeVisibility,
+        System.Collections.Immutable.ImmutableArray<string> profileScopeHiddenMemberPaths,
+        bool emitStudentReferenceScope,
+        ProfileVisibilityKind studentReferenceVisibility,
+        System.Collections.Immutable.ImmutableArray<string> studentReferenceHiddenMemberPaths
+    )
+    {
+        _rootVisibility = rootVisibility;
+        _rootHiddenMemberPaths = rootHiddenMemberPaths;
+        _profileScopeVisibility = profileScopeVisibility;
+        _profileScopeHiddenMemberPaths = profileScopeHiddenMemberPaths;
+        _emitStudentReferenceScope = emitStudentReferenceScope;
+        _studentReferenceVisibility = studentReferenceVisibility;
+        _studentReferenceHiddenMemberPaths = studentReferenceHiddenMemberPaths;
+    }
+
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    )
+    {
+        var rootAddress = new ScopeInstanceAddress("$", []);
+        var profileScopeAddress = new ScopeInstanceAddress("$.profileScope", []);
+        var storedScopeStates = new List<StoredScopeState>
+        {
+            new(Address: rootAddress, Visibility: _rootVisibility, HiddenMemberPaths: _rootHiddenMemberPaths),
+            new(
+                Address: profileScopeAddress,
+                Visibility: _profileScopeVisibility,
+                HiddenMemberPaths: _profileScopeHiddenMemberPaths
+            ),
+        };
+
+        if (_emitStudentReferenceScope)
+        {
+            storedScopeStates.Add(
+                new StoredScopeState(
+                    Address: new ScopeInstanceAddress("$.studentReference", []),
+                    Visibility: _studentReferenceVisibility,
+                    HiddenMemberPaths: _studentReferenceHiddenMemberPaths
+                )
+            );
+        }
+
+        return new ProfileAppliedWriteContext(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates: [.. storedScopeStates],
+            VisibleStoredCollectionRows: []
+        );
+    }
+}
+
+internal static class MssqlProfileRootOnlyFixtureSupport
+{
+    public const string FixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge";
+
+    public static readonly QualifiedResourceName ProfileRootOnlyMergeItemResource = new(
+        "Ed-Fi",
+        "ProfileRootOnlyMergeItem"
+    );
+
+    public static readonly ResourceInfo ProfileRootOnlyMergeItemResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("ProfileRootOnlyMergeItem"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private static readonly (string JsonScope, ScopeKind Kind) ProfileScopeInlinedScope = (
+        "$.profileScope",
+        ScopeKind.NonCollection
+    );
+
+    private static readonly (string JsonScope, ScopeKind Kind) StudentReferenceInlinedScope = (
+        "$.studentReference",
+        ScopeKind.NonCollection
+    );
+
+    public static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlReferenceResolver();
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    public static DocumentInfo CreateDocumentInfo(int profileRootOnlyMergeItemId)
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.profileRootOnlyMergeItemId"),
+                profileRootOnlyMergeItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                ProfileRootOnlyMergeItemResourceInfo,
+                identity
+            ),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    public static BackendProfileWriteContext CreateProfileContext(
+        ResourceWritePlan writePlan,
+        JsonNode requestBody,
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        ProfileVisibilityKind profileScopeVisibility,
+        System.Collections.Immutable.ImmutableArray<string> profileScopeHiddenMemberPaths,
+        ProfileVisibilityKind? studentReferenceRequestVisibility = null,
+        ProfileVisibilityKind? studentReferenceStoredVisibility = null,
+        System.Collections.Immutable.ImmutableArray<string> studentReferenceStoredHiddenMemberPaths = default,
+        bool creatable = true,
+        string profileName = "root-only-merge-profile"
+    )
+    {
+        var emitStudentReferenceScope =
+            studentReferenceRequestVisibility is not null
+            || studentReferenceStoredVisibility is not null
+            || (
+                !studentReferenceStoredHiddenMemberPaths.IsDefault
+                && !studentReferenceStoredHiddenMemberPaths.IsEmpty
+            );
+        var normalizedStudentReferenceHiddenMemberPaths = studentReferenceStoredHiddenMemberPaths.IsDefault
+            ? []
+            : studentReferenceStoredHiddenMemberPaths;
+        var additionalScopes = emitStudentReferenceScope
+            ? new[] { ProfileScopeInlinedScope, StudentReferenceInlinedScope }
+            : new[] { ProfileScopeInlinedScope };
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan, additionalScopes);
+        var scopeStates = new List<RequestScopeState>
+        {
+            new(Address: new ScopeInstanceAddress("$", []), Visibility: rootVisibility, Creatable: creatable),
+            new(
+                Address: new ScopeInstanceAddress("$.profileScope", []),
+                Visibility: profileScopeVisibility,
+                Creatable: creatable
+            ),
+        };
+
+        if (emitStudentReferenceScope)
+        {
+            scopeStates.Add(
+                new RequestScopeState(
+                    Address: new ScopeInstanceAddress("$.studentReference", []),
+                    Visibility: studentReferenceRequestVisibility ?? ProfileVisibilityKind.VisiblePresent,
+                    Creatable: creatable
+                )
+            );
+        }
+
+        return new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody,
+                RootResourceCreatable: creatable,
+                RequestScopeStates: [.. scopeStates],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: profileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new MssqlProfileRootOnlyFixtureProjectionInvoker(
+                rootVisibility,
+                rootHiddenMemberPaths,
+                profileScopeVisibility,
+                profileScopeHiddenMemberPaths,
+                emitStudentReferenceScope,
+                studentReferenceStoredVisibility
+                    ?? studentReferenceRequestVisibility
+                    ?? ProfileVisibilityKind.VisiblePresent,
+                normalizedStudentReferenceHiddenMemberPaths
+            )
+        );
+    }
+
+    public static async Task<UpsertResult> SeedAsync(
+        ServiceProvider serviceProvider,
+        MssqlGeneratedDdlTestDatabase database,
+        MappingSet mappingSet,
+        int profileRootOnlyMergeItemId,
+        JsonNode body,
+        DocumentUuid documentUuid,
+        string traceLabel
+    )
+    {
+        using var scope = serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootOnlyFixture",
+                    ConnectionString: database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: CreateDocumentInfo(profileRootOnlyMergeItemId),
+            MappingSet: mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId(traceLabel),
+            DocumentUuid: documentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    public static async Task<IReadOnlyDictionary<string, object?>> ReadItemRowAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        DocumentUuid documentUuid
+    )
+    {
+        var rows = await database.QueryRowsAsync(
+            """
+            SELECT
+                i.[ProfileRootOnlyMergeItemId],
+                i.[DisplayName],
+                i.[ProfileScopeClearableText],
+                i.[ProfileScopePreservedText]
+            FROM [edfi].[ProfileRootOnlyMergeItem] i
+            INNER JOIN [dms].[Document] d ON d.[DocumentId] = i.[DocumentId]
+            WHERE d.[DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", documentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Prerequisite-seed helpers (MSSQL dialect). Mirror of the pgsql sibling
+    //  file; dialect differences: bracket identifiers, SqlParameter, bit (0/1)
+    //  for boolean, OUTPUT INSERTED for scalar return. See pgsql file header
+    //  comment for rationale + trigger behavior; triggers on edfi.Student and
+    //  edfi.ProfileRootOnlyMergeItem manage dms.ReferentialIdentity for their
+    //  own rows, but descriptors need manual insertion.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public static async Task<short> GetResourceKeyIdAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        string projectName,
+        string resourceName
+    )
+    {
+        return await database.ExecuteScalarAsync<short>(
+            """
+            SELECT [ResourceKeyId]
+            FROM [dms].[ResourceKey]
+            WHERE [ProjectName] = @projectName
+              AND [ResourceName] = @resourceName;
+            """,
+            new SqlParameter("@projectName", projectName),
+            new SqlParameter("@resourceName", resourceName)
+        );
+    }
+
+    public static async Task<long> InsertDocumentRowAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        short resourceKeyId
+    )
+    {
+        // dms.Document has the TR_Document_Journal trigger; OUTPUT without INTO is rejected
+        // in that case, so route the inserted DocumentId through a table variable.
+        return await database.ExecuteScalarAsync<long>(
+            """
+            DECLARE @Inserted TABLE ([DocumentId] bigint);
+            INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId])
+            OUTPUT INSERTED.[DocumentId] INTO @Inserted ([DocumentId])
+            VALUES (@documentUuid, @resourceKeyId);
+            SELECT TOP (1) [DocumentId] FROM @Inserted;
+            """,
+            new SqlParameter("@documentUuid", documentUuid),
+            new SqlParameter("@resourceKeyId", resourceKeyId)
+        );
+    }
+
+    public static async Task InsertReferentialIdentityRowAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        Guid referentialId,
+        long documentId,
+        short resourceKeyId
+    )
+    {
+        await database.ExecuteNonQueryAsync(
+            """
+            IF NOT EXISTS (
+                SELECT 1 FROM [dms].[ReferentialIdentity] WHERE [ReferentialId] = @referentialId
+            )
+            INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+            VALUES (@referentialId, @documentId, @resourceKeyId);
+            """,
+            new SqlParameter("@referentialId", referentialId),
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@resourceKeyId", resourceKeyId)
+        );
+    }
+
+    public static async Task<long> SeedStudentAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        string studentUniqueId,
+        string firstName = "Seed"
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "Student");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [edfi].[Student] ([DocumentId], [StudentUniqueId], [FirstName])
+            VALUES (@documentId, @studentUniqueId, @firstName);
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@studentUniqueId", studentUniqueId),
+            new SqlParameter("@firstName", firstName)
+        );
+        return documentId;
+    }
+
+    public static async Task<long> SeedSchoolTypeDescriptorAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "SchoolTypeDescriptor");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+        var uri = $"{@namespace}#{codeValue}";
+        const string discriminator = "Ed-Fi:SchoolTypeDescriptor";
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [dms].[Descriptor] (
+                [DocumentId],
+                [Namespace],
+                [CodeValue],
+                [ShortDescription],
+                [Description],
+                [Discriminator],
+                [Uri]
+            )
+            VALUES (
+                @documentId,
+                @namespace,
+                @codeValue,
+                @shortDescription,
+                @shortDescription,
+                @discriminator,
+                @uri
+            );
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@namespace", @namespace),
+            new SqlParameter("@codeValue", codeValue),
+            new SqlParameter("@shortDescription", shortDescription),
+            new SqlParameter("@discriminator", discriminator),
+            new SqlParameter("@uri", uri)
+        );
+
+        var descriptorResourceInfo = new BaseResourceInfo(
+            new ProjectName("Ed-Fi"),
+            new ResourceName("SchoolTypeDescriptor"),
+            true
+        );
+        var descriptorIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(DocumentIdentity.DescriptorIdentityJsonPath, uri.ToLowerInvariant()),
+        ]);
+        var referentialId = ReferentialIdCalculator.ReferentialIdFrom(
+            descriptorResourceInfo,
+            descriptorIdentity
+        );
+        await InsertReferentialIdentityRowAsync(database, referentialId.Value, documentId, resourceKeyId);
+
+        return documentId;
+    }
+
+    public static async Task<long> SeedProfileRootOnlyMergeItemRowAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        int profileRootOnlyMergeItemId,
+        string displayName,
+        string? clearableText,
+        string? preservedText,
+        long? studentDocumentId,
+        string? studentUniqueId,
+        long? unifiedDescriptorId,
+        bool primaryPresent,
+        bool secondaryPresent
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "ProfileRootOnlyMergeItem");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [edfi].[ProfileRootOnlyMergeItem] (
+                [DocumentId],
+                [ProfileRootOnlyMergeItemId],
+                [DisplayName],
+                [ProfileScopeClearableText],
+                [ProfileScopePreservedText],
+                [StudentReference_DocumentId],
+                [StudentReference_StudentUniqueId],
+                [PrimarySchoolTypeDescriptor_DescriptorId_Present],
+                [SecondarySchoolTypeDescriptor_DescriptorId_Present],
+                [PrimarySchoolTypeDescriptor_Unified_DescriptorId]
+            )
+            VALUES (
+                @documentId,
+                @profileRootOnlyMergeItemId,
+                @displayName,
+                @clearableText,
+                @preservedText,
+                @studentDocumentId,
+                @studentUniqueId,
+                @primaryPresent,
+                @secondaryPresent,
+                @unifiedDescriptorId
+            );
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@profileRootOnlyMergeItemId", profileRootOnlyMergeItemId),
+            new SqlParameter("@displayName", (object?)displayName ?? DBNull.Value),
+            new SqlParameter("@clearableText", (object?)clearableText ?? DBNull.Value),
+            new SqlParameter("@preservedText", (object?)preservedText ?? DBNull.Value),
+            new SqlParameter("@studentDocumentId", (object?)studentDocumentId ?? DBNull.Value),
+            new SqlParameter("@studentUniqueId", (object?)studentUniqueId ?? DBNull.Value),
+            new SqlParameter("@primaryPresent", primaryPresent ? (object)(byte)1 : DBNull.Value),
+            new SqlParameter("@secondaryPresent", secondaryPresent ? (object)(byte)1 : DBNull.Value),
+            new SqlParameter("@unifiedDescriptorId", (object?)unifiedDescriptorId ?? DBNull.Value)
+        );
+
+        return documentId;
+    }
+
+    public static async Task<IReadOnlyDictionary<string, object?>> ReadItemRowWithReferenceColumnsAsync(
+        MssqlGeneratedDdlTestDatabase database,
+        DocumentUuid documentUuid
+    )
+    {
+        var rows = await database.QueryRowsAsync(
+            """
+            SELECT
+                i.[ProfileRootOnlyMergeItemId],
+                i.[DisplayName],
+                i.[ProfileScopeClearableText],
+                i.[ProfileScopePreservedText],
+                i.[StudentReference_DocumentId],
+                i.[StudentReference_StudentUniqueId],
+                i.[PrimarySchoolTypeDescriptor_DescriptorId_Present],
+                i.[SecondarySchoolTypeDescriptor_DescriptorId_Present],
+                i.[PrimarySchoolTypeDescriptor_Unified_DescriptorId]
+            FROM [edfi].[ProfileRootOnlyMergeItem] i
+            INNER JOIN [dms].[Document] d ON d.[DocumentId] = i.[DocumentId]
+            WHERE d.[DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", documentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+
+    public static DocumentInfo CreateDocumentInfoWithReferences(
+        int profileRootOnlyMergeItemId,
+        DocumentReference[] documentReferences,
+        DescriptorReference[] descriptorReferences
+    )
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.profileRootOnlyMergeItemId"),
+                profileRootOnlyMergeItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                ProfileRootOnlyMergeItemResourceInfo,
+                identity
+            ),
+            DocumentReferences: documentReferences,
+            DocumentReferenceArrays: [],
+            DescriptorReferences: descriptorReferences,
+            SuperclassIdentity: null
+        );
+    }
+
+    public static DescriptorReference BuildSchoolTypeDescriptorReference(string uri, string referenceJsonPath)
+    {
+        var descriptorResourceInfo = new BaseResourceInfo(
+            new ProjectName("Ed-Fi"),
+            new ResourceName("SchoolTypeDescriptor"),
+            true
+        );
+        var descriptorIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(DocumentIdentity.DescriptorIdentityJsonPath, uri.ToLowerInvariant()),
+        ]);
+        return new DescriptorReference(
+            ResourceInfo: descriptorResourceInfo,
+            DocumentIdentity: descriptorIdentity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                descriptorResourceInfo,
+                descriptorIdentity
+            ),
+            Path: new JsonPath(referenceJsonPath)
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture A: Hidden inlined preservation on the root scope.
+//  Spec scenario 5 — hidden inlined column preservation, multi-column.
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Put_With_Hidden_Inlined_PreservedText_On_Root_Scope
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("bb100001-0000-0000-0000-000000000001")
+    );
+    private const int ItemId = 9101;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "OriginalDisplay",
+            ["profileScope"] = new JsonObject
+            {
+                ["clearableText"] = "OriginalClearable",
+                ["preservedText"] = "OriginalPreserved",
+            },
+        };
+        var seedResult = await MssqlProfileRootOnlyFixtureSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            ItemId,
+            seedBody,
+            DocumentUuid,
+            "mssql-profile-root-only-hidden-inlined-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["profileScope"] = new JsonObject { ["clearableText"] = "UpdatedClearable" },
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await MssqlProfileRootOnlyFixtureSupport.ReadItemRowAsync(_database, DocumentUuid);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_updates_profile_scope_clearable_text() =>
+        _rowAfterPut["ProfileScopeClearableText"].Should().Be("UpdatedClearable");
+
+    [Test]
+    public void It_preserves_profile_scope_preserved_text() =>
+        _rowAfterPut["ProfileScopePreservedText"].Should().Be("OriginalPreserved");
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = MssqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: ["preservedText"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: MssqlProfileRootOnlyFixtureSupport.CreateDocumentInfo(ItemId),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-root-only-hidden-inlined-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture B: Visible-absent inlined scope clears clearable, preserves hidden.
+//  Spec scenario 4 — visible-absent inlined scope clears clearable only, with
+//  hidden-override precedence protecting preservedText.
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Put_With_VisibleAbsent_Inlined_Scope_Clears_Clearable_And_Preserves_Hidden
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("bb100002-0000-0000-0000-000000000002")
+    );
+    private const int ItemId = 9102;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "OriginalDisplay",
+            ["profileScope"] = new JsonObject
+            {
+                ["clearableText"] = "OriginalClearable",
+                ["preservedText"] = "OriginalPreserved",
+            },
+        };
+        var seedResult = await MssqlProfileRootOnlyFixtureSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            ItemId,
+            seedBody,
+            DocumentUuid,
+            "mssql-profile-root-only-visible-absent-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await MssqlProfileRootOnlyFixtureSupport.ReadItemRowAsync(_database, DocumentUuid);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_clears_profile_scope_clearable_text() =>
+        _rowAfterPut["ProfileScopeClearableText"].Should().BeNull();
+
+    [Test]
+    public void It_preserves_profile_scope_preserved_text() =>
+        _rowAfterPut["ProfileScopePreservedText"].Should().Be("OriginalPreserved");
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = MssqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisibleAbsent,
+            profileScopeHiddenMemberPaths: ["preservedText"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: MssqlProfileRootOnlyFixtureSupport.CreateDocumentInfo(ItemId),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-root-only-visible-absent-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture C.1: Hidden member path under the dedicated inlined reference scope
+//  preserves FK + propagated identity. MSSQL mirror of the pgsql Fixture C.1.
+//  Regression for profile hidden-reference governance (profiles.md:782):
+//  governing $.studentReference.studentUniqueId through the $.studentReference
+//  scope must preserve the FK column and every propagated identity binding as a
+//  single reference-derived group.
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_Mssql_ProfiledRootOnly_HiddenSubReferenceMember_PreservesFKAndPropagatedIdentity
+{
+    private static readonly Guid ItemDocumentUuid = Guid.Parse("bb100004-0000-0000-0000-000000000004");
+    private static readonly Guid StudentDocumentUuid = Guid.Parse("bb100004-1000-0000-0000-000000000004");
+    private static readonly Guid PublicDescriptorDocumentUuid = Guid.Parse(
+        "bb100004-2000-0000-0000-000000000004"
+    );
+    private const int ItemId = 9104;
+    private const string StudentUniqueId = "STU-104";
+    private const string DescriptorNamespace = "uri://ed-fi.org/SchoolTypeDescriptor";
+    private const string PublicCodeValue = "Public";
+    private static readonly string PublicUri = $"{DescriptorNamespace}#{PublicCodeValue}";
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private long _studentDocumentId;
+    private long _publicDescriptorDocumentId;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        _studentDocumentId = await MssqlProfileRootOnlyFixtureSupport.SeedStudentAsync(
+            _database,
+            StudentDocumentUuid,
+            StudentUniqueId
+        );
+        _publicDescriptorDocumentId = await MssqlProfileRootOnlyFixtureSupport.SeedSchoolTypeDescriptorAsync(
+            _database,
+            PublicDescriptorDocumentUuid,
+            DescriptorNamespace,
+            PublicCodeValue,
+            PublicCodeValue
+        );
+        await MssqlProfileRootOnlyFixtureSupport.SeedProfileRootOnlyMergeItemRowAsync(
+            _database,
+            ItemDocumentUuid,
+            ItemId,
+            displayName: "OriginalDisplay",
+            clearableText: null,
+            preservedText: null,
+            studentDocumentId: _studentDocumentId,
+            studentUniqueId: StudentUniqueId,
+            unifiedDescriptorId: _publicDescriptorDocumentId,
+            primaryPresent: true,
+            secondaryPresent: true
+        );
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["primarySchoolTypeDescriptor"] = PublicUri,
+            ["secondarySchoolTypeDescriptor"] = PublicUri,
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await MssqlProfileRootOnlyFixtureSupport.ReadItemRowWithReferenceColumnsAsync(
+            _database,
+            new DocumentUuid(ItemDocumentUuid)
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_preserves_student_reference_document_id() =>
+        _rowAfterPut["StudentReference_DocumentId"].Should().Be(_studentDocumentId);
+
+    [Test]
+    public void It_preserves_student_reference_student_unique_id() =>
+        _rowAfterPut["StudentReference_StudentUniqueId"].Should().Be(StudentUniqueId);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootOnlyFixtureSubRefHidden",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = MssqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: [],
+            studentReferenceRequestVisibility: ProfileVisibilityKind.VisibleAbsent,
+            studentReferenceStoredVisibility: ProfileVisibilityKind.VisiblePresent,
+            studentReferenceStoredHiddenMemberPaths: ["studentUniqueId"]
+        );
+        var descriptorReferences = new[]
+        {
+            MssqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.primarySchoolTypeDescriptor"
+            ),
+            MssqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.secondarySchoolTypeDescriptor"
+            ),
+        };
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: MssqlProfileRootOnlyFixtureSupport.CreateDocumentInfoWithReferences(
+                ItemId,
+                documentReferences: [],
+                descriptorReferences: descriptorReferences
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-root-only-hidden-sub-ref-put"),
+            DocumentUuid: new DocumentUuid(ItemDocumentUuid),
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture D: Key-unification hidden member + visible agreement.
+//  MSSQL mirror of scenario 7a.
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_Mssql_ProfiledRootOnly_KeyUnificationHiddenMember_AgreementSucceeds
+{
+    private static readonly Guid ItemDocumentUuid = Guid.Parse("bb100004-0000-0000-0000-000000000004");
+    private static readonly Guid PublicDescriptorDocumentUuid = Guid.Parse(
+        "bb100004-2000-0000-0000-000000000004"
+    );
+    private const int ItemId = 9104;
+    private const string DescriptorNamespace = "uri://ed-fi.org/SchoolTypeDescriptor";
+    private const string PublicCodeValue = "Public";
+    private static readonly string PublicUri = $"{DescriptorNamespace}#{PublicCodeValue}";
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private long _publicDescriptorDocumentId;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        _publicDescriptorDocumentId = await MssqlProfileRootOnlyFixtureSupport.SeedSchoolTypeDescriptorAsync(
+            _database,
+            PublicDescriptorDocumentUuid,
+            DescriptorNamespace,
+            PublicCodeValue,
+            PublicCodeValue
+        );
+        await MssqlProfileRootOnlyFixtureSupport.SeedProfileRootOnlyMergeItemRowAsync(
+            _database,
+            ItemDocumentUuid,
+            ItemId,
+            displayName: "OriginalDisplay",
+            clearableText: null,
+            preservedText: null,
+            studentDocumentId: null,
+            studentUniqueId: null,
+            unifiedDescriptorId: _publicDescriptorDocumentId,
+            primaryPresent: true,
+            secondaryPresent: true
+        );
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["primarySchoolTypeDescriptor"] = PublicUri,
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await MssqlProfileRootOnlyFixtureSupport.ReadItemRowWithReferenceColumnsAsync(
+            _database,
+            new DocumentUuid(ItemDocumentUuid)
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_preserves_unified_descriptor_canonical_fk() =>
+        _rowAfterPut["PrimarySchoolTypeDescriptor_Unified_DescriptorId"]
+            .Should()
+            .Be(_publicDescriptorDocumentId);
+
+    [Test]
+    public void It_preserves_primary_descriptor_synthetic_presence() =>
+        _rowAfterPut["PrimarySchoolTypeDescriptor_DescriptorId_Present"].Should().Be(true);
+
+    [Test]
+    public void It_preserves_secondary_descriptor_synthetic_presence() =>
+        _rowAfterPut["SecondarySchoolTypeDescriptor_DescriptorId_Present"].Should().Be(true);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = MssqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: ["secondarySchoolTypeDescriptor"],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: []
+        );
+        var descriptorReferences = new[]
+        {
+            MssqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.primarySchoolTypeDescriptor"
+            ),
+        };
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: MssqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: MssqlProfileRootOnlyFixtureSupport.CreateDocumentInfoWithReferences(
+                ItemId,
+                documentReferences: [],
+                descriptorReferences: descriptorReferences
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-root-only-ku-agreement-put"),
+            DocumentUuid: new DocumentUuid(ItemDocumentUuid),
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
@@ -1,0 +1,876 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+// Resource choice for Slice 2 profile merge integration tests:
+//   NamingStressItem (from the Ed-Fi.DataManagementService.Backend.Ddl.Tests.Unit
+//   small/naming-stress fixture). It is single-table, non-descriptor, has an integer
+//   identity plus multiple nullable scalar columns (Order, ShortName), and has no
+//   document references, descriptor references, or key-unification plans. That lets
+//   us exercise hidden-inlined preservation, visible-absent clearing, and create-new
+//   without extra fixtures. Fixtures 4/5/6/7/8 from the design spec are deferred
+//   because NamingStressItem does not carry the shapes they target (nested scope,
+//   document references, descriptors, key unification). See the pgsql sibling file
+//   for detailed rationale.
+//
+// Fixture 9 (shape-gate) uses the School resource from the focused
+// stable-key-extension-child-collections fixture, which has a multi-table write plan.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+file sealed class MssqlProfileMergeAllowAllResourceAuthorizationHandler : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class MssqlProfileMergeNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+/// <summary>
+/// Test-configurable <see cref="IStoredStateProjectionInvoker"/> for MSSQL Slice 2 fixtures.
+/// Emits a single non-collection stored scope at <c>$</c> with caller-supplied visibility
+/// and hidden member paths.
+/// </summary>
+internal sealed class MssqlConfigurableStoredStateProjectionInvoker : IStoredStateProjectionInvoker
+{
+    private readonly ProfileVisibilityKind _rootVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _rootHiddenMemberPaths;
+
+    public MssqlConfigurableStoredStateProjectionInvoker(
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths
+    )
+    {
+        _rootVisibility = rootVisibility;
+        _rootHiddenMemberPaths = rootHiddenMemberPaths;
+    }
+
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    )
+    {
+        var rootAddress = new ScopeInstanceAddress("$", []);
+        return new ProfileAppliedWriteContext(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates:
+            [
+                new StoredScopeState(
+                    Address: rootAddress,
+                    Visibility: _rootVisibility,
+                    HiddenMemberPaths: _rootHiddenMemberPaths
+                ),
+            ],
+            VisibleStoredCollectionRows: []
+        );
+    }
+}
+
+internal static class MssqlProfileRootTableOnlyMergeSupport
+{
+    public const string NamingStressFixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress";
+    public const string SchoolFixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections";
+
+    public static readonly QualifiedResourceName NamingStressItemResource = new("Ed-Fi", "NamingStressItem");
+
+    public static readonly ResourceInfo NamingStressItemResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("NamingStressItem"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    public static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlReferenceResolver();
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    public static DocumentInfo CreateNamingStressDocumentInfo(int namingStressItemId)
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.namingStressItemId"),
+                namingStressItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(NamingStressItemResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    public static BackendProfileWriteContext CreateProfileContext(
+        ResourceWritePlan writePlan,
+        JsonNode requestBody,
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        bool creatable = true,
+        string profileName = "root-only-profile"
+    )
+    {
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+        RequestScopeState[] scopeStates =
+        [
+            new RequestScopeState(
+                Address: new ScopeInstanceAddress("$", []),
+                Visibility: rootVisibility,
+                Creatable: creatable
+            ),
+        ];
+        return new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody,
+                RootResourceCreatable: creatable,
+                RequestScopeStates: [.. scopeStates],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: profileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new MssqlConfigurableStoredStateProjectionInvoker(
+                rootVisibility,
+                rootHiddenMemberPaths
+            )
+        );
+    }
+
+    public static async Task<UpsertResult> SeedAsync(
+        ServiceProvider serviceProvider,
+        MssqlGeneratedDdlTestDatabase database,
+        MappingSet mappingSet,
+        int namingStressItemId,
+        JsonNode body,
+        DocumentUuid documentUuid,
+        string traceLabel
+    )
+    {
+        using var scope = serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMerge",
+                    ConnectionString: database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: NamingStressItemResourceInfo,
+            DocumentInfo: CreateNamingStressDocumentInfo(namingStressItemId),
+            MappingSet: mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId(traceLabel),
+            DocumentUuid: documentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 1: Profiled PUT with hidden inlined preservation (MSSQL)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Put_With_Hidden_Inlined_Column_Preservation
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("11111111-1111-1111-1111-211111111111")
+    );
+    private const int NamingStressItemId = 8011;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+        var seedResult = await MssqlProfileRootTableOnlyMergeSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            NamingStressItemId,
+            seedBody,
+            DocumentUuid,
+            "mssql-profile-merge-hidden-preservation-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Updated",
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_writes_the_visible_scalar_value() => _rowAfterPut["ShortName"].Should().Be("Updated");
+
+    [Test]
+    public void It_preserves_the_hidden_scalar_value() =>
+        Convert.ToInt32(_rowAfterPut["Order"], CultureInfo.InvariantCulture).Should().Be(42);
+
+    [Test]
+    public void It_preserves_the_identity_column() =>
+        Convert
+            .ToInt32(_rowAfterPut["NamingStressItemId"], CultureInfo.InvariantCulture)
+            .Should()
+            .Be(NamingStressItemId);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = MssqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            ["order"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: MssqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-merge-hidden-preservation-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi.[NamingStressItemId], nsi.[ShortName], nsi.[Order]
+            FROM [edfi].[NamingStressItem] nsi
+            INNER JOIN [dms].[Document] d ON d.[DocumentId] = nsi.[DocumentId]
+            WHERE d.[DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", DocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 3: Profiled POST create-new (MSSQL)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Post_Create_New_For_Root_Only_Resource
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("22222222-2222-2222-2222-222222222222")
+    );
+    private const int NamingStressItemId = 8022;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpsertResult _postResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPost = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Created",
+            ["order"] = 99,
+        };
+        _postResult = await ExecuteProfiledPostAsync(writeBody);
+        _rowAfterPost = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_insert_success() => _postResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+    [Test]
+    public void It_writes_the_identity_value() =>
+        Convert
+            .ToInt32(_rowAfterPost["NamingStressItemId"], CultureInfo.InvariantCulture)
+            .Should()
+            .Be(NamingStressItemId);
+
+    [Test]
+    public void It_writes_the_visible_scalar_values()
+    {
+        _rowAfterPost["ShortName"].Should().Be("Created");
+        Convert.ToInt32(_rowAfterPost["Order"], CultureInfo.InvariantCulture).Should().Be(99);
+    }
+
+    private async Task<UpsertResult> ExecuteProfiledPostAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = MssqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            []
+        );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: MssqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-merge-create-new-post"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi.[NamingStressItemId], nsi.[ShortName], nsi.[Order]
+            FROM [edfi].[NamingStressItem] nsi
+            INNER JOIN [dms].[Document] d ON d.[DocumentId] = nsi.[DocumentId]
+            WHERE d.[DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", DocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 2: Profiled POST-as-update with hidden inlined preservation (MSSQL)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Post_As_Update_With_Hidden_Inlined_Preservation
+{
+    private static readonly DocumentUuid SeedDocumentUuid = new(
+        Guid.Parse("33333333-3333-3333-3333-333333333333")
+    );
+    private static readonly DocumentUuid PostAsUpdateDocumentUuid = new(
+        Guid.Parse("33333333-4444-4444-4444-333333333333")
+    );
+    private const int NamingStressItemId = 8033;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpsertResult _postResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPost = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "OriginalPost",
+            ["order"] = 55,
+        };
+        var seedResult = await MssqlProfileRootTableOnlyMergeSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            NamingStressItemId,
+            seedBody,
+            SeedDocumentUuid,
+            "mssql-profile-merge-post-as-update-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "UpdatedViaPost",
+        };
+        _postResult = await ExecuteProfiledPostAsUpdateAsync(writeBody);
+        _rowAfterPost = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success_via_post_as_update() =>
+        _postResult.Should().BeOfType<UpsertResult.UpdateSuccess>();
+
+    [Test]
+    public void It_writes_the_visible_scalar_value() =>
+        _rowAfterPost["ShortName"].Should().Be("UpdatedViaPost");
+
+    [Test]
+    public void It_preserves_the_hidden_scalar_value() =>
+        Convert.ToInt32(_rowAfterPost["Order"], CultureInfo.InvariantCulture).Should().Be(55);
+
+    private async Task<UpsertResult> ExecuteProfiledPostAsUpdateAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = MssqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            ["order"]
+        );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: MssqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: MssqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-merge-post-as-update-profiled"),
+            DocumentUuid: PostAsUpdateDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi.[NamingStressItemId], nsi.[ShortName], nsi.[Order]
+            FROM [edfi].[NamingStressItem] nsi
+            INNER JOIN [dms].[Document] d ON d.[DocumentId] = nsi.[DocumentId]
+            WHERE d.[DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", SeedDocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 9: Multi-table plan → Slice 2 shape-gate failure (MSSQL)
+// ─────────────────────────────────────────────────────────────────────────────
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_Gate_Failure
+{
+    private const string RequestBodyJson = """
+        {
+          "schoolId": 255901
+        }
+        """;
+
+    private static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+    private static readonly DocumentUuid ExistingDocumentUuid = new(
+        Guid.Parse("99999999-9999-9999-9999-999999999999")
+    );
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _profiledPutResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.SchoolFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var createResult = await ExecuteNonProfiledUpsertAsync();
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        _profiledPutResult = await ExecuteProfiledPutAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_unknown_failure_with_slice_two_shape_gate_message()
+    {
+        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
+        _profiledPutResult
+            .As<UpdateResult.UnknownFailure>()
+            .FailureMessage.Should()
+            .Contain("single-table root-only");
+    }
+
+    [Test]
+    public void It_references_dms_1124_in_the_shape_gate_message()
+    {
+        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
+        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("DMS-1124");
+    }
+
+    private static DocumentInfo CreateSchoolDocumentInfo()
+    {
+        var schoolIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(new JsonPath("$.schoolId"), "255901"),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: schoolIdentity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, schoolIdentity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    private async Task<UpsertResult> ExecuteNonProfiledUpsertAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMergeShapeGate",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: CreateSchoolDocumentInfo(),
+            MappingSet: _mappingSet,
+            EdfiDoc: JsonNode.Parse(RequestBodyJson)!,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-merge-shape-gate-seed"),
+            DocumentUuid: ExistingDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileRootTableOnlyMergeShapeGate",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var writePlan = _mappingSet.WritePlansByResource[SchoolResource];
+        var requestBody = JsonNode.Parse(RequestBodyJson)!;
+
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+        var rootScopeState = new RequestScopeState(
+            Address: new ScopeInstanceAddress("$", []),
+            Visibility: ProfileVisibilityKind.VisiblePresent,
+            Creatable: true
+        );
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody.DeepClone(),
+                RootResourceCreatable: true,
+                RequestScopeStates: [rootScopeState],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: "shape-gate-profile",
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new MssqlConfigurableStoredStateProjectionInvoker(
+                ProfileVisibilityKind.VisiblePresent,
+                []
+            )
+        );
+
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: CreateSchoolDocumentInfo(),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-profile-merge-shape-gate-put"),
+            DocumentUuid: ExistingDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
@@ -684,13 +684,19 @@ public class Given_A_Mssql_Profiled_Post_As_Update_With_Hidden_Inlined_Preservat
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Fixture 9: Multi-table plan → Slice 2 shape-gate failure (MSSQL)
+//  Fixture 9: Multi-table plan with root-only runtime shape → profiled PUT success (MSSQL)
 // ─────────────────────────────────────────────────────────────────────────────
 
+/// <summary>
+/// Mirror of the PostgreSQL Fixture 9: a multi-table compiled plan whose profile
+/// metadata keeps runtime behavior confined to the root table is a supported Slice 2
+/// shape. Classifier returns RootTableOnly, the profile merge synthesizer returns a
+/// root-only merge result, and the persister leaves the extension table untouched.
+/// </summary>
 [TestFixture]
 [Category("DatabaseIntegration")]
 [Category("MssqlIntegration")]
-public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_Gate_Failure
+public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_And_Root_Only_Runtime_Shape_Succeeds
 {
     private const string RequestBodyJson = """
         {
@@ -755,21 +761,8 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
     }
 
     [Test]
-    public void It_returns_unknown_failure_with_slice_two_shape_gate_message()
-    {
-        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult
-            .As<UpdateResult.UnknownFailure>()
-            .FailureMessage.Should()
-            .Contain("single-table root-only");
-    }
-
-    [Test]
-    public void It_references_dms_1124_in_the_shape_gate_message()
-    {
-        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("DMS-1124");
-    }
+    public void It_returns_update_success() =>
+        _profiledPutResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
 
     private static DocumentInfo CreateSchoolDocumentInfo()
     {
@@ -795,7 +788,7 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
                 new DmsInstance(
                     Id: 1,
                     InstanceType: "test",
-                    InstanceName: "MssqlProfileRootTableOnlyMergeShapeGate",
+                    InstanceName: "MssqlProfileRootTableOnlyMergeMultiTableRootOnly",
                     ConnectionString: _database.ConnectionString,
                     RouteContext: []
                 )
@@ -806,7 +799,7 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
             MappingSet: _mappingSet,
             EdfiDoc: JsonNode.Parse(RequestBodyJson)!,
             Headers: [],
-            TraceId: new TraceId("mssql-profile-merge-shape-gate-seed"),
+            TraceId: new TraceId("mssql-profile-merge-multi-table-root-only-seed"),
             DocumentUuid: ExistingDocumentUuid,
             DocumentSecurityElements: new([], [], [], [], []),
             UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),
@@ -826,7 +819,7 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
                 new DmsInstance(
                     Id: 1,
                     InstanceType: "test",
-                    InstanceName: "MssqlProfileRootTableOnlyMergeShapeGate",
+                    InstanceName: "MssqlProfileRootTableOnlyMergeMultiTableRootOnly",
                     ConnectionString: _database.ConnectionString,
                     RouteContext: []
                 )
@@ -848,7 +841,7 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
                 RequestScopeStates: [rootScopeState],
                 VisibleRequestCollectionItems: []
             ),
-            ProfileName: "shape-gate-profile",
+            ProfileName: "multi-table-root-only-profile",
             CompiledScopeCatalog: scopeCatalog,
             StoredStateProjectionInvoker: new MssqlConfigurableStoredStateProjectionInvoker(
                 ProfileVisibilityKind.VisiblePresent,
@@ -862,7 +855,7 @@ public class Given_A_Mssql_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_
             MappingSet: _mappingSet,
             EdfiDoc: requestBody,
             Headers: [],
-            TraceId: new TraceId("mssql-profile-merge-shape-gate-put"),
+            TraceId: new TraceId("mssql-profile-merge-multi-table-root-only-put"),
             DocumentUuid: ExistingDocumentUuid,
             DocumentSecurityElements: new([], [], [], [], []),
             UpdateCascadeHandler: new MssqlProfileMergeNoOpUpdateCascadeHandler(),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
@@ -124,9 +124,19 @@ file static class ProfileRoutingTestSupport
         JsonNode requestBody
     )
     {
+        // Include the $._ext.sample extension scope so the slice-fence classifier returns
+        // SeparateTableNonCollection. Task 6 landed Slice 2 for RootTableOnly shapes, so a
+        // RootTableOnly classification with a multi-table plan now triggers the Slice 2 shape
+        // gate rather than the slice fence; these integration fixtures target the fence for
+        // non-RootTableOnly families, so include the extension scope to guarantee that.
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
         var rootScopeState = new RequestScopeState(
             Address: new ScopeInstanceAddress("$", []),
+            Visibility: ProfileVisibilityKind.VisiblePresent,
+            Creatable: true
+        );
+        var extensionScopeState = new RequestScopeState(
+            Address: new ScopeInstanceAddress("$._ext.sample", []),
             Visibility: ProfileVisibilityKind.VisiblePresent,
             Creatable: true
         );
@@ -135,7 +145,7 @@ file static class ProfileRoutingTestSupport
             Request: new ProfileAppliedWriteRequest(
                 WritableRequestBody: requestBody,
                 RootResourceCreatable: true,
-                RequestScopeStates: [rootScopeState],
+                RequestScopeStates: [rootScopeState, extensionScopeState],
                 VisibleRequestCollectionItems: []
             ),
             ProfileName: "test-profile",
@@ -361,7 +371,7 @@ public class Given_A_Profiled_Post_Create_Where_Root_Is_Not_Creatable
 
 /// <summary>
 /// Verifies that a profiled POST that resolves to post-as-update (existing document)
-/// reaches the slice fence and returns a family name like "RootTableOnly",
+/// reaches the slice fence and returns a family name like "SeparateTableNonCollection",
 /// instead of the old broad "DMS-1124 pending" message.
 /// </summary>
 [TestFixture]
@@ -472,7 +482,7 @@ public class Given_A_Profiled_Post_As_Update_Reaching_Slice_Fence
         _profiledPostAsUpdateResult
             .As<UpsertResult.UnknownFailure>()
             .FailureMessage.Should()
-            .Contain("RootTableOnly");
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]
@@ -580,7 +590,7 @@ public class Given_A_Profiled_Post_As_Update_Reaching_Slice_Fence
 
 /// <summary>
 /// Verifies that a profiled PUT targeting an existing document reaches the slice fence
-/// and returns a family name like "RootTableOnly", instead of the old broad
+/// and returns a family name like "SeparateTableNonCollection", instead of the old broad
 /// "DMS-1124 pending" message.
 /// </summary>
 [TestFixture]
@@ -685,7 +695,10 @@ public class Given_A_Profiled_Put_Reaching_Slice_Fence
     public void It_returns_unknown_failure_with_family_name_in_slice_fence()
     {
         _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("RootTableOnly");
+        _profiledPutResult
+            .As<UpdateResult.UnknownFailure>()
+            .FailureMessage.Should()
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
@@ -124,11 +124,9 @@ file static class ProfileRoutingTestSupport
         JsonNode requestBody
     )
     {
-        // Include the $._ext.sample extension scope so the slice-fence classifier returns
-        // SeparateTableNonCollection. Task 6 landed Slice 2 for RootTableOnly shapes, so a
-        // RootTableOnly classification with a multi-table plan now triggers the Slice 2 shape
-        // gate rather than the slice fence; these integration fixtures target the fence for
-        // non-RootTableOnly families, so include the extension scope to guarantee that.
+        // The extension scope below is intentional. Routing fixtures that use this helper
+        // expect the slice-fence family name to appear in the failure message, so the profile
+        // must include a non-root scope that forces a non-root-table-only classification.
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
         var rootScopeState = new RequestScopeState(
             Address: new ScopeInstanceAddress("$", []),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeFixtureTests.cs
@@ -1,0 +1,1315 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+// Supplemental Slice 2 profile merge integration coverage for ProfileRootOnlyMergeItem,
+// a synthetic single-table resource from the
+// src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge
+// fixture. The fixture exercises shapes that NamingStressItem (used by the sibling
+// PostgresqlProfileRootTableOnlyMergeTests file for Task 7) cannot:
+//
+//   - An inlined sub-object scope `$.profileScope` carrying two scalar columns
+//     (ProfileScopeClearableText, ProfileScopePreservedText).
+//   - A nullable document reference StudentReference (FK + propagated identity column).
+//   - Two descriptor references (PrimarySchoolTypeDescriptor, SecondarySchoolTypeDescriptor)
+//     with an equality constraint that compiles into a single key-unification plan with a
+//     unified canonical FK column and per-member synthetic presence columns.
+//
+// The single-table compilation yields the following columns on edfi.ProfileRootOnlyMergeItem:
+//   DocumentId (bigint, PK),
+//   PrimarySchoolTypeDescriptor_DescriptorId_Present (boolean, synthetic presence),
+//   PrimarySchoolTypeDescriptor_Unified_DescriptorId (bigint, canonical FK),
+//   SecondarySchoolTypeDescriptor_DescriptorId_Present (boolean, synthetic presence),
+//   StudentReference_DocumentId (bigint, FK),
+//   StudentReference_StudentUniqueId (varchar, propagated identity),
+//   PrimarySchoolTypeDescriptor_DescriptorId (generated; CASE on presence + canonical),
+//   SecondarySchoolTypeDescriptor_DescriptorId (generated; CASE on presence + canonical),
+//   DisplayName (varchar),
+//   ProfileRootOnlyMergeItemId (integer, natural key),
+//   ProfileScopeClearableText (varchar),
+//   ProfileScopePreservedText (varchar).
+//
+// The four scenarios landed in this file close the Slice 2 blocker for end-to-end
+// integration coverage of the root-table-only profile merge path:
+//   Fixture 1: Hidden inlined preservation on the root scope hides preservedText while
+//              leaving clearableText visible. A PUT that updates displayName + clearableText
+//              preserves preservedText.
+//   Fixture 2: Visible-absent inlined scope $.profileScope clears its clearable members
+//              (clearableText) while hidden-preserved preservedText is retained.
+//   Fixture 3 (C.1): Hiding a sub-member of a reference
+//              ($.studentReference.studentUniqueId) through the dedicated inlined reference
+//              scope preserves both the FK column and the propagated identity column.
+//   Fixture 4 (D/7a): Key-unification with one descriptor member hidden and the visible
+//              descriptor agreeing on the stored canonical — unified FK stays unchanged,
+//              both synthetic presence columns stay true, the PUT succeeds.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using EdFi.DataManagementService.Old.Postgresql;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+file sealed class ProfileRootOnlyFixtureNoOpHostApplicationLifetime : IHostApplicationLifetime
+{
+    public CancellationToken ApplicationStarted => CancellationToken.None;
+    public CancellationToken ApplicationStopping => CancellationToken.None;
+    public CancellationToken ApplicationStopped => CancellationToken.None;
+
+    public void StopApplication() { }
+}
+
+file sealed class ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class ProfileRootOnlyFixtureNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+/// <summary>
+/// Test-configurable <see cref="IStoredStateProjectionInvoker"/> that emits the root scope plus
+/// the inlined non-collection scopes used by the ProfileRootOnlyMergeItem fixture:
+/// <c>$.profileScope</c> and <c>$.studentReference</c>.
+/// </summary>
+internal sealed class ProfileRootOnlyFixtureProjectionInvoker : IStoredStateProjectionInvoker
+{
+    private readonly ProfileVisibilityKind _rootVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _rootHiddenMemberPaths;
+    private readonly ProfileVisibilityKind _profileScopeVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _profileScopeHiddenMemberPaths;
+    private readonly bool _emitStudentReferenceScope;
+    private readonly ProfileVisibilityKind _studentReferenceVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _studentReferenceHiddenMemberPaths;
+
+    public ProfileRootOnlyFixtureProjectionInvoker(
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        ProfileVisibilityKind profileScopeVisibility,
+        System.Collections.Immutable.ImmutableArray<string> profileScopeHiddenMemberPaths,
+        bool emitStudentReferenceScope,
+        ProfileVisibilityKind studentReferenceVisibility,
+        System.Collections.Immutable.ImmutableArray<string> studentReferenceHiddenMemberPaths
+    )
+    {
+        _rootVisibility = rootVisibility;
+        _rootHiddenMemberPaths = rootHiddenMemberPaths;
+        _profileScopeVisibility = profileScopeVisibility;
+        _profileScopeHiddenMemberPaths = profileScopeHiddenMemberPaths;
+        _emitStudentReferenceScope = emitStudentReferenceScope;
+        _studentReferenceVisibility = studentReferenceVisibility;
+        _studentReferenceHiddenMemberPaths = studentReferenceHiddenMemberPaths;
+    }
+
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    )
+    {
+        var rootAddress = new ScopeInstanceAddress("$", []);
+        var profileScopeAddress = new ScopeInstanceAddress("$.profileScope", []);
+        var storedScopeStates = new List<StoredScopeState>
+        {
+            new(Address: rootAddress, Visibility: _rootVisibility, HiddenMemberPaths: _rootHiddenMemberPaths),
+            new(
+                Address: profileScopeAddress,
+                Visibility: _profileScopeVisibility,
+                HiddenMemberPaths: _profileScopeHiddenMemberPaths
+            ),
+        };
+
+        if (_emitStudentReferenceScope)
+        {
+            storedScopeStates.Add(
+                new StoredScopeState(
+                    Address: new ScopeInstanceAddress("$.studentReference", []),
+                    Visibility: _studentReferenceVisibility,
+                    HiddenMemberPaths: _studentReferenceHiddenMemberPaths
+                )
+            );
+        }
+
+        return new ProfileAppliedWriteContext(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates: [.. storedScopeStates],
+            VisibleStoredCollectionRows: []
+        );
+    }
+}
+
+/// <summary>
+/// Shared helpers for the Slice 2 profile merge integration tests against the
+/// synthetic ProfileRootOnlyMergeItem fixture.
+/// </summary>
+internal static class PostgresqlProfileRootOnlyFixtureSupport
+{
+    public const string FixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge";
+
+    public static readonly QualifiedResourceName ProfileRootOnlyMergeItemResource = new(
+        "Ed-Fi",
+        "ProfileRootOnlyMergeItem"
+    );
+
+    public static readonly ResourceInfo ProfileRootOnlyMergeItemResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("ProfileRootOnlyMergeItem"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private static readonly (string JsonScope, ScopeKind Kind) ProfileScopeInlinedScope = (
+        "$.profileScope",
+        ScopeKind.NonCollection
+    );
+
+    private static readonly (string JsonScope, ScopeKind Kind) StudentReferenceInlinedScope = (
+        "$.studentReference",
+        ScopeKind.NonCollection
+    );
+
+    public static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton<IHostApplicationLifetime, ProfileRootOnlyFixtureNoOpHostApplicationLifetime>();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    public static DocumentInfo CreateDocumentInfo(int profileRootOnlyMergeItemId)
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.profileRootOnlyMergeItemId"),
+                profileRootOnlyMergeItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                ProfileRootOnlyMergeItemResourceInfo,
+                identity
+            ),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    public static BackendProfileWriteContext CreateProfileContext(
+        ResourceWritePlan writePlan,
+        JsonNode requestBody,
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        ProfileVisibilityKind profileScopeVisibility,
+        System.Collections.Immutable.ImmutableArray<string> profileScopeHiddenMemberPaths,
+        ProfileVisibilityKind? studentReferenceRequestVisibility = null,
+        ProfileVisibilityKind? studentReferenceStoredVisibility = null,
+        System.Collections.Immutable.ImmutableArray<string> studentReferenceStoredHiddenMemberPaths = default,
+        bool creatable = true,
+        string profileName = "root-only-merge-profile"
+    )
+    {
+        var emitStudentReferenceScope =
+            studentReferenceRequestVisibility is not null
+            || studentReferenceStoredVisibility is not null
+            || (
+                !studentReferenceStoredHiddenMemberPaths.IsDefault
+                && !studentReferenceStoredHiddenMemberPaths.IsEmpty
+            );
+        var normalizedStudentReferenceHiddenMemberPaths = studentReferenceStoredHiddenMemberPaths.IsDefault
+            ? []
+            : studentReferenceStoredHiddenMemberPaths;
+        var additionalScopes = emitStudentReferenceScope
+            ? new[] { ProfileScopeInlinedScope, StudentReferenceInlinedScope }
+            : new[] { ProfileScopeInlinedScope };
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan, additionalScopes);
+        var scopeStates = new List<RequestScopeState>
+        {
+            new(Address: new ScopeInstanceAddress("$", []), Visibility: rootVisibility, Creatable: creatable),
+            new(
+                Address: new ScopeInstanceAddress("$.profileScope", []),
+                Visibility: profileScopeVisibility,
+                Creatable: creatable
+            ),
+        };
+
+        if (emitStudentReferenceScope)
+        {
+            scopeStates.Add(
+                new RequestScopeState(
+                    Address: new ScopeInstanceAddress("$.studentReference", []),
+                    Visibility: studentReferenceRequestVisibility ?? ProfileVisibilityKind.VisiblePresent,
+                    Creatable: creatable
+                )
+            );
+        }
+
+        return new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody,
+                RootResourceCreatable: creatable,
+                RequestScopeStates: [.. scopeStates],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: profileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new ProfileRootOnlyFixtureProjectionInvoker(
+                rootVisibility,
+                rootHiddenMemberPaths,
+                profileScopeVisibility,
+                profileScopeHiddenMemberPaths,
+                emitStudentReferenceScope,
+                studentReferenceStoredVisibility
+                    ?? studentReferenceRequestVisibility
+                    ?? ProfileVisibilityKind.VisiblePresent,
+                normalizedStudentReferenceHiddenMemberPaths
+            )
+        );
+    }
+
+    public static async Task<UpsertResult> SeedAsync(
+        ServiceProvider serviceProvider,
+        PostgresqlGeneratedDdlTestDatabase database,
+        MappingSet mappingSet,
+        int profileRootOnlyMergeItemId,
+        JsonNode body,
+        DocumentUuid documentUuid,
+        string traceLabel
+    )
+    {
+        using var scope = serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootOnlyFixture",
+                    ConnectionString: database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: CreateDocumentInfo(profileRootOnlyMergeItemId),
+            MappingSet: mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId(traceLabel),
+            DocumentUuid: documentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    public static async Task<IReadOnlyDictionary<string, object?>> ReadItemRowAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        DocumentUuid documentUuid
+    )
+    {
+        var rows = await database.QueryRowsAsync(
+            """
+            SELECT
+                i."ProfileRootOnlyMergeItemId",
+                i."DisplayName",
+                i."ProfileScopeClearableText",
+                i."ProfileScopePreservedText"
+            FROM "edfi"."ProfileRootOnlyMergeItem" i
+            INNER JOIN "dms"."Document" d ON d."DocumentId" = i."DocumentId"
+            WHERE d."DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", documentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    //  Prerequisite-seed helpers. Used by the fixtures below that require
+    //  pre-existing Student + SchoolTypeDescriptor documents so the synthetic
+    //  ProfileRootOnlyMergeItem root row can carry FK + key-unification values
+    //  into the profiled PUT. Helpers are kept local (per DMS-1124 supplement
+    //  scope) and duplicated in the mssql sibling with dialect-specific SQL.
+    //
+    //  - Student inserts trigger TR_Student_ReferentialIdentity, which creates
+    //    the dms.ReferentialIdentity row for ResourceKeyId=3 automatically.
+    //  - Descriptors have no trigger, so we insert dms.ReferentialIdentity
+    //    explicitly for ResourceKeyId=2 using the ReferentialId computed from
+    //    the lowercase URI (identity path $.descriptor).
+    // ─────────────────────────────────────────────────────────────────────────
+
+    public static async Task<short> GetResourceKeyIdAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        string projectName,
+        string resourceName
+    )
+    {
+        return await database.ExecuteScalarAsync<short>(
+            """
+            SELECT "ResourceKeyId"
+            FROM "dms"."ResourceKey"
+            WHERE "ProjectName" = @projectName
+              AND "ResourceName" = @resourceName;
+            """,
+            new NpgsqlParameter("projectName", projectName),
+            new NpgsqlParameter("resourceName", resourceName)
+        );
+    }
+
+    public static async Task<long> InsertDocumentRowAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        short resourceKeyId
+    )
+    {
+        return await database.ExecuteScalarAsync<long>(
+            """
+            INSERT INTO "dms"."Document" ("DocumentUuid", "ResourceKeyId")
+            VALUES (@documentUuid, @resourceKeyId)
+            RETURNING "DocumentId";
+            """,
+            new NpgsqlParameter("documentUuid", documentUuid),
+            new NpgsqlParameter("resourceKeyId", resourceKeyId)
+        );
+    }
+
+    public static async Task InsertReferentialIdentityRowAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        Guid referentialId,
+        long documentId,
+        short resourceKeyId
+    )
+    {
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+            VALUES (@referentialId, @documentId, @resourceKeyId)
+            ON CONFLICT ("ReferentialId") DO NOTHING;
+            """,
+            new NpgsqlParameter("referentialId", referentialId),
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("resourceKeyId", resourceKeyId)
+        );
+    }
+
+    public static async Task<long> SeedStudentAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        string studentUniqueId,
+        string firstName = "Seed"
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "Student");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "edfi"."Student" ("DocumentId", "StudentUniqueId", "FirstName")
+            VALUES (@documentId, @studentUniqueId, @firstName);
+            """,
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("studentUniqueId", studentUniqueId),
+            new NpgsqlParameter("firstName", firstName)
+        );
+        return documentId;
+    }
+
+    public static async Task<long> SeedSchoolTypeDescriptorAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "SchoolTypeDescriptor");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+        var uri = $"{@namespace}#{codeValue}";
+        const string discriminator = "Ed-Fi:SchoolTypeDescriptor";
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "dms"."Descriptor" (
+                "DocumentId",
+                "Namespace",
+                "CodeValue",
+                "ShortDescription",
+                "Description",
+                "Discriminator",
+                "Uri"
+            )
+            VALUES (
+                @documentId,
+                @namespace,
+                @codeValue,
+                @shortDescription,
+                @shortDescription,
+                @discriminator,
+                @uri
+            );
+            """,
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("namespace", @namespace),
+            new NpgsqlParameter("codeValue", codeValue),
+            new NpgsqlParameter("shortDescription", shortDescription),
+            new NpgsqlParameter("discriminator", discriminator),
+            new NpgsqlParameter("uri", uri)
+        );
+
+        var descriptorResourceInfo = new BaseResourceInfo(
+            new ProjectName("Ed-Fi"),
+            new ResourceName("SchoolTypeDescriptor"),
+            true
+        );
+        var descriptorIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(DocumentIdentity.DescriptorIdentityJsonPath, uri.ToLowerInvariant()),
+        ]);
+        var referentialId = ReferentialIdCalculator.ReferentialIdFrom(
+            descriptorResourceInfo,
+            descriptorIdentity
+        );
+        await InsertReferentialIdentityRowAsync(database, referentialId.Value, documentId, resourceKeyId);
+
+        return documentId;
+    }
+
+    public static async Task<long> SeedProfileRootOnlyMergeItemRowAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        Guid documentUuid,
+        int profileRootOnlyMergeItemId,
+        string displayName,
+        string? clearableText,
+        string? preservedText,
+        long? studentDocumentId,
+        string? studentUniqueId,
+        long? unifiedDescriptorId,
+        bool primaryPresent,
+        bool secondaryPresent
+    )
+    {
+        var resourceKeyId = await GetResourceKeyIdAsync(database, "Ed-Fi", "ProfileRootOnlyMergeItem");
+        var documentId = await InsertDocumentRowAsync(database, documentUuid, resourceKeyId);
+
+        await database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "edfi"."ProfileRootOnlyMergeItem" (
+                "DocumentId",
+                "ProfileRootOnlyMergeItemId",
+                "DisplayName",
+                "ProfileScopeClearableText",
+                "ProfileScopePreservedText",
+                "StudentReference_DocumentId",
+                "StudentReference_StudentUniqueId",
+                "PrimarySchoolTypeDescriptor_DescriptorId_Present",
+                "SecondarySchoolTypeDescriptor_DescriptorId_Present",
+                "PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+            )
+            VALUES (
+                @documentId,
+                @profileRootOnlyMergeItemId,
+                @displayName,
+                @clearableText,
+                @preservedText,
+                @studentDocumentId,
+                @studentUniqueId,
+                @primaryPresent,
+                @secondaryPresent,
+                @unifiedDescriptorId
+            );
+            """,
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("profileRootOnlyMergeItemId", profileRootOnlyMergeItemId),
+            new NpgsqlParameter("displayName", (object?)displayName ?? DBNull.Value),
+            new NpgsqlParameter("clearableText", (object?)clearableText ?? DBNull.Value),
+            new NpgsqlParameter("preservedText", (object?)preservedText ?? DBNull.Value),
+            new NpgsqlParameter("studentDocumentId", (object?)studentDocumentId ?? DBNull.Value),
+            new NpgsqlParameter("studentUniqueId", (object?)studentUniqueId ?? DBNull.Value),
+            new NpgsqlParameter("primaryPresent", primaryPresent ? (object)true : DBNull.Value),
+            new NpgsqlParameter("secondaryPresent", secondaryPresent ? (object)true : DBNull.Value),
+            new NpgsqlParameter("unifiedDescriptorId", (object?)unifiedDescriptorId ?? DBNull.Value)
+        );
+
+        return documentId;
+    }
+
+    public static async Task<IReadOnlyDictionary<string, object?>> ReadItemRowWithReferenceColumnsAsync(
+        PostgresqlGeneratedDdlTestDatabase database,
+        DocumentUuid documentUuid
+    )
+    {
+        var rows = await database.QueryRowsAsync(
+            """
+            SELECT
+                i."ProfileRootOnlyMergeItemId",
+                i."DisplayName",
+                i."ProfileScopeClearableText",
+                i."ProfileScopePreservedText",
+                i."StudentReference_DocumentId",
+                i."StudentReference_StudentUniqueId",
+                i."PrimarySchoolTypeDescriptor_DescriptorId_Present",
+                i."SecondarySchoolTypeDescriptor_DescriptorId_Present",
+                i."PrimarySchoolTypeDescriptor_Unified_DescriptorId"
+            FROM "edfi"."ProfileRootOnlyMergeItem" i
+            INNER JOIN "dms"."Document" d ON d."DocumentId" = i."DocumentId"
+            WHERE d."DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", documentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+
+    public static DocumentInfo CreateDocumentInfoWithReferences(
+        int profileRootOnlyMergeItemId,
+        DocumentReference[] documentReferences,
+        DescriptorReference[] descriptorReferences
+    )
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.profileRootOnlyMergeItemId"),
+                profileRootOnlyMergeItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                ProfileRootOnlyMergeItemResourceInfo,
+                identity
+            ),
+            DocumentReferences: documentReferences,
+            DocumentReferenceArrays: [],
+            DescriptorReferences: descriptorReferences,
+            SuperclassIdentity: null
+        );
+    }
+
+    public static DescriptorReference BuildSchoolTypeDescriptorReference(string uri, string referenceJsonPath)
+    {
+        var descriptorResourceInfo = new BaseResourceInfo(
+            new ProjectName("Ed-Fi"),
+            new ResourceName("SchoolTypeDescriptor"),
+            true
+        );
+        var descriptorIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(DocumentIdentity.DescriptorIdentityJsonPath, uri.ToLowerInvariant()),
+        ]);
+        return new DescriptorReference(
+            ResourceInfo: descriptorResourceInfo,
+            DocumentIdentity: descriptorIdentity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(
+                descriptorResourceInfo,
+                descriptorIdentity
+            ),
+            Path: new JsonPath(referenceJsonPath)
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture A: Hidden inlined preservation on the root scope.
+//  Spec scenario 5 — hidden inlined column preservation, multi-column.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Seed a ProfileRootOnlyMergeItem with displayName + both inlined nested scalars. The
+/// profile context declares the root scope visible-present with
+/// <c>profileScope.preservedText</c> listed as a hidden member path. PUT a body that
+/// updates only displayName and profileScope.clearableText (omits preservedText).
+/// Assert: displayName + clearableText updated; preservedText preserved.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Put_With_Hidden_Inlined_PreservedText_On_Root_Scope
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("bb000001-0000-0000-0000-000000000001")
+    );
+    private const int ItemId = 9001;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "OriginalDisplay",
+            ["profileScope"] = new JsonObject
+            {
+                ["clearableText"] = "OriginalClearable",
+                ["preservedText"] = "OriginalPreserved",
+            },
+        };
+        var seedResult = await PostgresqlProfileRootOnlyFixtureSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            ItemId,
+            seedBody,
+            DocumentUuid,
+            "profile-root-only-hidden-inlined-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["profileScope"] = new JsonObject { ["clearableText"] = "UpdatedClearable" },
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await PostgresqlProfileRootOnlyFixtureSupport.ReadItemRowAsync(
+            _database,
+            DocumentUuid
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_updates_profile_scope_clearable_text() =>
+        _rowAfterPut["ProfileScopeClearableText"].Should().Be("UpdatedClearable");
+
+    [Test]
+    public void It_preserves_profile_scope_preserved_text() =>
+        _rowAfterPut["ProfileScopePreservedText"].Should().Be("OriginalPreserved");
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = PostgresqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: ["preservedText"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootOnlyFixtureSupport.CreateDocumentInfo(ItemId),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-root-only-hidden-inlined-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture B: Visible-absent inlined scope clears clearable, preserves hidden.
+//  Spec scenario 4 — visible-absent inlined scope clears clearable only, with
+//  hidden-override precedence protecting preservedText.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Seed a ProfileRootOnlyMergeItem with both inlined nested scalars populated. The
+/// request scope for <c>$.profileScope</c> is VisibleAbsent (the profile says the
+/// sub-object is not present in the request); the stored scope state also classifies
+/// <c>$.profileScope</c> as VisibleAbsent with <c>preservedText</c> listed as a hidden
+/// member path. PUT a body that omits profileScope entirely and updates displayName.
+/// Assert: displayName updated, profileScope.clearableText cleared to NULL,
+/// profileScope.preservedText preserved from seed.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Put_With_VisibleAbsent_Inlined_Scope_Clears_Clearable_And_Preserves_Hidden
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("bb000002-0000-0000-0000-000000000002")
+    );
+    private const int ItemId = 9002;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "OriginalDisplay",
+            ["profileScope"] = new JsonObject
+            {
+                ["clearableText"] = "OriginalClearable",
+                ["preservedText"] = "OriginalPreserved",
+            },
+        };
+        var seedResult = await PostgresqlProfileRootOnlyFixtureSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            ItemId,
+            seedBody,
+            DocumentUuid,
+            "profile-root-only-visible-absent-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        // The profile declares $.profileScope absent, so the writable body omits the sub-object.
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await PostgresqlProfileRootOnlyFixtureSupport.ReadItemRowAsync(
+            _database,
+            DocumentUuid
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_clears_profile_scope_clearable_text() =>
+        _rowAfterPut["ProfileScopeClearableText"].Should().BeNull();
+
+    [Test]
+    public void It_preserves_profile_scope_preserved_text() =>
+        _rowAfterPut["ProfileScopePreservedText"].Should().Be("OriginalPreserved");
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = PostgresqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisibleAbsent,
+            profileScopeHiddenMemberPaths: ["preservedText"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootOnlyFixtureSupport.CreateDocumentInfo(ItemId),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-root-only-visible-absent-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture C.1: Hidden *sub-reference* member path preserves FK + propagated identity.
+//  Regression for profile hidden-reference governance (profiles.md:782). Hiding a
+//  sub-member of a reference (studentReference.studentUniqueId) — rather than the
+//  whole reference root (studentReference) — must preserve the FK column and every
+//  propagated identity binding as a single reference-derived group. Under the
+//  pre-Phase-2 matching rule the FK binding stayed writable for this case because
+//  ancestor-or-exact matching on the binding's own path did not reach the FK root.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Seed a Student document and a ProfileRootOnlyMergeItem whose studentReference points
+/// at it. The profile governs the dedicated inlined reference scope <c>$.studentReference</c>
+/// and preserves its stored <c>studentUniqueId</c> hidden member path while the request
+/// omits the reference scope. The FK and propagated identity columns must still both be
+/// preserved because they are governed by the same owning reference root.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_ProfiledRootOnly_HiddenSubReferenceMember_PreservesFKAndPropagatedIdentity
+{
+    private static readonly Guid ItemDocumentUuid = Guid.Parse("bb000004-0000-0000-0000-000000000004");
+    private static readonly Guid StudentDocumentUuid = Guid.Parse("bb000004-1000-0000-0000-000000000004");
+    private static readonly Guid PublicDescriptorDocumentUuid = Guid.Parse(
+        "bb000004-2000-0000-0000-000000000004"
+    );
+    private const int ItemId = 9004;
+    private const string StudentUniqueId = "STU-004";
+    private const string DescriptorNamespace = "uri://ed-fi.org/SchoolTypeDescriptor";
+    private const string PublicCodeValue = "Public";
+    private static readonly string PublicUri = $"{DescriptorNamespace}#{PublicCodeValue}";
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private long _studentDocumentId;
+    private long _publicDescriptorDocumentId;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        _studentDocumentId = await PostgresqlProfileRootOnlyFixtureSupport.SeedStudentAsync(
+            _database,
+            StudentDocumentUuid,
+            StudentUniqueId
+        );
+        _publicDescriptorDocumentId =
+            await PostgresqlProfileRootOnlyFixtureSupport.SeedSchoolTypeDescriptorAsync(
+                _database,
+                PublicDescriptorDocumentUuid,
+                DescriptorNamespace,
+                PublicCodeValue,
+                PublicCodeValue
+            );
+        await PostgresqlProfileRootOnlyFixtureSupport.SeedProfileRootOnlyMergeItemRowAsync(
+            _database,
+            ItemDocumentUuid,
+            ItemId,
+            displayName: "OriginalDisplay",
+            clearableText: null,
+            preservedText: null,
+            studentDocumentId: _studentDocumentId,
+            studentUniqueId: StudentUniqueId,
+            unifiedDescriptorId: _publicDescriptorDocumentId,
+            primaryPresent: true,
+            secondaryPresent: true
+        );
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["primarySchoolTypeDescriptor"] = PublicUri,
+            ["secondarySchoolTypeDescriptor"] = PublicUri,
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await PostgresqlProfileRootOnlyFixtureSupport.ReadItemRowWithReferenceColumnsAsync(
+            _database,
+            new DocumentUuid(ItemDocumentUuid)
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_preserves_student_reference_document_id() =>
+        _rowAfterPut["StudentReference_DocumentId"].Should().Be(_studentDocumentId);
+
+    [Test]
+    public void It_preserves_student_reference_student_unique_id() =>
+        _rowAfterPut["StudentReference_StudentUniqueId"].Should().Be(StudentUniqueId);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootOnlyFixtureSubRefHidden",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = PostgresqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: [],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: [],
+            studentReferenceRequestVisibility: ProfileVisibilityKind.VisibleAbsent,
+            studentReferenceStoredVisibility: ProfileVisibilityKind.VisiblePresent,
+            studentReferenceStoredHiddenMemberPaths: ["studentUniqueId"]
+        );
+        var descriptorReferences = new[]
+        {
+            PostgresqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.primarySchoolTypeDescriptor"
+            ),
+            PostgresqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.secondarySchoolTypeDescriptor"
+            ),
+        };
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootOnlyFixtureSupport.CreateDocumentInfoWithReferences(
+                ItemId,
+                documentReferences: [],
+                descriptorReferences: descriptorReferences
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-root-only-hidden-sub-ref-put"),
+            DocumentUuid: new DocumentUuid(ItemDocumentUuid),
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture D: Key-unification hidden member + visible agreement.
+//  Spec scenario 7a — hiding one descriptor member while the other visibly
+//  resolves to the same canonical URI succeeds; the canonical FK is preserved
+//  and both synthetic presence columns stay TRUE. Covers the descriptor half
+//  of scenario 6 via symmetry (see Fixture C header comment).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Seed both descriptors with canonical unified = Public. Profile hides
+/// <c>secondarySchoolTypeDescriptor</c> on the root scope; the request
+/// supplies <c>primarySchoolTypeDescriptor</c> pointing at the same "Public"
+/// URI as stored, so the resolver's first-present-wins agreement check passes.
+/// Assert: displayName updated, unified canonical + both presence columns
+/// preserved.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_ProfiledRootOnly_KeyUnificationHiddenMember_AgreementSucceeds
+{
+    private static readonly Guid ItemDocumentUuid = Guid.Parse("bb000004-0000-0000-0000-000000000004");
+    private static readonly Guid PublicDescriptorDocumentUuid = Guid.Parse(
+        "bb000004-2000-0000-0000-000000000004"
+    );
+    private const int ItemId = 9004;
+    private const string DescriptorNamespace = "uri://ed-fi.org/SchoolTypeDescriptor";
+    private const string PublicCodeValue = "Public";
+    private static readonly string PublicUri = $"{DescriptorNamespace}#{PublicCodeValue}";
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private long _publicDescriptorDocumentId;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootOnlyFixtureSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootOnlyFixtureSupport.CreateServiceProvider();
+
+        _publicDescriptorDocumentId =
+            await PostgresqlProfileRootOnlyFixtureSupport.SeedSchoolTypeDescriptorAsync(
+                _database,
+                PublicDescriptorDocumentUuid,
+                DescriptorNamespace,
+                PublicCodeValue,
+                PublicCodeValue
+            );
+        await PostgresqlProfileRootOnlyFixtureSupport.SeedProfileRootOnlyMergeItemRowAsync(
+            _database,
+            ItemDocumentUuid,
+            ItemId,
+            displayName: "OriginalDisplay",
+            clearableText: null,
+            preservedText: null,
+            studentDocumentId: null,
+            studentUniqueId: null,
+            unifiedDescriptorId: _publicDescriptorDocumentId,
+            primaryPresent: true,
+            secondaryPresent: true
+        );
+
+        var writeBody = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = ItemId,
+            ["displayName"] = "UpdatedDisplay",
+            ["primarySchoolTypeDescriptor"] = PublicUri,
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+        _rowAfterPut = await PostgresqlProfileRootOnlyFixtureSupport.ReadItemRowWithReferenceColumnsAsync(
+            _database,
+            new DocumentUuid(ItemDocumentUuid)
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_updates_display_name() => _rowAfterPut["DisplayName"].Should().Be("UpdatedDisplay");
+
+    [Test]
+    public void It_preserves_unified_descriptor_canonical_fk() =>
+        _rowAfterPut["PrimarySchoolTypeDescriptor_Unified_DescriptorId"]
+            .Should()
+            .Be(_publicDescriptorDocumentId);
+
+    [Test]
+    public void It_preserves_primary_descriptor_synthetic_presence() =>
+        _rowAfterPut["PrimarySchoolTypeDescriptor_DescriptorId_Present"].Should().Be(true);
+
+    [Test]
+    public void It_preserves_secondary_descriptor_synthetic_presence() =>
+        _rowAfterPut["SecondarySchoolTypeDescriptor_DescriptorId_Present"].Should().Be(true);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootOnlyFixture",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResource
+        ];
+        var profileContext = PostgresqlProfileRootOnlyFixtureSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            rootVisibility: ProfileVisibilityKind.VisiblePresent,
+            rootHiddenMemberPaths: ["secondarySchoolTypeDescriptor"],
+            profileScopeVisibility: ProfileVisibilityKind.VisiblePresent,
+            profileScopeHiddenMemberPaths: []
+        );
+        var descriptorReferences = new[]
+        {
+            PostgresqlProfileRootOnlyFixtureSupport.BuildSchoolTypeDescriptorReference(
+                PublicUri,
+                "$.primarySchoolTypeDescriptor"
+            ),
+        };
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: PostgresqlProfileRootOnlyFixtureSupport.ProfileRootOnlyMergeItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootOnlyFixtureSupport.CreateDocumentInfoWithReferences(
+                ItemId,
+                documentReferences: [],
+                descriptorReferences: descriptorReferences
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-root-only-ku-agreement-put"),
+            DocumentUuid: new DocumentUuid(ItemDocumentUuid),
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileRootOnlyFixtureNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileRootOnlyFixtureAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
@@ -724,20 +724,22 @@ public class Given_A_Profiled_Post_As_Update_With_Hidden_Inlined_Preservation
 // reason as Fixture 7.
 
 // ─────────────────────────────────────────────────────────────────────────────
-//  Fixture 9: Multi-table plan → Slice 2 shape-gate failure
+//  Fixture 9: Multi-table plan with root-only runtime shape → profiled PUT success
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// <summary>
-/// Fixture 9: exercises the Slice 2 shape gate against a resource whose compiled
-/// write plan has more than one table. The profile context classifies the required
-/// slice family as RootTableOnly (only $ is a request scope) so the fence does not
-/// fire, and the shape gate must return UnknownFailure whose message references
-/// the Slice 2 single-table root-only constraint.
+/// Fixture 9: a resource whose compiled write plan has more than one table is still
+/// a supported Slice 2 shape as long as profile metadata confines runtime behavior
+/// to the root table. The profile context here makes only `$` a request scope and
+/// marks no stored scopes besides root; the classifier returns RootTableOnly, the
+/// profile merge synthesizer produces a root-only merge result, and the persister
+/// leaves the extension table untouched. The profiled PUT therefore completes with
+/// UpdateSuccess rather than the prior UnknownFailure shape-gate rejection.
 /// </summary>
 [TestFixture]
 [Category("DatabaseIntegration")]
 [Category("PostgresqlIntegration")]
-public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_Gate_Failure
+public class Given_A_Profiled_Put_With_Multi_Table_Plan_And_Root_Only_Runtime_Shape_Succeeds
 {
     private const string RequestBodyJson = """
         {
@@ -795,21 +797,8 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
     }
 
     [Test]
-    public void It_returns_unknown_failure_with_slice_two_shape_gate_message()
-    {
-        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult
-            .As<UpdateResult.UnknownFailure>()
-            .FailureMessage.Should()
-            .Contain("single-table root-only");
-    }
-
-    [Test]
-    public void It_references_dms_1124_in_the_shape_gate_message()
-    {
-        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
-        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("DMS-1124");
-    }
+    public void It_returns_update_success() =>
+        _profiledPutResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
 
     private static DocumentInfo CreateSchoolDocumentInfo()
     {
@@ -835,7 +824,7 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
                 new DmsInstance(
                     Id: 1,
                     InstanceType: "test",
-                    InstanceName: "PostgresqlProfileRootTableOnlyMergeShapeGate",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMergeMultiTableRootOnly",
                     ConnectionString: _database.ConnectionString,
                     RouteContext: []
                 )
@@ -846,7 +835,7 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
             MappingSet: _mappingSet,
             EdfiDoc: JsonNode.Parse(RequestBodyJson)!,
             Headers: [],
-            TraceId: new TraceId("profile-merge-shape-gate-seed"),
+            TraceId: new TraceId("profile-merge-multi-table-root-only-seed"),
             DocumentUuid: ExistingDocumentUuid,
             DocumentSecurityElements: new([], [], [], [], []),
             UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
@@ -866,7 +855,7 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
                 new DmsInstance(
                     Id: 1,
                     InstanceType: "test",
-                    InstanceName: "PostgresqlProfileRootTableOnlyMergeShapeGate",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMergeMultiTableRootOnly",
                     ConnectionString: _database.ConnectionString,
                     RouteContext: []
                 )
@@ -875,9 +864,9 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
         var writePlan = _mappingSet.WritePlansByResource[SchoolResource];
         var requestBody = JsonNode.Parse(RequestBodyJson)!;
 
-        // Build a profile context with only the $ scope (no inlined or collection scopes)
-        // so the slice-fence classifier returns RootTableOnly. The shape gate then fires
-        // because the compiled write plan has more than one table.
+        // Build a profile context with only the $ scope (no inlined or collection scopes).
+        // The slice-fence classifier returns RootTableOnly and the profile merge synthesizer
+        // produces a root-only merge result; the persister leaves the extension table alone.
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
         var rootScopeState = new RequestScopeState(
             Address: new ScopeInstanceAddress("$", []),
@@ -891,7 +880,7 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
                 RequestScopeStates: [rootScopeState],
                 VisibleRequestCollectionItems: []
             ),
-            ProfileName: "shape-gate-profile",
+            ProfileName: "multi-table-root-only-profile",
             CompiledScopeCatalog: scopeCatalog,
             StoredStateProjectionInvoker: new ConfigurableStoredStateProjectionInvoker(
                 ProfileVisibilityKind.VisiblePresent,
@@ -905,7 +894,7 @@ public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_
             MappingSet: _mappingSet,
             EdfiDoc: requestBody,
             Headers: [],
-            TraceId: new TraceId("profile-merge-shape-gate-put"),
+            TraceId: new TraceId("profile-merge-multi-table-root-only-put"),
             DocumentUuid: ExistingDocumentUuid,
             DocumentSecurityElements: new([], [], [], [], []),
             UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
@@ -1,0 +1,919 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+// Resource choice for Slice 2 profile merge integration tests:
+//   NamingStressItem (from the Ed-Fi.DataManagementService.Backend.Ddl.Tests.Unit
+//   small/naming-stress fixture). It is single-table, non-descriptor, has an integer
+//   identity plus multiple nullable scalar columns (Order, ShortName), and has no
+//   document references, descriptor references, or key-unification plans. That lets
+//   us exercise hidden-inlined preservation, visible-absent clearing, and create-new
+//   without extra fixtures. Fixtures 6/7/8 from the design spec are deferred because
+//   NamingStressItem does not carry the shapes they target (document references,
+//   descriptors, key unification).
+//
+// Fixture 9 (shape-gate) uses the School resource from the focused
+// stable-key-extension-child-collections fixture, which has a multi-table write plan.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using EdFi.DataManagementService.Old.Postgresql;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+file sealed class ProfileMergeNoOpHostApplicationLifetime : IHostApplicationLifetime
+{
+    public CancellationToken ApplicationStarted => CancellationToken.None;
+    public CancellationToken ApplicationStopping => CancellationToken.None;
+    public CancellationToken ApplicationStopped => CancellationToken.None;
+
+    public void StopApplication() { }
+}
+
+file sealed class ProfileMergeAllowAllResourceAuthorizationHandler : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class ProfileMergeNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+/// <summary>
+/// Test-configurable <see cref="IStoredStateProjectionInvoker"/> that emits a single
+/// non-collection stored scope at <c>$</c> with caller-supplied visibility and hidden
+/// member paths. Sufficient for Slice 2 root-only merge fixtures that need the
+/// synthesizer to see explicit hidden/absent dispositions from the projection.
+/// </summary>
+internal sealed class ConfigurableStoredStateProjectionInvoker : IStoredStateProjectionInvoker
+{
+    private readonly ProfileVisibilityKind _rootVisibility;
+    private readonly System.Collections.Immutable.ImmutableArray<string> _rootHiddenMemberPaths;
+
+    public ConfigurableStoredStateProjectionInvoker(
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths
+    )
+    {
+        _rootVisibility = rootVisibility;
+        _rootHiddenMemberPaths = rootHiddenMemberPaths;
+    }
+
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    )
+    {
+        var rootAddress = new ScopeInstanceAddress("$", []);
+        return new ProfileAppliedWriteContext(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates:
+            [
+                new StoredScopeState(
+                    Address: rootAddress,
+                    Visibility: _rootVisibility,
+                    HiddenMemberPaths: _rootHiddenMemberPaths
+                ),
+            ],
+            VisibleStoredCollectionRows: []
+        );
+    }
+}
+
+/// <summary>
+/// Shared helpers for the Slice 2 root-table-only profile merge integration tests.
+/// </summary>
+internal static class PostgresqlProfileRootTableOnlyMergeSupport
+{
+    public const string NamingStressFixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress";
+    public const string SchoolFixtureRelativePath =
+        "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections";
+
+    public static readonly QualifiedResourceName NamingStressItemResource = new("Ed-Fi", "NamingStressItem");
+
+    public static readonly ResourceInfo NamingStressItemResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("NamingStressItem"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    public static ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+        services.AddSingleton<IHostApplicationLifetime, ProfileMergeNoOpHostApplicationLifetime>();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    public static DocumentInfo CreateNamingStressDocumentInfo(int namingStressItemId)
+    {
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.namingStressItemId"),
+                namingStressItemId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(NamingStressItemResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    public static BackendProfileWriteContext CreateProfileContext(
+        ResourceWritePlan writePlan,
+        JsonNode requestBody,
+        ProfileVisibilityKind rootVisibility,
+        System.Collections.Immutable.ImmutableArray<string> rootHiddenMemberPaths,
+        bool creatable = true,
+        string profileName = "root-only-profile"
+    )
+    {
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+        RequestScopeState[] scopeStates =
+        [
+            new RequestScopeState(
+                Address: new ScopeInstanceAddress("$", []),
+                Visibility: rootVisibility,
+                Creatable: creatable
+            ),
+        ];
+        return new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody,
+                RootResourceCreatable: creatable,
+                RequestScopeStates: [.. scopeStates],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: profileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new ConfigurableStoredStateProjectionInvoker(
+                rootVisibility,
+                rootHiddenMemberPaths
+            )
+        );
+    }
+
+    public static async Task<UpsertResult> SeedAsync(
+        ServiceProvider serviceProvider,
+        PostgresqlGeneratedDdlTestDatabase database,
+        MappingSet mappingSet,
+        int namingStressItemId,
+        JsonNode body,
+        DocumentUuid documentUuid,
+        string traceLabel
+    )
+    {
+        using var scope = serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMerge",
+                    ConnectionString: database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: NamingStressItemResourceInfo,
+            DocumentInfo: CreateNamingStressDocumentInfo(namingStressItemId),
+            MappingSet: mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId(traceLabel),
+            DocumentUuid: documentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 1: Profiled PUT with hidden inlined preservation (root scope $)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Fixture 1 (spec ProfileHiddenInlinedColumnPreservation, simplified to one hidden column):
+/// seed a NamingStressItem with two scalars (shortName + order). The writable profile
+/// declares the root scope visible but marks "order" as a hidden member path. PUT a body
+/// that updates only shortName and omits order. Verify that order is preserved from the
+/// stored row while shortName is updated.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Put_With_Hidden_Inlined_Column_Preservation
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("11111111-1111-1111-1111-111111111111")
+    );
+    private const int NamingStressItemId = 7011;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _putResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPut = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        // Seed with both shortName and order set.
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+        var seedResult = await PostgresqlProfileRootTableOnlyMergeSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            NamingStressItemId,
+            seedBody,
+            DocumentUuid,
+            "profile-merge-hidden-preservation-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        // Profiled PUT: only shortName is visible+present; order is hidden-member-path-preserved.
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Updated",
+        };
+        _putResult = await ExecuteProfiledPutAsync(writeBody);
+
+        _rowAfterPut = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success() => _putResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
+
+    [Test]
+    public void It_writes_the_visible_scalar_value() => _rowAfterPut["ShortName"].Should().Be("Updated");
+
+    [Test]
+    public void It_preserves_the_hidden_scalar_value() =>
+        Convert.ToInt32(_rowAfterPut["Order"], CultureInfo.InvariantCulture).Should().Be(42);
+
+    [Test]
+    public void It_preserves_the_identity_column() =>
+        Convert
+            .ToInt32(_rowAfterPut["NamingStressItemId"], CultureInfo.InvariantCulture)
+            .Should()
+            .Be(NamingStressItemId);
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = PostgresqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            ["order"]
+        );
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-merge-hidden-preservation-put"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi."NamingStressItemId", nsi."ShortName", nsi."Order"
+            FROM "edfi"."NamingStressItem" nsi
+            INNER JOIN "dms"."Document" d ON d."DocumentId" = nsi."DocumentId"
+            WHERE d."DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", DocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 3: Profiled POST create-new
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Fixture 3: a profiled POST that creates a new root document (no stored state) through
+/// the Slice 2 profile merge path. Verifies insert success and that the writable body's
+/// values land in the root row. No preservation logic fires when CurrentState is null.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Post_Create_New_For_Root_Only_Resource
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("22222222-2222-2222-2222-222222222222")
+    );
+    private const int NamingStressItemId = 7022;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpsertResult _postResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPost = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Created",
+            ["order"] = 99,
+        };
+        _postResult = await ExecuteProfiledPostAsync(writeBody);
+        _rowAfterPost = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_insert_success() => _postResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+    [Test]
+    public void It_writes_the_identity_value() =>
+        Convert
+            .ToInt32(_rowAfterPost["NamingStressItemId"], CultureInfo.InvariantCulture)
+            .Should()
+            .Be(NamingStressItemId);
+
+    [Test]
+    public void It_writes_the_visible_scalar_values()
+    {
+        _rowAfterPost["ShortName"].Should().Be("Created");
+        Convert.ToInt32(_rowAfterPost["Order"], CultureInfo.InvariantCulture).Should().Be(99);
+    }
+
+    private async Task<UpsertResult> ExecuteProfiledPostAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = PostgresqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            []
+        );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-merge-create-new-post"),
+            DocumentUuid: DocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi."NamingStressItemId", nsi."ShortName", nsi."Order"
+            FROM "edfi"."NamingStressItem" nsi
+            INNER JOIN "dms"."Document" d ON d."DocumentId" = nsi."DocumentId"
+            WHERE d."DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", DocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 2: Profiled POST-as-update with hidden inlined preservation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Fixture 2: same preservation invariant as Fixture 1, but exercised through the
+/// POST-as-update flow (POST against an existing referential id that the executor
+/// resolves as an existing document).
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Post_As_Update_With_Hidden_Inlined_Preservation
+{
+    private static readonly DocumentUuid SeedDocumentUuid = new(
+        Guid.Parse("33333333-3333-3333-3333-333333333333")
+    );
+    private static readonly DocumentUuid PostAsUpdateDocumentUuid = new(
+        Guid.Parse("33333333-4444-4444-4444-333333333333")
+    );
+    private const int NamingStressItemId = 7033;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpsertResult _postResult = null!;
+    private IReadOnlyDictionary<string, object?> _rowAfterPost = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "OriginalPost",
+            ["order"] = 55,
+        };
+        var seedResult = await PostgresqlProfileRootTableOnlyMergeSupport.SeedAsync(
+            _serviceProvider,
+            _database,
+            _mappingSet,
+            NamingStressItemId,
+            seedBody,
+            SeedDocumentUuid,
+            "profile-merge-post-as-update-seed"
+        );
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        var writeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "UpdatedViaPost",
+        };
+        _postResult = await ExecuteProfiledPostAsUpdateAsync(writeBody);
+        _rowAfterPost = await ReadNamingStressItemRowAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_update_success_via_post_as_update() =>
+        _postResult.Should().BeOfType<UpsertResult.UpdateSuccess>();
+
+    [Test]
+    public void It_writes_the_visible_scalar_value() =>
+        _rowAfterPost["ShortName"].Should().Be("UpdatedViaPost");
+
+    [Test]
+    public void It_preserves_the_hidden_scalar_value() =>
+        Convert.ToInt32(_rowAfterPost["Order"], CultureInfo.InvariantCulture).Should().Be(55);
+
+    private async Task<UpsertResult> ExecuteProfiledPostAsUpdateAsync(JsonNode writeBody)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMerge",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResource
+        ];
+        var profileContext = PostgresqlProfileRootTableOnlyMergeSupport.CreateProfileContext(
+            writePlan,
+            writeBody.DeepClone(),
+            ProfileVisibilityKind.VisiblePresent,
+            ["order"]
+        );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: PostgresqlProfileRootTableOnlyMergeSupport.NamingStressItemResourceInfo,
+            DocumentInfo: PostgresqlProfileRootTableOnlyMergeSupport.CreateNamingStressDocumentInfo(
+                NamingStressItemId
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("profile-merge-post-as-update-profiled"),
+            DocumentUuid: PostAsUpdateDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadNamingStressItemRowAsync()
+    {
+        var rows = await _database.QueryRowsAsync(
+            """
+            SELECT nsi."NamingStressItemId", nsi."ShortName", nsi."Order"
+            FROM "edfi"."NamingStressItem" nsi
+            INNER JOIN "dms"."Document" d ON d."DocumentId" = nsi."DocumentId"
+            WHERE d."DocumentUuid" = @documentUuid;
+            """,
+            new NpgsqlParameter("documentUuid", SeedDocumentUuid.Value)
+        );
+        rows.Should().HaveCount(1);
+        return rows[0];
+    }
+}
+
+// Fixture 4 (VisibleAbsent inlined scope with hidden override) is deferred for this
+// resource choice: NamingStressItem is fully flat under the root scope $, so there
+// is no nested sub-object scope (like the spec's $.birthData) whose VisibleAbsent
+// classification could coexist with a hidden override on a sibling binding. Landing
+// this scenario requires a single-table non-descriptor resource with at least one
+// inlined sub-object — no authoritative DS 5.2 resource exercised by the existing
+// integration suite satisfies that shape, and adding a synthetic ApiSchema fixture
+// is out of scope for Slice 2 Task 7.
+
+// Fixture 5 (spec ProfileHiddenInlinedColumnPreservation) is subsumed by Fixture 1
+// for this resource. NamingStressItem has only two non-identity nullable scalars
+// (shortName, order); Fixture 1 already exercises the "hide one, update the other"
+// case. Extending the fixture to more columns would not add coverage against the
+// synthesizer, which classifies bindings per-scope rather than per-column count.
+
+// Fixture 6 (hidden document/descriptor reference preservation) is deferred because
+// NamingStressItem has no DocumentReference or DescriptorReference bindings.
+
+// Fixture 7 (key-unification hidden contribution + disagreement) is deferred because
+// NamingStressItem has no key-unification plans.
+
+// Fixture 8 (synthetic presence hidden-member preservation) is deferred for the same
+// reason as Fixture 7.
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  Fixture 9: Multi-table plan → Slice 2 shape-gate failure
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Fixture 9: exercises the Slice 2 shape gate against a resource whose compiled
+/// write plan has more than one table. The profile context classifies the required
+/// slice family as RootTableOnly (only $ is a request scope) so the fence does not
+/// fire, and the shape gate must return UnknownFailure whose message references
+/// the Slice 2 single-table root-only constraint.
+/// </summary>
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Profiled_Put_With_Multi_Table_Plan_Returns_Slice_Two_Shape_Gate_Failure
+{
+    private const string RequestBodyJson = """
+        {
+          "schoolId": 255901
+        }
+        """;
+
+    private static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+    private static readonly DocumentUuid ExistingDocumentUuid = new(
+        Guid.Parse("99999999-9999-9999-9999-999999999999")
+    );
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private UpdateResult _profiledPutResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.SchoolFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileRootTableOnlyMergeSupport.CreateServiceProvider();
+
+        var createResult = await ExecuteNonProfiledUpsertAsync();
+        createResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+        _profiledPutResult = await ExecuteProfiledPutAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_unknown_failure_with_slice_two_shape_gate_message()
+    {
+        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
+        _profiledPutResult
+            .As<UpdateResult.UnknownFailure>()
+            .FailureMessage.Should()
+            .Contain("single-table root-only");
+    }
+
+    [Test]
+    public void It_references_dms_1124_in_the_shape_gate_message()
+    {
+        _profiledPutResult.Should().BeOfType<UpdateResult.UnknownFailure>();
+        _profiledPutResult.As<UpdateResult.UnknownFailure>().FailureMessage.Should().Contain("DMS-1124");
+    }
+
+    private static DocumentInfo CreateSchoolDocumentInfo()
+    {
+        var schoolIdentity = new DocumentIdentity([
+            new DocumentIdentityElement(new JsonPath("$.schoolId"), "255901"),
+        ]);
+        return new DocumentInfo(
+            DocumentIdentity: schoolIdentity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, schoolIdentity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+    }
+
+    private async Task<UpsertResult> ExecuteNonProfiledUpsertAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMergeShapeGate",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: CreateSchoolDocumentInfo(),
+            MappingSet: _mappingSet,
+            EdfiDoc: JsonNode.Parse(RequestBodyJson)!,
+            Headers: [],
+            TraceId: new TraceId("profile-merge-shape-gate-seed"),
+            DocumentUuid: ExistingDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync()
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileRootTableOnlyMergeShapeGate",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var writePlan = _mappingSet.WritePlansByResource[SchoolResource];
+        var requestBody = JsonNode.Parse(RequestBodyJson)!;
+
+        // Build a profile context with only the $ scope (no inlined or collection scopes)
+        // so the slice-fence classifier returns RootTableOnly. The shape gate then fires
+        // because the compiled write plan has more than one table.
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+        var rootScopeState = new RequestScopeState(
+            Address: new ScopeInstanceAddress("$", []),
+            Visibility: ProfileVisibilityKind.VisiblePresent,
+            Creatable: true
+        );
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: requestBody.DeepClone(),
+                RootResourceCreatable: true,
+                RequestScopeStates: [rootScopeState],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: "shape-gate-profile",
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new ConfigurableStoredStateProjectionInvoker(
+                ProfileVisibilityKind.VisiblePresent,
+                []
+            )
+        );
+
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: CreateSchoolDocumentInfo(),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("profile-merge-shape-gate-put"),
+            DocumentUuid: ExistingDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new ProfileMergeNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new ProfileMergeAllowAllResourceAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -2565,41 +2565,44 @@ public class Given_Default_Relational_Write_Executor
 
         public RelationalWriteNoProfileMergeRequest? CapturedRequest { get; private set; }
 
-        public RelationalWriteNoProfileMergeResult? ResultToReturn { get; set; }
+        public RelationalWriteMergeResult? ResultToReturn { get; set; }
 
-        public RelationalWriteNoProfileMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request)
+        public RelationalWriteMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request)
         {
             SynthesizeCallCount++;
             CapturedRequest = request;
 
             return ResultToReturn
-                ?? new RelationalWriteNoProfileMergeResult([
-                    new RelationalWriteNoProfileTableState(
-                        request.WritePlan.TablePlansInDependencyOrder[0],
-                        [
-                            new RelationalWriteNoProfileTableRow(
-                                request.FlattenedWriteSet.RootRow.Values,
-                                request.FlattenedWriteSet.RootRow.Values
-                            ),
-                        ],
-                        [
-                            new RelationalWriteNoProfileTableRow(
-                                request.FlattenedWriteSet.RootRow.Values,
-                                request.FlattenedWriteSet.RootRow.Values
-                            ),
-                        ]
-                    ),
-                ]);
+                ?? new RelationalWriteMergeResult(
+                    [
+                        new RelationalWriteMergedTableState(
+                            request.WritePlan.TablePlansInDependencyOrder[0],
+                            [
+                                new RelationalWriteMergedTableRow(
+                                    request.FlattenedWriteSet.RootRow.Values,
+                                    request.FlattenedWriteSet.RootRow.Values
+                                ),
+                            ],
+                            [
+                                new RelationalWriteMergedTableRow(
+                                    request.FlattenedWriteSet.RootRow.Values,
+                                    request.FlattenedWriteSet.RootRow.Values
+                                ),
+                            ]
+                        ),
+                    ],
+                    supportsGuardedNoOp: true
+                );
         }
     }
 
-    private sealed class RecordingRelationalWriteNoProfilePersister : IRelationalWriteNoProfilePersister
+    private sealed class RecordingRelationalWriteNoProfilePersister : IRelationalWritePersister
     {
         public int TryPersistCallCount { get; private set; }
 
         public RelationalWriteExecutorRequest? CapturedRequest { get; private set; }
 
-        public RelationalWriteNoProfileMergeResult? CapturedMergeResult { get; private set; }
+        public RelationalWriteMergeResult? CapturedMergeResult { get; private set; }
 
         public IRelationalWriteSession? CapturedWriteSession { get; private set; }
 
@@ -2609,7 +2612,7 @@ public class Given_Default_Relational_Write_Executor
 
         public Task<RelationalWritePersistResult> PersistAsync(
             RelationalWriteExecutorRequest request,
-            RelationalWriteNoProfileMergeResult mergeResult,
+            RelationalWriteMergeResult mergeResult,
             IRelationalWriteSession writeSession,
             CancellationToken cancellationToken = default
         )
@@ -2642,20 +2645,23 @@ public class Given_Default_Relational_Write_Executor
             };
     }
 
-    private static RelationalWriteNoProfileMergeResult CreateMergeResult(
+    private static RelationalWriteMergeResult CreateMergeResult(
         TableWritePlan rootTableWritePlan,
         int currentSchoolId,
         int mergedSchoolId,
         string currentName = "Lincoln High",
         string mergedName = "Lincoln High"
     ) =>
-        new([
-            new RelationalWriteNoProfileTableState(
-                rootTableWritePlan,
-                [CreateRootTableRow(345L, currentSchoolId, currentName)],
-                [CreateRootTableRow(345L, mergedSchoolId, mergedName)]
-            ),
-        ]);
+        new(
+            [
+                new RelationalWriteMergedTableState(
+                    rootTableWritePlan,
+                    [CreateRootTableRow(345L, currentSchoolId, currentName)],
+                    [CreateRootTableRow(345L, mergedSchoolId, mergedName)]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
 
     private static RelationalWriteCurrentState CreateCurrentState(
         RelationalWriteExecutorRequest request,
@@ -2688,7 +2694,7 @@ public class Given_Default_Relational_Write_Executor
         );
     }
 
-    private static RelationalWriteNoProfileTableRow CreateRootTableRow(
+    private static RelationalWriteMergedTableRow CreateRootTableRow(
         long documentId,
         int schoolId,
         string name

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -1936,8 +1936,12 @@ public class Given_Default_Relational_Write_Executor
     }
 
     [Test]
-    public async Task It_gates_profiled_root_table_only_request_when_write_plan_has_multiple_tables()
+    public async Task It_synthesizes_profile_merge_for_multi_table_plan_when_runtime_shape_is_root_only()
     {
+        // A multi-table compiled plan (root + separate-table extension) whose profile metadata
+        // leaves non-root scopes out of the request surface still classifies as RootTableOnly.
+        // The profile merge synthesizer handles the root table; the persister leaves the
+        // extension table untouched because it is absent from the produced merge result.
         var writableBody = JsonNode.Parse("""{"schoolId":255901}""")!;
         var rootPlan = CreateRootPlan();
         var extensionTableModel = AdapterFactoryTestFixtures.BuildRootExtensionTableModel();
@@ -1979,30 +1983,68 @@ public class Given_Default_Relational_Write_Executor
             ProfileWriteContext = profileContext,
         };
 
+        // Pre-configure the flattener: for multi-table plans the default fallback uses .Single()
+        // on the plan's table list. The profile merge synthesizer only uses the root row, so a
+        // root-only FlattenedWriteSet is the correct handoff shape for Slice 2 regardless of
+        // how many tables the compiled plan carries.
+        _writeFlattener.ResultToReturn = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [
+                    FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                    new FlattenedWriteValue.Literal(255901),
+                    new FlattenedWriteValue.Literal("Lincoln High"),
+                ]
+            )
+        );
+
+        _profileMergeSynthesizer.ResultToReturn = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [],
+                    [
+                        new RelationalWriteMergedTableRow(
+                            [
+                                FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                                new FlattenedWriteValue.Literal(255901),
+                                new FlattenedWriteValue.Literal("Lincoln High"),
+                            ],
+                            [
+                                FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                                new FlattenedWriteValue.Literal(255901),
+                                new FlattenedWriteValue.Literal("Lincoln High"),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: false
+        );
+
         var result = await _sut.ExecuteAsync(request);
 
-        _profileMergeSynthesizer
-            .SynthesizeCallCount.Should()
-            .Be(0, "profile synthesizer must not run when the Slice 2 shape gate fires");
         _writeFlattener
             .FlattenCallCount.Should()
-            .Be(0, "flattener must not run when the Slice 2 shape gate fires");
+            .Be(1, "the profile path must flatten once classification passes");
+        _profileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(1, "the profile synthesizer must run for root-only runtime shapes even on multi-table plans");
+        _profileMergeSynthesizer.CapturedRequest.Should().NotBeNull();
+        _profileMergeSynthesizer.CapturedRequest!.WritePlan.Should().BeSameAs(resourceWritePlan);
+        _noProfileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(0, "the no-profile synthesizer must not run for profiled writes");
         _noProfilePersister
             .TryPersistCallCount.Should()
-            .Be(0, "persister must not run when the Slice 2 shape gate fires");
-        _writeSessionFactory
-            .Session.RollbackCallCount.Should()
-            .Be(1, "session must be rolled back when the Slice 2 shape gate fires");
-        _writeSessionFactory
-            .Session.CommitCallCount.Should()
-            .Be(0, "session must not be committed when the Slice 2 shape gate fires");
+            .Be(1, "the persister must receive the profile merge result");
+        _noProfilePersister.CapturedMergeResult.Should().BeSameAs(_profileMergeSynthesizer.ResultToReturn);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(0);
 
         var upsertResult = result.Should().BeOfType<RelationalWriteExecutorResult.Upsert>().Subject;
-        upsertResult
-            .Result.Should()
-            .BeOfType<UpsertResult.UnknownFailure>()
-            .Which.FailureMessage.Should()
-            .Be("Slice 2 only supports profiled single-table root-only write plans (DMS-1124).");
+        upsertResult.Result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        result.AttemptOutcome.Should().Be(RelationalWriteExecutorAttemptOutcome.AppliedWrite.Instance);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -10,6 +10,8 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Profile;
+using EdFi.DataManagementService.Backend.Tests.Unit.Profile;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Profile;
@@ -31,6 +33,7 @@ public class Given_Default_Relational_Write_Executor
     private RecordingRelationalWriteTargetLookupResolver _targetLookupResolver = null!;
     private RecordingRelationalWriteFreshnessChecker _writeFreshnessChecker = null!;
     private RecordingRelationalWriteNoProfileMergeSynthesizer _noProfileMergeSynthesizer = null!;
+    private RecordingRelationalWriteProfileMergeSynthesizer _profileMergeSynthesizer = null!;
     private RecordingRelationalWriteNoProfilePersister _noProfilePersister = null!;
     private RecordingRelationalWriteExceptionClassifier _writeExceptionClassifier = null!;
     private RecordingRelationalWriteConstraintResolver _writeConstraintResolver = null!;
@@ -48,6 +51,7 @@ public class Given_Default_Relational_Write_Executor
         _targetLookupResolver = new RecordingRelationalWriteTargetLookupResolver();
         _writeFreshnessChecker = new RecordingRelationalWriteFreshnessChecker();
         _noProfileMergeSynthesizer = new RecordingRelationalWriteNoProfileMergeSynthesizer();
+        _profileMergeSynthesizer = new RecordingRelationalWriteProfileMergeSynthesizer();
         _noProfilePersister = new RecordingRelationalWriteNoProfilePersister();
         _writeExceptionClassifier = new RecordingRelationalWriteExceptionClassifier();
         _writeConstraintResolver = new RecordingRelationalWriteConstraintResolver();
@@ -61,6 +65,7 @@ public class Given_Default_Relational_Write_Executor
             _targetLookupResolver,
             _writeFreshnessChecker,
             _noProfileMergeSynthesizer,
+            _profileMergeSynthesizer,
             _noProfilePersister,
             _writeExceptionClassifier,
             _writeConstraintResolver,
@@ -649,6 +654,7 @@ public class Given_Default_Relational_Write_Executor
             _targetLookupResolver,
             _writeFreshnessChecker,
             new RelationalWriteNoProfileMergeSynthesizer(),
+            _profileMergeSynthesizer,
             _noProfilePersister,
             _writeExceptionClassifier,
             _writeConstraintResolver,
@@ -1637,8 +1643,18 @@ public class Given_Default_Relational_Write_Executor
     {
         var writableBody = JsonNode.Parse("""{"schoolId":255901}""")!;
         var rootPlan = CreateRootPlan();
-        var resourceModel = CreateRelationalResourceModel(rootPlan.TableModel);
-        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var extensionTableModel = AdapterFactoryTestFixtures.BuildRootExtensionTableModel();
+        var extensionPlan = AdapterFactoryTestFixtures.BuildRootExtensionTableWritePlan(extensionTableModel);
+        var resourceModel = new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "School"),
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootPlan.TableModel,
+            TablesInDependencyOrder: [rootPlan.TableModel, extensionTableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan, extensionPlan]);
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(resourceWritePlan);
         var profileContext = new BackendProfileWriteContext(
             Request: new ProfileAppliedWriteRequest(
@@ -1651,6 +1667,11 @@ public class Given_Default_Relational_Write_Executor
                         Visibility: ProfileVisibilityKind.VisiblePresent,
                         Creatable: true
                     ),
+                    new RequestScopeState(
+                        Address: new ScopeInstanceAddress("$._ext.sample", []),
+                        Visibility: ProfileVisibilityKind.VisiblePresent,
+                        Creatable: true
+                    ),
                 ],
                 VisibleRequestCollectionItems: []
             ),
@@ -1659,8 +1680,10 @@ public class Given_Default_Relational_Write_Executor
             StoredStateProjectionInvoker: A.Fake<IStoredStateProjectionInvoker>()
         );
 
-        var request = CreateRequest(RelationalWriteOperationKind.Post, selectedBody: writableBody) with
+        var baseRequest = CreateRequest(RelationalWriteOperationKind.Post, selectedBody: writableBody);
+        var request = baseRequest with
         {
+            WritePlan = resourceWritePlan,
             ProfileWriteContext = profileContext,
         };
 
@@ -1672,6 +1695,9 @@ public class Given_Default_Relational_Write_Executor
         _noProfileMergeSynthesizer
             .SynthesizeCallCount.Should()
             .Be(0, "no-profile merge must not run when profile context is present");
+        _profileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(0, "profile merge must not run when the required family is fenced");
         _noProfilePersister
             .TryPersistCallCount.Should()
             .Be(0, "no-profile persister must not run when profile context is present");
@@ -1690,7 +1716,7 @@ public class Given_Default_Relational_Write_Executor
             .Result.Should()
             .BeOfType<UpsertResult.UnknownFailure>()
             .Which.FailureMessage.Should()
-            .Contain("RootTableOnly");
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]
@@ -1746,25 +1772,41 @@ public class Given_Default_Relational_Write_Executor
     {
         var writableBody = JsonNode.Parse("""{"schoolId":255901}""")!;
         var rootPlan = CreateRootPlan();
-        var resourceModel = CreateRelationalResourceModel(rootPlan.TableModel);
-        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var extensionTableModel = AdapterFactoryTestFixtures.BuildRootExtensionTableModel();
+        var extensionPlan = AdapterFactoryTestFixtures.BuildRootExtensionTableWritePlan(extensionTableModel);
+        var resourceModel = new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "School"),
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootPlan.TableModel,
+            TablesInDependencyOrder: [rootPlan.TableModel, extensionTableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan, extensionPlan]);
         var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(resourceWritePlan);
 
         var storedStateProjectionInvoker = A.Fake<IStoredStateProjectionInvoker>();
+        var profileRequest = new ProfileAppliedWriteRequest(
+            WritableRequestBody: writableBody,
+            RootResourceCreatable: true,
+            RequestScopeStates:
+            [
+                new RequestScopeState(
+                    Address: new ScopeInstanceAddress("$", []),
+                    Visibility: ProfileVisibilityKind.VisiblePresent,
+                    Creatable: true
+                ),
+                new RequestScopeState(
+                    Address: new ScopeInstanceAddress("$._ext.sample", []),
+                    Visibility: ProfileVisibilityKind.VisiblePresent,
+                    Creatable: true
+                ),
+            ],
+            VisibleRequestCollectionItems: []
+        );
         var expectedAppliedWriteContext = new ProfileAppliedWriteContext(
-            Request: new ProfileAppliedWriteRequest(
-                WritableRequestBody: writableBody,
-                RootResourceCreatable: true,
-                RequestScopeStates:
-                [
-                    new RequestScopeState(
-                        Address: new ScopeInstanceAddress("$", []),
-                        Visibility: ProfileVisibilityKind.VisiblePresent,
-                        Creatable: true
-                    ),
-                ],
-                VisibleRequestCollectionItems: []
-            ),
+            Request: profileRequest,
             VisibleStoredBody: JsonNode.Parse("""{"schoolId":255901}""")!,
             StoredScopeStates:
             [
@@ -1787,26 +1829,16 @@ public class Given_Default_Relational_Write_Executor
             .Returns(expectedAppliedWriteContext);
 
         var profileContext = new BackendProfileWriteContext(
-            Request: new ProfileAppliedWriteRequest(
-                WritableRequestBody: writableBody,
-                RootResourceCreatable: true,
-                RequestScopeStates:
-                [
-                    new RequestScopeState(
-                        Address: new ScopeInstanceAddress("$", []),
-                        Visibility: ProfileVisibilityKind.VisiblePresent,
-                        Creatable: true
-                    ),
-                ],
-                VisibleRequestCollectionItems: []
-            ),
+            Request: profileRequest,
             ProfileName: "test-write-profile",
             CompiledScopeCatalog: scopeCatalog,
             StoredStateProjectionInvoker: storedStateProjectionInvoker
         );
 
-        var request = CreateRequest(RelationalWriteOperationKind.Put, selectedBody: writableBody) with
+        var baseRequest = CreateRequest(RelationalWriteOperationKind.Put, selectedBody: writableBody);
+        var request = baseRequest with
         {
+            WritePlan = resourceWritePlan,
             ProfileWriteContext = profileContext,
         };
 
@@ -1835,7 +1867,7 @@ public class Given_Default_Relational_Write_Executor
             .Result.Should()
             .BeOfType<UpdateResult.UnknownFailure>()
             .Which.FailureMessage.Should()
-            .Contain("RootTableOnly");
+            .Contain("SeparateTableNonCollection");
     }
 
     [Test]
@@ -1901,6 +1933,161 @@ public class Given_Default_Relational_Write_Executor
         _readMaterializer
             .MaterializeCallCount.Should()
             .Be(0, "materializer must not be called when no profile context is present");
+    }
+
+    [Test]
+    public async Task It_gates_profiled_root_table_only_request_when_write_plan_has_multiple_tables()
+    {
+        var writableBody = JsonNode.Parse("""{"schoolId":255901}""")!;
+        var rootPlan = CreateRootPlan();
+        var extensionTableModel = AdapterFactoryTestFixtures.BuildRootExtensionTableModel();
+        var extensionPlan = AdapterFactoryTestFixtures.BuildRootExtensionTableWritePlan(extensionTableModel);
+        var resourceModel = new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "School"),
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootPlan.TableModel,
+            TablesInDependencyOrder: [rootPlan.TableModel, extensionTableModel],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan, extensionPlan]);
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(resourceWritePlan);
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: writableBody,
+                RootResourceCreatable: true,
+                RequestScopeStates:
+                [
+                    new RequestScopeState(
+                        Address: new ScopeInstanceAddress("$", []),
+                        Visibility: ProfileVisibilityKind.VisiblePresent,
+                        Creatable: true
+                    ),
+                ],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: "test-write-profile",
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: A.Fake<IStoredStateProjectionInvoker>()
+        );
+
+        var baseRequest = CreateRequest(RelationalWriteOperationKind.Post, selectedBody: writableBody);
+        var request = baseRequest with
+        {
+            WritePlan = resourceWritePlan,
+            ProfileWriteContext = profileContext,
+        };
+
+        var result = await _sut.ExecuteAsync(request);
+
+        _profileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(0, "profile synthesizer must not run when the Slice 2 shape gate fires");
+        _writeFlattener
+            .FlattenCallCount.Should()
+            .Be(0, "flattener must not run when the Slice 2 shape gate fires");
+        _noProfilePersister
+            .TryPersistCallCount.Should()
+            .Be(0, "persister must not run when the Slice 2 shape gate fires");
+        _writeSessionFactory
+            .Session.RollbackCallCount.Should()
+            .Be(1, "session must be rolled back when the Slice 2 shape gate fires");
+        _writeSessionFactory
+            .Session.CommitCallCount.Should()
+            .Be(0, "session must not be committed when the Slice 2 shape gate fires");
+
+        var upsertResult = result.Should().BeOfType<RelationalWriteExecutorResult.Upsert>().Subject;
+        upsertResult
+            .Result.Should()
+            .BeOfType<UpsertResult.UnknownFailure>()
+            .Which.FailureMessage.Should()
+            .Be("Slice 2 only supports profiled single-table root-only write plans (DMS-1124).");
+    }
+
+    [Test]
+    public async Task It_synthesizes_profile_merge_for_root_table_only_create_new_request()
+    {
+        var writableBody = JsonNode.Parse("""{"schoolId":255901}""")!;
+        var rootPlan = CreateRootPlan();
+        var resourceModel = CreateRelationalResourceModel(rootPlan.TableModel);
+        var resourceWritePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(resourceWritePlan);
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: writableBody,
+                RootResourceCreatable: true,
+                RequestScopeStates:
+                [
+                    new RequestScopeState(
+                        Address: new ScopeInstanceAddress("$", []),
+                        Visibility: ProfileVisibilityKind.VisiblePresent,
+                        Creatable: true
+                    ),
+                ],
+                VisibleRequestCollectionItems: []
+            ),
+            ProfileName: "test-write-profile",
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: A.Fake<IStoredStateProjectionInvoker>()
+        );
+
+        var request = CreateRequest(RelationalWriteOperationKind.Post, selectedBody: writableBody) with
+        {
+            ProfileWriteContext = profileContext,
+        };
+
+        _profileMergeSynthesizer.ResultToReturn = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [],
+                    [
+                        new RelationalWriteMergedTableRow(
+                            [
+                                FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                                new FlattenedWriteValue.Literal(255901),
+                                new FlattenedWriteValue.Literal("Lincoln High"),
+                            ],
+                            [
+                                FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                                new FlattenedWriteValue.Literal(255901),
+                                new FlattenedWriteValue.Literal("Lincoln High"),
+                            ]
+                        ),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: false
+        );
+
+        var result = await _sut.ExecuteAsync(request);
+
+        _writeFlattener
+            .FlattenCallCount.Should()
+            .Be(1, "the profile path must flatten before invoking the profile synthesizer");
+        _profileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(1, "the profile synthesizer must be invoked when the Slice 2 gates pass");
+        _profileMergeSynthesizer.CapturedRequest.Should().NotBeNull();
+        _profileMergeSynthesizer.CapturedRequest!.WritePlan.Should().BeSameAs(request.WritePlan);
+        _profileMergeSynthesizer.CapturedRequest!.WritableRequestBody.Should().BeSameAs(writableBody);
+        _profileMergeSynthesizer.CapturedRequest!.CurrentState.Should().BeNull();
+        _profileMergeSynthesizer.CapturedRequest!.ProfileRequest.Should().BeSameAs(profileContext.Request);
+        _profileMergeSynthesizer.CapturedRequest!.ProfileAppliedContext.Should().BeNull();
+        _noProfileMergeSynthesizer
+            .SynthesizeCallCount.Should()
+            .Be(0, "the no-profile synthesizer must not run for profiled writes");
+        _noProfilePersister
+            .TryPersistCallCount.Should()
+            .Be(1, "the persister must receive the profile merge result");
+        _noProfilePersister.CapturedMergeResult.Should().BeSameAs(_profileMergeSynthesizer.ResultToReturn);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(0);
+
+        var upsertResult = result.Should().BeOfType<RelationalWriteExecutorResult.Upsert>().Subject;
+        upsertResult.Result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        result.AttemptOutcome.Should().Be(RelationalWriteExecutorAttemptOutcome.AppliedWrite.Instance);
     }
 
     private static RelationalWriteExecutorRequest CreateRequest(
@@ -2592,6 +2779,39 @@ public class Given_Default_Relational_Write_Executor
                         ),
                     ],
                     supportsGuardedNoOp: true
+                );
+        }
+    }
+
+    private sealed class RecordingRelationalWriteProfileMergeSynthesizer
+        : IRelationalWriteProfileMergeSynthesizer
+    {
+        public int SynthesizeCallCount { get; private set; }
+
+        public RelationalWriteProfileMergeRequest? CapturedRequest { get; private set; }
+
+        public RelationalWriteMergeResult? ResultToReturn { get; set; }
+
+        public RelationalWriteMergeResult Synthesize(RelationalWriteProfileMergeRequest request)
+        {
+            SynthesizeCallCount++;
+            CapturedRequest = request;
+
+            return ResultToReturn
+                ?? new RelationalWriteMergeResult(
+                    [
+                        new RelationalWriteMergedTableState(
+                            request.WritePlan.TablePlansInDependencyOrder[0],
+                            [],
+                            [
+                                new RelationalWriteMergedTableRow(
+                                    request.FlattenedWriteSet.RootRow.Values,
+                                    request.FlattenedWriteSet.RootRow.Values
+                                ),
+                            ]
+                        ),
+                    ],
+                    supportsGuardedNoOp: false
                 );
         }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/MssqlReferenceResolverServiceCollectionExtensionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/MssqlReferenceResolverServiceCollectionExtensionsTests.cs
@@ -36,8 +36,7 @@ public class Given_Mssql_Reference_Resolver_Service_Collection_Extensions
             scope.ServiceProvider.GetRequiredService<IRelationalWriteFreshnessChecker>();
         var noProfileMergeSynthesizer =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfileMergeSynthesizer>();
-        var noProfilePersister =
-            scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfilePersister>();
+        var noProfilePersister = scope.ServiceProvider.GetRequiredService<IRelationalWritePersister>();
         var targetLookupService =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteTargetLookupService>();
         var targetLookupResolver =

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PostgresqlReferenceResolverServiceCollectionExtensionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PostgresqlReferenceResolverServiceCollectionExtensionsTests.cs
@@ -43,8 +43,7 @@ public class Given_Postgresql_Reference_Resolver_Service_Collection_Extensions
             scope.ServiceProvider.GetRequiredService<IRelationalWriteFreshnessChecker>();
         var noProfileMergeSynthesizer =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfileMergeSynthesizer>();
-        var noProfilePersister =
-            scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfilePersister>();
+        var noProfilePersister = scope.ServiceProvider.GetRequiredService<IRelationalWritePersister>();
         var targetLookupService =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteTargetLookupService>();
         var targetLookupResolver =

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileMemberGovernanceRulesTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileMemberGovernanceRulesTests.cs
@@ -20,7 +20,7 @@ public class Given_IsHiddenGoverned_with_exact_match_and_exact_path
     public void Setup()
     {
         _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "birthDate",
+            governingPath: "birthDate",
             hiddenMemberPaths: ImmutableArray.Create("birthDate"),
             matchKind: HiddenPathMatchKind.Exact
         );
@@ -39,7 +39,7 @@ public class Given_IsHiddenGoverned_with_exact_match_and_different_path
     public void Setup()
     {
         _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "middleName",
+            governingPath: "middleName",
             hiddenMemberPaths: ImmutableArray.Create("birthDate"),
             matchKind: HiddenPathMatchKind.Exact
         );
@@ -50,17 +50,19 @@ public class Given_IsHiddenGoverned_with_exact_match_and_different_path
 }
 
 [TestFixture]
-public class Given_IsHiddenGoverned_with_ancestor_match_and_whole_reference_hidden
+public class Given_IsHiddenGoverned_reference_rooted_with_whole_reference_hidden
 {
+    // Whole reference hidden: HiddenMemberPaths contains "schoolReference". A reference-rooted
+    // binding whose governing path is also "schoolReference" is preserved by exact match.
     private bool _result;
 
     [SetUp]
     public void Setup()
     {
         _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "schoolReference.schoolId",
+            governingPath: "schoolReference",
             hiddenMemberPaths: ImmutableArray.Create("schoolReference"),
-            matchKind: HiddenPathMatchKind.AncestorOrExact
+            matchKind: HiddenPathMatchKind.ReferenceRooted
         );
     }
 
@@ -69,46 +71,83 @@ public class Given_IsHiddenGoverned_with_ancestor_match_and_whole_reference_hidd
 }
 
 [TestFixture]
-public class Given_IsHiddenGoverned_with_ancestor_match_and_exact_child_hidden
+public class Given_IsHiddenGoverned_reference_rooted_with_sub_reference_path_hidden
 {
-    private bool _child;
-    private bool _sibling;
+    // profiles.md:782 contract: a hidden path naming a sub-member of a reference
+    // (schoolReference.schoolId) preserves the entire reference-derived storage family
+    // keyed on the reference root (schoolReference). All three bindings whose governing
+    // reference root is "schoolReference" are preserved — FK, this identity part, and any
+    // sibling identity part.
+    private bool _fkBinding;
+    private bool _hiddenChildBinding;
+    private bool _siblingChildBinding;
 
     [SetUp]
     public void Setup()
     {
         var hidden = ImmutableArray.Create("schoolReference.schoolId");
-        _child = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "schoolReference.schoolId",
+
+        _fkBinding = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            governingPath: "schoolReference",
             hiddenMemberPaths: hidden,
-            matchKind: HiddenPathMatchKind.AncestorOrExact
+            matchKind: HiddenPathMatchKind.ReferenceRooted
         );
-        _sibling = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "schoolReference.localEducationAgencyId",
+        _hiddenChildBinding = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            governingPath: "schoolReference",
             hiddenMemberPaths: hidden,
-            matchKind: HiddenPathMatchKind.AncestorOrExact
+            matchKind: HiddenPathMatchKind.ReferenceRooted
+        );
+        _siblingChildBinding = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            governingPath: "schoolReference",
+            hiddenMemberPaths: hidden,
+            matchKind: HiddenPathMatchKind.ReferenceRooted
         );
     }
 
     [Test]
-    public void It_matches_the_exact_child() => _child.Should().BeTrue();
+    public void It_preserves_the_FK_binding() => _fkBinding.Should().BeTrue();
 
     [Test]
-    public void It_does_not_match_a_sibling_child() => _sibling.Should().BeFalse();
+    public void It_preserves_the_exact_child_binding() => _hiddenChildBinding.Should().BeTrue();
+
+    [Test]
+    public void It_preserves_the_sibling_child_binding() => _siblingChildBinding.Should().BeTrue();
 }
 
 [TestFixture]
-public class Given_IsHiddenGoverned_with_ancestor_match_and_prefix_without_dot_boundary
+public class Given_IsHiddenGoverned_reference_rooted_with_unrelated_prefix_without_dot_boundary
 {
+    // Defensive: a hidden path like "school" must not match governing path "schoolReference"
+    // even though the strings share a prefix — the dot boundary is required.
     private bool _result;
 
     [SetUp]
     public void Setup()
     {
         _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "schoolReference.schoolId",
+            governingPath: "schoolReference",
             hiddenMemberPaths: ImmutableArray.Create("school"),
-            matchKind: HiddenPathMatchKind.AncestorOrExact
+            matchKind: HiddenPathMatchKind.ReferenceRooted
+        );
+    }
+
+    [Test]
+    public void It_returns_false() => _result.Should().BeFalse();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_reference_rooted_with_disjoint_hidden_path
+{
+    // A hidden path for an unrelated reference (or scalar) must not govern this reference.
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            governingPath: "schoolReference",
+            hiddenMemberPaths: ImmutableArray.Create("studentReference.studentUniqueId"),
+            matchKind: HiddenPathMatchKind.ReferenceRooted
         );
     }
 
@@ -119,13 +158,16 @@ public class Given_IsHiddenGoverned_with_ancestor_match_and_prefix_without_dot_b
 [TestFixture]
 public class Given_IsHiddenGoverned_with_exact_match_and_ancestor_path
 {
+    // Exact-match bindings (scalar, descriptor) only match their own path exactly; a hidden path
+    // naming an ancestor scope does not reach the scalar because scope-level hiding is expressed
+    // via stored-scope visibility, not via ancestor member paths.
     private bool _result;
 
     [SetUp]
     public void Setup()
     {
         _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
-            memberPath: "studentReference.studentUniqueId",
+            governingPath: "studentReference.studentUniqueId",
             hiddenMemberPaths: ImmutableArray.Create("studentReference"),
             matchKind: HiddenPathMatchKind.Exact
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileMemberGovernanceRulesTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileMemberGovernanceRulesTests.cs
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using EdFi.DataManagementService.Backend.Profile;
+using FluentAssertions;
+using NUnit.Framework;
+using HiddenPathMatchKind = EdFi.DataManagementService.Backend.Profile.ProfileMemberGovernanceRules.HiddenPathMatchKind;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_exact_match_and_exact_path
+{
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "birthDate",
+            hiddenMemberPaths: ImmutableArray.Create("birthDate"),
+            matchKind: HiddenPathMatchKind.Exact
+        );
+    }
+
+    [Test]
+    public void It_returns_true() => _result.Should().BeTrue();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_exact_match_and_different_path
+{
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "middleName",
+            hiddenMemberPaths: ImmutableArray.Create("birthDate"),
+            matchKind: HiddenPathMatchKind.Exact
+        );
+    }
+
+    [Test]
+    public void It_returns_false() => _result.Should().BeFalse();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_ancestor_match_and_whole_reference_hidden
+{
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "schoolReference.schoolId",
+            hiddenMemberPaths: ImmutableArray.Create("schoolReference"),
+            matchKind: HiddenPathMatchKind.AncestorOrExact
+        );
+    }
+
+    [Test]
+    public void It_returns_true() => _result.Should().BeTrue();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_ancestor_match_and_exact_child_hidden
+{
+    private bool _child;
+    private bool _sibling;
+
+    [SetUp]
+    public void Setup()
+    {
+        var hidden = ImmutableArray.Create("schoolReference.schoolId");
+        _child = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "schoolReference.schoolId",
+            hiddenMemberPaths: hidden,
+            matchKind: HiddenPathMatchKind.AncestorOrExact
+        );
+        _sibling = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "schoolReference.localEducationAgencyId",
+            hiddenMemberPaths: hidden,
+            matchKind: HiddenPathMatchKind.AncestorOrExact
+        );
+    }
+
+    [Test]
+    public void It_matches_the_exact_child() => _child.Should().BeTrue();
+
+    [Test]
+    public void It_does_not_match_a_sibling_child() => _sibling.Should().BeFalse();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_ancestor_match_and_prefix_without_dot_boundary
+{
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "schoolReference.schoolId",
+            hiddenMemberPaths: ImmutableArray.Create("school"),
+            matchKind: HiddenPathMatchKind.AncestorOrExact
+        );
+    }
+
+    [Test]
+    public void It_returns_false() => _result.Should().BeFalse();
+}
+
+[TestFixture]
+public class Given_IsHiddenGoverned_with_exact_match_and_ancestor_path
+{
+    private bool _result;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = ProfileMemberGovernanceRules.IsHiddenGoverned(
+            memberPath: "studentReference.studentUniqueId",
+            hiddenMemberPaths: ImmutableArray.Create("studentReference"),
+            matchKind: HiddenPathMatchKind.Exact
+        );
+    }
+
+    [Test]
+    public void It_returns_false() => _result.Should().BeFalse();
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootKeyUnificationResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootKeyUnificationResolverTests.cs
@@ -1,0 +1,593 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Profile;
+using FluentAssertions;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Backend.Tests.Unit.Profile.ProfileTestDoubles;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
+
+[TestFixture]
+public class Given_Resolver_with_single_visible_present_scalar_member
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+    private int _presenceIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        _canonicalIndex = canonicalIdx;
+        _presenceIndex = presenceIndicesByPath["$.memberA"];
+
+        var body = new JsonObject { ["memberA"] = 42 };
+        var context = BuildResolverContext(
+            plan,
+            writableBody: body,
+            profileRequest: CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"))
+        );
+
+        _row = BuildInitialRow(plan);
+        var resolverOwned = ImmutableHashSet.Create(_canonicalIndex, _presenceIndex);
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_value_from_request_body() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().Be(42);
+
+    [Test]
+    public void It_writes_synthetic_presence_true() =>
+        ((FlattenedWriteValue.Literal)_row[_presenceIndex]).Value.Should().Be(true);
+
+    private static FlattenedWriteValue[] BuildInitialRow(ResourceWritePlan plan)
+    {
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        return row;
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_single_visible_absent_member
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+    private int _presenceIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers(
+            [
+                new KeyUnificationMemberSpec(
+                    RelativePath: "$.memberA",
+                    SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                    PresenceSynthetic: true
+                ),
+            ],
+            canonicalIsNullable: true
+        );
+        _canonicalIndex = canonicalIdx;
+        _presenceIndex = presenceIndicesByPath["$.memberA"];
+
+        var context = BuildResolverContext(
+            plan,
+            profileRequest: CreateRequest(scopeStates: RequestVisibleAbsentScope("$"))
+        );
+        _row = NewInitialRow(plan);
+        var resolverOwned = ImmutableHashSet.Create(_canonicalIndex, _presenceIndex);
+
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_null() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().BeNull();
+
+    [Test]
+    public void It_writes_synthetic_presence_null() =>
+        ((FlattenedWriteValue.Literal)_row[_presenceIndex]).Value.Should().BeNull();
+
+    private static FlattenedWriteValue[] NewInitialRow(ResourceWritePlan plan)
+    {
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        return row;
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_single_hidden_stored_present_member
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+    private int _presenceIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        _canonicalIndex = canonicalIdx;
+        _presenceIndex = presenceIndicesByPath["$.memberA"];
+
+        var request = CreateRequest(scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "memberA")
+        );
+
+        var memberColumn = MemberPathColumnFor("$.memberA");
+        var presenceColumn = PresenceColumnFor("$.memberA");
+        var currentRow = new Dictionary<DbColumnName, object?>
+        {
+            [memberColumn] = 99,
+            [presenceColumn] = true,
+        };
+
+        var context = BuildResolverContext(
+            plan,
+            currentRootRowByColumnName: currentRow,
+            profileRequest: request,
+            profileAppliedContext: appliedContext
+        );
+        _row = NewInitialRow(plan);
+        var resolverOwned = ImmutableHashSet.Create(_canonicalIndex, _presenceIndex);
+
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_from_stored_hidden_value() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().Be(99);
+
+    [Test]
+    public void It_writes_synthetic_presence_true_for_stored_present() =>
+        ((FlattenedWriteValue.Literal)_row[_presenceIndex]).Value.Should().Be(true);
+
+    private static FlattenedWriteValue[] NewInitialRow(ResourceWritePlan plan)
+    {
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        return row;
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_visible_and_hidden_members_agreeing
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, _) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberB",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+        ]);
+        _canonicalIndex = canonicalIdx;
+
+        var body = new JsonObject { ["memberA"] = 42 };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "memberB")
+        );
+
+        var currentRow = new Dictionary<DbColumnName, object?>
+        {
+            [MemberPathColumnFor("$.memberA")] = null,
+            [MemberPathColumnFor("$.memberB")] = 42,
+        };
+
+        var context = BuildResolverContext(
+            plan,
+            writableBody: body,
+            currentRootRowByColumnName: currentRow,
+            profileRequest: request,
+            profileAppliedContext: appliedContext
+        );
+        _row = NewInitialRow(plan);
+        var resolverOwned = ImmutableHashSet.Create(_canonicalIndex);
+
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_from_visible_or_hidden_consistently() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().Be(42);
+
+    private static FlattenedWriteValue[] NewInitialRow(ResourceWritePlan plan)
+    {
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        return row;
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_visible_and_hidden_members_disagreeing
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, _) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberB",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+        ]);
+
+        var body = new JsonObject { ["memberA"] = 1 };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "memberB")
+        );
+
+        var currentRow = new Dictionary<DbColumnName, object?>
+        {
+            [MemberPathColumnFor("$.memberA")] = null,
+            [MemberPathColumnFor("$.memberB")] = 2,
+        };
+
+        var context = BuildResolverContext(
+            plan,
+            writableBody: body,
+            currentRootRowByColumnName: currentRow,
+            profileRequest: request,
+            profileAppliedContext: appliedContext
+        );
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        var resolverOwned = ImmutableHashSet.Create(canonicalIdx);
+
+        _act = () =>
+            new ProfileRootKeyUnificationResolver().Resolve(
+                plan.TablePlansInDependencyOrder[0],
+                context,
+                row,
+                resolverOwned
+            );
+    }
+
+    [Test]
+    public void It_throws_validation_exception_with_key_unification_conflict_message()
+    {
+        _act.Should()
+            .Throw<RelationalWriteRequestValidationException>()
+            .Where(e => e.ValidationFailures[0].Message.Contains("Key-unification conflict"));
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_presence_non_null_and_canonical_null_guardrail
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        var presenceIdx = presenceIndicesByPath["$.memberA"];
+
+        // Stored scope hides memberA; stored presence column is non-null (so the resolver
+        // treats the member as present) while the stored value is null. Resolver writes
+        // presence=true and canonical=null; the presence-gated-null guardrail must fire.
+        var request = CreateRequest(scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "memberA")
+        );
+
+        var currentRow = new Dictionary<DbColumnName, object?>
+        {
+            [MemberPathColumnFor("$.memberA")] = null,
+            [PresenceColumnFor("$.memberA")] = true,
+        };
+
+        var context = BuildResolverContext(
+            plan,
+            currentRootRowByColumnName: currentRow,
+            profileRequest: request,
+            profileAppliedContext: appliedContext
+        );
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        var resolverOwned = ImmutableHashSet.Create(canonicalIdx, presenceIdx);
+
+        _act = () =>
+            new ProfileRootKeyUnificationResolver().Resolve(
+                plan.TablePlansInDependencyOrder[0],
+                context,
+                row,
+                resolverOwned
+            );
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException_for_presence_gated_null()
+    {
+        _act.Should().Throw<InvalidOperationException>().WithMessage("*resolved to null while presence*");
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_with_canonical_non_nullable_and_no_member_present_guardrail
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, _) = BuildRootPlanWithKeyUnificationMembers(
+            [
+                new KeyUnificationMemberSpec(
+                    RelativePath: "$.memberA",
+                    SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                    PresenceSynthetic: false
+                ),
+            ],
+            canonicalIsNullable: false
+        );
+
+        // Visible-absent, no hidden — canonical ends up null, and canonical column is
+        // non-nullable → guardrail throws.
+        var context = BuildResolverContext(
+            plan,
+            profileRequest: CreateRequest(scopeStates: RequestVisibleAbsentScope("$"))
+        );
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        var resolverOwned = ImmutableHashSet.Create(canonicalIdx);
+
+        _act = () =>
+            new ProfileRootKeyUnificationResolver().Resolve(
+                plan.TablePlansInDependencyOrder[0],
+                context,
+                row,
+                resolverOwned
+            );
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException_for_non_nullable_canonical_null()
+    {
+        _act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*is not nullable but resolved to null*");
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_for_CreateNew_with_no_stored_state_collapses_to_flattener_result
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, _) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+        ]);
+        _canonicalIndex = canonicalIdx;
+
+        var body = new JsonObject { ["memberA"] = 7 };
+        // No profile request scope states → no governance → behaves like flattener.
+        var context = BuildResolverContext(plan, writableBody: body);
+
+        _row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < _row.Length; i++)
+        {
+            _row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        var resolverOwned = ImmutableHashSet.Create(canonicalIdx);
+
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_matching_flattener_evaluation() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().Be(7);
+}
+
+[TestFixture]
+public class Given_Resolver_writes_every_canonical_and_synthetic_presence_binding_required
+{
+    private FlattenedWriteValue[] _row = null!;
+    private ImmutableHashSet<int> _resolverOwned = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberB",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        var presenceAIdx = presenceIndicesByPath["$.memberA"];
+        var presenceBIdx = presenceIndicesByPath["$.memberB"];
+
+        var body = new JsonObject { ["memberA"] = 11 };
+        var context = BuildResolverContext(plan, writableBody: body);
+
+        _row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < _row.Length; i++)
+        {
+            _row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        _resolverOwned = ImmutableHashSet.Create(canonicalIdx, presenceAIdx, presenceBIdx);
+
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            _resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_assigns_a_literal_to_every_resolver_owned_index()
+    {
+        foreach (var idx in _resolverOwned)
+        {
+            _row[idx].Should().BeOfType<FlattenedWriteValue.Literal>();
+        }
+    }
+}
+
+[TestFixture]
+public class Given_Resolver_does_not_write_outside_resolver_owned_indices
+{
+    private FlattenedWriteValue[] _row = null!;
+    private int _nonResolverOwnedIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        var presenceIdx = presenceIndicesByPath["$.memberA"];
+
+        // Locate a binding outside canonical and synthetic-presence indices so the
+        // resolver's invariant of not touching non-resolver-owned indices can be verified.
+        var bindings = plan.TablePlansInDependencyOrder[0].ColumnBindings;
+        for (var i = 0; i < bindings.Length; i++)
+        {
+            if (i != canonicalIdx && i != presenceIdx)
+            {
+                _nonResolverOwnedIndex = i;
+                break;
+            }
+        }
+
+        var body = new JsonObject { ["memberA"] = 1 };
+        var context = BuildResolverContext(plan, writableBody: body);
+
+        _row = new FlattenedWriteValue[bindings.Length];
+        for (var i = 0; i < _row.Length; i++)
+        {
+            _row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        // Preseed the non-resolver-owned binding with a sentinel value.
+        _row[_nonResolverOwnedIndex] = new FlattenedWriteValue.Literal("SENTINEL");
+
+        var resolverOwned = ImmutableHashSet.Create(canonicalIdx, presenceIdx);
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_preserves_pre_existing_value_at_non_resolver_owned_index() =>
+        ((FlattenedWriteValue.Literal)_row[_nonResolverOwnedIndex]).Value.Should().Be("SENTINEL");
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootKeyUnificationResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootKeyUnificationResolverTests.cs
@@ -591,3 +591,64 @@ public class Given_Resolver_does_not_write_outside_resolver_owned_indices
     public void It_preserves_pre_existing_value_at_non_resolver_owned_index() =>
         ((FlattenedWriteValue.Literal)_row[_nonResolverOwnedIndex]).Value.Should().Be("SENTINEL");
 }
+
+[TestFixture]
+public class Given_Resolver_with_reference_derived_member_and_hidden_sibling_sub_reference_path
+{
+    // Hidden-reference-governance regression (profiles.md:782): hiding a sibling identity path
+    // of the same reference (schoolReference.schoolId) must still preserve THIS reference-derived
+    // member (schoolReference.localEducationAgencyId) because both derive from the same owning
+    // reference root (schoolReference). Under the pre-Phase-2 rule this member would not have
+    // been governed by the hidden sibling path and would have picked up a visible-absent value.
+    private FlattenedWriteValue[] _row = null!;
+    private int _canonicalIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, _, memberColumnName) = BuildRootPlanWithReferenceDerivedKeyUnificationMember(
+            referenceMemberPath: "$.schoolReference",
+            derivedMemberPath: "$.schoolReference.localEducationAgencyId"
+        );
+        _canonicalIndex = canonicalIdx;
+
+        var request = CreateRequest(scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "schoolReference.schoolId")
+        );
+
+        // Stored value that must be preserved by hidden-reference governance.
+        var currentRow = new Dictionary<DbColumnName, object?> { [memberColumnName] = 777 };
+
+        var context = BuildResolverContext(
+            plan,
+            currentRootRowByColumnName: currentRow,
+            profileRequest: request,
+            profileAppliedContext: appliedContext
+        );
+
+        _row = NewInitialRow(plan);
+        var resolverOwned = ImmutableHashSet.Create(_canonicalIndex);
+        new ProfileRootKeyUnificationResolver().Resolve(
+            plan.TablePlansInDependencyOrder[0],
+            context,
+            _row,
+            resolverOwned
+        );
+    }
+
+    [Test]
+    public void It_writes_canonical_from_stored_hidden_reference_derived_value() =>
+        ((FlattenedWriteValue.Literal)_row[_canonicalIndex]).Value.Should().Be(777);
+
+    private static FlattenedWriteValue[] NewInitialRow(ResourceWritePlan plan)
+    {
+        var row = new FlattenedWriteValue[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        for (var i = 0; i < row.Length; i++)
+        {
+            row[i] = new FlattenedWriteValue.Literal(null);
+        }
+        return row;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootTableBindingClassifierTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootTableBindingClassifierTests.cs
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Profile;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
+
+[TestFixture]
+public class Given_Classifier_for_CreateNew_with_single_scalar_binding
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan();
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(
+            plan,
+            request,
+            profileAppliedContext: null
+        );
+    }
+
+    [Test]
+    public void It_classifies_the_single_binding_as_VisibleWritable() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.VisibleWritable);
+
+    [Test]
+    public void It_has_no_resolver_owned_indices() => _result.ResolverOwnedBindingIndices.Should().BeEmpty();
+}
+
+[TestFixture]
+public class Given_Classifier_with_key_unification_plan
+{
+    private ProfileRootTableBindingClassification _result = null!;
+    private int _canonicalIndex;
+    private int _syntheticPresenceIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIdx) = ProfileTestDoubles.BuildRootPlanWithKeyUnificationPlan();
+        _canonicalIndex = canonicalIdx;
+        _syntheticPresenceIndex = presenceIdx;
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(
+            plan,
+            request,
+            profileAppliedContext: null
+        );
+    }
+
+    [Test]
+    public void It_includes_canonical_binding_in_resolver_owned() =>
+        _result.ResolverOwnedBindingIndices.Should().Contain(_canonicalIndex);
+
+    [Test]
+    public void It_includes_synthetic_presence_binding_in_resolver_owned() =>
+        _result.ResolverOwnedBindingIndices.Should().Contain(_syntheticPresenceIndex);
+
+    [Test]
+    public void It_marks_resolver_owned_bindings_as_StorageManaged()
+    {
+        _result.BindingsByIndex[_canonicalIndex].Should().Be(RootBindingDisposition.StorageManaged);
+        _result.BindingsByIndex[_syntheticPresenceIndex].Should().Be(RootBindingDisposition.StorageManaged);
+    }
+}
+
+[TestFixture]
+public class Given_Classifier_with_ParentKeyPart_source_on_root_table
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildRootPlanWithParentKeyPartBinding();
+        var request = ProfileTestDoubles.CreateRequest();
+        _act = () =>
+            new ProfileRootTableBindingClassifier().Classify(plan, request, profileAppliedContext: null);
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException_for_plan_shape_violation()
+    {
+        _act.Should().Throw<InvalidOperationException>().WithMessage("*plan-shape violation*");
+    }
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_stored_hidden_scope
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.firstName");
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredHiddenScope("$")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_classifies_the_binding_as_HiddenPreserved() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_hidden_scalar_member_path
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.birthDate");
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$", "birthDate")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_classifies_the_binding_as_HiddenPreserved() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_request_visible_absent_and_no_hidden
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(
+            scalarRelativePath: "$.birthData.birthCity"
+        );
+        var request = ProfileTestDoubles.CreateRequest(
+            writableBody: null,
+            rootResourceCreatable: true,
+            ProfileTestDoubles.RequestVisiblePresentScope("$"),
+            ProfileTestDoubles.RequestVisibleAbsentScope("$.birthData")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisibleAbsentScope("$.birthData")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_classifies_the_binding_as_ClearOnVisibleAbsent() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.ClearOnVisibleAbsent);
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_hidden_member_and_request_visible_absent
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(
+            scalarRelativePath: "$.birthData.birthCountryDescriptor"
+        );
+        var request = ProfileTestDoubles.CreateRequest(
+            writableBody: null,
+            rootResourceCreatable: true,
+            ProfileTestDoubles.RequestVisiblePresentScope("$"),
+            ProfileTestDoubles.RequestVisibleAbsentScope("$.birthData")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisibleAbsentScope(
+                "$.birthData",
+                "birthCountryDescriptor"
+            )
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_classifies_hidden_binding_as_HiddenPreserved_overriding_visible_absent() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
+}
+
+[TestFixture]
+public class Given_Classifier_with_document_reference_whole_reference_hidden
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Root plan: [0] = FK for $.schoolReference,
+        //            [1] = derived $.schoolReference.schoolId,
+        //            [2] = derived $.schoolReference.localEducationAgencyId.
+        var derivedMemberPaths = new[]
+        {
+            "$.schoolReference.schoolId",
+            "$.schoolReference.localEducationAgencyId",
+        };
+        var plan = ProfileTestDoubles.BuildRootPlanWithDocumentReferenceBindings(
+            referenceMemberPath: "$.schoolReference",
+            derivedMemberPaths: derivedMemberPaths
+        );
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$", "schoolReference")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_preserves_the_FK_binding() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
+
+    [Test]
+    public void It_preserves_every_derived_binding()
+    {
+        _result.BindingsByIndex[1].Should().Be(RootBindingDisposition.HiddenPreserved);
+        _result.BindingsByIndex[2].Should().Be(RootBindingDisposition.HiddenPreserved);
+    }
+}
+
+[TestFixture]
+public class Given_Classifier_with_document_reference_exact_child_hidden
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var derivedMemberPaths = new[]
+        {
+            "$.schoolReference.schoolId",
+            "$.schoolReference.localEducationAgencyId",
+        };
+        var plan = ProfileTestDoubles.BuildRootPlanWithDocumentReferenceBindings(
+            referenceMemberPath: "$.schoolReference",
+            derivedMemberPaths: derivedMemberPaths
+        );
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$", "schoolReference.schoolId")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_does_not_preserve_the_FK_binding_exact_child_miss() =>
+        // FK binding's member path is "schoolReference"; the hidden path is "schoolReference.schoolId"
+        // (a descendant). Ancestor-or-exact matching does NOT consider descendants of memberPath
+        // as ancestors of hiddenPath. So FK is VisibleWritable.
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.VisibleWritable);
+
+    [Test]
+    public void It_preserves_only_the_exact_matching_derived_binding() =>
+        _result.BindingsByIndex[1].Should().Be(RootBindingDisposition.HiddenPreserved);
+
+    [Test]
+    public void It_does_not_preserve_sibling_derived_binding() =>
+        _result.BindingsByIndex[2].Should().Be(RootBindingDisposition.VisibleWritable);
+}
+
+[TestFixture]
+public class Given_Classifier_with_descriptor_reference_and_exact_match_hidden_path
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildRootPlanWithDescriptorReferenceBinding(
+            relativePath: "$.sexDescriptor"
+        );
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$", "sexDescriptor")
+        );
+        _result = new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_preserves_descriptor_binding_on_exact_match() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_stored_scope_unresolvable_to_any_root_binding
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Root plan has only a $.firstName scalar binding. Profile reports a stored scope at
+        // $.unrelatedScope with no binding under it — upstream metadata drift.
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.firstName");
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$.unrelatedScope")
+        );
+        _act = () => new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException_for_unresolvable_stored_scope()
+    {
+        _act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*Stored scope*does not resolve to any root-table binding*");
+    }
+}
+
+[TestFixture]
+public class Given_Classifier_for_ExistingDocument_with_hidden_member_path_unresolvable_to_any_binding
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Root plan has only a $.firstName scalar binding. Stored scope $ exists but its
+        // HiddenMemberPaths contains "lastName" — no binding under $ exact-matches "lastName".
+        var plan = ProfileTestDoubles.BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.firstName");
+        var request = ProfileTestDoubles.CreateRequest(
+            scopeStates: ProfileTestDoubles.RequestVisiblePresentScope("$")
+        );
+        var context = ProfileTestDoubles.CreateContext(
+            request,
+            storedScopeStates: ProfileTestDoubles.StoredVisiblePresentScope("$", "lastName")
+        );
+        _act = () => new ProfileRootTableBindingClassifier().Classify(plan, request, context);
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException_for_unresolvable_hidden_member_path()
+    {
+        _act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*Hidden member path*does not resolve to any root-table binding under that scope*");
+    }
+}
+
+[TestFixture]
+public class Given_Classifier_with_Precomputed_and_DocumentId_sources
+{
+    private ProfileRootTableBindingClassification _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = ProfileTestDoubles.BuildRootPlanWithPrecomputedAndDocumentIdBindings();
+        var request = ProfileTestDoubles.CreateRequest();
+        _result = new ProfileRootTableBindingClassifier().Classify(
+            plan,
+            request,
+            profileAppliedContext: null
+        );
+    }
+
+    [Test]
+    public void It_classifies_precomputed_as_StorageManaged() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.StorageManaged);
+
+    [Test]
+    public void It_classifies_document_id_as_StorageManaged() =>
+        _result.BindingsByIndex[1].Should().Be(RootBindingDisposition.StorageManaged);
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootTableBindingClassifierTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileRootTableBindingClassifierTests.cs
@@ -248,8 +248,13 @@ public class Given_Classifier_with_document_reference_whole_reference_hidden
 }
 
 [TestFixture]
-public class Given_Classifier_with_document_reference_exact_child_hidden
+public class Given_Classifier_with_document_reference_sub_reference_member_hidden
 {
+    // profiles.md:782: a hidden path naming a sub-member of a document reference
+    // (schoolReference.schoolId) preserves the entire reference-derived storage family
+    // because the FK and every derived identity column are all governed by the same owning
+    // reference root (schoolReference). Sibling identity parts are preserved even though
+    // the hidden path names only one of them.
     private ProfileRootTableBindingClassification _result = null!;
 
     [SetUp]
@@ -275,19 +280,16 @@ public class Given_Classifier_with_document_reference_exact_child_hidden
     }
 
     [Test]
-    public void It_does_not_preserve_the_FK_binding_exact_child_miss() =>
-        // FK binding's member path is "schoolReference"; the hidden path is "schoolReference.schoolId"
-        // (a descendant). Ancestor-or-exact matching does NOT consider descendants of memberPath
-        // as ancestors of hiddenPath. So FK is VisibleWritable.
-        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.VisibleWritable);
+    public void It_preserves_the_FK_binding() =>
+        _result.BindingsByIndex[0].Should().Be(RootBindingDisposition.HiddenPreserved);
 
     [Test]
-    public void It_preserves_only_the_exact_matching_derived_binding() =>
+    public void It_preserves_the_exact_matching_derived_binding() =>
         _result.BindingsByIndex[1].Should().Be(RootBindingDisposition.HiddenPreserved);
 
     [Test]
-    public void It_does_not_preserve_sibling_derived_binding() =>
-        _result.BindingsByIndex[2].Should().Be(RootBindingDisposition.VisibleWritable);
+    public void It_preserves_the_sibling_derived_binding() =>
+        _result.BindingsByIndex[2].Should().Be(RootBindingDisposition.HiddenPreserved);
 }
 
 [TestFixture]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
@@ -7,6 +7,8 @@ using System.Collections.Immutable;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Profile;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Profile;
 
 namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
@@ -286,6 +288,219 @@ internal static class ProfileTestDoubles
         return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []);
     }
 
+    // ── Resolver-context builders ─────────────────────────────────────────
+
+    /// <summary>
+    /// Compositional per-member spec for <see cref="BuildRootPlanWithKeyUnificationMembers"/>.
+    /// </summary>
+    internal sealed record KeyUnificationMemberSpec(
+        string RelativePath,
+        KeyUnificationMemberSourceKind SourceKind,
+        bool PresenceSynthetic,
+        string? MemberColumnName = null,
+        string? PresenceColumnName = null
+    );
+
+    internal enum KeyUnificationMemberSourceKind
+    {
+        Scalar,
+        Descriptor,
+    }
+
+    /// <summary>
+    /// Predictable naming helpers so tests can populate <c>CurrentRootRowByColumnName</c>
+    /// with the same column names the multi-member builder uses.
+    /// </summary>
+    internal static DbColumnName MemberPathColumnFor(string relativePath) =>
+        new("Member_" + SanitizePath(relativePath));
+
+    internal static DbColumnName PresenceColumnFor(string relativePath) =>
+        new("Presence_" + SanitizePath(relativePath));
+
+    internal static DbColumnName CanonicalColumnFor() => new("KU_Canonical");
+
+    private static string SanitizePath(string relativePath)
+    {
+        if (string.IsNullOrEmpty(relativePath))
+        {
+            return "root";
+        }
+        return new string(relativePath.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+    }
+
+    /// <summary>
+    /// Build a root plan with a key-unification plan composed of one-or-more members.
+    /// Bindings are: [0] = canonical (Precomputed), [1..N] = synthetic presence bindings
+    /// (Precomputed) for each member that has <c>PresenceSynthetic</c> true, followed by
+    /// per-member value bindings (Scalar for ScalarMember, DescriptorReference for
+    /// DescriptorMember). Returns the plan along with the canonical binding index and a
+    /// map from member relative path → synthetic-presence binding index (only for members
+    /// that have a synthetic presence column).
+    /// </summary>
+    internal static (
+        ResourceWritePlan Plan,
+        int CanonicalBindingIndex,
+        IReadOnlyDictionary<string, int> PresenceBindingIndicesByRelativePath
+    ) BuildRootPlanWithKeyUnificationMembers(
+        IReadOnlyList<KeyUnificationMemberSpec> members,
+        bool canonicalIsNullable = true
+    )
+    {
+        if (members is null || members.Count == 0)
+        {
+            throw new ArgumentException("At least one member spec is required.", nameof(members));
+        }
+
+        var canonicalColumn = Column(
+            CanonicalColumnFor().Value,
+            ColumnKind.Scalar,
+            Int32Type(),
+            isNullable: canonicalIsNullable
+        );
+        var columns = new List<DbColumnModel> { canonicalColumn };
+        var bindings = new List<WriteColumnBinding>
+        {
+            new(canonicalColumn, new WriteValueSource.Precomputed(), canonicalColumn.ColumnName.Value),
+        };
+        var canonicalBindingIndex = 0;
+
+        var presenceBindingIndicesByRelativePath = new Dictionary<string, int>(StringComparer.Ordinal);
+        var memberBindingIndicesByRelativePath = new Dictionary<string, int>(StringComparer.Ordinal);
+        var memberColumnsByRelativePath = new Dictionary<string, DbColumnModel>(StringComparer.Ordinal);
+        var presenceColumnsByRelativePath = new Dictionary<string, DbColumnModel>(StringComparer.Ordinal);
+
+        foreach (var spec in members)
+        {
+            var memberColumn = Column(
+                spec.MemberColumnName ?? MemberPathColumnFor(spec.RelativePath).Value,
+                ColumnKind.Scalar,
+                spec.SourceKind == KeyUnificationMemberSourceKind.Scalar ? Int32Type() : Int64Type(),
+                sourceJsonPath: Path(spec.RelativePath)
+            );
+            memberColumnsByRelativePath[spec.RelativePath] = memberColumn;
+            columns.Add(memberColumn);
+
+            if (spec.PresenceSynthetic)
+            {
+                var presenceColumn = Column(
+                    spec.PresenceColumnName ?? PresenceColumnFor(spec.RelativePath).Value,
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Boolean)
+                );
+                presenceColumnsByRelativePath[spec.RelativePath] = presenceColumn;
+                columns.Add(presenceColumn);
+
+                var presenceBinding = new WriteColumnBinding(
+                    presenceColumn,
+                    new WriteValueSource.Precomputed(),
+                    presenceColumn.ColumnName.Value
+                );
+                bindings.Add(presenceBinding);
+                presenceBindingIndicesByRelativePath[spec.RelativePath] = bindings.Count - 1;
+            }
+
+            WriteValueSource memberSource = spec.SourceKind switch
+            {
+                KeyUnificationMemberSourceKind.Scalar => new WriteValueSource.Scalar(
+                    Path(spec.RelativePath),
+                    Int32Type()
+                ),
+                KeyUnificationMemberSourceKind.Descriptor => new WriteValueSource.DescriptorReference(
+                    new QualifiedResourceName("Ed-Fi", "SampleDescriptor"),
+                    Path(spec.RelativePath),
+                    DescriptorValuePath: null
+                ),
+                _ => throw new InvalidOperationException($"Unsupported source kind '{spec.SourceKind}'."),
+            };
+            var memberBinding = new WriteColumnBinding(
+                memberColumn,
+                memberSource,
+                memberColumn.ColumnName.Value
+            );
+            bindings.Add(memberBinding);
+            memberBindingIndicesByRelativePath[spec.RelativePath] = bindings.Count - 1;
+        }
+
+        var rootModel = RootTable("Thing", columns);
+
+        var memberWritePlans = members
+            .Select<KeyUnificationMemberSpec, KeyUnificationMemberWritePlan>(spec =>
+            {
+                var memberColumn = memberColumnsByRelativePath[spec.RelativePath];
+                presenceColumnsByRelativePath.TryGetValue(spec.RelativePath, out var presenceColumn);
+                presenceBindingIndicesByRelativePath.TryGetValue(
+                    spec.RelativePath,
+                    out var presenceBindingIndex
+                );
+                int? presenceBindingIndexOrNull = spec.PresenceSynthetic ? presenceBindingIndex : null;
+
+                return spec.SourceKind switch
+                {
+                    KeyUnificationMemberSourceKind.Scalar => new KeyUnificationMemberWritePlan.ScalarMember(
+                        MemberPathColumn: memberColumn.ColumnName,
+                        RelativePath: Path(spec.RelativePath),
+                        ScalarType: Int32Type(),
+                        PresenceColumn: presenceColumn?.ColumnName,
+                        PresenceBindingIndex: presenceBindingIndexOrNull,
+                        PresenceIsSynthetic: spec.PresenceSynthetic
+                    ),
+                    KeyUnificationMemberSourceKind.Descriptor =>
+                        new KeyUnificationMemberWritePlan.DescriptorMember(
+                            MemberPathColumn: memberColumn.ColumnName,
+                            RelativePath: Path(spec.RelativePath),
+                            DescriptorResource: new QualifiedResourceName("Ed-Fi", "SampleDescriptor"),
+                            PresenceColumn: presenceColumn?.ColumnName,
+                            PresenceBindingIndex: presenceBindingIndexOrNull,
+                            PresenceIsSynthetic: spec.PresenceSynthetic
+                        ),
+                    _ => throw new InvalidOperationException($"Unsupported source kind '{spec.SourceKind}'."),
+                };
+            })
+            .ToList();
+
+        var keyUnificationPlan = new KeyUnificationWritePlan(
+            CanonicalColumn: canonicalColumn.ColumnName,
+            CanonicalBindingIndex: canonicalBindingIndex,
+            MembersInOrder: memberWritePlans
+        );
+        var rootPlan = RootPlan(rootModel, bindings, keyUnificationPlans: [keyUnificationPlan]);
+        return (
+            WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []),
+            canonicalBindingIndex,
+            presenceBindingIndicesByRelativePath
+        );
+    }
+
+    internal static ProfileRootKeyUnificationContext BuildResolverContext(
+        ResourceWritePlan writePlan,
+        JsonNode? writableBody = null,
+        RelationalWriteCurrentState? currentState = null,
+        IReadOnlyDictionary<DbColumnName, object?>? currentRootRowByColumnName = null,
+        ResolvedReferenceSet? resolvedReferences = null,
+        ProfileAppliedWriteRequest? profileRequest = null,
+        ProfileAppliedWriteContext? profileAppliedContext = null
+    ) =>
+        new(
+            WritePlan: writePlan,
+            WritableRequestBody: writableBody ?? new JsonObject(),
+            CurrentState: currentState,
+            CurrentRootRowByColumnName: currentRootRowByColumnName ?? new Dictionary<DbColumnName, object?>(),
+            ResolvedReferences: resolvedReferences ?? EmptyResolvedReferenceSet(),
+            ProfileRequest: profileRequest ?? CreateRequest(),
+            ProfileAppliedContext: profileAppliedContext
+        );
+
+    internal static ResolvedReferenceSet EmptyResolvedReferenceSet() =>
+        new(
+            SuccessfulDocumentReferencesByPath: new Dictionary<JsonPath, ResolvedDocumentReference>(),
+            SuccessfulDescriptorReferencesByPath: new Dictionary<JsonPath, ResolvedDescriptorReference>(),
+            LookupsByReferentialId: new Dictionary<ReferentialId, ReferenceLookupSnapshot>(),
+            InvalidDocumentReferences: [],
+            InvalidDescriptorReferences: [],
+            DocumentReferenceOccurrences: [],
+            DescriptorReferenceOccurrences: []
+        );
+
     // ── Helpers ────────────────────────────────────────────────────────────
 
     private static RelationalScalarType StringType() => new(ScalarKind.String, MaxLength: 50);
@@ -300,13 +515,14 @@ internal static class ProfileTestDoubles
         string columnName,
         ColumnKind kind,
         RelationalScalarType? scalarType,
-        JsonPathExpression? sourceJsonPath = null
+        JsonPathExpression? sourceJsonPath = null,
+        bool isNullable = true
     ) =>
         new(
             ColumnName: new DbColumnName(columnName),
             Kind: kind,
             ScalarType: scalarType,
-            IsNullable: true,
+            IsNullable: isNullable,
             SourceJsonPath: sourceJsonPath,
             TargetResource: null,
             Storage: new ColumnStorage.Stored()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
@@ -110,6 +110,92 @@ internal static class ProfileTestDoubles
     }
 
     /// <summary>
+    /// Build a root plan with a KeyUnificationWritePlan whose single member is a
+    /// ReferenceDerivedMember. Useful for tests that need the resolver's reference-rooted
+    /// governance path. Bindings: [0] = canonical (Precomputed), [1] = ReferenceDerived
+    /// member value column. No presence column.
+    /// </summary>
+    internal static (
+        ResourceWritePlan Plan,
+        int CanonicalBindingIndex,
+        int MemberBindingIndex,
+        DbColumnName MemberColumnName
+    ) BuildRootPlanWithReferenceDerivedKeyUnificationMember(
+        string referenceMemberPath,
+        string derivedMemberPath
+    )
+    {
+        var referenceObjectPath = Path(referenceMemberPath);
+        var identitySegment = derivedMemberPath[(referenceMemberPath.Length + 1)..];
+
+        var canonicalColumn = Column("KU_Canonical", ColumnKind.Scalar, Int32Type());
+        var memberColumn = Column(
+            "KU_" + SanitizePath(identitySegment) + "_FromReference",
+            ColumnKind.Scalar,
+            Int32Type(),
+            sourceJsonPath: Path(derivedMemberPath)
+        );
+        var rootModel = RootTable("RefKUHost", [canonicalColumn, memberColumn]);
+
+        var canonicalBinding = new WriteColumnBinding(
+            canonicalColumn,
+            new WriteValueSource.Precomputed(),
+            canonicalColumn.ColumnName.Value
+        );
+        var referenceSource = new ReferenceDerivedValueSourceMetadata(
+            BindingIndex: 0,
+            ReferenceObjectPath: referenceObjectPath,
+            IdentityJsonPath: Path("$." + identitySegment),
+            ReferenceJsonPath: Path(derivedMemberPath)
+        );
+        var memberBinding = new WriteColumnBinding(
+            memberColumn,
+            new WriteValueSource.ReferenceDerived(referenceSource),
+            memberColumn.ColumnName.Value
+        );
+
+        var keyUnificationPlan = new KeyUnificationWritePlan(
+            CanonicalColumn: canonicalColumn.ColumnName,
+            CanonicalBindingIndex: 0,
+            MembersInOrder:
+            [
+                new KeyUnificationMemberWritePlan.ReferenceDerivedMember(
+                    MemberPathColumn: memberColumn.ColumnName,
+                    RelativePath: Path(derivedMemberPath),
+                    ReferenceSource: referenceSource,
+                    PresenceColumn: null,
+                    PresenceBindingIndex: null,
+                    PresenceIsSynthetic: false
+                ),
+            ]
+        );
+
+        var rootPlan = RootPlan(
+            rootModel,
+            [canonicalBinding, memberBinding],
+            keyUnificationPlans: [keyUnificationPlan]
+        );
+
+        // Register a DocumentReferenceBinding so the resource model carries the owning reference.
+        var fkColumn = Column("UnusedRef_DocumentId", ColumnKind.DocumentFk, Int64Type());
+        var docRefBinding = new DocumentReferenceBinding(
+            IsIdentityComponent: false,
+            ReferenceObjectPath: referenceObjectPath,
+            Table: rootModel.Table,
+            FkColumn: fkColumn.ColumnName,
+            TargetResource: new QualifiedResourceName("Ed-Fi", "School"),
+            IdentityBindings: []
+        );
+
+        return (
+            WrapPlan(rootModel, [rootPlan], documentReferenceBindings: [docRefBinding]),
+            0,
+            1,
+            memberColumn.ColumnName
+        );
+    }
+
+    /// <summary>
     /// Build a root plan with a KeyUnificationWritePlan whose scalar member has a synthetic
     /// presence column. Returns the plan plus resolver-owned binding indices.
     /// Bindings: [0] = canonical scalar (Precomputed), [1] = synthetic presence (Precomputed),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
@@ -476,19 +476,22 @@ internal static class ProfileTestDoubles
         JsonNode? writableBody = null,
         RelationalWriteCurrentState? currentState = null,
         IReadOnlyDictionary<DbColumnName, object?>? currentRootRowByColumnName = null,
-        ResolvedReferenceSet? resolvedReferences = null,
+        FlatteningResolvedReferenceLookupSet? resolvedReferenceLookups = null,
         ProfileAppliedWriteRequest? profileRequest = null,
         ProfileAppliedWriteContext? profileAppliedContext = null
     ) =>
         new(
-            WritePlan: writePlan,
             WritableRequestBody: writableBody ?? new JsonObject(),
             CurrentState: currentState,
             CurrentRootRowByColumnName: currentRootRowByColumnName ?? new Dictionary<DbColumnName, object?>(),
-            ResolvedReferences: resolvedReferences ?? EmptyResolvedReferenceSet(),
+            ResolvedReferenceLookups: resolvedReferenceLookups ?? EmptyResolvedReferenceLookups(writePlan),
             ProfileRequest: profileRequest ?? CreateRequest(),
             ProfileAppliedContext: profileAppliedContext
         );
+
+    internal static FlatteningResolvedReferenceLookupSet EmptyResolvedReferenceLookups(
+        ResourceWritePlan writePlan
+    ) => FlatteningResolvedReferenceLookupSet.Create(writePlan, EmptyResolvedReferenceSet());
 
     internal static ResolvedReferenceSet EmptyResolvedReferenceSet() =>
         new(
@@ -500,6 +503,91 @@ internal static class ProfileTestDoubles
             DocumentReferenceOccurrences: [],
             DescriptorReferenceOccurrences: []
         );
+
+    // ── Synthesizer builders and stubs ─────────────────────────────────────
+
+    /// <summary>
+    /// Build a <see cref="RelationalWriteProfileMergeSynthesizer"/> composed with real
+    /// classifier and resolver instances. This is the end-to-end entry point for tests
+    /// that verify the synthesizer's composition behavior.
+    /// </summary>
+    internal static RelationalWriteProfileMergeSynthesizer BuildProfileSynthesizer() =>
+        new(new ProfileRootTableBindingClassifier(), new ProfileRootKeyUnificationResolver());
+
+    /// <summary>
+    /// Build a minimal <see cref="FlattenedWriteSet"/> whose root row has literal values
+    /// in binding-index order, one per supplied value. Bindings not covered are <c>null</c>
+    /// literals.
+    /// </summary>
+    internal static FlattenedWriteSet BuildFlattenedWriteSetFrom(
+        ResourceWritePlan writePlan,
+        params object?[] literalValuesByBindingIndex
+    )
+    {
+        var rootPlan = writePlan.TablePlansInDependencyOrder[0];
+        var bindings = rootPlan.ColumnBindings;
+        var values = new FlattenedWriteValue[bindings.Length];
+        for (var i = 0; i < bindings.Length; i++)
+        {
+            values[i] = new FlattenedWriteValue.Literal(
+                i < literalValuesByBindingIndex.Length ? literalValuesByBindingIndex[i] : null
+            );
+        }
+        return new FlattenedWriteSet(new RootWriteRowBuffer(rootPlan, values));
+    }
+
+    /// <summary>
+    /// Build a <see cref="RelationalWriteCurrentState"/> with a single root-table row
+    /// (and no other tables). Column-ordinal order is the root table's
+    /// <see cref="DbTableModel.Columns"/> order.
+    /// </summary>
+    internal static RelationalWriteCurrentState BuildCurrentStateWithSingleRootRow(
+        ResourceWritePlan writePlan,
+        params object?[] columnValues
+    ) =>
+        new(
+            new DocumentMetadataRow(
+                DocumentId: 345L,
+                DocumentUuid: Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"),
+                ContentVersion: 1L,
+                IdentityVersion: 1L,
+                ContentLastModifiedAt: new DateTimeOffset(2026, 4, 17, 12, 0, 0, TimeSpan.Zero),
+                IdentityLastModifiedAt: new DateTimeOffset(2026, 4, 17, 12, 0, 0, TimeSpan.Zero)
+            ),
+            [new HydratedTableRows(writePlan.TablePlansInDependencyOrder[0].TableModel, [columnValues])],
+            []
+        );
+
+    /// <summary>
+    /// Pre-canned classifier used by invariant tests that need to force a specific
+    /// binding disposition without going through real scope matching.
+    /// </summary>
+    internal sealed class StubClassifier(ProfileRootTableBindingClassification classification)
+        : IProfileRootTableBindingClassifier
+    {
+        public ProfileRootTableBindingClassification Classify(
+            ResourceWritePlan writePlan,
+            ProfileAppliedWriteRequest profileRequest,
+            ProfileAppliedWriteContext? profileAppliedContext
+        ) => classification;
+    }
+
+    /// <summary>
+    /// No-op resolver used alongside <see cref="StubClassifier"/> when a test wants to
+    /// isolate the synthesizer's overlay behavior.
+    /// </summary>
+    internal sealed class NoOpResolver : IProfileRootKeyUnificationResolver
+    {
+        public void Resolve(
+            TableWritePlan rootTableWritePlan,
+            ProfileRootKeyUnificationContext context,
+            FlattenedWriteValue[] mergedRowValuesMutable,
+            ImmutableHashSet<int> resolverOwnedBindingIndices
+        )
+        {
+            // Intentionally does nothing; tests that use this stub verify overlay-only paths.
+        }
+    }
 
     // ── Helpers ────────────────────────────────────────────────────────────
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileTestDoubles.cs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
+
+/// <summary>
+/// Shared test-double factories for profile-governance and root-table binding-classifier tests.
+/// Keeps ResourceWritePlan construction minimal and parameterized so tests stay readable.
+/// </summary>
+internal static class ProfileTestDoubles
+{
+    private static readonly QualifiedResourceName _defaultResource = new("Ed-Fi", "Student");
+    private static readonly DbSchemaName _defaultSchema = new("edfi");
+
+    // ── Profile-request / profile-context factories ────────────────────────
+
+    internal static ProfileAppliedWriteRequest CreateRequest(
+        JsonNode? writableBody = null,
+        bool rootResourceCreatable = true,
+        params RequestScopeState[] scopeStates
+    ) =>
+        new(
+            writableBody ?? new JsonObject(),
+            rootResourceCreatable,
+            scopeStates.ToImmutableArray(),
+            ImmutableArray<VisibleRequestCollectionItem>.Empty
+        );
+
+    internal static ProfileAppliedWriteContext CreateContext(
+        ProfileAppliedWriteRequest request,
+        JsonNode? visibleStoredBody = null,
+        params StoredScopeState[] storedScopeStates
+    ) =>
+        new(
+            request,
+            visibleStoredBody ?? new JsonObject(),
+            storedScopeStates.ToImmutableArray(),
+            ImmutableArray<VisibleStoredCollectionRow>.Empty
+        );
+
+    internal static StoredScopeState StoredVisiblePresentScope(
+        string scopeCanonical,
+        params string[] hiddenMemberPaths
+    ) =>
+        new(
+            new ScopeInstanceAddress(scopeCanonical, []),
+            ProfileVisibilityKind.VisiblePresent,
+            hiddenMemberPaths.ToImmutableArray()
+        );
+
+    internal static StoredScopeState StoredHiddenScope(string scopeCanonical) =>
+        new(
+            new ScopeInstanceAddress(scopeCanonical, []),
+            ProfileVisibilityKind.Hidden,
+            ImmutableArray<string>.Empty
+        );
+
+    internal static StoredScopeState StoredVisibleAbsentScope(
+        string scopeCanonical,
+        params string[] hiddenMemberPaths
+    ) =>
+        new(
+            new ScopeInstanceAddress(scopeCanonical, []),
+            ProfileVisibilityKind.VisibleAbsent,
+            hiddenMemberPaths.ToImmutableArray()
+        );
+
+    internal static RequestScopeState RequestVisiblePresentScope(
+        string scopeCanonical,
+        bool creatable = true
+    ) => new(new ScopeInstanceAddress(scopeCanonical, []), ProfileVisibilityKind.VisiblePresent, creatable);
+
+    internal static RequestScopeState RequestVisibleAbsentScope(
+        string scopeCanonical,
+        bool creatable = true
+    ) => new(new ScopeInstanceAddress(scopeCanonical, []), ProfileVisibilityKind.VisibleAbsent, creatable);
+
+    internal static RequestScopeState RequestHiddenScope(string scopeCanonical, bool creatable = false) =>
+        new(new ScopeInstanceAddress(scopeCanonical, []), ProfileVisibilityKind.Hidden, creatable);
+
+    // ── ResourceWritePlan builders ─────────────────────────────────────────
+
+    /// <summary>
+    /// Build a ResourceWritePlan with a single-column root table. The column is a Scalar
+    /// whose relative path is <paramref name="scalarRelativePath"/>. Bindings: [0] = Scalar.
+    /// </summary>
+    internal static ResourceWritePlan BuildSingleScalarBindingRootPlan(
+        string scalarRelativePath = "$.firstName"
+    )
+    {
+        var scalarColumn = Column("FirstName", ColumnKind.Scalar, StringType());
+        var rootModel = RootTable("Student", [scalarColumn]);
+        var scalarBinding = new WriteColumnBinding(
+            scalarColumn,
+            new WriteValueSource.Scalar(Path(scalarRelativePath), StringType()),
+            "FirstName"
+        );
+        var rootPlan = RootPlan(rootModel, [scalarBinding]);
+        return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []);
+    }
+
+    /// <summary>
+    /// Build a root plan with a KeyUnificationWritePlan whose scalar member has a synthetic
+    /// presence column. Returns the plan plus resolver-owned binding indices.
+    /// Bindings: [0] = canonical scalar (Precomputed), [1] = synthetic presence (Precomputed),
+    /// [2] = member-path scalar (Scalar).
+    /// </summary>
+    internal static (
+        ResourceWritePlan Plan,
+        int CanonicalBindingIndex,
+        int SyntheticPresenceBindingIndex
+    ) BuildRootPlanWithKeyUnificationPlan()
+    {
+        var canonicalColumn = Column("SchoolId_Canonical", ColumnKind.Scalar, Int32Type());
+        var presenceColumn = Column("SchoolId_LocalAlias_Present", ColumnKind.Scalar, Int32Type());
+        var memberColumn = Column(
+            "SchoolId_LocalAlias",
+            ColumnKind.Scalar,
+            Int32Type(),
+            sourceJsonPath: Path("$.localSchoolId")
+        );
+        var rootModel = RootTable("Thing", [canonicalColumn, presenceColumn, memberColumn]);
+
+        var canonicalBinding = new WriteColumnBinding(
+            canonicalColumn,
+            new WriteValueSource.Precomputed(),
+            "SchoolId_Canonical"
+        );
+        var presenceBinding = new WriteColumnBinding(
+            presenceColumn,
+            new WriteValueSource.Precomputed(),
+            "SchoolId_LocalAlias_Present"
+        );
+        var memberBinding = new WriteColumnBinding(
+            memberColumn,
+            new WriteValueSource.Scalar(Path("$.localSchoolId"), Int32Type()),
+            "SchoolId_LocalAlias"
+        );
+
+        var keyUnificationPlan = new KeyUnificationWritePlan(
+            CanonicalColumn: canonicalColumn.ColumnName,
+            CanonicalBindingIndex: 0,
+            MembersInOrder:
+            [
+                new KeyUnificationMemberWritePlan.ScalarMember(
+                    MemberPathColumn: memberColumn.ColumnName,
+                    RelativePath: Path("$.localSchoolId"),
+                    ScalarType: Int32Type(),
+                    PresenceColumn: presenceColumn.ColumnName,
+                    PresenceBindingIndex: 1,
+                    PresenceIsSynthetic: true
+                ),
+            ]
+        );
+
+        var rootPlan = RootPlan(
+            rootModel,
+            [canonicalBinding, presenceBinding, memberBinding],
+            keyUnificationPlans: [keyUnificationPlan]
+        );
+        return (WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []), 0, 1);
+    }
+
+    /// <summary>
+    /// Build a root plan whose root table has one binding with WriteValueSource.ParentKeyPart
+    /// (intentionally invalid for a root table — for the plan-shape-violation test).
+    /// Bindings: [0] = ParentKeyPart.
+    /// </summary>
+    internal static ResourceWritePlan BuildRootPlanWithParentKeyPartBinding()
+    {
+        var column = Column("ParentKeyAlien", ColumnKind.Scalar, Int32Type());
+        var rootModel = RootTable("ThingRoot", [column]);
+        var binding = new WriteColumnBinding(column, new WriteValueSource.ParentKeyPart(0), "ParentKeyAlien");
+        var rootPlan = RootPlan(rootModel, [binding]);
+        return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []);
+    }
+
+    /// <summary>
+    /// Build a root plan whose root table has a DocumentReference FK binding followed by
+    /// ReferenceDerived bindings. Bindings: [0] = DocumentReference FK,
+    /// [1..] = ReferenceDerived entries in the supplied <paramref name="derivedMemberPaths"/> order.
+    /// The RelationalResourceModel carries a matching DocumentReferenceBinding whose
+    /// ReferenceObjectPath equals <paramref name="referenceMemberPath"/>.
+    /// </summary>
+    internal static ResourceWritePlan BuildRootPlanWithDocumentReferenceBindings(
+        string referenceMemberPath,
+        string[] derivedMemberPaths
+    )
+    {
+        var referenceObjectPath = Path(referenceMemberPath);
+        var fkColumn = Column("Target_DocumentId", ColumnKind.DocumentFk, Int64Type());
+        var derivedColumns = derivedMemberPaths
+            .Select(
+                (p, i) => Column($"Target_Ref{i}", ColumnKind.Scalar, Int32Type(), sourceJsonPath: Path(p))
+            )
+            .ToArray();
+
+        var allColumns = new List<DbColumnModel> { fkColumn };
+        allColumns.AddRange(derivedColumns);
+        var rootModel = RootTable("RefHost", allColumns);
+
+        var fkBinding = new WriteColumnBinding(
+            fkColumn,
+            new WriteValueSource.DocumentReference(0),
+            "Target_DocumentId"
+        );
+        var derivedBindings = derivedColumns
+            .Select(
+                (col, i) =>
+                    new WriteColumnBinding(
+                        col,
+                        new WriteValueSource.ReferenceDerived(
+                            new ReferenceDerivedValueSourceMetadata(
+                                BindingIndex: 0,
+                                ReferenceObjectPath: referenceObjectPath,
+                                IdentityJsonPath: Path(
+                                    "$." + derivedMemberPaths[i][(referenceMemberPath.Length + 1)..]
+                                ),
+                                ReferenceJsonPath: Path(derivedMemberPaths[i])
+                            )
+                        ),
+                        col.ColumnName.Value
+                    )
+            )
+            .ToArray();
+
+        var allBindings = new List<WriteColumnBinding> { fkBinding };
+        allBindings.AddRange(derivedBindings);
+
+        var documentReferenceBinding = new DocumentReferenceBinding(
+            IsIdentityComponent: false,
+            ReferenceObjectPath: referenceObjectPath,
+            Table: rootModel.Table,
+            FkColumn: fkColumn.ColumnName,
+            TargetResource: new QualifiedResourceName("Ed-Fi", "Target"),
+            IdentityBindings: []
+        );
+
+        var rootPlan = RootPlan(rootModel, allBindings);
+        return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: [documentReferenceBinding]);
+    }
+
+    /// <summary>
+    /// Build a root plan with a single DescriptorReference binding at <paramref name="relativePath"/>.
+    /// Bindings: [0] = DescriptorReference.
+    /// </summary>
+    internal static ResourceWritePlan BuildRootPlanWithDescriptorReferenceBinding(string relativePath)
+    {
+        var column = Column("SexDescriptor_DescriptorId", ColumnKind.DescriptorFk, Int64Type());
+        var rootModel = RootTable("DescriptorHost", [column]);
+        var binding = new WriteColumnBinding(
+            column,
+            new WriteValueSource.DescriptorReference(
+                new QualifiedResourceName("Ed-Fi", "SexDescriptor"),
+                Path(relativePath),
+                DescriptorValuePath: null
+            ),
+            "SexDescriptor_DescriptorId"
+        );
+        var rootPlan = RootPlan(rootModel, [binding]);
+        return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []);
+    }
+
+    /// <summary>
+    /// Build a root plan with one Precomputed binding at [0] and one DocumentId binding at [1].
+    /// </summary>
+    internal static ResourceWritePlan BuildRootPlanWithPrecomputedAndDocumentIdBindings()
+    {
+        var preColumn = Column("PreCalc", ColumnKind.Scalar, Int32Type());
+        var docIdColumn = Column("DocumentId", ColumnKind.ParentKeyPart, Int64Type());
+        var rootModel = RootTable("StorageOnly", [preColumn, docIdColumn]);
+        var bindings = new[]
+        {
+            new WriteColumnBinding(preColumn, new WriteValueSource.Precomputed(), "PreCalc"),
+            new WriteColumnBinding(docIdColumn, new WriteValueSource.DocumentId(), "DocumentId"),
+        };
+        var rootPlan = RootPlan(rootModel, bindings);
+        return WrapPlan(rootModel, [rootPlan], documentReferenceBindings: []);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private static RelationalScalarType StringType() => new(ScalarKind.String, MaxLength: 50);
+
+    private static RelationalScalarType Int32Type() => new(ScalarKind.Int32);
+
+    private static RelationalScalarType Int64Type() => new(ScalarKind.Int64);
+
+    private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    private static DbColumnModel Column(
+        string columnName,
+        ColumnKind kind,
+        RelationalScalarType? scalarType,
+        JsonPathExpression? sourceJsonPath = null
+    ) =>
+        new(
+            ColumnName: new DbColumnName(columnName),
+            Kind: kind,
+            ScalarType: scalarType,
+            IsNullable: true,
+            SourceJsonPath: sourceJsonPath,
+            TargetResource: null,
+            Storage: new ColumnStorage.Stored()
+        );
+
+    private static DbTableModel RootTable(string name, IReadOnlyList<DbColumnModel> columns) =>
+        new(
+            Table: new DbTableName(_defaultSchema, name),
+            JsonScope: Path("$"),
+            Key: new TableKey(
+                "PK_" + name,
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns: columns,
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+    private static TableWritePlan RootPlan(
+        DbTableModel tableModel,
+        IReadOnlyList<WriteColumnBinding> bindings,
+        IReadOnlyList<KeyUnificationWritePlan>? keyUnificationPlans = null
+    ) =>
+        new(
+            TableModel: tableModel,
+            InsertSql: $"INSERT INTO {tableModel.Table.Schema.Value}.\"{tableModel.Table.Name}\" DEFAULT VALUES",
+            UpdateSql: null,
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(1000, Math.Max(1, bindings.Count), 65535),
+            ColumnBindings: bindings,
+            KeyUnificationPlans: keyUnificationPlans ?? []
+        );
+
+    private static ResourceWritePlan WrapPlan(
+        DbTableModel rootModel,
+        IReadOnlyList<TableWritePlan> tablePlans,
+        IReadOnlyList<DocumentReferenceBinding> documentReferenceBindings
+    ) =>
+        new(
+            new RelationalResourceModel(
+                Resource: _defaultResource,
+                PhysicalSchema: _defaultSchema,
+                StorageKind: ResourceStorageKind.RelationalTables,
+                Root: rootModel,
+                TablesInDependencyOrder: tablePlans.Select(p => p.TableModel).ToList(),
+                DocumentReferenceBindings: documentReferenceBindings,
+                DescriptorEdgeSources: []
+            ),
+            tablePlans
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
@@ -266,6 +266,107 @@ public class Given_ProfileSynthesizer_request_with_inconsistent_current_state_an
 }
 
 [TestFixture]
+public class Given_ProfileMergeRequest_with_root_extension_rows_present
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan();
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        var rootPlan = plan.TablePlansInDependencyOrder[0];
+        var extensionTableModel = AdapterFactoryTestFixtures.BuildRootExtensionTableModel();
+        var extensionPlan = AdapterFactoryTestFixtures.BuildRootExtensionTableWritePlan(extensionTableModel);
+        var extensionRow = new RootExtensionWriteRowBuffer(
+            extensionPlan,
+            [new FlattenedWriteValue.Literal(null), new FlattenedWriteValue.Literal("Blue")]
+        );
+        var flattenedWriteSet = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [new FlattenedWriteValue.Literal("Ada")],
+                rootExtensionRows: [extensionRow]
+            )
+        );
+
+        _act = () =>
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: flattenedWriteSet,
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: null,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            );
+    }
+
+    [Test]
+    public void It_throws_ArgumentException_about_root_only_shape()
+    {
+        _act.Should().Throw<ArgumentException>().WithMessage("*root-only*fenced upstream*");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileMergeRequest_with_root_collection_candidates_present
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan();
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        var rootPlan = plan.TablePlansInDependencyOrder[0];
+        var collectionTableModel = AdapterFactoryTestFixtures.BuildCollectionTableModel();
+        var collectionPlan = AdapterFactoryTestFixtures.BuildCollectionTableWritePlan(collectionTableModel);
+        var collectionCandidate = new CollectionWriteCandidate(
+            tableWritePlan: collectionPlan,
+            ordinalPath: [0],
+            requestOrder: 0,
+            values:
+            [
+                FlattenedWriteValue.UnresolvedCollectionItemId.Create(),
+                FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                new FlattenedWriteValue.Literal(0),
+                new FlattenedWriteValue.Literal("Physical"),
+            ],
+            semanticIdentityValues: ["Physical"]
+        );
+        var flattenedWriteSet = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [new FlattenedWriteValue.Literal("Ada")],
+                collectionCandidates: [collectionCandidate]
+            )
+        );
+
+        _act = () =>
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: flattenedWriteSet,
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: null,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            );
+    }
+
+    [Test]
+    public void It_throws_ArgumentException_about_root_only_shape()
+    {
+        _act.Should().Throw<ArgumentException>().WithMessage("*root-only*fenced upstream*");
+    }
+}
+
+[TestFixture]
 public class Given_ProfileSynthesizer_with_key_unification_plan_visible_member
 {
     private RelationalWriteMergeResult _result = null!;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Profile;
+using EdFi.DataManagementService.Core.Profile;
+using FluentAssertions;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Backend.Tests.Unit.Profile.ProfileTestDoubles;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
+
+[TestFixture]
+public class Given_ProfileSynthesizer_for_CreateNew_with_single_scalar_binding
+{
+    private RelationalWriteMergeResult _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.firstName");
+        var body = new JsonObject { ["firstName"] = "Ada" };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        var synthesizer = BuildProfileSynthesizer();
+        _result = synthesizer.Synthesize(
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "Ada"),
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: null,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            )
+        );
+    }
+
+    [Test]
+    public void It_does_not_support_guarded_no_op() => _result.SupportsGuardedNoOp.Should().BeFalse();
+
+    [Test]
+    public void It_produces_single_table_state() => _result.TablesInDependencyOrder.Length.Should().Be(1);
+
+    [Test]
+    public void It_has_empty_current_rows() =>
+        _result.TablesInDependencyOrder[0].CurrentRows.Should().BeEmpty();
+
+    [Test]
+    public void It_has_one_merged_row_with_flattener_value()
+    {
+        _result.TablesInDependencyOrder[0].MergedRows.Should().ContainSingle();
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].MergedRows[0].Values[0])
+            .Value.Should()
+            .Be("Ada");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_for_ExistingDocument_with_hidden_scalar_binding
+{
+    private RelationalWriteMergeResult _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.birthDate");
+        var body = new JsonObject { ["birthDate"] = "2026-01-01" };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "birthDate")
+        );
+
+        var synthesizer = BuildProfileSynthesizer();
+        _result = synthesizer.Synthesize(
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "request-value"),
+                writableRequestBody: body,
+                currentState: BuildCurrentStateWithSingleRootRow(plan, "stored-value"),
+                profileRequest: request,
+                profileAppliedContext: appliedContext,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            )
+        );
+    }
+
+    [Test]
+    public void It_preserves_stored_value_on_hidden_binding()
+    {
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].MergedRows[0].Values[0])
+            .Value.Should()
+            .Be("stored-value");
+    }
+
+    [Test]
+    public void It_includes_projected_current_row()
+    {
+        _result.TablesInDependencyOrder[0].CurrentRows.Should().ContainSingle();
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].CurrentRows[0].Values[0])
+            .Value.Should()
+            .Be("stored-value");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_for_ExistingDocument_with_visible_absent_inlined_scope
+{
+    private RelationalWriteMergeResult _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.birthData.birthCity");
+        var body = new JsonObject();
+        var request = CreateRequest(
+            writableBody: body,
+            rootResourceCreatable: true,
+            RequestVisiblePresentScope("$"),
+            RequestVisibleAbsentScope("$.birthData")
+        );
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisibleAbsentScope("$.birthData")
+        );
+
+        var synthesizer = BuildProfileSynthesizer();
+        _result = synthesizer.Synthesize(
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "flattener-value"),
+                writableRequestBody: body,
+                currentState: BuildCurrentStateWithSingleRootRow(plan, "stored-value"),
+                profileRequest: request,
+                profileAppliedContext: appliedContext,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            )
+        );
+    }
+
+    [Test]
+    public void It_writes_null_literal_for_visible_absent_binding()
+    {
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].MergedRows[0].Values[0])
+            .Value.Should()
+            .BeNull();
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_with_HiddenPreserved_binding_and_null_CurrentState
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan(scalarRelativePath: "$.firstName");
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        // Force HiddenPreserved disposition using a stub classifier, while passing null
+        // CurrentState. The synthesizer must refuse to proceed and surface the drift as
+        // an InvalidOperationException.
+        var classification = new ProfileRootTableBindingClassification(
+            BindingsByIndex: [RootBindingDisposition.HiddenPreserved],
+            ResolverOwnedBindingIndices: ImmutableHashSet<int>.Empty
+        );
+        var synthesizer = new RelationalWriteProfileMergeSynthesizer(
+            new StubClassifier(classification),
+            new NoOpResolver()
+        );
+
+        _act = () =>
+            synthesizer.Synthesize(
+                new RelationalWriteProfileMergeRequest(
+                    writePlan: plan,
+                    flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "value"),
+                    writableRequestBody: body,
+                    currentState: null,
+                    profileRequest: request,
+                    profileAppliedContext: null,
+                    resolvedReferences: EmptyResolvedReferenceSet()
+                )
+            );
+    }
+
+    [Test]
+    public void It_throws_InvalidOperationException()
+    {
+        _act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage("*HiddenPreserved*no current row is available*");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_request_with_multi_table_plan
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Construct a plan with a single root table, then compose a second ResourceWritePlan
+        // artificially by wrapping a duplicate TableWritePlan reference — quickest way to
+        // violate the invariant without fabricating a second table model.
+        var plan = BuildSingleScalarBindingRootPlan();
+        var rootPlan = plan.TablePlansInDependencyOrder[0];
+        var multiPlan = new ResourceWritePlan(plan.Model, [rootPlan, rootPlan]);
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        _act = () =>
+            new RelationalWriteProfileMergeRequest(
+                writePlan: multiPlan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "x"),
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: null,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            );
+    }
+
+    [Test]
+    public void It_throws_ArgumentException_about_single_table_write_plan()
+    {
+        _act.Should().Throw<ArgumentException>().WithMessage("*single-table write plan*");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_request_with_mismatched_applied_context_request
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan();
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var otherRequest = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var mismatchedAppliedContext = CreateContext(otherRequest);
+
+        _act = () =>
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "x"),
+                writableRequestBody: body,
+                currentState: BuildCurrentStateWithSingleRootRow(plan, "stored"),
+                profileRequest: request,
+                profileAppliedContext: mismatchedAppliedContext,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            );
+    }
+
+    [Test]
+    public void It_throws_ArgumentException_about_same_instance()
+    {
+        _act.Should().Throw<ArgumentException>().WithMessage("*same instance*");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_request_with_inconsistent_current_state_and_applied_context
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var plan = BuildSingleScalarBindingRootPlan();
+        var body = new JsonObject();
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(request);
+
+        _act = () =>
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "x"),
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: appliedContext,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            );
+    }
+
+    [Test]
+    public void It_throws_ArgumentException_about_both_null_or_both_non_null()
+    {
+        _act.Should().Throw<ArgumentException>().WithMessage("*both be null*both be non-null*");
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_with_key_unification_plan_visible_member
+{
+    private RelationalWriteMergeResult _result = null!;
+    private int _canonicalIndex;
+    private int _presenceIndex;
+    private int _memberIndex;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, canonicalIdx, presenceIndicesByPath) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: true
+            ),
+        ]);
+        _canonicalIndex = canonicalIdx;
+        _presenceIndex = presenceIndicesByPath["$.memberA"];
+        // Bindings: 0=canonical (Precomputed), 1=presence (Precomputed), 2=member (Scalar).
+        _memberIndex = 2;
+
+        var body = new JsonObject { ["memberA"] = 42 };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+
+        var synthesizer = BuildProfileSynthesizer();
+        // Flattener sourced value goes at the member (scalar) binding index. Canonical and
+        // presence bindings are resolver-owned so their flattener positions are ignored.
+        var flattenerValues = new object?[plan.TablePlansInDependencyOrder[0].ColumnBindings.Length];
+        flattenerValues[_memberIndex] = 42;
+
+        _result = synthesizer.Synthesize(
+            new RelationalWriteProfileMergeRequest(
+                writePlan: plan,
+                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, flattenerValues),
+                writableRequestBody: body,
+                currentState: null,
+                profileRequest: request,
+                profileAppliedContext: null,
+                resolvedReferences: EmptyResolvedReferenceSet()
+            )
+        );
+    }
+
+    [Test]
+    public void It_does_not_support_guarded_no_op() => _result.SupportsGuardedNoOp.Should().BeFalse();
+
+    [Test]
+    public void It_writes_canonical_from_resolver()
+    {
+        (
+            (FlattenedWriteValue.Literal)
+                _result.TablesInDependencyOrder[0].MergedRows[0].Values[_canonicalIndex]
+        )
+            .Value.Should()
+            .Be(42);
+    }
+
+    [Test]
+    public void It_writes_synthetic_presence_true_from_resolver()
+    {
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].MergedRows[0].Values[_presenceIndex])
+            .Value.Should()
+            .Be(true);
+    }
+
+    [Test]
+    public void It_preserves_flattener_sourced_member_binding()
+    {
+        ((FlattenedWriteValue.Literal)_result.TablesInDependencyOrder[0].MergedRows[0].Values[_memberIndex])
+            .Value.Should()
+            .Be(42);
+    }
+}
+
+[TestFixture]
+public class Given_ProfileSynthesizer_propagates_resolver_disagreement_exception
+{
+    private Action _act = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var (plan, _, _) = BuildRootPlanWithKeyUnificationMembers([
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberA",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+            new KeyUnificationMemberSpec(
+                RelativePath: "$.memberB",
+                SourceKind: KeyUnificationMemberSourceKind.Scalar,
+                PresenceSynthetic: false
+            ),
+        ]);
+
+        // memberA visible (from body) = 1, memberB hidden-preserved from stored = 2.
+        // Resolver's first-present-wins should detect disagreement and raise a validation
+        // exception, which the synthesizer must propagate unchanged.
+        var body = new JsonObject { ["memberA"] = 1 };
+        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
+        var appliedContext = CreateContext(
+            request,
+            storedScopeStates: StoredVisiblePresentScope("$", "memberB")
+        );
+
+        var rootTable = plan.TablePlansInDependencyOrder[0];
+        // Columns: 0=canonical, 1=memberA, 2=memberB (no presence columns since synthetic=false).
+        var storedRow = new object?[rootTable.TableModel.Columns.Count];
+        storedRow[0] = null;
+        storedRow[1] = null;
+        storedRow[2] = 2;
+
+        var synthesizer = BuildProfileSynthesizer();
+        _act = () =>
+            synthesizer.Synthesize(
+                new RelationalWriteProfileMergeRequest(
+                    writePlan: plan,
+                    flattenedWriteSet: BuildFlattenedWriteSetFrom(plan),
+                    writableRequestBody: body,
+                    currentState: BuildCurrentStateWithSingleRootRow(plan, storedRow),
+                    profileRequest: request,
+                    profileAppliedContext: appliedContext,
+                    resolvedReferences: EmptyResolvedReferenceSet()
+                )
+            );
+    }
+
+    [Test]
+    public void It_propagates_RelationalWriteRequestValidationException()
+    {
+        _act.Should().Throw<RelationalWriteRequestValidationException>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/RelationalWriteProfileMergeSynthesizerTests.cs
@@ -201,42 +201,6 @@ public class Given_ProfileSynthesizer_with_HiddenPreserved_binding_and_null_Curr
 }
 
 [TestFixture]
-public class Given_ProfileSynthesizer_request_with_multi_table_plan
-{
-    private Action _act = null!;
-
-    [SetUp]
-    public void Setup()
-    {
-        // Construct a plan with a single root table, then compose a second ResourceWritePlan
-        // artificially by wrapping a duplicate TableWritePlan reference — quickest way to
-        // violate the invariant without fabricating a second table model.
-        var plan = BuildSingleScalarBindingRootPlan();
-        var rootPlan = plan.TablePlansInDependencyOrder[0];
-        var multiPlan = new ResourceWritePlan(plan.Model, [rootPlan, rootPlan]);
-        var body = new JsonObject();
-        var request = CreateRequest(writableBody: body, scopeStates: RequestVisiblePresentScope("$"));
-
-        _act = () =>
-            new RelationalWriteProfileMergeRequest(
-                writePlan: multiPlan,
-                flattenedWriteSet: BuildFlattenedWriteSetFrom(plan, "x"),
-                writableRequestBody: body,
-                currentState: null,
-                profileRequest: request,
-                profileAppliedContext: null,
-                resolvedReferences: EmptyResolvedReferenceSet()
-            );
-    }
-
-    [Test]
-    public void It_throws_ArgumentException_about_single_table_write_plan()
-    {
-        _act.Should().Throw<ArgumentException>().WithMessage("*single-table write plan*");
-    }
-}
-
-[TestFixture]
 public class Given_ProfileSynthesizer_request_with_mismatched_applied_context_request
 {
     private Action _act = null!;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverServiceCollectionExtensionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverServiceCollectionExtensionsTests.cs
@@ -73,8 +73,7 @@ public class Given_ReferenceResolver_Service_Collection_Extensions
             scope.ServiceProvider.GetRequiredService<IRelationalWriteFreshnessChecker>();
         var noProfileMergeSynthesizer =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfileMergeSynthesizer>();
-        var noProfilePersister =
-            scope.ServiceProvider.GetRequiredService<IRelationalWriteNoProfilePersister>();
+        var noProfilePersister = scope.ServiceProvider.GetRequiredService<IRelationalWritePersister>();
         var writeExceptionClassifier =
             scope.ServiceProvider.GetRequiredService<IRelationalWriteExceptionClassifier>();
         var descriptorWriteHandler = scope.ServiceProvider.GetRequiredService<IDescriptorWriteHandler>();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteExtensionCollectionMergeSynthesizerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteExtensionCollectionMergeSynthesizerTests.cs
@@ -258,8 +258,8 @@ public class Given_Relational_Write_No_Profile_Merge_Synthesizer_Extension_Colle
         RelationalWriteGuardedNoOp.IsNoOpCandidate(result).Should().BeTrue();
     }
 
-    private static RelationalWriteNoProfileTableState RequireState(
-        RelationalWriteNoProfileMergeResult result,
+    private static RelationalWriteMergedTableState RequireState(
+        RelationalWriteMergeResult result,
         TableWritePlan tableWritePlan
     )
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteNoProfilePersisterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteNoProfilePersisterTests.cs
@@ -35,18 +35,21 @@ public class Given_Relational_Write_No_Profile_Persister
         var rootExtensionPlan = CreateRootExtensionPlan();
         var writePlan = CreateWritePlan([rootPlan, rootExtensionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Post);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [],
-                [CreateRow(FlattenedWriteValue.UnresolvedRootDocumentId.Instance, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                rootExtensionPlan,
-                [],
-                [CreateRow(FlattenedWriteValue.UnresolvedRootDocumentId.Instance, "BLUE")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [],
+                    [CreateRow(FlattenedWriteValue.UnresolvedRootDocumentId.Instance, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    rootExtensionPlan,
+                    [],
+                    [CreateRow(FlattenedWriteValue.UnresolvedRootDocumentId.Instance, "BLUE")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(ScalarResult: 910L),
             new CommandResponse(),
@@ -86,13 +89,16 @@ public class Given_Relational_Write_No_Profile_Persister
         var rootPlan = CreateRootPlan(includeShortName: true);
         var writePlan = CreateWritePlan([rootPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High", "LHS")],
-                [CreateRow(345L, 255901, "Lincoln High Updated", null)]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High", "LHS")],
+                    [CreateRow(345L, 255901, "Lincoln High Updated", null)]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([new CommandResponse()]);
 
         var result = await _sut.PersistAsync(request, mergeResult, writeSession);
@@ -120,14 +126,17 @@ public class Given_Relational_Write_No_Profile_Persister
         var rootExtensionPlan = CreateRootExtensionPlan();
         var writePlan = CreateWritePlan([rootPlan, rootExtensionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(rootExtensionPlan, [CreateRow(345L, "BLUE")], []),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(rootExtensionPlan, [CreateRow(345L, "BLUE")], []),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([new CommandResponse()]);
 
         await _sut.PersistAsync(request, mergeResult, writeSession);
@@ -145,23 +154,26 @@ public class Given_Relational_Write_No_Profile_Persister
         var collectionExtensionScopePlan = CreateCollectionExtensionScopePlan();
         var writePlan = CreateWritePlan([rootPlan, collectionPlan, collectionExtensionScopePlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [CreateRow(44L, 345L, 0, "Mailing")],
-                [CreateRow(44L, 345L, 0, "Mailing")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [CreateRow(44L, "Blue")],
-                [CreateRow(44L, "Red")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [CreateRow(44L, 345L, 0, "Mailing")],
+                    [CreateRow(44L, 345L, 0, "Mailing")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [CreateRow(44L, "Blue")],
+                    [CreateRow(44L, "Red")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([new CommandResponse()]);
 
         await _sut.PersistAsync(request, mergeResult, writeSession);
@@ -186,38 +198,41 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan, collectionExtensionScopePlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ],
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [],
-                [
-                    CreateRow(44L, "Blue"),
-                    CreateRow(45L, "Red"),
-                    CreateRow(46L, "Orange"),
-                    CreateRow(47L, "Purple"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ],
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [],
+                    [
+                        CreateRow(44L, "Blue"),
+                        CreateRow(45L, "Red"),
+                        CreateRow(46L, "Orange"),
+                        CreateRow(47L, "Purple"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -262,43 +277,46 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan, collectionExtensionScopePlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ],
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [
-                    CreateRow(44L, "Blue"),
-                    CreateRow(45L, "Green"),
-                    CreateRow(46L, "Orange"),
-                    CreateRow(47L, "Purple"),
-                ],
-                [
-                    CreateRow(44L, "Blue-Updated"),
-                    CreateRow(45L, "Green-Updated"),
-                    CreateRow(46L, "Orange-Updated"),
-                    CreateRow(47L, "Purple-Updated"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ],
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [
+                        CreateRow(44L, "Blue"),
+                        CreateRow(45L, "Green"),
+                        CreateRow(46L, "Orange"),
+                        CreateRow(47L, "Purple"),
+                    ],
+                    [
+                        CreateRow(44L, "Blue-Updated"),
+                        CreateRow(45L, "Green-Updated"),
+                        CreateRow(46L, "Orange-Updated"),
+                        CreateRow(47L, "Purple-Updated"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -343,38 +361,41 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan, collectionExtensionScopePlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ],
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                    CreateRow(47L, 345L, 3, "Shipping"),
-                ]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [
-                    CreateRow(44L, "Blue"),
-                    CreateRow(45L, "Green"),
-                    CreateRow(46L, "Orange"),
-                    CreateRow(47L, "Purple"),
-                ],
-                []
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ],
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                        CreateRow(47L, 345L, 3, "Shipping"),
+                    ]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [
+                        CreateRow(44L, "Blue"),
+                        CreateRow(45L, "Green"),
+                        CreateRow(46L, "Orange"),
+                        CreateRow(47L, "Purple"),
+                    ],
+                    []
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -413,23 +434,26 @@ public class Given_Relational_Write_No_Profile_Persister
         var writePlan = CreateWritePlan([rootPlan, collectionExtensionScopePlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
         var addressCollectionItemId = NewCollectionItemId();
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [],
-                [CreateRow(addressCollectionItemId, "Blue")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [],
-                [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [],
+                    [CreateRow(addressCollectionItemId, "Blue")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [],
+                    [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(ScalarResult: 910L),
             new CommandResponse(),
@@ -458,31 +482,34 @@ public class Given_Relational_Write_No_Profile_Persister
         var collectionExtensionScopePlan = CreateCollectionExtensionScopePlan();
         var writePlan = CreateWritePlan([rootPlan, collectionPlan, collectionExtensionScopePlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                ],
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Work"),
-                ]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionExtensionScopePlan,
-                [CreateRow(44L, "Blue"), CreateRow(45L, "Green")],
-                [CreateRow(44L, "Purple"), CreateRow(46L, "Orange")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                    ],
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Work"),
+                    ]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionExtensionScopePlan,
+                    [CreateRow(44L, "Blue"), CreateRow(45L, "Green")],
+                    [CreateRow(44L, "Purple"), CreateRow(46L, "Orange")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -512,18 +539,21 @@ public class Given_Relational_Write_No_Profile_Persister
         var collectionPlan = CreateCollectionPlan();
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [CreateRow(44L, 345L, 0, "Mailing"), CreateRow(45L, 345L, 1, "Home")],
-                [CreateRow(45L, 345L, 0, "Home"), CreateRow(NewCollectionItemId(), 345L, 1, "Physical")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [CreateRow(44L, 345L, 0, "Mailing"), CreateRow(45L, 345L, 1, "Home")],
+                    [CreateRow(45L, 345L, 0, "Home"), CreateRow(NewCollectionItemId(), 345L, 1, "Physical")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -567,23 +597,26 @@ public class Given_Relational_Write_No_Profile_Persister
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
         var addressCollectionItemId = NewCollectionItemId();
         var periodCollectionItemId = NewCollectionItemId();
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                addressPlan,
-                [],
-                [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                periodPlan,
-                [],
-                [CreateRow(periodCollectionItemId, 345L, addressCollectionItemId, 0, "2026-09-01")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    addressPlan,
+                    [],
+                    [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
+                ),
+                new RelationalWriteMergedTableState(
+                    periodPlan,
+                    [],
+                    [CreateRow(periodCollectionItemId, 345L, addressCollectionItemId, 0, "2026-09-01")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(ScalarResult: 910L),
             new CommandResponse(),
@@ -616,21 +649,24 @@ public class Given_Relational_Write_No_Profile_Persister
         var extensionCollectionPlan = CreateExtensionCollectionPlan();
         var writePlan = CreateWritePlan([rootPlan, extensionCollectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                extensionCollectionPlan,
-                [CreateRow(44L, 345L, 0, "Tutor"), CreateRow(45L, 345L, 1, "Mentor")],
-                [
-                    CreateRow(45L, 345L, 0, "Mentor Updated"),
-                    CreateRow(NewCollectionItemId(), 345L, 1, "Coach"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    extensionCollectionPlan,
+                    [CreateRow(44L, 345L, 0, "Tutor"), CreateRow(45L, 345L, 1, "Mentor")],
+                    [
+                        CreateRow(45L, 345L, 0, "Mentor Updated"),
+                        CreateRow(NewCollectionItemId(), 345L, 1, "Coach"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -672,26 +708,29 @@ public class Given_Relational_Write_No_Profile_Persister
         var collectionAlignedExtensionChildPlan = CreateCollectionAlignedExtensionChildCollectionPlan();
         var writePlan = CreateWritePlan([rootPlan, addressPlan, collectionAlignedExtensionChildPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                addressPlan,
-                [CreateRow(44L, 345L, 0, "Home")],
-                [CreateRow(44L, 345L, 0, "Home")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionAlignedExtensionChildPlan,
-                [CreateRow(500L, 345L, 44L, 0, "Bus"), CreateRow(501L, 345L, 44L, 1, "Meal")],
-                [
-                    CreateRow(501L, 345L, 44L, 0, "Meal Updated"),
-                    CreateRow(NewCollectionItemId(), 345L, 44L, 1, "Tutor"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    addressPlan,
+                    [CreateRow(44L, 345L, 0, "Home")],
+                    [CreateRow(44L, 345L, 0, "Home")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionAlignedExtensionChildPlan,
+                    [CreateRow(500L, 345L, 44L, 0, "Bus"), CreateRow(501L, 345L, 44L, 1, "Meal")],
+                    [
+                        CreateRow(501L, 345L, 44L, 0, "Meal Updated"),
+                        CreateRow(NewCollectionItemId(), 345L, 44L, 1, "Tutor"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -737,23 +776,26 @@ public class Given_Relational_Write_No_Profile_Persister
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
         var addressCollectionItemId = NewCollectionItemId();
         var serviceCollectionItemId = NewCollectionItemId();
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                addressPlan,
-                [],
-                [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionAlignedExtensionChildPlan,
-                [],
-                [CreateRow(serviceCollectionItemId, 345L, addressCollectionItemId, 0, "Bus")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    addressPlan,
+                    [],
+                    [CreateRow(addressCollectionItemId, 345L, 0, "Home")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionAlignedExtensionChildPlan,
+                    [],
+                    [CreateRow(serviceCollectionItemId, 345L, addressCollectionItemId, 0, "Bus")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(ScalarResult: 910L),
             new CommandResponse(),
@@ -793,30 +835,33 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Physical"),
-                    CreateRow(47L, 345L, 3, "Temporary"),
-                    CreateRow(48L, 345L, 4, "Shipping"),
-                ],
-                [
-                    CreateRow(44L, 345L, 0, "Mailing Updated"),
-                    CreateRow(45L, 345L, 1, "Home Updated"),
-                    CreateRow(46L, 345L, 2, "Physical Updated"),
-                    CreateRow(47L, 345L, 3, "Temporary Updated"),
-                    CreateRow(48L, 345L, 4, "Shipping Updated"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Physical"),
+                        CreateRow(47L, 345L, 3, "Temporary"),
+                        CreateRow(48L, 345L, 4, "Shipping"),
+                    ],
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing Updated"),
+                        CreateRow(45L, 345L, 1, "Home Updated"),
+                        CreateRow(46L, 345L, 2, "Physical Updated"),
+                        CreateRow(47L, 345L, 3, "Temporary Updated"),
+                        CreateRow(48L, 345L, 4, "Shipping Updated"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -862,24 +907,27 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Physical"),
-                    CreateRow(47L, 345L, 3, "Temporary"),
-                    CreateRow(48L, 345L, 4, "Shipping"),
-                ],
-                []
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Physical"),
+                        CreateRow(47L, 345L, 3, "Temporary"),
+                        CreateRow(48L, 345L, 4, "Shipping"),
+                    ],
+                    []
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -927,24 +975,27 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put, SqlDialect.Mssql);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [
-                    CreateRow(44L, 345L, 0, "Mailing"),
-                    CreateRow(45L, 345L, 1, "Home"),
-                    CreateRow(46L, 345L, 2, "Physical"),
-                    CreateRow(47L, 345L, 3, "Temporary"),
-                    CreateRow(48L, 345L, 4, "Shipping"),
-                ],
-                []
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [
+                        CreateRow(44L, 345L, 0, "Mailing"),
+                        CreateRow(45L, 345L, 1, "Home"),
+                        CreateRow(46L, 345L, 2, "Physical"),
+                        CreateRow(47L, 345L, 3, "Temporary"),
+                        CreateRow(48L, 345L, 4, "Shipping"),
+                    ],
+                    []
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -992,18 +1043,21 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [CreateRow(44L, 345L, 0, "Mailing"), CreateRow(45L, 345L, 1, "Home")],
-                [CreateRow(45L, 345L, 0, "Home"), CreateRow(44L, 345L, 1, "Mailing")]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [CreateRow(44L, 345L, 0, "Mailing"), CreateRow(45L, 345L, 1, "Home")],
+                    [CreateRow(45L, 345L, 0, "Home"), CreateRow(44L, 345L, 1, "Mailing")]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(),
             new CommandResponse(),
@@ -1048,24 +1102,27 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [],
-                [
-                    CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
-                    CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
-                    CreateRow(NewCollectionItemId(), 345L, 2, "Physical"),
-                    CreateRow(NewCollectionItemId(), 345L, 3, "Temporary"),
-                    CreateRow(NewCollectionItemId(), 345L, 4, "Shipping"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [],
+                    [
+                        CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
+                        CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
+                        CreateRow(NewCollectionItemId(), 345L, 2, "Physical"),
+                        CreateRow(NewCollectionItemId(), 345L, 3, "Temporary"),
+                        CreateRow(NewCollectionItemId(), 345L, 4, "Shipping"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(
                 ReservationRows:
@@ -1129,21 +1186,24 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put, SqlDialect.Mssql);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [],
-                [
-                    CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
-                    CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [],
+                    [
+                        CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
+                        CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(
                 ReservationRows:
@@ -1183,24 +1243,27 @@ public class Given_Relational_Write_No_Profile_Persister
         };
         var writePlan = CreateWritePlan([rootPlan, collectionPlan]);
         var request = CreateRequest(writePlan, RelationalWriteOperationKind.Put, SqlDialect.Mssql);
-        var mergeResult = new RelationalWriteNoProfileMergeResult([
-            new RelationalWriteNoProfileTableState(
-                rootPlan,
-                [CreateRow(345L, 255901, "Lincoln High")],
-                [CreateRow(345L, 255901, "Lincoln High")]
-            ),
-            new RelationalWriteNoProfileTableState(
-                collectionPlan,
-                [],
-                [
-                    CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
-                    CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
-                    CreateRow(NewCollectionItemId(), 345L, 2, "Physical"),
-                    CreateRow(NewCollectionItemId(), 345L, 3, "Temporary"),
-                    CreateRow(NewCollectionItemId(), 345L, 4, "Shipping"),
-                ]
-            ),
-        ]);
+        var mergeResult = new RelationalWriteMergeResult(
+            [
+                new RelationalWriteMergedTableState(
+                    rootPlan,
+                    [CreateRow(345L, 255901, "Lincoln High")],
+                    [CreateRow(345L, 255901, "Lincoln High")]
+                ),
+                new RelationalWriteMergedTableState(
+                    collectionPlan,
+                    [],
+                    [
+                        CreateRow(NewCollectionItemId(), 345L, 0, "Mailing"),
+                        CreateRow(NewCollectionItemId(), 345L, 1, "Home"),
+                        CreateRow(NewCollectionItemId(), 345L, 2, "Physical"),
+                        CreateRow(NewCollectionItemId(), 345L, 3, "Temporary"),
+                        CreateRow(NewCollectionItemId(), 345L, 4, "Shipping"),
+                    ]
+                ),
+            ],
+            supportsGuardedNoOp: true
+        );
         var writeSession = new RecordingRelationalWriteSession([
             new CommandResponse(
                 ReservationRows:
@@ -2017,9 +2080,9 @@ public class Given_Relational_Write_No_Profile_Persister
         );
     }
 
-    private static RelationalWriteNoProfileTableRow CreateRow(params object?[] values)
+    private static RelationalWriteMergedTableRow CreateRow(params object?[] values)
     {
-        return new RelationalWriteNoProfileTableRow(
+        return new RelationalWriteMergedTableRow(
             values.Select(value =>
                 value switch
                 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -25,6 +25,7 @@ internal sealed class DefaultRelationalWriteExecutor(
     IRelationalWriteTargetLookupResolver targetLookupResolver,
     IRelationalWriteFreshnessChecker writeFreshnessChecker,
     IRelationalWriteNoProfileMergeSynthesizer noProfileMergeSynthesizer,
+    IRelationalWriteProfileMergeSynthesizer profileMergeSynthesizer,
     IRelationalWritePersister persister,
     IRelationalWriteExceptionClassifier writeExceptionClassifier,
     IRelationalWriteConstraintResolver writeConstraintResolver,
@@ -56,6 +57,9 @@ internal sealed class DefaultRelationalWriteExecutor(
 
     private readonly IRelationalWriteNoProfileMergeSynthesizer _noProfileMergeSynthesizer =
         noProfileMergeSynthesizer ?? throw new ArgumentNullException(nameof(noProfileMergeSynthesizer));
+
+    private readonly IRelationalWriteProfileMergeSynthesizer _profileMergeSynthesizer =
+        profileMergeSynthesizer ?? throw new ArgumentNullException(nameof(profileMergeSynthesizer));
 
     private readonly IRelationalWritePersister _persister =
         persister ?? throw new ArgumentNullException(nameof(persister));
@@ -149,7 +153,9 @@ internal sealed class DefaultRelationalWriteExecutor(
                 currentState = inSessionTargetResolution.CurrentState;
             }
 
-            // Profile decision sequence — runs before flattening
+            RelationalWriteMergeResult mergeResult;
+
+            // Profile decision sequence — runs before flattening for profile-aware dispatch
             if (request.ProfileWriteContext is not null)
             {
                 var profileWriteContext = request.ProfileWriteContext;
@@ -246,25 +252,61 @@ internal sealed class DefaultRelationalWriteExecutor(
                         topologyIndex
                     );
 
-                // After Slice 1 lands, no families are landed.
-                // Later slices remove families from this fence.
-                await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                return BuildSliceFenceResult(request.OperationKind, requiredFamily);
+                if (requiredFamily != RequiredSliceFamily.RootTableOnly)
+                {
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return BuildSliceFenceResult(request.OperationKind, requiredFamily);
+                }
+
+                if (request.WritePlan.TablePlansInDependencyOrder.Length > 1)
+                {
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return BuildSliceTwoShapeGateResult(request.OperationKind);
+                }
+
+                // Slice-2 gate passed: flatten + profile synthesize.
+                var profileFlattenedWriteSet = _writeFlattener.Flatten(
+                    new FlatteningInput(
+                        executionRequest.OperationKind,
+                        executionRequest.TargetContext,
+                        executionRequest.WritePlan,
+                        executionRequest.SelectedBody,
+                        resolvedReferences
+                    )
+                );
+
+                mergeResult = _profileMergeSynthesizer.Synthesize(
+                    new RelationalWriteProfileMergeRequest(
+                        executionRequest.WritePlan,
+                        profileFlattenedWriteSet,
+                        executionRequest.SelectedBody,
+                        currentState,
+                        profileWriteContext.Request,
+                        profileAppliedWriteContext,
+                        resolvedReferences
+                    )
+                );
             }
+            else
+            {
+                var flattenedWriteSet = _writeFlattener.Flatten(
+                    new FlatteningInput(
+                        executionRequest.OperationKind,
+                        executionRequest.TargetContext,
+                        executionRequest.WritePlan,
+                        executionRequest.SelectedBody,
+                        resolvedReferences
+                    )
+                );
 
-            var flattenedWriteSet = _writeFlattener.Flatten(
-                new FlatteningInput(
-                    executionRequest.OperationKind,
-                    executionRequest.TargetContext,
-                    executionRequest.WritePlan,
-                    executionRequest.SelectedBody,
-                    resolvedReferences
-                )
-            );
-
-            var mergeResult = _noProfileMergeSynthesizer.Synthesize(
-                new RelationalWriteNoProfileMergeRequest(request.WritePlan, flattenedWriteSet, currentState)
-            );
+                mergeResult = _noProfileMergeSynthesizer.Synthesize(
+                    new RelationalWriteNoProfileMergeRequest(
+                        request.WritePlan,
+                        flattenedWriteSet,
+                        currentState
+                    )
+                );
+            }
 
             var identityStabilityFailure = RelationalWriteIdentityStability.TryBuildFailureResult(
                 executionRequest,
@@ -572,6 +614,24 @@ internal sealed class DefaultRelationalWriteExecutor(
     )
     {
         var message = $"Profile-aware persist for {requiredFamily} shapes is not yet supported (DMS-1124).";
+        return operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UnknownFailure(message)
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UnknownFailure(message)
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
+        };
+    }
+
+    private static RelationalWriteExecutorResult BuildSliceTwoShapeGateResult(
+        RelationalWriteOperationKind operationKind
+    )
+    {
+        const string message =
+            "Slice 2 only supports profiled single-table root-only write plans (DMS-1124).";
         return operationKind switch
         {
             RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -258,13 +258,11 @@ internal sealed class DefaultRelationalWriteExecutor(
                     return BuildSliceFenceResult(request.OperationKind, requiredFamily);
                 }
 
-                if (request.WritePlan.TablePlansInDependencyOrder.Length > 1)
-                {
-                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                    return BuildSliceTwoShapeGateResult(request.OperationKind);
-                }
-
-                // Slice-2 gate passed: flatten + profile synthesize.
+                // Slice-2 classification passed: flatten + profile synthesize. The profile merge
+                // synthesizer itself is root-only; non-root tables absent from its merge result are
+                // left untouched by the persister, which is the correct behavior for Slice 2 shapes
+                // whose runtime semantics are confined to the root table (e.g. hidden separate-table
+                // scopes on an existing document).
                 var profileFlattenedWriteSet = _writeFlattener.Flatten(
                     new FlatteningInput(
                         executionRequest.OperationKind,
@@ -614,24 +612,6 @@ internal sealed class DefaultRelationalWriteExecutor(
     )
     {
         var message = $"Profile-aware persist for {requiredFamily} shapes is not yet supported (DMS-1124).";
-        return operationKind switch
-        {
-            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
-                new UpsertResult.UnknownFailure(message)
-            ),
-            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
-                new UpdateResult.UnknownFailure(message)
-            ),
-            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
-        };
-    }
-
-    private static RelationalWriteExecutorResult BuildSliceTwoShapeGateResult(
-        RelationalWriteOperationKind operationKind
-    )
-    {
-        const string message =
-            "Slice 2 only supports profiled single-table root-only write plans (DMS-1124).";
         return operationKind switch
         {
             RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -259,10 +259,12 @@ internal sealed class DefaultRelationalWriteExecutor(
                 }
 
                 // Slice-2 classification passed: flatten + profile synthesize. The profile merge
-                // synthesizer itself is root-only; non-root tables absent from its merge result are
-                // left untouched by the persister, which is the correct behavior for Slice 2 shapes
-                // whose runtime semantics are confined to the root table (e.g. hidden separate-table
-                // scopes on an existing document).
+                // synthesizer itself is root-only, but the compiled write plan may still carry
+                // multiple tables — those remain valid Slice 2 inputs as long as the flattened
+                // handoff is root-only. Non-root flattened buffers on the root row (root-extension
+                // rows, collection candidates) must fail closed; the synthesizer's input contract
+                // enforces that invariant so upstream fencing bugs surface here rather than
+                // silently producing a partial merge result.
                 var profileFlattenedWriteSet = _writeFlattener.Flatten(
                     new FlatteningInput(
                         executionRequest.OperationKind,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -25,7 +25,7 @@ internal sealed class DefaultRelationalWriteExecutor(
     IRelationalWriteTargetLookupResolver targetLookupResolver,
     IRelationalWriteFreshnessChecker writeFreshnessChecker,
     IRelationalWriteNoProfileMergeSynthesizer noProfileMergeSynthesizer,
-    IRelationalWriteNoProfilePersister noProfilePersister,
+    IRelationalWritePersister persister,
     IRelationalWriteExceptionClassifier writeExceptionClassifier,
     IRelationalWriteConstraintResolver writeConstraintResolver,
     IRelationalReadMaterializer readMaterializer
@@ -57,8 +57,8 @@ internal sealed class DefaultRelationalWriteExecutor(
     private readonly IRelationalWriteNoProfileMergeSynthesizer _noProfileMergeSynthesizer =
         noProfileMergeSynthesizer ?? throw new ArgumentNullException(nameof(noProfileMergeSynthesizer));
 
-    private readonly IRelationalWriteNoProfilePersister _noProfilePersister =
-        noProfilePersister ?? throw new ArgumentNullException(nameof(noProfilePersister));
+    private readonly IRelationalWritePersister _persister =
+        persister ?? throw new ArgumentNullException(nameof(persister));
 
     private readonly IRelationalWriteExceptionClassifier _writeExceptionClassifier =
         writeExceptionClassifier ?? throw new ArgumentNullException(nameof(writeExceptionClassifier));
@@ -262,13 +262,13 @@ internal sealed class DefaultRelationalWriteExecutor(
                 )
             );
 
-            var noProfileMergeResult = _noProfileMergeSynthesizer.Synthesize(
+            var mergeResult = _noProfileMergeSynthesizer.Synthesize(
                 new RelationalWriteNoProfileMergeRequest(request.WritePlan, flattenedWriteSet, currentState)
             );
 
             var identityStabilityFailure = RelationalWriteIdentityStability.TryBuildFailureResult(
                 executionRequest,
-                noProfileMergeResult
+                mergeResult
             );
 
             if (identityStabilityFailure is not null)
@@ -279,7 +279,8 @@ internal sealed class DefaultRelationalWriteExecutor(
 
             if (
                 targetContext is RelationalWriteTargetContext.ExistingDocument guardedTarget
-                && RelationalWriteGuardedNoOp.IsNoOpCandidate(noProfileMergeResult)
+                && mergeResult.SupportsGuardedNoOp
+                && RelationalWriteGuardedNoOp.IsNoOpCandidate(mergeResult)
             )
             {
                 var isCurrent = await _writeFreshnessChecker
@@ -312,8 +313,8 @@ internal sealed class DefaultRelationalWriteExecutor(
                 );
             }
 
-            var persistedTarget = await _noProfilePersister
-                .PersistAsync(executionRequest, noProfileMergeResult, writeSession, cancellationToken)
+            var persistedTarget = await _persister
+                .PersistAsync(executionRequest, mergeResult, writeSession, cancellationToken)
                 .ConfigureAwait(false);
 
             ValidatePersistedTargetIdentity(executionRequest.TargetContext, persistedTarget);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/FlattenerMemberEvaluation.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/FlattenerMemberEvaluation.cs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Shared member-evaluation helpers used by the flattener and the post-overlay
+/// key-unification resolver. Extracted without behavior change from
+/// <see cref="RelationalWriteFlattener"/>.
+/// </summary>
+internal static class FlattenerMemberEvaluation
+{
+    internal static KeyUnificationMemberEvaluation EvaluateKeyUnificationMember(
+        TableWritePlan tableWritePlan,
+        KeyUnificationMemberWritePlan member,
+        JsonNode scopeNode,
+        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
+        ReadOnlySpan<int> ordinalPath
+    )
+    {
+        var absolutePath = RelationalJsonPathSupport.CombineRestrictedCanonical(
+            tableWritePlan.TableModel.JsonScope,
+            member.RelativePath
+        );
+
+        return member switch
+        {
+            KeyUnificationMemberWritePlan.ScalarMember scalarMember => EvaluateScalarKeyUnificationMember(
+                tableWritePlan,
+                scalarMember,
+                absolutePath,
+                scopeNode
+            ),
+            KeyUnificationMemberWritePlan.DescriptorMember descriptorMember =>
+                EvaluateDescriptorKeyUnificationMember(
+                    tableWritePlan,
+                    descriptorMember,
+                    absolutePath,
+                    scopeNode,
+                    resolvedReferenceLookups,
+                    ordinalPath
+                ),
+            KeyUnificationMemberWritePlan.ReferenceDerivedMember referenceDerivedMember =>
+                EvaluateReferenceDerivedKeyUnificationMember(
+                    tableWritePlan,
+                    referenceDerivedMember,
+                    absolutePath,
+                    scopeNode,
+                    resolvedReferenceLookups,
+                    ordinalPath
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported key-unification member kind '{member.GetType().Name}' on table '{RelationalWriteFlattener.FormatTable(tableWritePlan)}'."
+            ),
+        };
+    }
+
+    private static KeyUnificationMemberEvaluation EvaluateScalarKeyUnificationMember(
+        TableWritePlan tableWritePlan,
+        KeyUnificationMemberWritePlan.ScalarMember member,
+        string absolutePath,
+        JsonNode scopeNode
+    )
+    {
+        if (
+            !RelationalWriteFlattener.TryGetRelativeLeafNode(
+                scopeNode,
+                member.RelativePath,
+                out var memberNode
+            ) || memberNode is null
+        )
+        {
+            return KeyUnificationMemberEvaluation.Absent;
+        }
+
+        var conversionContext = RelationalWriteFlattener.CreateKeyUnificationScalarConversionContext(
+            tableWritePlan,
+            member,
+            absolutePath
+        );
+
+        if (memberNode is not JsonValue jsonValue)
+        {
+            throw RelationalWriteFlattener.CreateInvalidRequestDerivedScalarException(
+                conversionContext,
+                member.ScalarType,
+                $"encountered non-scalar JSON node type '{memberNode.GetType().Name}'"
+            );
+        }
+
+        return KeyUnificationMemberEvaluation.Present(
+            RelationalWriteFlattener.ConvertRequestDerivedJsonValue(
+                jsonValue,
+                member.ScalarType,
+                conversionContext
+            )
+        );
+    }
+
+    private static KeyUnificationMemberEvaluation EvaluateDescriptorKeyUnificationMember(
+        TableWritePlan tableWritePlan,
+        KeyUnificationMemberWritePlan.DescriptorMember member,
+        string absolutePath,
+        JsonNode scopeNode,
+        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
+        ReadOnlySpan<int> ordinalPath
+    )
+    {
+        if (
+            !RelationalWriteFlattener.TryGetRelativeLeafNode(
+                scopeNode,
+                member.RelativePath,
+                out var memberNode
+            ) || memberNode is null
+        )
+        {
+            return KeyUnificationMemberEvaluation.Absent;
+        }
+
+        if (memberNode is not JsonValue jsonValue || !jsonValue.TryGetValue<string>(out _))
+        {
+            throw RelationalWriteFlattener.CreateRequestShapeValidationException(
+                absolutePath,
+                $"Key-unification member '{member.MemberPathColumn.Value}' on table '{RelationalWriteFlattener.FormatTable(tableWritePlan)}' "
+                    + $"expected a descriptor URI string at path '{absolutePath}', but encountered "
+                    + $"JSON value kind '{RelationalWriteFlattener.GetJsonValueKind(memberNode)}'."
+            );
+        }
+
+        var descriptorId = resolvedReferenceLookups.GetDescriptorId(
+            member.DescriptorResource,
+            absolutePath,
+            ordinalPath
+        );
+
+        if (descriptorId is null)
+        {
+            throw new InvalidOperationException(
+                $"Key-unification member '{member.MemberPathColumn.Value}' on table '{RelationalWriteFlattener.FormatTable(tableWritePlan)}' "
+                    + $"did not have a resolved descriptor id for path '{absolutePath}' and descriptor resource "
+                    + $"'{RelationalWriteSupport.FormatResource(member.DescriptorResource)}'."
+            );
+        }
+
+        return KeyUnificationMemberEvaluation.Present(descriptorId.Value);
+    }
+
+    private static KeyUnificationMemberEvaluation EvaluateReferenceDerivedKeyUnificationMember(
+        TableWritePlan tableWritePlan,
+        KeyUnificationMemberWritePlan.ReferenceDerivedMember member,
+        string absolutePath,
+        JsonNode scopeNode,
+        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
+        ReadOnlySpan<int> ordinalPath
+    )
+    {
+        if (
+            !RelationalWriteFlattener.TryGetReferenceObjectNode(
+                tableWritePlan,
+                scopeNode,
+                member.ReferenceSource,
+                out var referenceNode
+            ) || referenceNode is null
+        )
+        {
+            return KeyUnificationMemberEvaluation.Absent;
+        }
+
+        var memberPathColumn = RelationalWriteFlattener.GetRequiredColumnModel(
+            tableWritePlan,
+            member.MemberPathColumn
+        );
+        var concreteAbsolutePath = RelationalWriteFlattener.MaterializeValidationPath(
+            absolutePath,
+            ordinalPath
+        );
+
+        return KeyUnificationMemberEvaluation.Present(
+            RelationalWriteFlattener.ResolveReferenceDerivedLiteralValue(
+                tableWritePlan,
+                memberPathColumn,
+                member.MemberPathColumn,
+                member.ReferenceSource,
+                concreteAbsolutePath,
+                resolvedReferenceLookups,
+                ordinalPath
+            )
+        );
+    }
+}
+
+internal sealed record KeyUnificationMemberEvaluation(bool IsPresent, object? Value)
+{
+    public static KeyUnificationMemberEvaluation Absent { get; } = new(false, null);
+
+    public static KeyUnificationMemberEvaluation Present(object value)
+    {
+        return new(true, value);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileKeyUnificationGuardrails.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileKeyUnificationGuardrails.cs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Shared key-unification guardrail helper used by the flattener and the
+/// post-overlay resolver. Extracted without behavior change from
+/// <see cref="RelationalWriteFlattener"/>; exception typing preserved
+/// (InvalidOperationException for presence-gated-null and non-nullable-canonical
+/// violations).
+/// </summary>
+internal static class ProfileKeyUnificationGuardrails
+{
+    internal static void Validate(
+        TableWritePlan tableWritePlan,
+        KeyUnificationWritePlan keyUnificationPlan,
+        object? canonicalValue,
+        IReadOnlyList<FlattenedWriteValue> values,
+        IReadOnlyList<bool> valueAssigned
+    )
+    {
+        foreach (var member in keyUnificationPlan.MembersInOrder)
+        {
+            if (member.PresenceBindingIndex is not int presenceBindingIndex)
+            {
+                continue;
+            }
+
+            if (!valueAssigned[presenceBindingIndex])
+            {
+                throw new InvalidOperationException(
+                    $"Presence binding for key-unification member '{member.MemberPathColumn.Value}' on table "
+                        + $"'{RelationalWriteFlattener.FormatTable(tableWritePlan)}' was not assigned before guardrail validation."
+                );
+            }
+
+            if (values[presenceBindingIndex] is not FlattenedWriteValue.Literal presenceValue)
+            {
+                throw new InvalidOperationException(
+                    $"Presence binding for key-unification member '{member.MemberPathColumn.Value}' on table "
+                        + $"'{RelationalWriteFlattener.FormatTable(tableWritePlan)}' was not materialized as a literal value."
+                );
+            }
+
+            if (presenceValue.Value is not null && canonicalValue is null)
+            {
+                throw new InvalidOperationException(
+                    $"Key-unification canonical column '{keyUnificationPlan.CanonicalColumn.Value}' on table "
+                        + $"'{RelationalWriteFlattener.FormatTable(tableWritePlan)}' resolved to null while presence column "
+                        + $"'{member.PresenceColumn!.Value}' indicated member '{member.MemberPathColumn.Value}' was present."
+                );
+            }
+        }
+
+        var canonicalBinding = tableWritePlan.ColumnBindings[keyUnificationPlan.CanonicalBindingIndex];
+
+        if (!canonicalBinding.Column.IsNullable && canonicalValue is null)
+        {
+            throw new InvalidOperationException(
+                $"Key-unification canonical column '{canonicalBinding.Column.ColumnName.Value}' on table "
+                    + $"'{RelationalWriteFlattener.FormatTable(tableWritePlan)}' is not nullable but resolved to null."
+            );
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
@@ -18,21 +18,40 @@ internal static class ProfileMemberGovernanceRules
 {
     internal enum HiddenPathMatchKind
     {
-        /// <summary>Exact-path match only (Scalar, DescriptorReference).</summary>
+        /// <summary>
+        /// Hidden path must equal the binding's governing path exactly. Used for scalar
+        /// and descriptor bindings, where governance is keyed on the binding's own member path.
+        /// </summary>
         Exact,
 
-        /// <summary>Ancestor-or-exact match (DocumentReference, ReferenceDerived).</summary>
-        AncestorOrExact,
+        /// <summary>
+        /// Hidden path must equal the binding's governing reference path, or be a descendant
+        /// of it. Used for document-reference FK bindings and reference-derived bindings: the
+        /// governing path is the owning reference root (e.g. <c>schoolReference</c>), and any
+        /// hidden member at or below that root (e.g. <c>schoolReference.schoolId</c>) preserves
+        /// the entire reference-derived storage family.
+        /// See <c>profiles.md:782</c> and <c>02-root-table-only-profile-merge.md:75</c>.
+        /// </summary>
+        ReferenceRooted,
     }
 
+    /// <summary>
+    /// Returns true iff any hidden member path in <paramref name="hiddenMemberPaths"/> governs
+    /// a binding with the given <paramref name="governingPath"/> and <paramref name="matchKind"/>.
+    /// </summary>
+    /// <param name="governingPath">
+    /// Scope-relative path used for hidden-path matching. For <see cref="HiddenPathMatchKind.Exact"/>
+    /// this is the binding's own member path. For <see cref="HiddenPathMatchKind.ReferenceRooted"/>
+    /// this is the owning document-reference root path.
+    /// </param>
     internal static bool IsHiddenGoverned(
-        string memberPath,
+        string governingPath,
         ImmutableArray<string> hiddenMemberPaths,
         HiddenPathMatchKind matchKind
     )
     {
-        ArgumentNullException.ThrowIfNull(memberPath);
-        return hiddenMemberPaths.Any(hidden => IsMatch(memberPath, hidden, matchKind));
+        ArgumentNullException.ThrowIfNull(governingPath);
+        return hiddenMemberPaths.Any(hidden => IsMatch(governingPath, hidden, matchKind));
     }
 
     internal static HiddenPathMatchKind MatchKindFor(WriteValueSource source) =>
@@ -40,13 +59,26 @@ internal static class ProfileMemberGovernanceRules
         {
             WriteValueSource.Scalar => HiddenPathMatchKind.Exact,
             WriteValueSource.DescriptorReference => HiddenPathMatchKind.Exact,
-            WriteValueSource.DocumentReference => HiddenPathMatchKind.AncestorOrExact,
-            WriteValueSource.ReferenceDerived => HiddenPathMatchKind.AncestorOrExact,
+            WriteValueSource.DocumentReference => HiddenPathMatchKind.ReferenceRooted,
+            WriteValueSource.ReferenceDerived => HiddenPathMatchKind.ReferenceRooted,
             _ => throw new ArgumentOutOfRangeException(
                 nameof(source),
                 source.GetType().Name,
                 $"ProfileMemberGovernanceRules.MatchKindFor does not handle '{source.GetType().Name}'. "
                     + "The classifier filters Precomputed/DocumentId/ParentKeyPart/Ordinal before calling."
+            ),
+        };
+
+    internal static HiddenPathMatchKind MatchKindFor(KeyUnificationMemberWritePlan member) =>
+        member switch
+        {
+            KeyUnificationMemberWritePlan.ScalarMember => HiddenPathMatchKind.Exact,
+            KeyUnificationMemberWritePlan.DescriptorMember => HiddenPathMatchKind.Exact,
+            KeyUnificationMemberWritePlan.ReferenceDerivedMember => HiddenPathMatchKind.ReferenceRooted,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(member),
+                member.GetType().Name,
+                $"ProfileMemberGovernanceRules.MatchKindFor does not handle KeyUnificationMemberWritePlan subtype '{member.GetType().Name}'."
             ),
         };
 
@@ -60,17 +92,17 @@ internal static class ProfileMemberGovernanceRules
         string scopeCanonical
     ) => context.StoredScopeStates.FirstOrDefault(state => state.Address.JsonScope == scopeCanonical);
 
-    private static bool IsMatch(string memberPath, string hiddenPath, HiddenPathMatchKind matchKind)
+    private static bool IsMatch(string governingPath, string hiddenPath, HiddenPathMatchKind matchKind)
     {
-        if (string.Equals(memberPath, hiddenPath, StringComparison.Ordinal))
+        if (string.Equals(governingPath, hiddenPath, StringComparison.Ordinal))
         {
             return true;
         }
         if (
-            matchKind == HiddenPathMatchKind.AncestorOrExact
-            && memberPath.StartsWith(hiddenPath, StringComparison.Ordinal)
-            && memberPath.Length > hiddenPath.Length
-            && memberPath[hiddenPath.Length] == '.'
+            matchKind == HiddenPathMatchKind.ReferenceRooted
+            && hiddenPath.StartsWith(governingPath, StringComparison.Ordinal)
+            && hiddenPath.Length > governingPath.Length
+            && hiddenPath[governingPath.Length] == '.'
         )
         {
             return true;

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Shared governance helper: single source of truth for visibility lookup and
+/// hidden-path matching. The root-table binding classifier and the post-overlay
+/// key-unification resolver both consult this so precedence rules can't drift.
+/// </summary>
+internal static class ProfileMemberGovernanceRules
+{
+    internal enum HiddenPathMatchKind
+    {
+        /// <summary>Exact-path match only (Scalar, DescriptorReference).</summary>
+        Exact,
+
+        /// <summary>Ancestor-or-exact match (DocumentReference, ReferenceDerived).</summary>
+        AncestorOrExact,
+    }
+
+    internal static bool IsHiddenGoverned(
+        string memberPath,
+        ImmutableArray<string> hiddenMemberPaths,
+        HiddenPathMatchKind matchKind
+    )
+    {
+        ArgumentNullException.ThrowIfNull(memberPath);
+        return hiddenMemberPaths.Any(hidden => IsMatch(memberPath, hidden, matchKind));
+    }
+
+    internal static HiddenPathMatchKind MatchKindFor(WriteValueSource source) =>
+        source switch
+        {
+            WriteValueSource.Scalar => HiddenPathMatchKind.Exact,
+            WriteValueSource.DescriptorReference => HiddenPathMatchKind.Exact,
+            WriteValueSource.DocumentReference => HiddenPathMatchKind.AncestorOrExact,
+            WriteValueSource.ReferenceDerived => HiddenPathMatchKind.AncestorOrExact,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(source),
+                source.GetType().Name,
+                $"ProfileMemberGovernanceRules.MatchKindFor does not handle '{source.GetType().Name}'. "
+                    + "The classifier filters Precomputed/DocumentId/ParentKeyPart/Ordinal before calling."
+            ),
+        };
+
+    internal static RequestScopeState? LookupRequestScope(
+        ProfileAppliedWriteRequest profileRequest,
+        string scopeCanonical
+    ) => profileRequest.RequestScopeStates.FirstOrDefault(state => state.Address.JsonScope == scopeCanonical);
+
+    internal static StoredScopeState? LookupStoredScope(
+        ProfileAppliedWriteContext context,
+        string scopeCanonical
+    ) => context.StoredScopeStates.FirstOrDefault(state => state.Address.JsonScope == scopeCanonical);
+
+    private static bool IsMatch(string memberPath, string hiddenPath, HiddenPathMatchKind matchKind)
+    {
+        if (string.Equals(memberPath, hiddenPath, StringComparison.Ordinal))
+        {
+            return true;
+        }
+        if (
+            matchKind == HiddenPathMatchKind.AncestorOrExact
+            && memberPath.StartsWith(hiddenPath, StringComparison.Ordinal)
+            && memberPath.Length > hiddenPath.Length
+            && memberPath[hiddenPath.Length] == '.'
+        )
+        {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileMemberGovernanceRules.cs
@@ -98,15 +98,18 @@ internal static class ProfileMemberGovernanceRules
         {
             return true;
         }
-        if (
-            matchKind == HiddenPathMatchKind.ReferenceRooted
-            && hiddenPath.StartsWith(governingPath, StringComparison.Ordinal)
-            && hiddenPath.Length > governingPath.Length
-            && hiddenPath[governingPath.Length] == '.'
-        )
+        if (matchKind != HiddenPathMatchKind.ReferenceRooted)
+        {
+            return false;
+        }
+        // Empty governingPath means the containing scope IS the reference root, so every
+        // hidden member path under that scope is governed by this reference family.
+        if (governingPath.Length == 0)
         {
             return true;
         }
-        return false;
+        return hiddenPath.StartsWith(governingPath, StringComparison.Ordinal)
+            && hiddenPath.Length > governingPath.Length
+            && hiddenPath[governingPath.Length] == '.';
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
@@ -226,8 +226,16 @@ internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnifica
         var storedScope = context.ProfileAppliedContext is not null
             ? ProfileMemberGovernanceRules.LookupStoredScope(context.ProfileAppliedContext, containingScope)
             : null;
-        var matchKind = MatchKindForMember(member);
+        var matchKind = ProfileMemberGovernanceRules.MatchKindFor(member);
         var strippedMemberPath = StripScopePrefix(memberPath, containingScope);
+        var governingPath = member switch
+        {
+            KeyUnificationMemberWritePlan.ReferenceDerivedMember refDerived => StripScopePrefix(
+                refDerived.ReferenceSource.ReferenceObjectPath.Canonical,
+                containingScope
+            ),
+            _ => strippedMemberPath,
+        };
 
         if (storedScope is not null)
         {
@@ -237,7 +245,7 @@ internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnifica
             }
             if (
                 ProfileMemberGovernanceRules.IsHiddenGoverned(
-                    strippedMemberPath,
+                    governingPath,
                     storedScope.HiddenMemberPaths,
                     matchKind
                 )
@@ -373,25 +381,6 @@ internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnifica
         }
         return bindingPath[(scope.Length + 1)..];
     }
-
-    private static ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKindForMember(
-        KeyUnificationMemberWritePlan member
-    ) =>
-        member switch
-        {
-            KeyUnificationMemberWritePlan.ScalarMember => ProfileMemberGovernanceRules
-                .HiddenPathMatchKind
-                .Exact,
-            KeyUnificationMemberWritePlan.DescriptorMember => ProfileMemberGovernanceRules
-                .HiddenPathMatchKind
-                .Exact,
-            KeyUnificationMemberWritePlan.ReferenceDerivedMember => ProfileMemberGovernanceRules
-                .HiddenPathMatchKind
-                .AncestorOrExact,
-            _ => throw new InvalidOperationException(
-                $"ProfileRootKeyUnificationResolver does not handle key-unification member kind '{member.GetType().Name}'."
-            ),
-        };
 
     private static string FormatTable(TableWritePlan tableWritePlan) =>
         $"{tableWritePlan.TableModel.Table.Schema.Value}.{tableWritePlan.TableModel.Table.Name}";

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Context carried into the post-overlay key-unification resolver. Assembled by
+/// the profile merge synthesizer after it applies the classifier's per-binding
+/// dispositions to merge the root row. The resolver recomputes canonical and
+/// synthetic-presence values from merged request + stored state — visible
+/// members are evaluated from <see cref="WritableRequestBody"/>, hidden-governed
+/// members from <see cref="CurrentRootRowByColumnName"/>, and visible-absent
+/// members are treated as absent.
+/// </summary>
+/// <remarks>
+/// <see cref="WritePlan"/> is required because the flattener's
+/// <see cref="FlatteningResolvedReferenceLookupSet"/> factory needs descriptor-edge
+/// and document-reference metadata from the full <see cref="ResourceWritePlan"/>
+/// to compile its lookup maps. The synthesizer already has this plan in hand.
+/// </remarks>
+internal sealed record ProfileRootKeyUnificationContext(
+    ResourceWritePlan WritePlan,
+    JsonNode WritableRequestBody,
+    RelationalWriteCurrentState? CurrentState,
+    IReadOnlyDictionary<DbColumnName, object?> CurrentRootRowByColumnName,
+    ResolvedReferenceSet ResolvedReferences,
+    ProfileAppliedWriteRequest ProfileRequest,
+    ProfileAppliedWriteContext? ProfileAppliedContext
+);
+
+/// <summary>
+/// Post-overlay key-unification resolver. Run by the profile merge synthesizer
+/// after it applies the classifier's per-binding dispositions to the merged
+/// root row. For every <see cref="KeyUnificationWritePlan"/> on the root table,
+/// the resolver evaluates each member via profile-aware routing
+/// (visible-present → request body, hidden-governed → stored row,
+/// visible-absent → absent), writes the synthetic-presence binding (when
+/// resolver-owned), enforces first-present-wins canonical agreement, writes
+/// the canonical binding, and then delegates to
+/// <see cref="ProfileKeyUnificationGuardrails"/> for presence-gated-null and
+/// canonical-non-nullable checks.
+/// </summary>
+/// <remarks>
+/// Exception typing is preserved from the flattener:
+/// canonical-disagreement raises <see cref="RelationalWriteRequestValidationException"/>
+/// (request-shape failure); presence-gated-null, canonical-non-nullable,
+/// missing hidden column, and resolver/classifier drift raise
+/// <see cref="InvalidOperationException"/> (invariant violations).
+/// </remarks>
+internal interface IProfileRootKeyUnificationResolver
+{
+    void Resolve(
+        TableWritePlan rootTableWritePlan,
+        ProfileRootKeyUnificationContext context,
+        FlattenedWriteValue[] mergedRowValuesMutable,
+        ImmutableHashSet<int> resolverOwnedBindingIndices
+    );
+}
+
+internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnificationResolver
+{
+    public void Resolve(
+        TableWritePlan rootTableWritePlan,
+        ProfileRootKeyUnificationContext context,
+        FlattenedWriteValue[] mergedRowValuesMutable,
+        ImmutableHashSet<int> resolverOwnedBindingIndices
+    )
+    {
+        ArgumentNullException.ThrowIfNull(rootTableWritePlan);
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(mergedRowValuesMutable);
+        ArgumentNullException.ThrowIfNull(resolverOwnedBindingIndices);
+
+        if (mergedRowValuesMutable.Length != rootTableWritePlan.ColumnBindings.Length)
+        {
+            throw new InvalidOperationException(
+                $"Merged row value buffer length {mergedRowValuesMutable.Length} does not match "
+                    + $"root table '{FormatTable(rootTableWritePlan)}' binding count "
+                    + $"{rootTableWritePlan.ColumnBindings.Length}."
+            );
+        }
+
+        if (rootTableWritePlan.KeyUnificationPlans.Length == 0)
+        {
+            return;
+        }
+
+        var valueAssigned = new bool[mergedRowValuesMutable.Length];
+        for (var i = 0; i < mergedRowValuesMutable.Length; i++)
+        {
+            valueAssigned[i] = mergedRowValuesMutable[i] is not null;
+        }
+
+        var candidateScopes = BuildCandidateScopeSet(context.ProfileRequest, context.ProfileAppliedContext);
+        var resolvedReferenceLookups = FlatteningResolvedReferenceLookupSet.Create(
+            context.WritePlan,
+            context.ResolvedReferences
+        );
+
+        foreach (var keyUnificationPlan in rootTableWritePlan.KeyUnificationPlans)
+        {
+            ResolveOne(
+                rootTableWritePlan,
+                keyUnificationPlan,
+                context,
+                candidateScopes,
+                resolvedReferenceLookups,
+                mergedRowValuesMutable,
+                valueAssigned,
+                resolverOwnedBindingIndices
+            );
+        }
+    }
+
+    private static void ResolveOne(
+        TableWritePlan rootTableWritePlan,
+        KeyUnificationWritePlan keyUnificationPlan,
+        ProfileRootKeyUnificationContext context,
+        ImmutableArray<string> candidateScopes,
+        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
+        FlattenedWriteValue[] mergedRowValuesMutable,
+        bool[] valueAssigned,
+        ImmutableHashSet<int> resolverOwnedBindingIndices
+    )
+    {
+        object? canonicalValue = null;
+        KeyUnificationMemberWritePlan? firstPresentMember = null;
+
+        foreach (var member in keyUnificationPlan.MembersInOrder)
+        {
+            var visibility = ClassifyMemberVisibility(member, context, candidateScopes);
+            var evaluation = EvaluateMember(
+                rootTableWritePlan,
+                member,
+                visibility,
+                context,
+                resolvedReferenceLookups
+            );
+
+            if (member.PresenceIsSynthetic && member.PresenceBindingIndex is int presenceBindingIndex)
+            {
+                if (!resolverOwnedBindingIndices.Contains(presenceBindingIndex))
+                {
+                    throw new InvalidOperationException(
+                        $"Resolver cannot write synthetic presence binding index {presenceBindingIndex} on table "
+                            + $"'{FormatTable(rootTableWritePlan)}' because the classifier did not mark it resolver-owned."
+                    );
+                }
+
+                mergedRowValuesMutable[presenceBindingIndex] = new FlattenedWriteValue.Literal(
+                    evaluation.IsPresent ? true : null
+                );
+                valueAssigned[presenceBindingIndex] = true;
+            }
+
+            if (!evaluation.IsPresent)
+            {
+                continue;
+            }
+
+            if (firstPresentMember is null)
+            {
+                canonicalValue = evaluation.Value;
+                firstPresentMember = member;
+                continue;
+            }
+
+            if (!Equals(canonicalValue, evaluation.Value))
+            {
+                throw RelationalWriteFlattener.CreateRequestShapeValidationException(
+                    RelationalJsonPathSupport.CombineRestrictedCanonical(
+                        rootTableWritePlan.TableModel.JsonScope,
+                        member.RelativePath
+                    ),
+                    $"Key-unification conflict for canonical column '{keyUnificationPlan.CanonicalColumn.Value}' "
+                        + $"on table '{FormatTable(rootTableWritePlan)}': member '{firstPresentMember.MemberPathColumn.Value}' "
+                        + $"resolved to {FormatLiteral(canonicalValue)} but member '{member.MemberPathColumn.Value}' "
+                        + $"resolved to {FormatLiteral(evaluation.Value)}."
+                );
+            }
+        }
+
+        if (!resolverOwnedBindingIndices.Contains(keyUnificationPlan.CanonicalBindingIndex))
+        {
+            throw new InvalidOperationException(
+                $"Resolver cannot write canonical binding index {keyUnificationPlan.CanonicalBindingIndex} on table "
+                    + $"'{FormatTable(rootTableWritePlan)}' because the classifier did not mark it resolver-owned."
+            );
+        }
+
+        mergedRowValuesMutable[keyUnificationPlan.CanonicalBindingIndex] = new FlattenedWriteValue.Literal(
+            canonicalValue
+        );
+        valueAssigned[keyUnificationPlan.CanonicalBindingIndex] = true;
+
+        ProfileKeyUnificationGuardrails.Validate(
+            rootTableWritePlan,
+            keyUnificationPlan,
+            canonicalValue,
+            mergedRowValuesMutable,
+            valueAssigned
+        );
+    }
+
+    private static MemberVisibility ClassifyMemberVisibility(
+        KeyUnificationMemberWritePlan member,
+        ProfileRootKeyUnificationContext context,
+        ImmutableArray<string> candidateScopes
+    )
+    {
+        var memberPath = member.RelativePath.Canonical;
+        var containingScope = TryMatchLongestScope(memberPath, candidateScopes);
+
+        if (containingScope is null)
+        {
+            // No profile governance touches this member; treat as fully visible.
+            return MemberVisibility.VisiblePresent;
+        }
+
+        var storedScope = context.ProfileAppliedContext is not null
+            ? ProfileMemberGovernanceRules.LookupStoredScope(context.ProfileAppliedContext, containingScope)
+            : null;
+        var matchKind = MatchKindForMember(member);
+        var strippedMemberPath = StripScopePrefix(memberPath, containingScope);
+
+        if (storedScope is not null)
+        {
+            if (storedScope.Visibility == ProfileVisibilityKind.Hidden)
+            {
+                return MemberVisibility.HiddenGoverned;
+            }
+            if (
+                ProfileMemberGovernanceRules.IsHiddenGoverned(
+                    strippedMemberPath,
+                    storedScope.HiddenMemberPaths,
+                    matchKind
+                )
+            )
+            {
+                return MemberVisibility.HiddenGoverned;
+            }
+        }
+
+        var requestScope = ProfileMemberGovernanceRules.LookupRequestScope(
+            context.ProfileRequest,
+            containingScope
+        );
+        if (requestScope is not null && requestScope.Visibility == ProfileVisibilityKind.VisibleAbsent)
+        {
+            return MemberVisibility.VisibleAbsent;
+        }
+
+        return MemberVisibility.VisiblePresent;
+    }
+
+    private static KeyUnificationMemberEvaluation EvaluateMember(
+        TableWritePlan rootTableWritePlan,
+        KeyUnificationMemberWritePlan member,
+        MemberVisibility visibility,
+        ProfileRootKeyUnificationContext context,
+        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups
+    ) =>
+        visibility switch
+        {
+            MemberVisibility.VisibleAbsent => KeyUnificationMemberEvaluation.Absent,
+            MemberVisibility.HiddenGoverned => EvaluateHiddenMember(rootTableWritePlan, member, context),
+            MemberVisibility.VisiblePresent => FlattenerMemberEvaluation.EvaluateKeyUnificationMember(
+                rootTableWritePlan,
+                member,
+                context.WritableRequestBody,
+                resolvedReferenceLookups,
+                ReadOnlySpan<int>.Empty
+            ),
+            _ => throw new InvalidOperationException(
+                $"Unhandled member visibility '{visibility}' on table '{FormatTable(rootTableWritePlan)}'."
+            ),
+        };
+
+    private static KeyUnificationMemberEvaluation EvaluateHiddenMember(
+        TableWritePlan rootTableWritePlan,
+        KeyUnificationMemberWritePlan member,
+        ProfileRootKeyUnificationContext context
+    )
+    {
+        if (!context.CurrentRootRowByColumnName.TryGetValue(member.MemberPathColumn, out var storedValue))
+        {
+            throw new InvalidOperationException(
+                $"Hidden key-unification member '{member.MemberPathColumn.Value}' on table "
+                    + $"'{FormatTable(rootTableWritePlan)}' requires stored column "
+                    + $"'{member.MemberPathColumn.Value}' in the current-state row projection, "
+                    + "but it was not present."
+            );
+        }
+
+        bool isPresent;
+        if (member.PresenceColumn is { } presenceColumn)
+        {
+            if (!context.CurrentRootRowByColumnName.TryGetValue(presenceColumn, out var presenceValue))
+            {
+                throw new InvalidOperationException(
+                    $"Hidden key-unification member '{member.MemberPathColumn.Value}' on table "
+                        + $"'{FormatTable(rootTableWritePlan)}' requires presence column "
+                        + $"'{presenceColumn.Value}' in the current-state row projection, "
+                        + "but it was not present."
+                );
+            }
+
+            // Presence is non-nullness of the stored presence column; presence columns are
+            // synthetic nullable bit/bool, never interpreted as boolean truthiness.
+            isPresent = presenceValue is not null;
+        }
+        else
+        {
+            isPresent = storedValue is not null;
+        }
+
+        return isPresent
+            ? KeyUnificationMemberEvaluation.Present(storedValue!)
+            : KeyUnificationMemberEvaluation.Absent;
+    }
+
+    private static ImmutableArray<string> BuildCandidateScopeSet(
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext
+    )
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var state in profileRequest.RequestScopeStates)
+        {
+            set.Add(state.Address.JsonScope);
+        }
+        if (profileAppliedContext is not null)
+        {
+            foreach (var state in profileAppliedContext.StoredScopeStates)
+            {
+                set.Add(state.Address.JsonScope);
+            }
+        }
+        return [.. set.OrderByDescending(s => s.Length).ThenBy(s => s, StringComparer.Ordinal)];
+    }
+
+    private static string? TryMatchLongestScope(string bindingPath, ImmutableArray<string> candidateScopes)
+    {
+        foreach (var scope in candidateScopes)
+        {
+            if (string.Equals(bindingPath, scope, StringComparison.Ordinal))
+            {
+                return scope;
+            }
+            if (
+                bindingPath.StartsWith(scope, StringComparison.Ordinal)
+                && bindingPath.Length > scope.Length
+                && bindingPath[scope.Length] == '.'
+            )
+            {
+                return scope;
+            }
+        }
+        return null;
+    }
+
+    private static string StripScopePrefix(string bindingPath, string scope)
+    {
+        if (string.Equals(bindingPath, scope, StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+        return bindingPath[(scope.Length + 1)..];
+    }
+
+    private static ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKindForMember(
+        KeyUnificationMemberWritePlan member
+    ) =>
+        member switch
+        {
+            KeyUnificationMemberWritePlan.ScalarMember => ProfileMemberGovernanceRules
+                .HiddenPathMatchKind
+                .Exact,
+            KeyUnificationMemberWritePlan.DescriptorMember => ProfileMemberGovernanceRules
+                .HiddenPathMatchKind
+                .Exact,
+            KeyUnificationMemberWritePlan.ReferenceDerivedMember => ProfileMemberGovernanceRules
+                .HiddenPathMatchKind
+                .AncestorOrExact,
+            _ => throw new InvalidOperationException(
+                $"ProfileRootKeyUnificationResolver does not handle key-unification member kind '{member.GetType().Name}'."
+            ),
+        };
+
+    private static string FormatTable(TableWritePlan tableWritePlan) =>
+        $"{tableWritePlan.TableModel.Table.Schema.Value}.{tableWritePlan.TableModel.Table.Name}";
+
+    private static string FormatLiteral(object? value) =>
+        value switch
+        {
+            null => "null",
+            string stringValue => $"'{stringValue}'",
+            bool boolValue => boolValue ? "true" : "false",
+            _ => Convert.ToString(value, CultureInfo.InvariantCulture) ?? value.ToString() ?? "<unknown>",
+        };
+
+    private enum MemberVisibility
+    {
+        VisiblePresent,
+        HiddenGoverned,
+        VisibleAbsent,
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootKeyUnificationResolver.cs
@@ -22,17 +22,18 @@ namespace EdFi.DataManagementService.Backend.Profile;
 /// members are treated as absent.
 /// </summary>
 /// <remarks>
-/// <see cref="WritePlan"/> is required because the flattener's
-/// <see cref="FlatteningResolvedReferenceLookupSet"/> factory needs descriptor-edge
-/// and document-reference metadata from the full <see cref="ResourceWritePlan"/>
-/// to compile its lookup maps. The synthesizer already has this plan in hand.
+/// <see cref="ResolvedReferenceLookups"/> is supplied pre-built by the caller
+/// (the profile merge synthesizer). It is the flattener's
+/// <see cref="FlatteningResolvedReferenceLookupSet"/>, compiled once per
+/// synthesis from the full <see cref="ResourceWritePlan"/> and
+/// <see cref="ResolvedReferenceSet"/>, and reused across every key-unification
+/// plan the resolver evaluates for the root table.
 /// </remarks>
 internal sealed record ProfileRootKeyUnificationContext(
-    ResourceWritePlan WritePlan,
     JsonNode WritableRequestBody,
     RelationalWriteCurrentState? CurrentState,
     IReadOnlyDictionary<DbColumnName, object?> CurrentRootRowByColumnName,
-    ResolvedReferenceSet ResolvedReferences,
+    FlatteningResolvedReferenceLookupSet ResolvedReferenceLookups,
     ProfileAppliedWriteRequest ProfileRequest,
     ProfileAppliedWriteContext? ProfileAppliedContext
 );
@@ -101,10 +102,6 @@ internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnifica
         }
 
         var candidateScopes = BuildCandidateScopeSet(context.ProfileRequest, context.ProfileAppliedContext);
-        var resolvedReferenceLookups = FlatteningResolvedReferenceLookupSet.Create(
-            context.WritePlan,
-            context.ResolvedReferences
-        );
 
         foreach (var keyUnificationPlan in rootTableWritePlan.KeyUnificationPlans)
         {
@@ -113,7 +110,7 @@ internal sealed class ProfileRootKeyUnificationResolver : IProfileRootKeyUnifica
                 keyUnificationPlan,
                 context,
                 candidateScopes,
-                resolvedReferenceLookups,
+                context.ResolvedReferenceLookups,
                 mergedRowValuesMutable,
                 valueAssigned,
                 resolverOwnedBindingIndices

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootTableBindingClassifier.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootTableBindingClassifier.cs
@@ -74,12 +74,14 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
         // Sort scope canonicals longest-first so longest-prefix wins.
         var candidateScopes = BuildCandidateScopeSet(profileRequest, profileAppliedContext);
 
-        // Records the (memberPath, matchKind) of every ordinary binding that resolved to a
-        // profile-governed containing scope. Drives the post-pass drift check below.
-        var bindingsByContainingScope = new Dictionary<
-            string,
-            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
-        >(StringComparer.Ordinal);
+        // Records the (memberPath, governingPath, matchKind) inventory of every ordinary
+        // binding that resolved to a profile-governed containing scope. `memberPath` is the
+        // binding's own scope-relative path; `governingPath` is the path used for hidden-path
+        // matching — equal to `memberPath` for scalar/descriptor, and the owning document-
+        // reference root for reference-sourced bindings. Drives the post-pass drift check.
+        var bindingsByContainingScope = new Dictionary<string, List<GovernedBindingEntry>>(
+            StringComparer.Ordinal
+        );
 
         var dispositions = new RootBindingDisposition[rootTable.ColumnBindings.Length];
         for (var bindingIndex = 0; bindingIndex < rootTable.ColumnBindings.Length; bindingIndex++)
@@ -98,6 +100,47 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
                 profileAppliedContext,
                 bindingsByContainingScope
             );
+        }
+
+        // Register key-unification member paths into the drift-check inventory.
+        // K-u members are not ordinary bindings (their canonical + presence bindings are
+        // resolver-owned), but they are legitimate targets for profile-hidden paths — the
+        // resolver evaluates them in ProfileRootKeyUnificationResolver.EvaluateMember.
+        // Without this registration, ValidateStoredScopeMetadata would reject hidden
+        // paths targeting k-u members as upstream contract drift, which is wrong.
+        foreach (var keyUnificationPlan in rootTable.KeyUnificationPlans)
+        {
+            foreach (var member in keyUnificationPlan.MembersInOrder)
+            {
+                var memberPathAbsolute = member.RelativePath.Canonical;
+                var containingScope = TryMatchLongestScope(memberPathAbsolute, candidateScopes);
+
+                if (containingScope is null)
+                {
+                    continue;
+                }
+
+                var strippedMemberPath = StripScopePrefix(memberPathAbsolute, containingScope);
+                var matchKind = ProfileMemberGovernanceRules.MatchKindFor(member);
+                var governingPath = member switch
+                {
+                    KeyUnificationMemberWritePlan.ReferenceDerivedMember refDerived => StripScopePrefix(
+                        refDerived.ReferenceSource.ReferenceObjectPath.Canonical,
+                        containingScope
+                    ),
+                    _ => strippedMemberPath,
+                };
+
+                if (!bindingsByContainingScope.TryGetValue(containingScope, out var bindingsUnderScope))
+                {
+                    bindingsUnderScope = [];
+                    bindingsByContainingScope[containingScope] = bindingsUnderScope;
+                }
+
+                bindingsUnderScope.Add(
+                    new GovernedBindingEntry(strippedMemberPath, governingPath, matchKind)
+                );
+            }
         }
 
         // Fail-closed metadata-drift check: every stored scope and every hidden member path
@@ -159,10 +202,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
         ImmutableArray<string> candidateScopes,
         ProfileAppliedWriteRequest profileRequest,
         ProfileAppliedWriteContext? profileAppliedContext,
-        Dictionary<
-            string,
-            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
-        > bindingsByContainingScope
+        Dictionary<string, List<GovernedBindingEntry>> bindingsByContainingScope
     )
     {
         var binding = rootTable.ColumnBindings[bindingIndex];
@@ -182,6 +222,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
         }
 
         var bindingPath = ResolveBindingRootRelativePath(writePlan, binding, bindingIndex, rootTable);
+        var governingPathAbsolute = ResolveBindingGoverningPath(writePlan, binding, bindingIndex, rootTable);
 
         // Longest-prefix scope match. If no profile scope matches, the binding is ungoverned.
         var containingScope = TryMatchLongestScope(bindingPath, candidateScopes);
@@ -191,6 +232,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
         }
 
         var memberPath = StripScopePrefix(bindingPath, containingScope);
+        var governingPath = StripScopePrefix(governingPathAbsolute, containingScope);
         var matchKind = ProfileMemberGovernanceRules.MatchKindFor(binding.Source);
 
         // Record this binding under its containing scope so the post-pass drift check can
@@ -200,7 +242,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
             bindingsUnderScope = [];
             bindingsByContainingScope[containingScope] = bindingsUnderScope;
         }
-        bindingsUnderScope.Add((memberPath, matchKind));
+        bindingsUnderScope.Add(new GovernedBindingEntry(memberPath, governingPath, matchKind));
 
         if (profileAppliedContext is null)
         {
@@ -219,7 +261,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
             }
             if (
                 ProfileMemberGovernanceRules.IsHiddenGoverned(
-                    memberPath,
+                    governingPath,
                     storedScope.HiddenMemberPaths,
                     matchKind
                 )
@@ -248,10 +290,7 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
     /// </summary>
     private static void ValidateStoredScopeMetadata(
         ProfileAppliedWriteContext profileAppliedContext,
-        Dictionary<
-            string,
-            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
-        > bindingsByContainingScope,
+        Dictionary<string, List<GovernedBindingEntry>> bindingsByContainingScope,
         TableWritePlan rootTable
     )
     {
@@ -272,18 +311,14 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
 
             foreach (var hiddenPath in storedScope.HiddenMemberPaths)
             {
-                var matched = false;
                 var singleHiddenPath = ImmutableArray.Create(hiddenPath);
-                foreach (var (memberPath, matchKind) in bindingsUnderScope)
-                {
-                    if (
-                        ProfileMemberGovernanceRules.IsHiddenGoverned(memberPath, singleHiddenPath, matchKind)
+                var matched = bindingsUnderScope.Exists(entry =>
+                    ProfileMemberGovernanceRules.IsHiddenGoverned(
+                        entry.GoverningPath,
+                        singleHiddenPath,
+                        entry.MatchKind
                     )
-                    {
-                        matched = true;
-                        break;
-                    }
-                }
+                );
                 if (!matched)
                 {
                     throw new InvalidOperationException(
@@ -323,6 +358,39 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
             ),
         };
 
+    /// <summary>
+    /// Absolute JSONPath used to match the binding against profile <c>HiddenMemberPaths</c>.
+    /// Equals <see cref="ResolveBindingRootRelativePath"/> for scalar/descriptor bindings; for
+    /// document-reference and reference-derived bindings it is the owning reference root
+    /// (<c>DocumentReferenceBinding.ReferenceObjectPath</c> / <c>ReferenceDerivedValueSourceMetadata.ReferenceObjectPath</c>),
+    /// so a single hidden sub-reference path preserves the whole reference-derived storage family.
+    /// </summary>
+    private static string ResolveBindingGoverningPath(
+        ResourceWritePlan writePlan,
+        WriteColumnBinding binding,
+        int bindingIndex,
+        TableWritePlan rootTable
+    ) =>
+        binding.Source switch
+        {
+            WriteValueSource.Scalar scalar => scalar.RelativePath.Canonical,
+            WriteValueSource.DescriptorReference descriptor => descriptor.RelativePath.Canonical,
+            WriteValueSource.DocumentReference documentReference => writePlan
+                .Model
+                .DocumentReferenceBindings[documentReference.BindingIndex]
+                .ReferenceObjectPath
+                .Canonical,
+            WriteValueSource.ReferenceDerived referenceDerived => referenceDerived
+                .ReferenceSource
+                .ReferenceObjectPath
+                .Canonical,
+            _ => throw new InvalidOperationException(
+                $"Root-table binding at index {bindingIndex} on table '{FormatTable(rootTable)}' "
+                    + $"has a WriteValueSource kind '{binding.Source.GetType().Name}' that the classifier "
+                    + "does not know how to resolve for governance. Storage-managed and plan-shape kinds must be filtered upstream."
+            ),
+        };
+
     private static string? TryMatchLongestScope(string bindingPath, ImmutableArray<string> candidateScopes)
     {
         // candidateScopes is pre-sorted longest-first.
@@ -358,4 +426,10 @@ internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindi
 
     private static string FormatTable(TableWritePlan rootTable) =>
         $"{rootTable.TableModel.Table.Schema.Value}.{rootTable.TableModel.Table.Name}";
+
+    private readonly record struct GovernedBindingEntry(
+        string MemberPath,
+        string GoverningPath,
+        ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind
+    );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootTableBindingClassifier.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileRootTableBindingClassifier.cs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Per-binding disposition produced by <see cref="IProfileRootTableBindingClassifier"/>.
+/// </summary>
+internal enum RootBindingDisposition
+{
+    /// <summary>
+    /// The profile makes this binding writable in this request. The synthesizer should
+    /// evaluate the binding from the writable request body.
+    /// </summary>
+    VisibleWritable,
+
+    /// <summary>
+    /// The profile hides this binding on the stored side (either the whole scope is hidden,
+    /// or the binding's member path is on the stored hidden-paths list). The synthesizer
+    /// must preserve the stored value.
+    /// </summary>
+    HiddenPreserved,
+
+    /// <summary>
+    /// The profile makes this binding's containing scope visible but the request omits it.
+    /// The synthesizer should clear the stored value.
+    /// </summary>
+    ClearOnVisibleAbsent,
+
+    /// <summary>
+    /// The binding is storage-managed (DocumentId, Precomputed, or resolver-owned). The
+    /// synthesizer must not derive its value from request JSON.
+    /// </summary>
+    StorageManaged,
+}
+
+/// <summary>
+/// Classification result for the root table's column bindings.
+/// </summary>
+internal sealed record ProfileRootTableBindingClassification(
+    ImmutableArray<RootBindingDisposition> BindingsByIndex,
+    ImmutableHashSet<int> ResolverOwnedBindingIndices
+);
+
+internal interface IProfileRootTableBindingClassifier
+{
+    ProfileRootTableBindingClassification Classify(
+        ResourceWritePlan writePlan,
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext
+    );
+}
+
+internal sealed class ProfileRootTableBindingClassifier : IProfileRootTableBindingClassifier
+{
+    public ProfileRootTableBindingClassification Classify(
+        ResourceWritePlan writePlan,
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext
+    )
+    {
+        ArgumentNullException.ThrowIfNull(writePlan);
+        ArgumentNullException.ThrowIfNull(profileRequest);
+
+        var rootTable = writePlan.TablePlansInDependencyOrder[0];
+        var resolverOwned = CollectResolverOwnedIndices(rootTable);
+
+        // Sort scope canonicals longest-first so longest-prefix wins.
+        var candidateScopes = BuildCandidateScopeSet(profileRequest, profileAppliedContext);
+
+        // Records the (memberPath, matchKind) of every ordinary binding that resolved to a
+        // profile-governed containing scope. Drives the post-pass drift check below.
+        var bindingsByContainingScope = new Dictionary<
+            string,
+            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
+        >(StringComparer.Ordinal);
+
+        var dispositions = new RootBindingDisposition[rootTable.ColumnBindings.Length];
+        for (var bindingIndex = 0; bindingIndex < rootTable.ColumnBindings.Length; bindingIndex++)
+        {
+            if (resolverOwned.Contains(bindingIndex))
+            {
+                dispositions[bindingIndex] = RootBindingDisposition.StorageManaged;
+                continue;
+            }
+            dispositions[bindingIndex] = ClassifyOrdinary(
+                writePlan,
+                rootTable,
+                bindingIndex,
+                candidateScopes,
+                profileRequest,
+                profileAppliedContext,
+                bindingsByContainingScope
+            );
+        }
+
+        // Fail-closed metadata-drift check: every stored scope and every hidden member path
+        // must resolve to at least one root-table binding. Anything that doesn't is upstream
+        // Core / write-plan contract drift, not silent under-preservation.
+        if (profileAppliedContext is not null)
+        {
+            ValidateStoredScopeMetadata(profileAppliedContext, bindingsByContainingScope, rootTable);
+        }
+
+        return new ProfileRootTableBindingClassification(dispositions.ToImmutableArray(), resolverOwned);
+    }
+
+    private static ImmutableHashSet<int> CollectResolverOwnedIndices(TableWritePlan rootTable)
+    {
+        var builder = ImmutableHashSet.CreateBuilder<int>();
+        foreach (var plan in rootTable.KeyUnificationPlans)
+        {
+            builder.Add(plan.CanonicalBindingIndex);
+            foreach (var member in plan.MembersInOrder)
+            {
+                if (member.PresenceIsSynthetic && member.PresenceBindingIndex is int presenceBindingIndex)
+                {
+                    builder.Add(presenceBindingIndex);
+                }
+            }
+        }
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Builds the candidate scope canonical set by union of request and stored scope addresses,
+    /// sorted longest-first so longest-prefix matching is straightforward.
+    /// </summary>
+    private static ImmutableArray<string> BuildCandidateScopeSet(
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext
+    )
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var state in profileRequest.RequestScopeStates)
+        {
+            set.Add(state.Address.JsonScope);
+        }
+        if (profileAppliedContext is not null)
+        {
+            foreach (var state in profileAppliedContext.StoredScopeStates)
+            {
+                set.Add(state.Address.JsonScope);
+            }
+        }
+        return [.. set.OrderByDescending(s => s.Length).ThenBy(s => s, StringComparer.Ordinal)];
+    }
+
+    private static RootBindingDisposition ClassifyOrdinary(
+        ResourceWritePlan writePlan,
+        TableWritePlan rootTable,
+        int bindingIndex,
+        ImmutableArray<string> candidateScopes,
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext,
+        Dictionary<
+            string,
+            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
+        > bindingsByContainingScope
+    )
+    {
+        var binding = rootTable.ColumnBindings[bindingIndex];
+
+        switch (binding.Source)
+        {
+            case WriteValueSource.Precomputed:
+            case WriteValueSource.DocumentId:
+                return RootBindingDisposition.StorageManaged;
+            case WriteValueSource.ParentKeyPart:
+            case WriteValueSource.Ordinal:
+                throw new InvalidOperationException(
+                    $"Root table '{FormatTable(rootTable)}' contains a "
+                        + $"{binding.Source.GetType().Name} binding at index {bindingIndex}, "
+                        + "which is a plan-shape violation for a root table."
+                );
+        }
+
+        var bindingPath = ResolveBindingRootRelativePath(writePlan, binding, bindingIndex, rootTable);
+
+        // Longest-prefix scope match. If no profile scope matches, the binding is ungoverned.
+        var containingScope = TryMatchLongestScope(bindingPath, candidateScopes);
+        if (containingScope is null)
+        {
+            return RootBindingDisposition.VisibleWritable;
+        }
+
+        var memberPath = StripScopePrefix(bindingPath, containingScope);
+        var matchKind = ProfileMemberGovernanceRules.MatchKindFor(binding.Source);
+
+        // Record this binding under its containing scope so the post-pass drift check can
+        // verify every stored scope / hidden-member-path resolves to at least one binding.
+        if (!bindingsByContainingScope.TryGetValue(containingScope, out var bindingsUnderScope))
+        {
+            bindingsUnderScope = [];
+            bindingsByContainingScope[containingScope] = bindingsUnderScope;
+        }
+        bindingsUnderScope.Add((memberPath, matchKind));
+
+        if (profileAppliedContext is null)
+        {
+            return RootBindingDisposition.VisibleWritable;
+        }
+
+        var storedScope = ProfileMemberGovernanceRules.LookupStoredScope(
+            profileAppliedContext,
+            containingScope
+        );
+        if (storedScope is not null)
+        {
+            if (storedScope.Visibility == ProfileVisibilityKind.Hidden)
+            {
+                return RootBindingDisposition.HiddenPreserved;
+            }
+            if (
+                ProfileMemberGovernanceRules.IsHiddenGoverned(
+                    memberPath,
+                    storedScope.HiddenMemberPaths,
+                    matchKind
+                )
+            )
+            {
+                return RootBindingDisposition.HiddenPreserved;
+            }
+        }
+
+        var requestScope = ProfileMemberGovernanceRules.LookupRequestScope(profileRequest, containingScope);
+        if (requestScope is not null && requestScope.Visibility == ProfileVisibilityKind.VisibleAbsent)
+        {
+            return RootBindingDisposition.ClearOnVisibleAbsent;
+        }
+
+        return RootBindingDisposition.VisibleWritable;
+    }
+
+    /// <summary>
+    /// Verifies that every stored scope in the profile context resolves to at least one
+    /// ordinary root-table binding, and that every <c>HiddenMemberPath</c> within each stored
+    /// scope is matched (per its binding's <see cref="ProfileMemberGovernanceRules.HiddenPathMatchKind"/>)
+    /// by at least one binding under that scope. Throws <see cref="InvalidOperationException"/>
+    /// otherwise. This converts upstream Core / write-plan contract drift into a deterministic
+    /// invariant failure rather than silent under-preservation.
+    /// </summary>
+    private static void ValidateStoredScopeMetadata(
+        ProfileAppliedWriteContext profileAppliedContext,
+        Dictionary<
+            string,
+            List<(string MemberPath, ProfileMemberGovernanceRules.HiddenPathMatchKind MatchKind)>
+        > bindingsByContainingScope,
+        TableWritePlan rootTable
+    )
+    {
+        foreach (var storedScope in profileAppliedContext.StoredScopeStates)
+        {
+            var scopeCanonical = storedScope.Address.JsonScope;
+            if (
+                !bindingsByContainingScope.TryGetValue(scopeCanonical, out var bindingsUnderScope)
+                || bindingsUnderScope.Count == 0
+            )
+            {
+                throw new InvalidOperationException(
+                    $"Stored scope '{scopeCanonical}' on root table '{FormatTable(rootTable)}' "
+                        + "does not resolve to any root-table binding. This indicates upstream "
+                        + "Core / write-plan contract drift."
+                );
+            }
+
+            foreach (var hiddenPath in storedScope.HiddenMemberPaths)
+            {
+                var matched = false;
+                var singleHiddenPath = ImmutableArray.Create(hiddenPath);
+                foreach (var (memberPath, matchKind) in bindingsUnderScope)
+                {
+                    if (
+                        ProfileMemberGovernanceRules.IsHiddenGoverned(memberPath, singleHiddenPath, matchKind)
+                    )
+                    {
+                        matched = true;
+                        break;
+                    }
+                }
+                if (!matched)
+                {
+                    throw new InvalidOperationException(
+                        $"Hidden member path '{hiddenPath}' in stored scope '{scopeCanonical}' "
+                            + $"on root table '{FormatTable(rootTable)}' does not resolve to any "
+                            + "root-table binding under that scope. This indicates upstream "
+                            + "Core / write-plan contract drift."
+                    );
+                }
+            }
+        }
+    }
+
+    private static string ResolveBindingRootRelativePath(
+        ResourceWritePlan writePlan,
+        WriteColumnBinding binding,
+        int bindingIndex,
+        TableWritePlan rootTable
+    ) =>
+        binding.Source switch
+        {
+            WriteValueSource.Scalar scalar => scalar.RelativePath.Canonical,
+            WriteValueSource.DescriptorReference descriptor => descriptor.RelativePath.Canonical,
+            WriteValueSource.DocumentReference documentReference => writePlan
+                .Model
+                .DocumentReferenceBindings[documentReference.BindingIndex]
+                .ReferenceObjectPath
+                .Canonical,
+            WriteValueSource.ReferenceDerived referenceDerived => referenceDerived
+                .ReferenceSource
+                .ReferenceJsonPath
+                .Canonical,
+            _ => throw new InvalidOperationException(
+                $"Root-table binding at index {bindingIndex} on table '{FormatTable(rootTable)}' "
+                    + $"has a WriteValueSource kind '{binding.Source.GetType().Name}' that the classifier "
+                    + "does not know how to resolve. Storage-managed and plan-shape kinds must be filtered upstream."
+            ),
+        };
+
+    private static string? TryMatchLongestScope(string bindingPath, ImmutableArray<string> candidateScopes)
+    {
+        // candidateScopes is pre-sorted longest-first.
+        foreach (var scope in candidateScopes)
+        {
+            if (string.Equals(bindingPath, scope, StringComparison.Ordinal))
+            {
+                return scope;
+            }
+            if (
+                bindingPath.StartsWith(scope, StringComparison.Ordinal)
+                && bindingPath.Length > scope.Length
+                && bindingPath[scope.Length] == '.'
+            )
+            {
+                return scope;
+            }
+        }
+        return null;
+    }
+
+    private static string StripScopePrefix(string bindingPath, string scope)
+    {
+        if (string.Equals(bindingPath, scope, StringComparison.Ordinal))
+        {
+            // Binding path equals the scope itself — member path is empty (rare; an exact-path
+            // hidden match would also have to be empty-string for it to govern).
+            return string.Empty;
+        }
+        // bindingPath = scope + '.' + memberPath
+        return bindingPath[(scope.Length + 1)..];
+    }
+
+    private static string FormatTable(TableWritePlan rootTable) =>
+        $"{rootTable.TableModel.Table.Schema.Value}.{rootTable.TableModel.Table.Name}";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileSliceFenceClassifier.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileSliceFenceClassifier.cs
@@ -14,9 +14,13 @@ namespace EdFi.DataManagementService.Backend.Profile;
 /// </summary>
 /// <remarks>
 /// Visibility rule for scope-state streams:
-/// <see cref="ProfileVisibilityKind.Hidden"/> scope-state metadata is preserve-only
-/// and does not escalate; <see cref="ProfileVisibilityKind.VisiblePresent"/> and
-/// <see cref="ProfileVisibilityKind.VisibleAbsent"/> both escalate by topology.
+/// On the request side (create-new), <see cref="ProfileVisibilityKind.Hidden"/> scope-state
+/// metadata is preserve-only and does not escalate; only
+/// <see cref="ProfileVisibilityKind.VisiblePresent"/> and
+/// <see cref="ProfileVisibilityKind.VisibleAbsent"/> escalate by topology.
+/// On the stored side, scope states always participate in family selection regardless of
+/// visibility — even hidden stored scopes require the owning slice family because the
+/// existing-document flow still has to preserve them correctly.
 /// Row streams (<c>VisibleRequestCollectionItems</c>, <c>VisibleStoredCollectionRows</c>)
 /// are visible-only by contract and continue to escalate unconditionally.
 /// </remarks>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
+
+namespace EdFi.DataManagementService.Backend.Profile;
+
+/// <summary>
+/// Input contract for the profile merge synthesizer. Slice 2 constrains this to a
+/// single-table (root-only) write plan; the synthesizer invariants are checked in
+/// the constructor so downstream code may assume a shape it can rely on.
+/// </summary>
+internal sealed record RelationalWriteProfileMergeRequest
+{
+    public RelationalWriteProfileMergeRequest(
+        ResourceWritePlan writePlan,
+        FlattenedWriteSet flattenedWriteSet,
+        JsonNode writableRequestBody,
+        RelationalWriteCurrentState? currentState,
+        ProfileAppliedWriteRequest profileRequest,
+        ProfileAppliedWriteContext? profileAppliedContext,
+        ResolvedReferenceSet resolvedReferences
+    )
+    {
+        WritePlan = writePlan ?? throw new ArgumentNullException(nameof(writePlan));
+        FlattenedWriteSet = flattenedWriteSet ?? throw new ArgumentNullException(nameof(flattenedWriteSet));
+        WritableRequestBody =
+            writableRequestBody ?? throw new ArgumentNullException(nameof(writableRequestBody));
+        CurrentState = currentState;
+        ProfileRequest = profileRequest ?? throw new ArgumentNullException(nameof(profileRequest));
+        ProfileAppliedContext = profileAppliedContext;
+        ResolvedReferences =
+            resolvedReferences ?? throw new ArgumentNullException(nameof(resolvedReferences));
+
+        if (WritePlan.TablePlansInDependencyOrder.Length != 1)
+        {
+            throw new ArgumentException(
+                "RelationalWriteProfileMergeRequest requires a single-table write plan for Slice 2.",
+                nameof(writePlan)
+            );
+        }
+        if (
+            !ReferenceEquals(
+                WritePlan.TablePlansInDependencyOrder[0],
+                FlattenedWriteSet.RootRow.TableWritePlan
+            )
+        )
+        {
+            throw new ArgumentException(
+                $"{nameof(flattenedWriteSet)} must use the root table from the supplied {nameof(writePlan)}.",
+                nameof(flattenedWriteSet)
+            );
+        }
+        if (
+            ProfileAppliedContext is not null
+            && !ReferenceEquals(ProfileAppliedContext.Request, ProfileRequest)
+        )
+        {
+            throw new ArgumentException(
+                $"{nameof(profileAppliedContext)}.Request must be the same instance as {nameof(profileRequest)}.",
+                nameof(profileAppliedContext)
+            );
+        }
+        if ((CurrentState is null) != (ProfileAppliedContext is null))
+        {
+            throw new ArgumentException(
+                $"{nameof(currentState)} and {nameof(profileAppliedContext)} must both be null (create-new) "
+                    + "or both be non-null (existing-document)."
+            );
+        }
+    }
+
+    public ResourceWritePlan WritePlan { get; init; }
+
+    public FlattenedWriteSet FlattenedWriteSet { get; init; }
+
+    public JsonNode WritableRequestBody { get; init; }
+
+    public RelationalWriteCurrentState? CurrentState { get; init; }
+
+    public ProfileAppliedWriteRequest ProfileRequest { get; init; }
+
+    public ProfileAppliedWriteContext? ProfileAppliedContext { get; init; }
+
+    public ResolvedReferenceSet ResolvedReferences { get; init; }
+}
+
+internal interface IRelationalWriteProfileMergeSynthesizer
+{
+    RelationalWriteMergeResult Synthesize(RelationalWriteProfileMergeRequest request);
+}
+
+/// <summary>
+/// Root-table-only profile merge synthesizer for Slice 2. Composes the root-table binding
+/// classifier, the per-disposition overlay, and the post-overlay key-unification resolver
+/// into a single <see cref="RelationalWriteMergeResult"/>. Slice 2 does not support
+/// guarded no-op; <see cref="RelationalWriteMergeResult.SupportsGuardedNoOp"/> is always
+/// <c>false</c>.
+/// </summary>
+internal sealed class RelationalWriteProfileMergeSynthesizer(
+    IProfileRootTableBindingClassifier classifier,
+    IProfileRootKeyUnificationResolver resolver
+) : IRelationalWriteProfileMergeSynthesizer
+{
+    private readonly IProfileRootTableBindingClassifier _classifier =
+        classifier ?? throw new ArgumentNullException(nameof(classifier));
+    private readonly IProfileRootKeyUnificationResolver _resolver =
+        resolver ?? throw new ArgumentNullException(nameof(resolver));
+
+    public RelationalWriteMergeResult Synthesize(RelationalWriteProfileMergeRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var rootTable = request.WritePlan.TablePlansInDependencyOrder[0];
+
+        // 1. Project the current root row (binding-indexed) and the column-name projection for
+        //    the resolver context. Both come from the same hydrated row via shared support
+        //    helpers so downstream normalization stays symmetric.
+        RelationalWriteMergedTableRow? projectedCurrentRootRow = null;
+        IReadOnlyDictionary<DbColumnName, object?> currentRootRowByColumnName = ImmutableDictionary<
+            DbColumnName,
+            object?
+        >.Empty;
+
+        if (request.CurrentState is not null)
+        {
+            var hydrated = request.CurrentState.TableRowsInDependencyOrder.Single(h =>
+                h.TableModel.Table.Equals(rootTable.TableModel.Table)
+            );
+            if (hydrated.Rows.Count != 1)
+            {
+                throw new InvalidOperationException(
+                    $"Root table '{FormatTable(rootTable)}' has {hydrated.Rows.Count} current rows "
+                        + "for profiled existing-document merge; expected exactly one."
+                );
+            }
+
+            var projected = RelationalWriteMergeSupport.ProjectCurrentRows(rootTable, hydrated.Rows);
+            projectedCurrentRootRow = projected[0];
+            currentRootRowByColumnName = RelationalWriteMergeSupport.BuildCurrentRootRowByColumnName(
+                rootTable.TableModel,
+                hydrated.Rows[0]
+            );
+        }
+
+        // 2. Classify root-table bindings.
+        var classification = _classifier.Classify(
+            request.WritePlan,
+            request.ProfileRequest,
+            request.ProfileAppliedContext
+        );
+
+        // 3. Overlay per disposition. Skip resolver-owned bindings; the resolver writes them
+        //    in step 4.
+        var mergedValues = new FlattenedWriteValue[rootTable.ColumnBindings.Length];
+        for (var bindingIndex = 0; bindingIndex < mergedValues.Length; bindingIndex++)
+        {
+            if (classification.ResolverOwnedBindingIndices.Contains(bindingIndex))
+            {
+                // Resolver will write; leave a default so the array is fully populated before
+                // the resolver call (the resolver overwrites these indices).
+                continue;
+            }
+            switch (classification.BindingsByIndex[bindingIndex])
+            {
+                case RootBindingDisposition.VisibleWritable:
+                case RootBindingDisposition.StorageManaged:
+                    mergedValues[bindingIndex] = request.FlattenedWriteSet.RootRow.Values[bindingIndex];
+                    break;
+                case RootBindingDisposition.HiddenPreserved:
+                    if (projectedCurrentRootRow is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Root-table binding at index {bindingIndex} on table '{FormatTable(rootTable)}' "
+                                + "classified HiddenPreserved, but no current row is available. "
+                                + "Upstream contract violation between classifier and synthesizer."
+                        );
+                    }
+                    mergedValues[bindingIndex] = projectedCurrentRootRow.Values[bindingIndex];
+                    break;
+                case RootBindingDisposition.ClearOnVisibleAbsent:
+                    mergedValues[bindingIndex] = new FlattenedWriteValue.Literal(null);
+                    break;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected RootBindingDisposition '{classification.BindingsByIndex[bindingIndex]}' "
+                            + $"at index {bindingIndex} on table '{FormatTable(rootTable)}'."
+                    );
+            }
+        }
+
+        // 4. Build the resolver context and recompute canonical + synthetic-presence bindings.
+        var resolvedReferenceLookups = FlatteningResolvedReferenceLookupSet.Create(
+            request.WritePlan,
+            request.ResolvedReferences
+        );
+        var resolverContext = new ProfileRootKeyUnificationContext(
+            WritableRequestBody: request.WritableRequestBody,
+            CurrentState: request.CurrentState,
+            CurrentRootRowByColumnName: currentRootRowByColumnName,
+            ResolvedReferenceLookups: resolvedReferenceLookups,
+            ProfileRequest: request.ProfileRequest,
+            ProfileAppliedContext: request.ProfileAppliedContext
+        );
+
+        _resolver.Resolve(
+            rootTable,
+            resolverContext,
+            mergedValues,
+            classification.ResolverOwnedBindingIndices
+        );
+
+        // 5. Assemble the merge result.
+        var comparableValues = RelationalWriteMergeSupport.ProjectComparableValues(rootTable, mergedValues);
+        var mergedRow = new RelationalWriteMergedTableRow(mergedValues, comparableValues);
+
+        ImmutableArray<RelationalWriteMergedTableRow> currentRows = projectedCurrentRootRow is null
+            ? []
+            : [projectedCurrentRootRow];
+
+        var tableState = new RelationalWriteMergedTableState(rootTable, currentRows, [mergedRow]);
+        return new RelationalWriteMergeResult([tableState], supportsGuardedNoOp: false);
+    }
+
+    private static string FormatTable(TableWritePlan rootTable) =>
+        $"{rootTable.TableModel.Table.Schema.Value}.{rootTable.TableModel.Table.Name}";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
@@ -12,9 +12,10 @@ using EdFi.DataManagementService.Core.Profile;
 namespace EdFi.DataManagementService.Backend.Profile;
 
 /// <summary>
-/// Input contract for the profile merge synthesizer. Slice 2 constrains this to a
-/// single-table (root-only) write plan; the synthesizer invariants are checked in
-/// the constructor so downstream code may assume a shape it can rely on.
+/// Input contract for the profile merge synthesizer. Slice 2 merge itself is root-table-only,
+/// but the input write plan may carry additional tables (e.g. a separate-table extension scope
+/// that the profile renders hidden or request-absent). Those non-root tables are intentionally
+/// excluded from the produced merge result; the persister then leaves them untouched.
 /// </summary>
 internal sealed record RelationalWriteProfileMergeRequest
 {
@@ -38,13 +39,6 @@ internal sealed record RelationalWriteProfileMergeRequest
         ResolvedReferences =
             resolvedReferences ?? throw new ArgumentNullException(nameof(resolvedReferences));
 
-        if (WritePlan.TablePlansInDependencyOrder.Length != 1)
-        {
-            throw new ArgumentException(
-                "RelationalWriteProfileMergeRequest requires a single-table write plan for Slice 2.",
-                nameof(writePlan)
-            );
-        }
         if (
             !ReferenceEquals(
                 WritePlan.TablePlansInDependencyOrder[0],

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/RelationalWriteProfileMerge.cs
@@ -15,7 +15,10 @@ namespace EdFi.DataManagementService.Backend.Profile;
 /// Input contract for the profile merge synthesizer. Slice 2 merge itself is root-table-only,
 /// but the input write plan may carry additional tables (e.g. a separate-table extension scope
 /// that the profile renders hidden or request-absent). Those non-root tables are intentionally
-/// excluded from the produced merge result; the persister then leaves them untouched.
+/// excluded from the produced merge result; the persister then leaves them untouched. The
+/// handed-off <see cref="FlattenedWriteSet"/>, however, must itself be root-only: non-root
+/// flattened buffers (root-extension rows or collection candidates on the root row) must be
+/// fenced upstream and are rejected fail-closed here.
 /// </summary>
 internal sealed record RelationalWriteProfileMergeRequest
 {
@@ -48,6 +51,17 @@ internal sealed record RelationalWriteProfileMergeRequest
         {
             throw new ArgumentException(
                 $"{nameof(flattenedWriteSet)} must use the root table from the supplied {nameof(writePlan)}.",
+                nameof(flattenedWriteSet)
+            );
+        }
+        if (
+            !FlattenedWriteSet.RootRow.RootExtensionRows.IsDefaultOrEmpty
+            || !FlattenedWriteSet.RootRow.CollectionCandidates.IsDefaultOrEmpty
+        )
+        {
+            throw new ArgumentException(
+                "Slice 2 profile merge requires a root-only flattened shape; non-root flattened "
+                    + "buffers (root-extension rows or collection candidates) must be fenced upstream.",
                 nameof(flattenedWriteSet)
             );
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Profile;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -74,6 +75,18 @@ public static class ReferenceResolverServiceCollectionExtensions
             ServiceDescriptor.Scoped<
                 IRelationalWriteNoProfileMergeSynthesizer,
                 RelationalWriteNoProfileMergeSynthesizer
+            >()
+        );
+        services.TryAdd(
+            ServiceDescriptor.Scoped<IProfileRootTableBindingClassifier, ProfileRootTableBindingClassifier>()
+        );
+        services.TryAdd(
+            ServiceDescriptor.Scoped<IProfileRootKeyUnificationResolver, ProfileRootKeyUnificationResolver>()
+        );
+        services.TryAdd(
+            ServiceDescriptor.Scoped<
+                IRelationalWriteProfileMergeSynthesizer,
+                RelationalWriteProfileMergeSynthesizer
             >()
         );
         services.TryAdd(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -77,7 +77,7 @@ public static class ReferenceResolverServiceCollectionExtensions
             >()
         );
         services.TryAdd(
-            ServiceDescriptor.Scoped<IRelationalWriteNoProfilePersister, RelationalWriteNoProfilePersister>()
+            ServiceDescriptor.Scoped<IRelationalWritePersister, RelationalWriteNoProfilePersister>()
         );
         services.TryAdd(
             ServiceDescriptor.Scoped<

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFlattener.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFlattener.cs
@@ -547,7 +547,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
             );
             valueAssigned[keyUnificationPlan.CanonicalBindingIndex] = true;
 
-            ValidateKeyUnificationGuardrails(
+            Profile.ProfileKeyUnificationGuardrails.Validate(
                 tableWritePlan,
                 keyUnificationPlan,
                 canonicalValue,
@@ -572,7 +572,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
 
         foreach (var member in keyUnificationPlan.MembersInOrder)
         {
-            var evaluation = EvaluateKeyUnificationMember(
+            var evaluation = Profile.FlattenerMemberEvaluation.EvaluateKeyUnificationMember(
                 tableWritePlan,
                 member,
                 scopeNode,
@@ -616,214 +616,6 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         }
 
         return canonicalValue;
-    }
-
-    private static KeyUnificationMemberEvaluation EvaluateKeyUnificationMember(
-        TableWritePlan tableWritePlan,
-        KeyUnificationMemberWritePlan member,
-        JsonNode scopeNode,
-        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
-        ReadOnlySpan<int> ordinalPath
-    )
-    {
-        var absolutePath = RelationalJsonPathSupport.CombineRestrictedCanonical(
-            tableWritePlan.TableModel.JsonScope,
-            member.RelativePath
-        );
-
-        return member switch
-        {
-            KeyUnificationMemberWritePlan.ScalarMember scalarMember => EvaluateScalarKeyUnificationMember(
-                tableWritePlan,
-                scalarMember,
-                absolutePath,
-                scopeNode
-            ),
-            KeyUnificationMemberWritePlan.DescriptorMember descriptorMember =>
-                EvaluateDescriptorKeyUnificationMember(
-                    tableWritePlan,
-                    descriptorMember,
-                    absolutePath,
-                    scopeNode,
-                    resolvedReferenceLookups,
-                    ordinalPath
-                ),
-            KeyUnificationMemberWritePlan.ReferenceDerivedMember referenceDerivedMember =>
-                EvaluateReferenceDerivedKeyUnificationMember(
-                    tableWritePlan,
-                    referenceDerivedMember,
-                    absolutePath,
-                    scopeNode,
-                    resolvedReferenceLookups,
-                    ordinalPath
-                ),
-            _ => throw new InvalidOperationException(
-                $"Unsupported key-unification member kind '{member.GetType().Name}' on table '{FormatTable(tableWritePlan)}'."
-            ),
-        };
-    }
-
-    private static KeyUnificationMemberEvaluation EvaluateScalarKeyUnificationMember(
-        TableWritePlan tableWritePlan,
-        KeyUnificationMemberWritePlan.ScalarMember member,
-        string absolutePath,
-        JsonNode scopeNode
-    )
-    {
-        if (!TryGetRelativeLeafNode(scopeNode, member.RelativePath, out var memberNode) || memberNode is null)
-        {
-            return KeyUnificationMemberEvaluation.Absent;
-        }
-
-        var conversionContext = CreateKeyUnificationScalarConversionContext(
-            tableWritePlan,
-            member,
-            absolutePath
-        );
-
-        if (memberNode is not JsonValue jsonValue)
-        {
-            throw CreateInvalidRequestDerivedScalarException(
-                conversionContext,
-                member.ScalarType,
-                $"encountered non-scalar JSON node type '{memberNode.GetType().Name}'"
-            );
-        }
-
-        return KeyUnificationMemberEvaluation.Present(
-            ConvertRequestDerivedJsonValue(jsonValue, member.ScalarType, conversionContext)
-        );
-    }
-
-    private static KeyUnificationMemberEvaluation EvaluateDescriptorKeyUnificationMember(
-        TableWritePlan tableWritePlan,
-        KeyUnificationMemberWritePlan.DescriptorMember member,
-        string absolutePath,
-        JsonNode scopeNode,
-        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
-        ReadOnlySpan<int> ordinalPath
-    )
-    {
-        if (!TryGetRelativeLeafNode(scopeNode, member.RelativePath, out var memberNode) || memberNode is null)
-        {
-            return KeyUnificationMemberEvaluation.Absent;
-        }
-
-        if (memberNode is not JsonValue jsonValue || !jsonValue.TryGetValue<string>(out _))
-        {
-            throw CreateRequestShapeValidationException(
-                absolutePath,
-                $"Key-unification member '{member.MemberPathColumn.Value}' on table '{FormatTable(tableWritePlan)}' "
-                    + $"expected a descriptor URI string at path '{absolutePath}', but encountered "
-                    + $"JSON value kind '{GetJsonValueKind(memberNode)}'."
-            );
-        }
-
-        var descriptorId = resolvedReferenceLookups.GetDescriptorId(
-            member.DescriptorResource,
-            absolutePath,
-            ordinalPath
-        );
-
-        if (descriptorId is null)
-        {
-            throw new InvalidOperationException(
-                $"Key-unification member '{member.MemberPathColumn.Value}' on table '{FormatTable(tableWritePlan)}' "
-                    + $"did not have a resolved descriptor id for path '{absolutePath}' and descriptor resource "
-                    + $"'{RelationalWriteSupport.FormatResource(member.DescriptorResource)}'."
-            );
-        }
-
-        return KeyUnificationMemberEvaluation.Present(descriptorId.Value);
-    }
-
-    private static KeyUnificationMemberEvaluation EvaluateReferenceDerivedKeyUnificationMember(
-        TableWritePlan tableWritePlan,
-        KeyUnificationMemberWritePlan.ReferenceDerivedMember member,
-        string absolutePath,
-        JsonNode scopeNode,
-        FlatteningResolvedReferenceLookupSet resolvedReferenceLookups,
-        ReadOnlySpan<int> ordinalPath
-    )
-    {
-        if (
-            !TryGetReferenceObjectNode(
-                tableWritePlan,
-                scopeNode,
-                member.ReferenceSource,
-                out var referenceNode
-            ) || referenceNode is null
-        )
-        {
-            return KeyUnificationMemberEvaluation.Absent;
-        }
-
-        var memberPathColumn = GetRequiredColumnModel(tableWritePlan, member.MemberPathColumn);
-        var concreteAbsolutePath = MaterializeValidationPath(absolutePath, ordinalPath);
-
-        return KeyUnificationMemberEvaluation.Present(
-            ResolveReferenceDerivedLiteralValue(
-                tableWritePlan,
-                memberPathColumn,
-                member.MemberPathColumn,
-                member.ReferenceSource,
-                concreteAbsolutePath,
-                resolvedReferenceLookups,
-                ordinalPath
-            )
-        );
-    }
-
-    private static void ValidateKeyUnificationGuardrails(
-        TableWritePlan tableWritePlan,
-        KeyUnificationWritePlan keyUnificationPlan,
-        object? canonicalValue,
-        IReadOnlyList<FlattenedWriteValue> values,
-        IReadOnlyList<bool> valueAssigned
-    )
-    {
-        foreach (var member in keyUnificationPlan.MembersInOrder)
-        {
-            if (member.PresenceBindingIndex is not int presenceBindingIndex)
-            {
-                continue;
-            }
-
-            if (!valueAssigned[presenceBindingIndex])
-            {
-                throw new InvalidOperationException(
-                    $"Presence binding for key-unification member '{member.MemberPathColumn.Value}' on table "
-                        + $"'{FormatTable(tableWritePlan)}' was not assigned before guardrail validation."
-                );
-            }
-
-            if (values[presenceBindingIndex] is not FlattenedWriteValue.Literal presenceValue)
-            {
-                throw new InvalidOperationException(
-                    $"Presence binding for key-unification member '{member.MemberPathColumn.Value}' on table "
-                        + $"'{FormatTable(tableWritePlan)}' was not materialized as a literal value."
-                );
-            }
-
-            if (presenceValue.Value is not null && canonicalValue is null)
-            {
-                throw new InvalidOperationException(
-                    $"Key-unification canonical column '{keyUnificationPlan.CanonicalColumn.Value}' on table "
-                        + $"'{FormatTable(tableWritePlan)}' resolved to null while presence column "
-                        + $"'{member.PresenceColumn!.Value}' indicated member '{member.MemberPathColumn.Value}' was present."
-                );
-            }
-        }
-
-        var canonicalBinding = tableWritePlan.ColumnBindings[keyUnificationPlan.CanonicalBindingIndex];
-
-        if (!canonicalBinding.Column.IsNullable && canonicalValue is null)
-        {
-            throw new InvalidOperationException(
-                $"Key-unification canonical column '{canonicalBinding.Column.ColumnName.Value}' on table "
-                    + $"'{FormatTable(tableWritePlan)}' is not nullable but resolved to null."
-            );
-        }
     }
 
     private static void EnsureAllBindingsAssigned(
@@ -1401,7 +1193,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
             );
     }
 
-    private static bool TryGetRelativeLeafNode(
+    internal static bool TryGetRelativeLeafNode(
         JsonNode scopeNode,
         JsonPathExpression relativePath,
         out JsonNode? value
@@ -1436,7 +1228,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         return TryNavigateRelativeNode(selectedBody, scopeSegments, out scopeNode);
     }
 
-    private static bool TryGetReferenceObjectNode(
+    internal static bool TryGetReferenceObjectNode(
         TableWritePlan tableWritePlan,
         JsonNode scopeNode,
         ReferenceDerivedValueSourceMetadata referenceSource,
@@ -1499,7 +1291,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         );
     }
 
-    private static DbColumnModel GetRequiredColumnModel(
+    internal static DbColumnModel GetRequiredColumnModel(
         TableWritePlan tableWritePlan,
         DbColumnName columnName
     )
@@ -1527,7 +1319,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         return ordinalPath;
     }
 
-    private static object ResolveReferenceDerivedLiteralValue(
+    internal static object ResolveReferenceDerivedLiteralValue(
         TableWritePlan tableWritePlan,
         DbColumnModel column,
         DbColumnName columnName,
@@ -1629,7 +1421,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         );
     }
 
-    private static object ConvertRequestDerivedJsonValue(
+    internal static object ConvertRequestDerivedJsonValue(
         JsonValue jsonValue,
         RelationalScalarType scalarType,
         RequestDerivedScalarConversionContext conversionContext
@@ -1855,7 +1647,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         );
     }
 
-    private static RequestDerivedScalarConversionContext CreateKeyUnificationScalarConversionContext(
+    internal static RequestDerivedScalarConversionContext CreateKeyUnificationScalarConversionContext(
         TableWritePlan tableWritePlan,
         KeyUnificationMemberWritePlan.ScalarMember member,
         string absolutePath
@@ -1867,7 +1659,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         );
     }
 
-    private static RelationalWriteRequestValidationException CreateInvalidRequestDerivedScalarException(
+    internal static RelationalWriteRequestValidationException CreateInvalidRequestDerivedScalarException(
         RequestDerivedScalarConversionContext conversionContext,
         RelationalScalarType scalarType,
         string reason
@@ -1884,7 +1676,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         );
     }
 
-    private static RelationalWriteRequestValidationException CreateRequestShapeValidationException(
+    internal static RelationalWriteRequestValidationException CreateRequestShapeValidationException(
         string path,
         string message
     )
@@ -1978,7 +1770,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         return $"[{string.Join(", ", ordinalPath.ToArray())}]";
     }
 
-    private static string GetJsonValueKind(JsonNode node)
+    internal static string GetJsonValueKind(JsonNode node)
     {
         return node switch
         {
@@ -1987,7 +1779,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         };
     }
 
-    private static string FormatTable(TableWritePlan tableWritePlan)
+    internal static string FormatTable(TableWritePlan tableWritePlan)
     {
         ArgumentNullException.ThrowIfNull(tableWritePlan);
         return $"{tableWritePlan.TableModel.Table.Schema.Value}.{tableWritePlan.TableModel.Table.Name}";
@@ -2071,7 +1863,7 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
         return concretePath.ToString();
     }
 
-    private static string MaterializeValidationPath(
+    internal static string MaterializeValidationPath(
         string wildcardOrConcretePath,
         ReadOnlySpan<int> ordinalPath
     )
@@ -2083,20 +1875,10 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
             : wildcardOrConcretePath;
     }
 
-    private sealed record RequestDerivedScalarConversionContext(
+    internal sealed record RequestDerivedScalarConversionContext(
         string AbsolutePath,
         string SubjectDescription
     );
-
-    private sealed record KeyUnificationMemberEvaluation(bool IsPresent, object? Value)
-    {
-        public static KeyUnificationMemberEvaluation Absent { get; } = new(false, null);
-
-        public static KeyUnificationMemberEvaluation Present(object value)
-        {
-            return new(true, value);
-        }
-    }
 
     private sealed record CollectionChildPlan(
         TableWritePlan TableWritePlan,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteGuardedNoOp.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteGuardedNoOp.cs
@@ -10,7 +10,7 @@ namespace EdFi.DataManagementService.Backend;
 
 internal static class RelationalWriteGuardedNoOp
 {
-    public static bool IsNoOpCandidate(RelationalWriteNoProfileMergeResult mergeResult)
+    public static bool IsNoOpCandidate(RelationalWriteMergeResult mergeResult)
     {
         ArgumentNullException.ThrowIfNull(mergeResult);
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteIdentityStability.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteIdentityStability.cs
@@ -13,18 +13,18 @@ internal static class RelationalWriteIdentityStability
 {
     public static RelationalWriteExecutorResult? TryBuildFailureResult(
         RelationalWriteExecutorRequest request,
-        RelationalWriteNoProfileMergeResult noProfileMergeResult
+        RelationalWriteMergeResult mergeResult
     )
     {
         ArgumentNullException.ThrowIfNull(request);
-        ArgumentNullException.ThrowIfNull(noProfileMergeResult);
+        ArgumentNullException.ThrowIfNull(mergeResult);
 
         if (request.TargetContext is not RelationalWriteTargetContext.ExistingDocument)
         {
             return null;
         }
 
-        var rootTableState = noProfileMergeResult.TablesInDependencyOrder.SingleOrDefault(tableState =>
+        var rootTableState = mergeResult.TablesInDependencyOrder.SingleOrDefault(tableState =>
             tableState.TableWritePlan.TableModel.Table.Equals(request.WritePlan.Model.Root.Table)
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeContract.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeContract.cs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+internal sealed record RelationalWriteMergedTableRow
+{
+    public RelationalWriteMergedTableRow(
+        IEnumerable<FlattenedWriteValue> values,
+        IEnumerable<FlattenedWriteValue> comparableValues
+    )
+    {
+        Values = FlattenedWriteContractSupport.ToImmutableArray(values, nameof(values));
+        ComparableValues = FlattenedWriteContractSupport.ToImmutableArray(
+            comparableValues,
+            nameof(comparableValues)
+        );
+    }
+
+    public ImmutableArray<FlattenedWriteValue> Values { get; init; }
+
+    public ImmutableArray<FlattenedWriteValue> ComparableValues { get; init; }
+}
+
+internal sealed record RelationalWriteMergedTableState
+{
+    public RelationalWriteMergedTableState(
+        TableWritePlan tableWritePlan,
+        IEnumerable<RelationalWriteMergedTableRow> currentRows,
+        IEnumerable<RelationalWriteMergedTableRow> mergedRows
+    )
+    {
+        TableWritePlan = tableWritePlan ?? throw new ArgumentNullException(nameof(tableWritePlan));
+        CurrentRows = FlattenedWriteContractSupport.ToImmutableArray(currentRows, nameof(currentRows));
+        MergedRows = FlattenedWriteContractSupport.ToImmutableArray(mergedRows, nameof(mergedRows));
+    }
+
+    public TableWritePlan TableWritePlan { get; init; }
+
+    public ImmutableArray<RelationalWriteMergedTableRow> CurrentRows { get; init; }
+
+    public ImmutableArray<RelationalWriteMergedTableRow> MergedRows { get; init; }
+}
+
+internal sealed record RelationalWriteMergeResult
+{
+    public RelationalWriteMergeResult(
+        IEnumerable<RelationalWriteMergedTableState> tablesInDependencyOrder,
+        bool supportsGuardedNoOp
+    )
+    {
+        TablesInDependencyOrder = FlattenedWriteContractSupport.ToImmutableArray(
+            tablesInDependencyOrder,
+            nameof(tablesInDependencyOrder)
+        );
+        SupportsGuardedNoOp = supportsGuardedNoOp;
+    }
+
+    public ImmutableArray<RelationalWriteMergedTableState> TablesInDependencyOrder { get; init; }
+
+    public bool SupportsGuardedNoOp { get; init; }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeSupport.cs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Shared, projection-focused helpers used by the relational write merge
+/// synthesizers (no-profile today, profile-merge in a later slice) and the
+/// post-overlay key-unification resolver. Extracted without behavior change
+/// from <see cref="RelationalWriteNoProfileMergeSynthesizer"/>.
+/// </summary>
+internal static class RelationalWriteMergeSupport
+{
+    internal static int FindBindingIndex(TableWritePlan tableWritePlan, DbColumnName columnName)
+    {
+        for (var bindingIndex = 0; bindingIndex < tableWritePlan.ColumnBindings.Length; bindingIndex++)
+        {
+            if (tableWritePlan.ColumnBindings[bindingIndex].Column.ColumnName.Equals(columnName))
+            {
+                return bindingIndex;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Table '{FormatTable(tableWritePlan)}' does not contain a binding for column '{columnName.Value}'."
+        );
+    }
+
+    internal static ImmutableArray<FlattenedWriteValue> ProjectComparableValues(
+        TableWritePlan tableWritePlan,
+        IReadOnlyList<FlattenedWriteValue> values
+    )
+    {
+        var bindingIndexes = tableWritePlan.CollectionMergePlan is null
+            ? Enumerable.Range(0, tableWritePlan.ColumnBindings.Length)
+            : tableWritePlan.CollectionMergePlan.CompareBindingIndexesInOrder;
+
+        FlattenedWriteValue[] comparableValues = bindingIndexes
+            .Select(bindingIndex => values[bindingIndex])
+            .ToArray();
+
+        return comparableValues.ToImmutableArray();
+    }
+
+    internal static object? NormalizeHydratedValue(DbColumnModel column, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(column);
+
+        if (value is null || column.ScalarType is null)
+        {
+            return value;
+        }
+
+        return column.ScalarType.Kind switch
+        {
+            ScalarKind.Date => NormalizeDateValue(value),
+            ScalarKind.Time => NormalizeTimeValue(value),
+            _ => value,
+        };
+    }
+
+    internal static ImmutableArray<RelationalWriteMergedTableRow> ProjectCurrentRows(
+        TableWritePlan tableWritePlan,
+        IReadOnlyList<object?[]> hydratedRows
+    )
+    {
+        List<RelationalWriteMergedTableRow> projectedRows = [];
+
+        foreach (var hydratedRow in hydratedRows)
+        {
+            FlattenedWriteValue[] bindingValues = new FlattenedWriteValue[
+                tableWritePlan.ColumnBindings.Length
+            ];
+
+            for (var bindingIndex = 0; bindingIndex < tableWritePlan.ColumnBindings.Length; bindingIndex++)
+            {
+                var binding = tableWritePlan.ColumnBindings[bindingIndex];
+                var columnOrdinal = FindColumnOrdinal(tableWritePlan.TableModel, binding.Column.ColumnName);
+                bindingValues[bindingIndex] = new FlattenedWriteValue.Literal(
+                    NormalizeHydratedValue(binding.Column, hydratedRow[columnOrdinal])
+                );
+            }
+
+            projectedRows.Add(
+                new RelationalWriteMergedTableRow(
+                    bindingValues,
+                    ProjectComparableValues(tableWritePlan, bindingValues)
+                )
+            );
+        }
+
+        return projectedRows.ToImmutableArray();
+    }
+
+    /// <summary>
+    /// Builds a normalized-by-column projection of a single hydrated table row, keyed
+    /// by column name. Includes every column in <paramref name="rootTableModel"/>.Columns,
+    /// both binding-backed and alias-only. Each value is normalized via
+    /// <see cref="NormalizeHydratedValue"/> so Date/Time comparisons in downstream
+    /// key-unification agreement checks match the binding-indexed projection's
+    /// normalization.
+    /// </summary>
+    internal static IReadOnlyDictionary<DbColumnName, object?> BuildCurrentRootRowByColumnName(
+        DbTableModel rootTableModel,
+        IReadOnlyList<object?> hydratedRow
+    )
+    {
+        ArgumentNullException.ThrowIfNull(rootTableModel);
+        ArgumentNullException.ThrowIfNull(hydratedRow);
+
+        var result = new Dictionary<DbColumnName, object?>();
+        for (var columnOrdinal = 0; columnOrdinal < rootTableModel.Columns.Count; columnOrdinal++)
+        {
+            var column = rootTableModel.Columns[columnOrdinal];
+            result[column.ColumnName] = NormalizeHydratedValue(column, hydratedRow[columnOrdinal]);
+        }
+        return result;
+    }
+
+    private static int FindColumnOrdinal(DbTableModel tableModel, DbColumnName columnName)
+    {
+        for (var columnOrdinal = 0; columnOrdinal < tableModel.Columns.Count; columnOrdinal++)
+        {
+            if (tableModel.Columns[columnOrdinal].ColumnName.Equals(columnName))
+            {
+                return columnOrdinal;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"Hydrated table '{tableModel.Table.Schema.Value}.{tableModel.Table.Name}' does not contain column '{columnName.Value}'."
+        );
+    }
+
+    private static object NormalizeDateValue(object value) =>
+        value switch
+        {
+            DateOnly => value,
+            DateTime dateTime => DateOnly.FromDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => DateOnly.FromDateTime(dateTimeOffset.DateTime),
+            _ => value,
+        };
+
+    private static object NormalizeTimeValue(object value) =>
+        value switch
+        {
+            TimeOnly => value,
+            TimeSpan timeSpan => TimeOnly.FromTimeSpan(timeSpan),
+            DateTime dateTime => TimeOnly.FromDateTime(dateTime),
+            DateTimeOffset dateTimeOffset => TimeOnly.FromDateTime(dateTimeOffset.DateTime),
+            _ => value,
+        };
+
+    private static string FormatTable(TableWritePlan tableWritePlan) =>
+        $"{tableWritePlan.TableModel.Table.Schema.Value}.{tableWritePlan.TableModel.Table.Name}";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfileMerge.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfileMerge.cs
@@ -229,7 +229,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
         IReadOnlyList<FlattenedWriteValue> values
     )
     {
-        var comparableValues = ProjectComparableValues(tableWritePlan, values);
+        var comparableValues = RelationalWriteMergeSupport.ProjectComparableValues(tableWritePlan, values);
 
         return new MergedRow(tableWritePlan, new RelationalWriteMergedTableRow(values, comparableValues));
     }
@@ -294,41 +294,12 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
         )
         {
             var columnName = tableWritePlan.TableModel.IdentityMetadata.PhysicalRowIdentityColumns[index];
-            physicalRowIdentityValues[index] = values[FindBindingIndex(tableWritePlan, columnName)];
+            physicalRowIdentityValues[index] = values[
+                RelationalWriteMergeSupport.FindBindingIndex(tableWritePlan, columnName)
+            ];
         }
 
         return physicalRowIdentityValues.ToImmutableArray();
-    }
-
-    private static ImmutableArray<FlattenedWriteValue> ProjectComparableValues(
-        TableWritePlan tableWritePlan,
-        IReadOnlyList<FlattenedWriteValue> values
-    )
-    {
-        var bindingIndexes = tableWritePlan.CollectionMergePlan is null
-            ? Enumerable.Range(0, tableWritePlan.ColumnBindings.Length)
-            : tableWritePlan.CollectionMergePlan.CompareBindingIndexesInOrder;
-
-        FlattenedWriteValue[] comparableValues = bindingIndexes
-            .Select(bindingIndex => values[bindingIndex])
-            .ToArray();
-
-        return comparableValues.ToImmutableArray();
-    }
-
-    private static int FindBindingIndex(TableWritePlan tableWritePlan, DbColumnName columnName)
-    {
-        for (var bindingIndex = 0; bindingIndex < tableWritePlan.ColumnBindings.Length; bindingIndex++)
-        {
-            if (tableWritePlan.ColumnBindings[bindingIndex].Column.ColumnName.Equals(columnName))
-            {
-                return bindingIndex;
-            }
-        }
-
-        throw new InvalidOperationException(
-            $"Table '{FormatTable(tableWritePlan)}' does not contain a binding for column '{columnName.Value}'."
-        );
     }
 
     private static string FormatTable(TableWritePlan tableWritePlan) =>
@@ -388,7 +359,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
 
             var parentBindingIndexes = tableWritePlan
                 .TableModel.IdentityMetadata.ImmediateParentScopeLocatorColumns.Select(columnName =>
-                    FindBindingIndex(tableWritePlan, columnName)
+                    RelationalWriteMergeSupport.FindBindingIndex(tableWritePlan, columnName)
                 )
                 .Append(mergePlan.OrdinalBindingIndex)
                 .ToArray();
@@ -403,7 +374,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
         {
             var parentBindingIndexes = tableWritePlan
                 .TableModel.IdentityMetadata.ImmediateParentScopeLocatorColumns.Select(columnName =>
-                    FindBindingIndex(tableWritePlan, columnName)
+                    RelationalWriteMergeSupport.FindBindingIndex(tableWritePlan, columnName)
                 )
                 .ToArray();
 
@@ -476,7 +447,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
                     tableWritePlan.TableModel.Table,
                     out var hydratedTableRows
                 )
-                    ? ProjectCurrentRows(tableWritePlan, hydratedTableRows.Rows)
+                    ? RelationalWriteMergeSupport.ProjectCurrentRows(tableWritePlan, hydratedTableRows.Rows)
                     : ImmutableArray<RelationalWriteMergedTableRow>.Empty;
 
                 currentRowsByTable.Add(tableWritePlan.TableModel.Table, projectedRows);
@@ -521,97 +492,6 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
                 semanticIdentityValues
             );
         }
-
-        private static ImmutableArray<RelationalWriteMergedTableRow> ProjectCurrentRows(
-            TableWritePlan tableWritePlan,
-            IReadOnlyList<object?[]> hydratedRows
-        )
-        {
-            List<RelationalWriteMergedTableRow> projectedRows = [];
-
-            foreach (var hydratedRow in hydratedRows)
-            {
-                FlattenedWriteValue[] bindingValues = new FlattenedWriteValue[
-                    tableWritePlan.ColumnBindings.Length
-                ];
-
-                for (
-                    var bindingIndex = 0;
-                    bindingIndex < tableWritePlan.ColumnBindings.Length;
-                    bindingIndex++
-                )
-                {
-                    var binding = tableWritePlan.ColumnBindings[bindingIndex];
-                    var columnOrdinal = FindColumnOrdinal(
-                        tableWritePlan.TableModel,
-                        binding.Column.ColumnName
-                    );
-                    bindingValues[bindingIndex] = new FlattenedWriteValue.Literal(
-                        NormalizeHydratedValue(binding.Column, hydratedRow[columnOrdinal])
-                    );
-                }
-
-                projectedRows.Add(
-                    new RelationalWriteMergedTableRow(
-                        bindingValues,
-                        ProjectComparableValues(tableWritePlan, bindingValues)
-                    )
-                );
-            }
-
-            return projectedRows.ToImmutableArray();
-        }
-
-        private static int FindColumnOrdinal(DbTableModel tableModel, DbColumnName columnName)
-        {
-            for (var columnOrdinal = 0; columnOrdinal < tableModel.Columns.Count; columnOrdinal++)
-            {
-                if (tableModel.Columns[columnOrdinal].ColumnName.Equals(columnName))
-                {
-                    return columnOrdinal;
-                }
-            }
-
-            throw new InvalidOperationException(
-                $"Hydrated table '{tableModel.Table.Schema.Value}.{tableModel.Table.Name}' does not contain column '{columnName.Value}'."
-            );
-        }
-
-        private static object? NormalizeHydratedValue(DbColumnModel column, object? value)
-        {
-            ArgumentNullException.ThrowIfNull(column);
-
-            if (value is null || column.ScalarType is null)
-            {
-                return value;
-            }
-
-            return column.ScalarType.Kind switch
-            {
-                ScalarKind.Date => NormalizeDateValue(value),
-                ScalarKind.Time => NormalizeTimeValue(value),
-                _ => value,
-            };
-        }
-
-        private static object NormalizeDateValue(object value) =>
-            value switch
-            {
-                DateOnly => value,
-                DateTime dateTime => DateOnly.FromDateTime(dateTime),
-                DateTimeOffset dateTimeOffset => DateOnly.FromDateTime(dateTimeOffset.DateTime),
-                _ => value,
-            };
-
-        private static object NormalizeTimeValue(object value) =>
-            value switch
-            {
-                TimeOnly => value,
-                TimeSpan timeSpan => TimeOnly.FromTimeSpan(timeSpan),
-                DateTime dateTime => TimeOnly.FromDateTime(dateTime),
-                DateTimeOffset dateTimeOffset => TimeOnly.FromDateTime(dateTimeOffset.DateTime),
-                _ => value,
-            };
     }
 
     private sealed class ProjectedCollectionTableState
@@ -694,7 +574,12 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             {
                 parentScopeKey[index] = ExtractLiteralValue(
                     tableWritePlan,
-                    values[FindBindingIndex(tableWritePlan, immediateParentScopeColumns[index])],
+                    values[
+                        RelationalWriteMergeSupport.FindBindingIndex(
+                            tableWritePlan,
+                            immediateParentScopeColumns[index]
+                        )
+                    ],
                     immediateParentScopeColumns[index]
                 );
             }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfileMerge.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfileMerge.cs
@@ -42,68 +42,14 @@ internal sealed record RelationalWriteNoProfileMergeRequest
     public RelationalWriteCurrentState? CurrentState { get; init; }
 }
 
-internal sealed record RelationalWriteNoProfileTableRow
-{
-    public RelationalWriteNoProfileTableRow(
-        IEnumerable<FlattenedWriteValue> values,
-        IEnumerable<FlattenedWriteValue> comparableValues
-    )
-    {
-        Values = FlattenedWriteContractSupport.ToImmutableArray(values, nameof(values));
-        ComparableValues = FlattenedWriteContractSupport.ToImmutableArray(
-            comparableValues,
-            nameof(comparableValues)
-        );
-    }
-
-    public ImmutableArray<FlattenedWriteValue> Values { get; init; }
-
-    public ImmutableArray<FlattenedWriteValue> ComparableValues { get; init; }
-}
-
-internal sealed record RelationalWriteNoProfileTableState
-{
-    public RelationalWriteNoProfileTableState(
-        TableWritePlan tableWritePlan,
-        IEnumerable<RelationalWriteNoProfileTableRow> currentRows,
-        IEnumerable<RelationalWriteNoProfileTableRow> mergedRows
-    )
-    {
-        TableWritePlan = tableWritePlan ?? throw new ArgumentNullException(nameof(tableWritePlan));
-        CurrentRows = FlattenedWriteContractSupport.ToImmutableArray(currentRows, nameof(currentRows));
-        MergedRows = FlattenedWriteContractSupport.ToImmutableArray(mergedRows, nameof(mergedRows));
-    }
-
-    public TableWritePlan TableWritePlan { get; init; }
-
-    public ImmutableArray<RelationalWriteNoProfileTableRow> CurrentRows { get; init; }
-
-    public ImmutableArray<RelationalWriteNoProfileTableRow> MergedRows { get; init; }
-}
-
-internal sealed record RelationalWriteNoProfileMergeResult
-{
-    public RelationalWriteNoProfileMergeResult(
-        IEnumerable<RelationalWriteNoProfileTableState> tablesInDependencyOrder
-    )
-    {
-        TablesInDependencyOrder = FlattenedWriteContractSupport.ToImmutableArray(
-            tablesInDependencyOrder,
-            nameof(tablesInDependencyOrder)
-        );
-    }
-
-    public ImmutableArray<RelationalWriteNoProfileTableState> TablesInDependencyOrder { get; init; }
-}
-
 internal interface IRelationalWriteNoProfileMergeSynthesizer
 {
-    RelationalWriteNoProfileMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request);
+    RelationalWriteMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request);
 }
 
 internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWriteNoProfileMergeSynthesizer
 {
-    public RelationalWriteNoProfileMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request)
+    public RelationalWriteMergeResult Synthesize(RelationalWriteNoProfileMergeRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
 
@@ -134,10 +80,11 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             tableStateBuilders
         );
 
-        return new RelationalWriteNoProfileMergeResult(
+        return new RelationalWriteMergeResult(
             request.WritePlan.TablePlansInDependencyOrder.Select(tableWritePlan =>
                 tableStateBuilders[tableWritePlan.TableModel.Table].Build()
-            )
+            ),
+            supportsGuardedNoOp: true
         );
     }
 
@@ -284,7 +231,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
     {
         var comparableValues = ProjectComparableValues(tableWritePlan, values);
 
-        return new MergedRow(tableWritePlan, new RelationalWriteNoProfileTableRow(values, comparableValues));
+        return new MergedRow(tableWritePlan, new RelationalWriteMergedTableRow(values, comparableValues));
     }
 
     private static ImmutableArray<FlattenedWriteValue> RewriteParentKeyPartValues(
@@ -387,27 +334,27 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
     private static string FormatTable(TableWritePlan tableWritePlan) =>
         $"{tableWritePlan.TableModel.Table.Schema.Value}.{tableWritePlan.TableModel.Table.Name}";
 
-    private sealed record MergedRow(TableWritePlan TableWritePlan, RelationalWriteNoProfileTableRow Row);
+    private sealed record MergedRow(TableWritePlan TableWritePlan, RelationalWriteMergedTableRow Row);
 
     private sealed class TableStateBuilder(
         TableWritePlan tableWritePlan,
-        ImmutableArray<RelationalWriteNoProfileTableRow> currentRows
+        ImmutableArray<RelationalWriteMergedTableRow> currentRows
     )
     {
-        private readonly List<RelationalWriteNoProfileTableRow> _mergedRows = [];
+        private readonly List<RelationalWriteMergedTableRow> _mergedRows = [];
 
-        public void AddMergedRow(RelationalWriteNoProfileTableRow row)
+        public void AddMergedRow(RelationalWriteMergedTableRow row)
         {
             ArgumentNullException.ThrowIfNull(row);
             _mergedRows.Add(row);
         }
 
-        public RelationalWriteNoProfileTableState Build()
+        public RelationalWriteMergedTableState Build()
         {
             var currentRowsForComparison = IsCollectionAlignedExtensionScope(tableWritePlan)
                 ? OrderCollectionAlignedExtensionScopeRowsIfFullyBound(tableWritePlan, currentRows)
                 : currentRows;
-            IReadOnlyList<RelationalWriteNoProfileTableRow> mergedRows;
+            IReadOnlyList<RelationalWriteMergedTableRow> mergedRows;
 
             if (tableWritePlan.CollectionMergePlan is not null)
             {
@@ -425,16 +372,12 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
                 mergedRows = _mergedRows;
             }
 
-            return new RelationalWriteNoProfileTableState(
-                tableWritePlan,
-                currentRowsForComparison,
-                mergedRows
-            );
+            return new RelationalWriteMergedTableState(tableWritePlan, currentRowsForComparison, mergedRows);
         }
 
-        private static IReadOnlyList<RelationalWriteNoProfileTableRow> OrderCollectionRowsIfFullyBound(
+        private static IReadOnlyList<RelationalWriteMergedTableRow> OrderCollectionRowsIfFullyBound(
             TableWritePlan tableWritePlan,
-            IReadOnlyList<RelationalWriteNoProfileTableRow> rows
+            IReadOnlyList<RelationalWriteMergedTableRow> rows
         )
         {
             var mergePlan =
@@ -453,9 +396,9 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             return OrderRowsByBindingIndexesIfFullyBound(rows, parentBindingIndexes);
         }
 
-        private static IReadOnlyList<RelationalWriteNoProfileTableRow> OrderCollectionAlignedExtensionScopeRowsIfFullyBound(
+        private static IReadOnlyList<RelationalWriteMergedTableRow> OrderCollectionAlignedExtensionScopeRowsIfFullyBound(
             TableWritePlan tableWritePlan,
-            IReadOnlyList<RelationalWriteNoProfileTableRow> rows
+            IReadOnlyList<RelationalWriteMergedTableRow> rows
         )
         {
             var parentBindingIndexes = tableWritePlan
@@ -467,8 +410,8 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             return OrderRowsByBindingIndexesIfFullyBound(rows, parentBindingIndexes);
         }
 
-        private static IReadOnlyList<RelationalWriteNoProfileTableRow> OrderRowsByBindingIndexesIfFullyBound(
-            IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        private static IReadOnlyList<RelationalWriteMergedTableRow> OrderRowsByBindingIndexesIfFullyBound(
+            IReadOnlyList<RelationalWriteMergedTableRow> rows,
             IReadOnlyList<int> bindingIndexes
         )
         {
@@ -496,7 +439,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
     {
         private readonly IReadOnlyDictionary<
             DbTableName,
-            ImmutableArray<RelationalWriteNoProfileTableRow>
+            ImmutableArray<RelationalWriteMergedTableRow>
         > _currentRowsByTable;
 
         private readonly IReadOnlyDictionary<
@@ -507,7 +450,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
         private CurrentStateProjection(
             IReadOnlyDictionary<
                 DbTableName,
-                ImmutableArray<RelationalWriteNoProfileTableRow>
+                ImmutableArray<RelationalWriteMergedTableRow>
             > currentRowsByTable,
             IReadOnlyDictionary<DbTableName, ProjectedCollectionTableState> collectionRowsByTable
         )
@@ -518,7 +461,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
 
         public static CurrentStateProjection Create(RelationalWriteNoProfileMergeRequest request)
         {
-            Dictionary<DbTableName, ImmutableArray<RelationalWriteNoProfileTableRow>> currentRowsByTable = [];
+            Dictionary<DbTableName, ImmutableArray<RelationalWriteMergedTableRow>> currentRowsByTable = [];
             Dictionary<DbTableName, ProjectedCollectionTableState> collectionRowsByTable = [];
 
             var hydratedRowsByTable = request.CurrentState is null
@@ -534,7 +477,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
                     out var hydratedTableRows
                 )
                     ? ProjectCurrentRows(tableWritePlan, hydratedTableRows.Rows)
-                    : ImmutableArray<RelationalWriteNoProfileTableRow>.Empty;
+                    : ImmutableArray<RelationalWriteMergedTableRow>.Empty;
 
                 currentRowsByTable.Add(tableWritePlan.TableModel.Table, projectedRows);
 
@@ -552,14 +495,12 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             return new CurrentStateProjection(currentRowsByTable, collectionRowsByTable);
         }
 
-        public ImmutableArray<RelationalWriteNoProfileTableRow> GetCurrentRows(
-            TableWritePlan tableWritePlan
-        ) =>
+        public ImmutableArray<RelationalWriteMergedTableRow> GetCurrentRows(TableWritePlan tableWritePlan) =>
             _currentRowsByTable.TryGetValue(tableWritePlan.TableModel.Table, out var currentRows)
                 ? currentRows
-                : ImmutableArray<RelationalWriteNoProfileTableRow>.Empty;
+                : ImmutableArray<RelationalWriteMergedTableRow>.Empty;
 
-        public RelationalWriteNoProfileTableRow? TryMatchCollectionRow(
+        public RelationalWriteMergedTableRow? TryMatchCollectionRow(
             TableWritePlan tableWritePlan,
             IReadOnlyList<FlattenedWriteValue> parentPhysicalRowIdentityValues,
             IReadOnlyList<object?> semanticIdentityValues
@@ -581,12 +522,12 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
             );
         }
 
-        private static ImmutableArray<RelationalWriteNoProfileTableRow> ProjectCurrentRows(
+        private static ImmutableArray<RelationalWriteMergedTableRow> ProjectCurrentRows(
             TableWritePlan tableWritePlan,
             IReadOnlyList<object?[]> hydratedRows
         )
         {
-            List<RelationalWriteNoProfileTableRow> projectedRows = [];
+            List<RelationalWriteMergedTableRow> projectedRows = [];
 
             foreach (var hydratedRow in hydratedRows)
             {
@@ -611,7 +552,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
                 }
 
                 projectedRows.Add(
-                    new RelationalWriteNoProfileTableRow(
+                    new RelationalWriteMergedTableRow(
                         bindingValues,
                         ProjectComparableValues(tableWritePlan, bindingValues)
                     )
@@ -677,19 +618,19 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
     {
         private readonly Dictionary<
             object?[],
-            Dictionary<object?[], RelationalWriteNoProfileTableRow>
+            Dictionary<object?[], RelationalWriteMergedTableRow>
         > _rowsByParentKey;
 
         public ProjectedCollectionTableState(
             TableWritePlan tableWritePlan,
-            IReadOnlyList<RelationalWriteNoProfileTableRow> currentRows
+            IReadOnlyList<RelationalWriteMergedTableRow> currentRows
         )
         {
             TableWritePlan = tableWritePlan ?? throw new ArgumentNullException(nameof(tableWritePlan));
 
             _rowsByParentKey = new Dictionary<
                 object?[],
-                Dictionary<object?[], RelationalWriteNoProfileTableRow>
+                Dictionary<object?[], RelationalWriteMergedTableRow>
             >(ObjectValueArrayComparer.Instance);
 
             foreach (var currentRow in currentRows)
@@ -699,7 +640,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
 
                 if (!_rowsByParentKey.TryGetValue(parentScopeKey, out var rowsBySemanticIdentity))
                 {
-                    rowsBySemanticIdentity = new Dictionary<object?[], RelationalWriteNoProfileTableRow>(
+                    rowsBySemanticIdentity = new Dictionary<object?[], RelationalWriteMergedTableRow>(
                         ObjectValueArrayComparer.Instance
                     );
                     _rowsByParentKey.Add(parentScopeKey, rowsBySemanticIdentity);
@@ -716,7 +657,7 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
 
         public TableWritePlan TableWritePlan { get; }
 
-        public RelationalWriteNoProfileTableRow? TryMatch(
+        public RelationalWriteMergedTableRow? TryMatch(
             IReadOnlyList<FlattenedWriteValue> parentPhysicalRowIdentityValues,
             IReadOnlyList<object?> semanticIdentityValues
         )
@@ -817,9 +758,9 @@ internal sealed class RelationalWriteNoProfileMergeSynthesizer : IRelationalWrit
     }
 
     private sealed class BoundRowComparer(IReadOnlyList<int> bindingIndexes)
-        : IComparer<RelationalWriteNoProfileTableRow>
+        : IComparer<RelationalWriteMergedTableRow>
     {
-        public int Compare(RelationalWriteNoProfileTableRow? left, RelationalWriteNoProfileTableRow? right)
+        public int Compare(RelationalWriteMergedTableRow? left, RelationalWriteMergedTableRow? right)
         {
             if (ReferenceEquals(left, right))
             {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfilePersister.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteNoProfilePersister.cs
@@ -12,21 +12,21 @@ using EdFi.DataManagementService.Core.External.Model;
 
 namespace EdFi.DataManagementService.Backend;
 
-internal interface IRelationalWriteNoProfilePersister
+internal interface IRelationalWritePersister
 {
     Task<RelationalWritePersistResult> PersistAsync(
         RelationalWriteExecutorRequest request,
-        RelationalWriteNoProfileMergeResult mergeResult,
+        RelationalWriteMergeResult mergeResult,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken = default
     );
 }
 
-internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProfilePersister
+internal sealed class RelationalWriteNoProfilePersister : IRelationalWritePersister
 {
     public async Task<RelationalWritePersistResult> PersistAsync(
         RelationalWriteExecutorRequest request,
-        RelationalWriteNoProfileMergeResult mergeResult,
+        RelationalWriteMergeResult mergeResult,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken = default
     )
@@ -83,7 +83,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task ExecuteDeletesAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileMergeResult mergeResult,
+        RelationalWriteMergeResult mergeResult,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -143,7 +143,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task ExecuteUpsertsAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileMergeResult mergeResult,
+        RelationalWriteMergeResult mergeResult,
         long rootDocumentId,
         Dictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -154,7 +154,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
         while (pendingTableStates.Length > 0)
         {
-            List<RelationalWriteNoProfileTableState> deferredTableStates = [];
+            List<RelationalWriteMergedTableState> deferredTableStates = [];
             var persistedTableCount = 0;
 
             foreach (var tableState in pendingTableStates)
@@ -239,7 +239,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     }
 
     private static bool HasBlockingUnresolvedCollectionItemIds(
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds
     )
     {
@@ -353,7 +353,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     }
 
     private static async Task DeleteOmittedNonCollectionRowAsync(
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -390,7 +390,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     }
 
     private static async Task UpsertNonCollectionRowAsync(
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -451,7 +451,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task DeleteOmittedCollectionAlignedScopeRowsAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -471,7 +471,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
             );
         }
 
-        List<RelationalWriteNoProfileTableRow> rowsToDelete = [];
+        List<RelationalWriteMergedTableRow> rowsToDelete = [];
 
         foreach (var currentRow in tableState.CurrentRows)
         {
@@ -502,7 +502,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task UpsertCollectionAlignedScopeRowsAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         Dictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -514,8 +514,8 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
             "current",
             tableState.TableWritePlan
         );
-        List<RelationalWriteNoProfileTableRow> rowsToUpdate = [];
-        List<RelationalWriteNoProfileTableRow> rowsToInsert = [];
+        List<RelationalWriteMergedTableRow> rowsToUpdate = [];
+        List<RelationalWriteMergedTableRow> rowsToInsert = [];
 
         foreach (var mergedRow in tableState.MergedRows)
         {
@@ -586,7 +586,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task DeleteOmittedCollectionRowsAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -599,7 +599,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
                 $"Collection table '{FormatTable(tableState.TableWritePlan)}' does not have a compiled collection merge plan."
             );
         var retainedStableRowIdentities = GetRetainedStableRowIdentities(tableState);
-        List<RelationalWriteNoProfileTableRow> rowsToDelete = [];
+        List<RelationalWriteMergedTableRow> rowsToDelete = [];
 
         foreach (var currentRow in tableState.CurrentRows)
         {
@@ -636,7 +636,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static async Task UpsertCollectionRowsAsync(
         SqlDialect dialect,
-        RelationalWriteNoProfileTableState tableState,
+        RelationalWriteMergedTableState tableState,
         long rootDocumentId,
         Dictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -654,8 +654,8 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
                 currentRow.Values[mergePlan.StableRowIdentityBindingIndex]
             )
         );
-        List<RelationalWriteNoProfileTableRow> rowsToUpdate = [];
-        List<RelationalWriteNoProfileTableRow> rowsToInsert = [];
+        List<RelationalWriteMergedTableRow> rowsToUpdate = [];
+        List<RelationalWriteMergedTableRow> rowsToInsert = [];
         var hasOrdinalReorder = false;
 
         foreach (var mergedRow in tableState.MergedRows)
@@ -767,7 +767,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
         }
     }
 
-    private static HashSet<long> GetRetainedStableRowIdentities(RelationalWriteNoProfileTableState tableState)
+    private static HashSet<long> GetRetainedStableRowIdentities(RelationalWriteMergedTableState tableState)
     {
         var mergePlan =
             tableState.TableWritePlan.CollectionMergePlan
@@ -1023,7 +1023,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
         TableWritePlan tableWritePlan,
         string sql,
         Func<WritePlanBatchSqlEmitter, int, string> emitBatchSql,
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -1065,7 +1065,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
         TableWritePlan tableWritePlan,
         string sql,
         Func<WritePlanBatchSqlEmitter, int, string> emitBatchSql,
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -1094,7 +1094,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     private static async Task ExecuteCollectionInsertBatchAsync(
         SqlDialect dialect,
         TableWritePlan tableWritePlan,
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds,
         IRelationalWriteSession writeSession,
@@ -1137,8 +1137,8 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
             .ConfigureAwait(false);
     }
 
-    private static RelationalWriteNoProfileTableRow? GetSingleRowOrThrow(
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+    private static RelationalWriteMergedTableRow? GetSingleRowOrThrow(
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         string rowKind,
         TableWritePlan tableWritePlan
     )
@@ -1156,14 +1156,14 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static IReadOnlyDictionary<
         string,
-        RelationalWriteNoProfileTableRow
+        RelationalWriteMergedTableRow
     > GetRowsByPhysicalIdentityOrThrow(
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         string rowKind,
         TableWritePlan tableWritePlan
     )
     {
-        Dictionary<string, RelationalWriteNoProfileTableRow> rowsByPhysicalIdentity = new(
+        Dictionary<string, RelationalWriteMergedTableRow> rowsByPhysicalIdentity = new(
             StringComparer.Ordinal
         );
 
@@ -1184,7 +1184,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
 
     private static string ResolvePhysicalRowIdentityKey(
         TableWritePlan tableWritePlan,
-        RelationalWriteNoProfileTableRow row
+        RelationalWriteMergedTableRow row
     )
     {
         var identityColumns = tableWritePlan.TableModel.IdentityMetadata.PhysicalRowIdentityColumns;
@@ -1230,7 +1230,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     private static RelationalCommand BuildRowCommand(
         TableWritePlan tableWritePlan,
         string sql,
-        RelationalWriteNoProfileTableRow row,
+        RelationalWriteMergedTableRow row,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds
     )
@@ -1258,7 +1258,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     private static RelationalCommand BuildBatchCommand(
         string sql,
         TableWritePlan tableWritePlan,
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         long rootDocumentId,
         IReadOnlyDictionary<FlattenedWriteValue.UnresolvedCollectionItemId, long> reservedCollectionItemIds
     )
@@ -1289,19 +1289,19 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
         return new RelationalCommand(sql, parameters);
     }
 
-    private static IReadOnlyList<RelationalWriteNoProfileTableRow> CreateTemporaryOrdinalRows(
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+    private static IReadOnlyList<RelationalWriteMergedTableRow> CreateTemporaryOrdinalRows(
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         int ordinalBindingIndex
     )
     {
-        RelationalWriteNoProfileTableRow[] temporaryRows = new RelationalWriteNoProfileTableRow[rows.Count];
+        RelationalWriteMergedTableRow[] temporaryRows = new RelationalWriteMergedTableRow[rows.Count];
 
         for (var rowIndex = 0; rowIndex < rows.Count; rowIndex++)
         {
             var temporaryValues = rows[rowIndex].Values.ToArray();
             temporaryValues[ordinalBindingIndex] = new FlattenedWriteValue.Literal(-1 - rowIndex);
 
-            temporaryRows[rowIndex] = new RelationalWriteNoProfileTableRow(
+            temporaryRows[rowIndex] = new RelationalWriteMergedTableRow(
                 temporaryValues,
                 rows[rowIndex].ComparableValues
             );
@@ -1311,7 +1311,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     }
 
     private static IReadOnlyList<FlattenedWriteValue.UnresolvedCollectionItemId> GetStableRowIdentityTokens(
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows,
+        IReadOnlyList<RelationalWriteMergedTableRow> rows,
         int stableRowIdentityBindingIndex
     )
     {
@@ -1332,7 +1332,7 @@ internal sealed class RelationalWriteNoProfilePersister : IRelationalWriteNoProf
     }
 
     private static IReadOnlyList<FlattenedWriteValue.UnresolvedCollectionItemId> GetUnresolvedCollectionItemIds(
-        IReadOnlyList<RelationalWriteNoProfileTableRow> rows
+        IReadOnlyList<RelationalWriteMergedTableRow> rows
     )
     {
         List<FlattenedWriteValue.UnresolvedCollectionItemId> unresolvedCollectionItemIds = [];

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/WebApplicationBuilderExtensionsTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/WebApplicationBuilderExtensionsTests.cs
@@ -163,7 +163,7 @@ public class WebApplicationBuilderExtensionsTests
                 .Should()
                 .BeOfType<RelationalWriteFreshnessChecker>();
             scope
-                .ServiceProvider.GetRequiredService<IRelationalWriteNoProfilePersister>()
+                .ServiceProvider.GetRequiredService<IRelationalWritePersister>()
                 .Should()
                 .BeOfType<RelationalWriteNoProfilePersister>();
             scope
@@ -269,7 +269,7 @@ public class WebApplicationBuilderExtensionsTests
                 .Should()
                 .BeOfType<RelationalWriteFreshnessChecker>();
             scope
-                .ServiceProvider.GetRequiredService<IRelationalWriteNoProfilePersister>()
+                .ServiceProvider.GetRequiredService<IRelationalWritePersister>()
                 .Should()
                 .BeOfType<RelationalWriteNoProfilePersister>();
             scope


### PR DESCRIPTION
## Summary
- implements Slice 2 profile-aware persist support for writes whose runtime behavior is confined to the root table
- routes supported profiled writes through the shared executor into a root-table-only profile merge path
- overlays visible request values onto stored root-row values for existing documents
- preserves hidden root and inlined values, including root-row FK/descriptor bindings
- clears only clear-on-visible-absent inlined bindings and preserves hidden-governed bindings
- recomputes root-table key-unification canonical values and synthetic presence after overlay
- supports profiled `PUT`, profiled `POST`-as-update, and profiled `POST` create-new for supported root-only shapes
- keeps separate-table scopes, collections, descendant scopes, and profiled guarded no-op fenced to later slices

## Validation
- `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/EdFi.DataManagementService.Backend.Tests.Unit.csproj --filter "Name=It_fences_profiled_create_new_with_slice_fence_before_flatten|Name=It_rejects_profiled_create_new_when_root_is_not_creatable|Name=It_synthesizes_profile_merge_for_root_table_only_create_new_request|Name=It_synthesizes_profile_merge_for_multi_table_plan_when_runtime_shape_is_root_only"`
- `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj --filter "Name=It_returns_profile_data_policy_failure_for_creatability_rejection|Name=It_returns_unknown_failure_with_family_name_in_slice_fence|Name=It_returns_unknown_failure_with_TopLevelCollection_family_in_slice_fence|Name=It_returns_update_success|Name=It_returns_update_success_via_post_as_update|Name=It_returns_insert_success"`
- `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj --filter "Name=It_returns_profile_data_policy_failure_for_creatability_rejection|Name=It_returns_unknown_failure_with_family_name_in_slice_fence|Name=It_returns_unknown_failure_with_TopLevelCollection_family_in_slice_fence|Name=It_returns_update_success|Name=It_returns_update_success_via_post_as_update|Name=It_returns_insert_success"`
- targeted hidden-preservation / visible-absent / FK-descriptor / key-unification parity checks in PostgreSQL and SQL Server fixture coverage
- GitHub CI on this PR