### PR TITLE
[DMS-1126] Centralize analyzer configuration and resolve SonarLint findings

### DIFF
--- a/src/config/Directory.Build.props
+++ b/src/config/Directory.Build.props
@@ -6,4 +6,14 @@
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
         <ErrorLog>results.sarif,version=2.1</ErrorLog>
     </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="SonarAnalyzer.CSharp">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakClientRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakClientRepository.cs
@@ -355,7 +355,7 @@ public class KeycloakClientRepository(
 
         void CheckAndUpdateEducationOrganizationIds(List<ClientProtocolMapper> protocolMappers)
         {
-            var edOrgClaim = protocolMappers.FirstOrDefault(x =>
+            var edOrgClaim = protocolMappers.Find(x =>
                 x.Config["claim.name"].Equals("educationOrganizationIds")
             );
             if (edOrgClaim != null)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakTokenManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Keycloak/KeycloakTokenManager.cs
@@ -5,9 +5,7 @@
 
 using System.Net;
 using System.Security.Cryptography;
-using Keycloak.Net.Models.Clients;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace EdFi.DmsConfigurationService.Backend.Keycloak;
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.OpenIddict/Services/ClientSecretHasher.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.OpenIddict/Services/ClientSecretHasher.cs
@@ -86,7 +86,7 @@ public class ClientSecretHasher(ILogger<ClientSecretHasher> logger, IOptions<Ide
             byte[] decoded = Convert.FromBase64String(hashedSecret);
             using var reader = new BinaryReader(new MemoryStream(decoded));
 
-            byte version = reader.ReadByte();
+            _ = reader.ReadByte(); // version byte — read past, value not used
             int saltLength = reader.ReadInt32();
             byte[] salt = reader.ReadBytes(saltLength);
             byte[] expectedSubkey = reader.ReadBytes(32);

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.OpenIddict/Validation/EnhancedTokenValidator.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.OpenIddict/Validation/EnhancedTokenValidator.cs
@@ -48,17 +48,11 @@ namespace EdFi.DmsConfigurationService.Backend.OpenIddict.Validation
 
     public class EnhancedTokenValidator : IEnhancedTokenValidator
     {
-        private readonly IServiceProvider _serviceProvider;
         private readonly ITokenManager _tokenManager;
         private readonly ILogger<EnhancedTokenValidator> _logger;
 
-        public EnhancedTokenValidator(
-            IServiceProvider serviceProvider,
-            ITokenManager tokenManager,
-            ILogger<EnhancedTokenValidator> logger
-        )
+        public EnhancedTokenValidator(ITokenManager tokenManager, ILogger<EnhancedTokenValidator> logger)
         {
-            _serviceProvider = serviceProvider;
             _tokenManager = tokenManager;
             _logger = logger;
         }
@@ -107,7 +101,7 @@ namespace EdFi.DmsConfigurationService.Backend.OpenIddict.Validation
 
                 // Use basic validation approach since OpenIddict transaction types don't exist in this version
                 // Fall back to manual principal creation
-                return await CreatePrincipalFromTokenAsync(token, cancellationToken);
+                return await CreatePrincipalFromTokenAsync(token);
             }
             catch (Exception ex)
             {
@@ -116,10 +110,7 @@ namespace EdFi.DmsConfigurationService.Backend.OpenIddict.Validation
             }
         }
 
-        private Task<ClaimsPrincipal?> CreatePrincipalFromTokenAsync(
-            string token,
-            CancellationToken cancellationToken
-        )
+        private Task<ClaimsPrincipal?> CreatePrincipalFromTokenAsync(string token)
         {
             try
             {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
@@ -6,7 +6,6 @@
 using EdFi.DmsConfigurationService.Backend.Postgresql.Repositories;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
-using EdFi.DmsConfigurationService.DataModel;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
@@ -345,9 +344,7 @@ public class ApplicationTests : DatabaseTest
             );
             getResult.Should().BeOfType<ApplicationQueryResult.Success>();
 
-            int count = ((ApplicationQueryResult.Success)getResult).ApplicationResponses.ToList().Count();
-
-            count.Should().Be(1);
+            ((ApplicationQueryResult.Success)getResult).ApplicationResponses.Should().HaveCount(1);
             ((ApplicationQueryResult.Success)getResult)
                 .ApplicationResponses.Count(v => v.Id == _application2Id)
                 .Should()

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
@@ -317,11 +317,11 @@ public class ClaimSetTests : DatabaseTest
             var claims = ((ClaimsHierarchyGetResult.Success)hierarchyResult).Claims;
 
             // Verify that "Test-Insert-ClaimSet" no longer exists
-            bool containsOldClaimSet = claims.Any(c => ContainsClaimSet(c, "Test-Insert-ClaimSet"));
+            bool containsOldClaimSet = claims.Exists(c => ContainsClaimSet(c, "Test-Insert-ClaimSet"));
             containsOldClaimSet.Should().BeFalse();
 
             // Verify that "Test-Update-ClaimSet" exists in all appropriate places
-            bool containsNewClaimSet = claims.Any(c => ContainsClaimSet(c, "Test-Update-ClaimSet"));
+            bool containsNewClaimSet = claims.Exists(c => ContainsClaimSet(c, "Test-Update-ClaimSet"));
             containsNewClaimSet.Should().BeTrue();
         }
 
@@ -341,12 +341,12 @@ public class ClaimSetTests : DatabaseTest
 
         private bool ContainsClaimSet(Claim claim, string claimSetName)
         {
-            if (claim.ClaimSets.Any(cs => cs.Name == claimSetName))
+            if (claim.ClaimSets.Exists(cs => cs.Name == claimSetName))
             {
                 return true;
             }
 
-            if (claim.Claims.Any(c => ContainsClaimSet(c, claimSetName)))
+            if (claim.Claims.Exists(c => ContainsClaimSet(c, claimSetName)))
             {
                 return true;
             }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimsDataLoaderTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimsDataLoaderTests.cs
@@ -753,7 +753,7 @@ public class ClaimsDataLoaderTests : DatabaseTestBase
                       ]
                     }
                     """;
-                File.WriteAllText(Path.Combine(tempPath, "Claims.json"), baseClaimsContent);
+                await File.WriteAllTextAsync(Path.Combine(tempPath, "Claims.json"), baseClaimsContent);
 
                 var filesystemClaimsOptions = Options.Create(
                     new ClaimsOptions { ClaimsSource = ClaimsSource.Filesystem, ClaimsDirectory = tempPath }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DmsInstanceRouteContextTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DmsInstanceRouteContextTests.cs
@@ -238,8 +238,6 @@ public class DmsInstanceRouteContextTests : DatabaseTest
     [TestFixture]
     public class QueryByInstanceTests : DmsInstanceRouteContextTests
     {
-        private long _id1;
-        private long _id2;
         private long _instanceId;
 
         [SetUp]
@@ -286,8 +284,8 @@ public class DmsInstanceRouteContextTests : DatabaseTest
             };
             var result1 = await _repository.InsertDmsInstanceRouteContext(cmd1);
             var result2 = await _repository.InsertDmsInstanceRouteContext(cmd2);
-            _id1 = ((DmsInstanceRouteContextInsertResult.Success)result1).Id;
-            _id2 = ((DmsInstanceRouteContextInsertResult.Success)result2).Id;
+            result1.Should().BeOfType<DmsInstanceRouteContextInsertResult.Success>();
+            result2.Should().BeOfType<DmsInstanceRouteContextInsertResult.Success>();
         }
 
         [Test]
@@ -299,8 +297,8 @@ public class DmsInstanceRouteContextTests : DatabaseTest
                 (InstanceRouteContextQueryByInstanceResult.Success)queryResult
             ).DmsInstanceRouteContextResponses.ToList();
             contexts.Should().HaveCount(2);
-            contexts.Any(c => c.ContextKey == "Key1" && c.ContextValue == "Value1").Should().BeTrue();
-            contexts.Any(c => c.ContextKey == "Key2" && c.ContextValue == "Value2").Should().BeTrue();
+            contexts.Exists(c => c.ContextKey == "Key1" && c.ContextValue == "Value1").Should().BeTrue();
+            contexts.Exists(c => c.ContextKey == "Key2" && c.ContextValue == "Value2").Should().BeTrue();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration.csproj
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -8,10 +8,6 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="FluentAssertions" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="NUnit" />

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/VendorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/VendorTests.cs
@@ -211,7 +211,7 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration
         {
             private long _vendorId1;
             private long _vendorId2;
-            private long _vendorIdNotExist = 9999;
+            private readonly long _vendorIdNotExist = 9999;
             private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/EdFi.DmsConfigurationService.Backend.Postgresql.csproj
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/EdFi.DmsConfigurationService.Backend.Postgresql.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -10,10 +10,6 @@
         <PackageReference Include="dbup-postgresql" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols" />
         <PackageReference Include="Npgsql" />
@@ -21,10 +17,6 @@
         <PackageReference Include="OpenIddict.Core" />
         <PackageReference Include="Polly" />
         <PackageReference Include="Polly.Extensions" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="System.Linq.Async" />
     </ItemGroup>

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/EdFi.DmsConfigurationService.Backend.Tests.Unit.csproj
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/EdFi.DmsConfigurationService.Backend.Tests.Unit.csproj
@@ -17,10 +17,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Using Include="NUnit.Framework" />

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/AuthorizationMetadata/AuthorizationMetadataResponseFactory.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/AuthorizationMetadata/AuthorizationMetadataResponseFactory.cs
@@ -97,7 +97,7 @@ public class AuthorizationMetadataResponseFactory(IClaimSetRepository _claimSetR
                         );
 
                         // Look for claim set specific metadata defined on the current claim
-                        var matchingClaimSet = currentClaim.ClaimSets.FirstOrDefault(cs =>
+                        var matchingClaimSet = currentClaim.ClaimSets.Find(cs =>
                             cs.Name.Equals(claimSetName, StringComparison.OrdinalIgnoreCase)
                         );
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/ClaimsFragmentComposer.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/ClaimsFragmentComposer.cs
@@ -222,7 +222,7 @@ public class ClaimsFragmentComposer(ILogger<ClaimsFragmentComposer> logger) : IC
     /// <summary>
     /// Converts transformation model back to JsonNode format
     /// </summary>
-    private JsonNode ConvertFromTransformationModel(List<TransformationClaim> claims)
+    private static JsonNode ConvertFromTransformationModel(List<TransformationClaim> claims)
     {
         string json = JsonSerializer.Serialize(claims, _outputJsonOptions);
         return JsonNode.Parse(json) ?? JsonNode.Parse("[]")!;
@@ -568,7 +568,7 @@ public class ClaimsFragmentComposer(ILogger<ClaimsFragmentComposer> logger) : IC
 
     #region Transformation Model Classes (Ported from CmsHierarchy.Model)
 
-    private class TransformationClaim
+    private sealed class TransformationClaim
     {
         public string? Name { get; set; }
         public TransformationDefaultAuthorization? DefaultAuthorization { get; set; }
@@ -576,59 +576,56 @@ public class ClaimsFragmentComposer(ILogger<ClaimsFragmentComposer> logger) : IC
         public List<TransformationClaim>? Claims { get; set; }
     }
 
-    private class TransformationDefaultAuthorization
+    private sealed class TransformationDefaultAuthorization
     {
         public List<TransformationAction>? Actions { get; set; }
     }
 
-    private class TransformationAction
+    private sealed class TransformationAction
     {
         public string? Name { get; set; }
         public List<TransformationAuthorizationStrategy>? AuthorizationStrategies { get; set; }
     }
 
-    private class TransformationClaimSet
+    private sealed class TransformationClaimSet
     {
         public string? Name { get; set; }
         public List<TransformationClaimSetAction>? Actions { get; set; }
     }
 
-    private class TransformationClaimSetAction
+    private sealed class TransformationClaimSetAction
     {
         public string? Name { get; set; }
         public List<TransformationAuthorizationStrategy>? AuthorizationStrategyOverrides { get; set; }
     }
 
-    private class TransformationAuthorizationStrategy
+    private sealed class TransformationAuthorizationStrategy
     {
         public string? Name { get; set; }
     }
 
-    // Fragment file structure classes (reused from CmsHierarchy.Model)
-    private class ResourceClaim
+    // Fragment file structure records (reused from CmsHierarchy.Model).
+    // Positional records — the primary constructor is what System.Text.Json calls during
+    // deserialization, satisfying analyzers that don't track reflection-based property writes.
+    private sealed record ResourceClaim(string? Name = null, bool IsParent = false)
     {
-        public string? Name { get; set; }
-        public bool IsParent { get; set; }
-
         [JsonPropertyName("_defaultAuthorizationStrategiesForCrud")]
-        public List<ClaimSetResourceClaimActionAuthStrategies?> DefaultAuthorizationStrategiesForCRUD { get; set; } =
+        public List<ClaimSetResourceClaimActionAuthStrategies?> DefaultAuthorizationStrategiesForCRUD { get; init; } =
         [];
-        public List<ClaimSetResourceClaimActionAuthStrategies?> AuthorizationStrategyOverridesForCRUD { get; set; } =
+        public List<ClaimSetResourceClaimActionAuthStrategies?> AuthorizationStrategyOverridesForCRUD { get; init; } =
         [];
-        public List<ResourceClaim> Children { get; set; } = [];
-        public List<TransformationClaimSet> ClaimSets { get; set; } = [];
+        public List<ResourceClaim> Children { get; init; } = [];
+        public List<TransformationClaimSet> ClaimSets { get; init; } = [];
     }
 
-    private class ClaimSetResourceClaimActionAuthStrategies
-    {
-        public string? ActionName { get; set; }
-        public IEnumerable<TransformationAuthorizationStrategy>? AuthorizationStrategies { get; set; }
-    }
+    private sealed record ClaimSetResourceClaimActionAuthStrategies(
+        string? ActionName = null,
+        IEnumerable<TransformationAuthorizationStrategy>? AuthorizationStrategies = null
+    );
 
-    private class ClaimSetResourceClaims
+    private sealed record ClaimSetResourceClaims(string? Name = null)
     {
-        public string? Name { get; set; }
-        public List<ResourceClaim> ResourceClaims { get; set; } = [];
+        public List<ResourceClaim> ResourceClaims { get; init; } = [];
     }
 
     #endregion

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/ClaimsValidator.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/ClaimsValidator.cs
@@ -94,14 +94,11 @@ public class ClaimsValidator(ILogger<ClaimsValidator> _logger) : IClaimsValidato
     /// <summary>
     /// JSON Schema validation of a Claims document
     /// </summary>
-    public List<ClaimsValidationFailure> Validate(JsonNode claimsDocument)
+    public List<ClaimsValidationFailure> Validate(JsonNode claimsContent)
     {
         try
         {
-            EvaluationResults results = _jsonSchemaForClaims.Value.Evaluate(
-                claimsDocument,
-                _validatorOptions
-            );
+            EvaluationResults results = _jsonSchemaForClaims.Value.Evaluate(claimsContent, _validatorOptions);
             return ValidationErrorsFrom(results);
         }
         catch (ArgumentException ex)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/ClaimsDataLoader/ClaimsDataLoader.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/ClaimsDataLoader/ClaimsDataLoader.cs
@@ -14,7 +14,7 @@ using Microsoft.Extensions.Logging;
 
 namespace EdFi.DmsConfigurationService.Backend.ClaimsDataLoader;
 
-internal class DatabaseOperationException(string message) : Exception(message);
+public class DatabaseOperationException(string message) : Exception(message);
 
 /// <summary>
 /// Service responsible for loading and updating claims data in the database from JSON sources.

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
@@ -54,7 +54,7 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
         foreach (var resourceClaim in importResourceClaims)
         {
             // Find or create the claim in the hierarchy
-            var claim = claims.FirstOrDefault(c => c.Name == resourceClaim.Name);
+            var claim = claims.Find(c => c.Name == resourceClaim.Name);
 
             // If the claim is not found, throw an exception
             // NOTE: The command for the import should already have been validated at this point, so this is purely a defensive check
@@ -67,7 +67,7 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
 
             // Find or create the ClaimSet for the metadata in the claims hierarchy
             // NOTE: It is expected that all claim set information will have been removed by a call to RemoveClaimSetFromHierarchy
-            var claimSet = claim.ClaimSets.FirstOrDefault(cs => cs.Name == claimSetName);
+            var claimSet = claim.ClaimSets.Find(cs => cs.Name == claimSetName);
 
             if (claimSet != null)
             {
@@ -84,18 +84,18 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
             if (resourceClaim.Actions != null)
             {
                 // Add actions with overrides (if present) from the ResourceClaim
-                foreach (var action in resourceClaim.Actions.Where(a => a.Enabled))
+                foreach (var actionName in resourceClaim.Actions.Where(a => a.Enabled).Select(a => a.Name))
                 {
                     // Create the action for the claim set
                     var newAction = new ClaimSetAction
                     {
-                        Name = action.Name ?? "",
+                        Name = actionName ?? "",
                         AuthorizationStrategyOverrides = [],
                     };
 
                     // Look for overrides on import command
                     var overrideForCrud = resourceClaim.AuthorizationStrategyOverridesForCRUD.SingleOrDefault(
-                        x => x?.ActionName == action.Name
+                        x => x?.ActionName == actionName
                     );
 
                     // If overrides for the action are present, apply them

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IClaimsHierarchyRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IClaimsHierarchyRepository.cs
@@ -5,7 +5,6 @@
 
 // ReSharper disable ClassNeverInstantiated.Global
 
-using System.Data;
 using System.Data.Common;
 using EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
 

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
@@ -41,7 +41,7 @@ public class ResourceClaimValidator
         );
     }
 
-    private void ValidateResourceClaimExists<T>(
+    private static void ValidateResourceClaimExists<T>(
         ValidationContext<T> context,
         ResourceClaim resourceClaim,
         IDictionary<string, string?> parentClaimByResourceClaim,
@@ -57,7 +57,7 @@ public class ResourceClaimValidator
         }
     }
 
-    private void ValidateNoDuplicateResourceClaims<T>(
+    private static void ValidateNoDuplicateResourceClaims<T>(
         ResourceClaim resourceClaim,
         ValidationContext<T> context,
         string propertyName
@@ -86,20 +86,16 @@ public class ResourceClaimValidator
 
         string? resourceKey = resourceClaim.Name;
 
-        if (!string.IsNullOrWhiteSpace(resourceKey))
+        if (
+            !string.IsNullOrWhiteSpace(resourceKey)
+            && !seenResources.Add(resourceKey)
+            && duplicateResources.Add(resourceKey)
+        )
         {
-            // Has this resource claim already been seen (i.e. it's a duplicate)?
-            if (!seenResources.Add(resourceKey))
-            {
-                // Track it as a duplicate, and only report the validation failure first time
-                if (duplicateResources.Add(resourceKey))
-                {
-                    context.AddFailure(
-                        propertyName,
-                        "Only unique resource claims can be added. The following is a duplicate resource: '{ResourceClaimName}'."
-                    );
-                }
-            }
+            context.AddFailure(
+                propertyName,
+                "Only unique resource claims can be added. The following is a duplicate resource: '{ResourceClaimName}'."
+            );
         }
     }
 
@@ -220,16 +216,17 @@ public class ResourceClaimValidator
                     continue;
                 }
 
-                foreach (var defaultAs in defaultASWithAction.AuthorizationStrategies)
-                {
-                    if (
-                        defaultAs.AuthorizationStrategyName != null
-                        && !dbAuthStrategies.Contains(defaultAs.AuthorizationStrategyName)
+                foreach (
+                    var authStrategyName in defaultASWithAction.AuthorizationStrategies.Select(defaultAs =>
+                        defaultAs.AuthorizationStrategyName
                     )
+                )
+                {
+                    if (authStrategyName != null && !dbAuthStrategies.Contains(authStrategyName))
                     {
                         context.MessageFormatter.AppendArgument(
                             "AuthorizationStrategyName",
-                            defaultAs.AuthorizationStrategyName
+                            authStrategyName
                         );
                         context.AddFailure(
                             propertyName,

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Profile/ProfileValidationUtils.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Profile/ProfileValidationUtils.cs
@@ -77,7 +77,10 @@ public static class ProfileValidationUtils
 
             using var stringReader = new StringReader(xml);
             using var xmlReader = XmlReader.Create(stringReader, settings);
-            while (xmlReader.Read()) { } // Read through the entire document to trigger validation
+            while (xmlReader.Read())
+            {
+                // Read through the entire document to trigger validation
+            }
 
             return new ProfileXmlValidationResult(isValid, errors);
         }
@@ -128,7 +131,7 @@ public static class ProfileValidationUtils
             {
                 if (
                     node.Attributes?["name"] == null
-                    || string.IsNullOrWhiteSpace(node?.Attributes?["name"]?.Value ?? string.Empty)
+                    || string.IsNullOrWhiteSpace(node.Attributes?["name"]?.Value ?? string.Empty)
                 )
                 {
                     return false;

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Vendor/VendorInsertCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Vendor/VendorInsertCommand.cs
@@ -29,7 +29,7 @@ public class VendorInsertCommand
                         ',',
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
                     );
-                    return split != null && !split.Any(x => x.Length > 128);
+                    return split != null && !Array.Exists(split, x => x.Length > 128);
                 })
                 .WithMessage("Each NamespacePrefix length must be 128 characters or fewer.");
         }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Vendor/VendorUpdateCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Vendor/VendorUpdateCommand.cs
@@ -26,7 +26,7 @@ public class VendorUpdateCommand : VendorInsertCommand
                         ',',
                         StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
                     );
-                    return split != null && !split.Any(x => x.Length > 128);
+                    return split != null && !Array.Exists(split, x => x.Length > 128);
                 })
                 .WithMessage("Each NamespacePrefix length must be 128 characters or fewer.");
         }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.csproj
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.csproj
@@ -10,10 +10,6 @@
         <PackageReference Include="FakeItEasy" />
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -23,10 +19,6 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     </ItemGroup>
     <ItemGroup>

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj
@@ -20,10 +20,6 @@
         <PackageReference Include="FluentValidation.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols" />
         <PackageReference Include="Serilog" />

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Extensions/OpenIddictIntegrationExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Extensions/OpenIddictIntegrationExtensions.cs
@@ -30,8 +30,13 @@ public static class OpenIddictIntegrationExtensions
             .AddOpenIddict()
             .AddValidation(options =>
             {
-                // Configure validation to use local authorization server
-                options.SetIssuer(configuration["Authentication:Authority"] ?? "https://localhost:5126");
+                // Configure validation to use the configured authorization server
+                options.SetIssuer(
+                    configuration["Authentication:Authority"]
+                        ?? throw new InvalidOperationException(
+                            "Configuration value 'Authentication:Authority' is required."
+                        )
+                );
 
                 // Register the System.Net.Http integration
                 options.UseSystemNetHttp();

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/Authorization/EndpointBuilderExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/Authorization/EndpointBuilderExtensions.cs
@@ -20,10 +20,10 @@ public static class EndpointBuilderExtensions
     {
         return endpoints
             .MapGet(pattern, handler)
-            .RequireAuthorization([
+            .RequireAuthorization(
                 SecurityConstants.ServicePolicy,
-                AuthorizationScopePolicies.ReadOnlyOrAdminScopePolicy,
-            ]);
+                AuthorizationScopePolicies.ReadOnlyOrAdminScopePolicy
+            );
     }
 
     public static RouteHandlerBuilder MapSecuredPost(
@@ -34,10 +34,10 @@ public static class EndpointBuilderExtensions
     {
         return endpoints
             .MapPost(pattern, handler)
-            .RequireAuthorization([
+            .RequireAuthorization(
                 SecurityConstants.ServicePolicy,
-                AuthorizationScopePolicies.AdminScopePolicy,
-            ]);
+                AuthorizationScopePolicies.AdminScopePolicy
+            );
     }
 
     public static RouteHandlerBuilder MapSecuredPut(
@@ -48,10 +48,10 @@ public static class EndpointBuilderExtensions
     {
         return endpoints
             .MapPut(pattern, handler)
-            .RequireAuthorization([
+            .RequireAuthorization(
                 SecurityConstants.ServicePolicy,
-                AuthorizationScopePolicies.AdminScopePolicy,
-            ]);
+                AuthorizationScopePolicies.AdminScopePolicy
+            );
     }
 
     public static RouteHandlerBuilder MapSecuredDelete(
@@ -62,10 +62,10 @@ public static class EndpointBuilderExtensions
     {
         return endpoints
             .MapDelete(pattern, handler)
-            .RequireAuthorization([
+            .RequireAuthorization(
                 SecurityConstants.ServicePolicy,
-                AuthorizationScopePolicies.AdminScopePolicy,
-            ]);
+                AuthorizationScopePolicies.AdminScopePolicy
+            );
     }
 
     public static RouteHandlerBuilder MapLimitedAccess(
@@ -76,10 +76,10 @@ public static class EndpointBuilderExtensions
     {
         return endpoints
             .MapGet(pattern, handler)
-            .RequireAuthorization([
+            .RequireAuthorization(
                 SecurityConstants.ServicePolicy,
-                AuthorizationScopePolicies.AdminOrAuthMetadataReadOnlyAccessScopePolicyOrReadOnly,
-            ]);
+                AuthorizationScopePolicies.AdminOrAuthMetadataReadOnlyAccessScopePolicyOrReadOnly
+            );
     }
 
     public static RouteHandlerBuilder MapPublic(

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/Authorization/ScopePolicyHandler.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/Authorization/ScopePolicyHandler.cs
@@ -25,7 +25,7 @@ public class ScopePolicyHandler : AuthorizationHandler<ScopePolicy>
         {
             var userScopes = scopeClaim.Value.Split(' ');
 
-            if (requirement.AllowedScopes.Any(scope => userScopes.Contains(scope)))
+            if (requirement.AllowedScopes.Exists(scope => userScopes.Contains(scope)))
             {
                 context.Succeed(requirement);
             }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Reflection;
-using System.Security.Cryptography;
 using System.Text.RegularExpressions;
 using EdFi.DmsConfigurationService.Backend;
 using EdFi.DmsConfigurationService.Backend.AuthorizationMetadata;
@@ -13,7 +12,6 @@ using EdFi.DmsConfigurationService.Backend.ClaimsDataLoader;
 using EdFi.DmsConfigurationService.Backend.Deploy;
 using EdFi.DmsConfigurationService.Backend.Keycloak;
 using EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
-using EdFi.DmsConfigurationService.Backend.OpenIddict;
 using EdFi.DmsConfigurationService.Backend.OpenIddict.Services;
 using EdFi.DmsConfigurationService.Backend.Postgresql;
 using EdFi.DmsConfigurationService.Backend.Postgresql.OpenIddict;

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationExtensions.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/WebApplicationExtensions.cs
@@ -25,15 +25,15 @@ public static class WebApplicationExtensions
         foreach (var moduleClass in moduleClasses)
         {
             // Exclude OpenID modules when not using self-contained identity provider
-            if (!string.Equals(identityProvider, "self-contained", StringComparison.OrdinalIgnoreCase))
-            {
-                if (
+            if (
+                !string.Equals(identityProvider, "self-contained", StringComparison.OrdinalIgnoreCase)
+                && (
                     moduleClass.Name == typeof(JwksEndpointModule).Name
                     || moduleClass.Name == typeof(OpenIdConfigurationModule).Name
                 )
-                {
-                    continue;
-                }
+            )
+            {
+                continue;
             }
 
             // Exclude TenantModule when multi-tenancy is disabled

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ActionsModule.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DmsConfigurationService.Backend.Repositories;
-using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure.Authorization;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApiClientModule.cs
@@ -89,7 +89,7 @@ public class ApiClientModule : IEndpointModule
             }
             else if (existingIdsResult is DmsInstanceIdsExistResult.FailureUnknown failure)
             {
-                logger.LogError("Error validating DmsInstanceIds: {message}", failure.FailureMessage);
+                logger.LogError("Error validating DmsInstanceIds: {Message}", failure.FailureMessage);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
             }
         }
@@ -127,11 +127,11 @@ public class ApiClientModule : IEndpointModule
         switch (clientCreateResult)
         {
             case ClientCreateResult.FailureUnknown failure:
-                logger.LogError("Failure creating client {failure}", failure);
+                logger.LogError("Failure creating client {Failure}", failure);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
             case ClientCreateResult.FailureIdentityProvider failureIdentityProvider:
                 logger.LogError(
-                    "Failure creating client: {failureMessage}",
+                    "Failure creating client: {FailureMessage}",
                     SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
                 );
                 return FailureResults.BadGateway(
@@ -176,7 +176,7 @@ public class ApiClientModule : IEndpointModule
                             new ValidationFailure("DmsInstanceId", "DMS instance does not exist."),
                         ]);
                     case ApiClientInsertResult.FailureUnknown failure:
-                        logger.LogError("Failure creating client {failure}", failure);
+                        logger.LogError("Failure creating client {Failure}", failure);
                         await clientRepository.DeleteClientAsync(clientSuccess.ClientUuid.ToString());
                         return FailureResults.Unknown(httpContext.TraceIdentifier);
                 }
@@ -230,7 +230,7 @@ public class ApiClientModule : IEndpointModule
         return LoggingUtility.SanitizeForLog(input);
     }
 
-    private async Task<IResult> UpdateApiClient(
+    private static async Task<IResult> UpdateApiClient(
         long id,
         ApiClientUpdateCommand command,
         ApiClientUpdateCommand.Validator validator,
@@ -299,24 +299,19 @@ public class ApiClientModule : IEndpointModule
             else if (existingIdsResult is DmsInstanceIdsExistResult.FailureUnknown failure)
             {
                 logger.LogError(
-                    "Error validating DmsInstanceIds: {message}",
+                    "Error validating DmsInstanceIds: {Message}",
                     SanitizeForLog(failure.FailureMessage)
                 );
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
             }
         }
 
-        // Get vendor details for rollback if needed
-        string namespacePrefixes;
-        switch (await vendorRepository.GetVendor(application.VendorId))
+        // Validate vendor exists
+        if (await vendorRepository.GetVendor(application.VendorId) is not VendorGetResult.Success)
         {
-            case VendorGetResult.Success success:
-                namespacePrefixes = success.VendorResponse.NamespacePrefixes;
-                break;
-            default:
-                throw new ValidationException([
-                    new ValidationFailure("VendorId", "Reference 'VendorId' does not exist."),
-                ]);
+            throw new ValidationException([
+                new ValidationFailure("VendorId", "Reference 'VendorId' does not exist."),
+            ]);
         }
 
         // Get original application for rollback if needed
@@ -341,11 +336,11 @@ public class ApiClientModule : IEndpointModule
         switch (clientUpdateResult)
         {
             case ClientUpdateResult.FailureUnknown failure:
-                logger.LogError("Failure updating client: {failure}", SanitizeForLog(failure.FailureMessage));
+                logger.LogError("Failure updating client: {Failure}", SanitizeForLog(failure.FailureMessage));
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
             case ClientUpdateResult.FailureIdentityProvider failureIdentityProvider:
                 logger.LogError(
-                    "Failure updating client: {failureMessage}",
+                    "Failure updating client: {FailureMessage}",
                     SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
                 );
                 return FailureResults.BadGateway(
@@ -354,7 +349,7 @@ public class ApiClientModule : IEndpointModule
                 );
             case ClientUpdateResult.FailureNotFound notFound:
                 logger.LogError(
-                    "Client not found in identity provider: {failure}",
+                    "Client not found in identity provider: {Failure}",
                     SanitizeForLog(notFound.FailureMessage)
                 );
                 return FailureResults.NotFound(
@@ -374,7 +369,7 @@ public class ApiClientModule : IEndpointModule
                         if (originalApplication != null)
                         {
                             logger.LogWarning(
-                                "Database update failed for ApiClient {id}, attempting to rollback identity provider changes",
+                                "Database update failed for ApiClient {Id}, attempting to rollback identity provider changes",
                                 id
                             );
                             await identityProviderRepository.UpdateClientAsync(
@@ -393,7 +388,7 @@ public class ApiClientModule : IEndpointModule
                         if (originalApplication != null)
                         {
                             logger.LogWarning(
-                                "Database update failed for ApiClient {id}, attempting to rollback identity provider changes",
+                                "Database update failed for ApiClient {Id}, attempting to rollback identity provider changes",
                                 id
                             );
                             await identityProviderRepository.UpdateClientAsync(
@@ -415,7 +410,7 @@ public class ApiClientModule : IEndpointModule
                         if (originalApplication != null)
                         {
                             logger.LogWarning(
-                                "Database update failed for ApiClient {id}, attempting to rollback identity provider changes",
+                                "Database update failed for ApiClient {Id}, attempting to rollback identity provider changes",
                                 id
                             );
                             await identityProviderRepository.UpdateClientAsync(
@@ -434,7 +429,7 @@ public class ApiClientModule : IEndpointModule
                         if (originalApplication != null)
                         {
                             logger.LogWarning(
-                                "Database update failed for ApiClient {id}, attempting to rollback identity provider changes",
+                                "Database update failed for ApiClient {Id}, attempting to rollback identity provider changes",
                                 id
                             );
                             await identityProviderRepository.UpdateClientAsync(
@@ -446,7 +441,7 @@ public class ApiClientModule : IEndpointModule
                             );
                         }
                         logger.LogError(
-                            "Failure updating client: {failure}",
+                            "Failure updating client: {Failure}",
                             SanitizeForLog(failure.FailureMessage)
                         );
                         return FailureResults.Unknown(httpContext.TraceIdentifier);
@@ -459,7 +454,7 @@ public class ApiClientModule : IEndpointModule
         return FailureResults.Unknown(httpContext.TraceIdentifier);
     }
 
-    private async Task<IResult> DeleteApiClient(
+    private static async Task<IResult> DeleteApiClient(
         long id,
         HttpContext httpContext,
         IApiClientRepository apiClientRepository,
@@ -501,7 +496,7 @@ public class ApiClientModule : IEndpointModule
         // Delete from identity provider FIRST
         try
         {
-            logger.LogInformation("Deleting client {clientId}", SanitizeForLog(apiClient.ClientId));
+            logger.LogInformation("Deleting client {ClientId}", SanitizeForLog(apiClient.ClientId));
             var clientDeleteResult = await identityProviderRepository.DeleteClientAsync(
                 apiClient.ClientUuid.ToString()
             );
@@ -510,7 +505,7 @@ public class ApiClientModule : IEndpointModule
             {
                 case ClientDeleteResult.FailureUnknown failureUnknown:
                     logger.LogError(
-                        "Error deleting client {clientId} {clientUuid}: {failureMessage}",
+                        "Error deleting client {ClientId} {ClientUuid}: {FailureMessage}",
                         SanitizeForLog(apiClient.ClientId),
                         SanitizeForLog(apiClient.ClientUuid.ToString()),
                         SanitizeForLog(failureUnknown.FailureMessage)
@@ -518,7 +513,7 @@ public class ApiClientModule : IEndpointModule
                     return FailureResults.Unknown(httpContext.TraceIdentifier);
                 case ClientDeleteResult.FailureIdentityProvider failureIdentityProvider:
                     logger.LogError(
-                        "Error deleting client from identity provider: {failureMessage}",
+                        "Error deleting client from identity provider: {FailureMessage}",
                         SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
                     );
                     return FailureResults.BadGateway(
@@ -530,7 +525,8 @@ public class ApiClientModule : IEndpointModule
         catch (Exception ex)
         {
             logger.LogError(
-                "Error deleting client {clientId} {clientUuid}: {message}",
+                ex,
+                "Error deleting client {ClientId} {ClientUuid}: {Message}",
                 SanitizeForLog(apiClient.ClientId),
                 SanitizeForLog(apiClient.ClientUuid.ToString()),
                 SanitizeForLog(ex.Message)
@@ -551,7 +547,7 @@ public class ApiClientModule : IEndpointModule
                 if (application != null && namespacePrefixes != null)
                 {
                     logger.LogError(
-                        "Database delete failed for ApiClient {id} after identity provider deletion succeeded. Attempting to recreate client in identity provider.",
+                        "Database delete failed for ApiClient {Id} after identity provider deletion succeeded. Attempting to recreate client in identity provider.",
                         id
                     );
                     try
@@ -567,14 +563,15 @@ public class ApiClientModule : IEndpointModule
                             [.. apiClient.DmsInstanceIds]
                         );
                         logger.LogWarning(
-                            "Successfully recreated client {clientId} in identity provider after database delete failure. CLIENT SECRET HAS BEEN CHANGED - manual intervention required.",
+                            "Successfully recreated client {ClientId} in identity provider after database delete failure. CLIENT SECRET HAS BEEN CHANGED - manual intervention required.",
                             SanitizeForLog(apiClient.ClientId)
                         );
                     }
                     catch (Exception rollbackEx)
                     {
                         logger.LogCritical(
-                            "CRITICAL: Failed to rollback identity provider after database delete failure for ApiClient {id}. Client {clientId} exists in identity provider but not in database. Manual cleanup required. Error: {error}",
+                            rollbackEx,
+                            "CRITICAL: Failed to rollback identity provider after database delete failure for ApiClient {Id}. Client {ClientId} exists in identity provider but not in database. Manual cleanup required. Error: {Error}",
                             id,
                             SanitizeForLog(apiClient.ClientId),
                             SanitizeForLog(rollbackEx.Message)
@@ -584,7 +581,7 @@ public class ApiClientModule : IEndpointModule
                 else
                 {
                     logger.LogCritical(
-                        "CRITICAL: Database delete failed for ApiClient {id} after identity provider deletion succeeded. Cannot rollback - missing application or vendor data. Client {clientId} deleted from identity provider but still in database. Manual cleanup required.",
+                        "CRITICAL: Database delete failed for ApiClient {Id} after identity provider deletion succeeded. Cannot rollback - missing application or vendor data. Client {ClientId} deleted from identity provider but still in database. Manual cleanup required.",
                         id,
                         SanitizeForLog(apiClient.ClientId)
                     );
@@ -595,7 +592,7 @@ public class ApiClientModule : IEndpointModule
                     : FailureResults.Unknown(httpContext.TraceIdentifier);
             default:
                 logger.LogCritical(
-                    "CRITICAL: Unexpected delete result for ApiClient {id} after identity provider deletion. Client {clientId} may be in inconsistent state.",
+                    "CRITICAL: Unexpected delete result for ApiClient {Id} after identity provider deletion. Client {ClientId} may be in inconsistent state.",
                     id,
                     SanitizeForLog(apiClient.ClientId)
                 );
@@ -625,7 +622,7 @@ public class ApiClientModule : IEndpointModule
         try
         {
             logger.LogInformation(
-                "Resetting credentials for client {clientId}",
+                "Resetting credentials for client {ClientId}",
                 SanitizeForLog(apiClient.ClientId)
             );
             var clientResetResult = await identityProviderRepository.ResetCredentialsAsync(
@@ -652,16 +649,15 @@ public class ApiClientModule : IEndpointModule
                         logger,
                         httpContext.TraceIdentifier
                     ),
-                ClientResetResult.FailureUnknown failure => FailureResults.Unknown(
-                    httpContext.TraceIdentifier
-                ),
+                ClientResetResult.FailureUnknown => FailureResults.Unknown(httpContext.TraceIdentifier),
                 _ => FailureResults.Unknown(httpContext.TraceIdentifier),
             };
         }
         catch (Exception ex)
         {
             logger.LogError(
-                "Error resetting client credentials {clientId} {clientUuid}: {message}",
+                ex,
+                "Error resetting client credentials {ClientId} {ClientUuid}: {Message}",
                 SanitizeForLog(apiClient.ClientId),
                 SanitizeForLog(apiClient.ClientUuid.ToString()),
                 SanitizeForLog(ex.Message)
@@ -677,13 +673,10 @@ public class ApiClientModule : IEndpointModule
     )
     {
         logger.LogError(
-            "Identity provider error during credential reset: {failureMessage}",
+            "Identity provider error during credential reset: {FailureMessage}",
             SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
         );
 
-        return FailureResults.BadGateway(
-            "Identity provider error during credential reset",
-            traceIdentifier
-        );
+        return FailureResults.BadGateway("Identity provider error during credential reset", traceIdentifier);
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
@@ -88,11 +88,11 @@ public class ApplicationModule : IEndpointModule
         switch (clientCreateResult)
         {
             case ClientCreateResult.FailureUnknown failure:
-                logger.LogError("Failure creating client {failure}", failure);
+                logger.LogError("Failure creating client {Failure}", failure);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
             case ClientCreateResult.FailureIdentityProvider failureIdentityProvider:
                 logger.LogError(
-                    "Failure creating client: {failureMessage}",
+                    "Failure creating client: {FailureMessage}",
                     SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
                 );
                 return FailureResults.BadGateway(
@@ -147,7 +147,7 @@ public class ApplicationModule : IEndpointModule
                             ),
                         ]);
                     case ApplicationInsertResult.FailureUnknown failure:
-                        logger.LogError("Failure creating client {failure}", failure);
+                        logger.LogError("Failure creating client {Failure}", failure);
                         await clientRepository.DeleteClientAsync(clientSuccess.ClientUuid.ToString());
                         return FailureResults.Unknown(httpContext.TraceIdentifier);
                 }
@@ -180,6 +180,7 @@ public class ApplicationModule : IEndpointModule
         ILogger<ApplicationModule> logger
     )
     {
+        logger.LogDebug("Entering Application GetById for id: {Id}", id);
         ApplicationGetResult getResult = await applicationRepository.GetApplication(id);
         return getResult switch
         {
@@ -216,7 +217,7 @@ public class ApplicationModule : IEndpointModule
                 var client = success.Clients.FirstOrDefault();
                 if (client != null)
                 {
-                    logger.LogInformation("Updating client {clientId}", client.ClientId);
+                    logger.LogInformation("Updating client {ClientId}", client.ClientId);
                     var clientUpdateResult = await clientRepository.UpdateClientAsync(
                         client.ClientUuid.ToString(),
                         command.ApplicationName,
@@ -276,8 +277,7 @@ public class ApplicationModule : IEndpointModule
 
                             return applicationUpdateResult switch
                             {
-                                ApplicationUpdateResult.Success updateApplicationSuccess =>
-                                    Results.NoContent(),
+                                ApplicationUpdateResult.Success => Results.NoContent(),
                                 ApplicationUpdateResult.FailureNotExists => FailureResults.NotFound(
                                     "Application not found",
                                     httpContext.TraceIdentifier
@@ -287,10 +287,8 @@ public class ApplicationModule : IEndpointModule
 
                         case ClientUpdateResult.FailureIdentityProvider failureIdentityProvider:
                             logger.LogError(
-                                "Failure updating client: {failureMessage}",
-                                SanitizeForLog(
-                                    failureIdentityProvider.IdentityProviderError.FailureMessage
-                                )
+                                "Failure updating client: {FailureMessage}",
+                                SanitizeForLog(failureIdentityProvider.IdentityProviderError.FailureMessage)
                             );
                             return FailureResults.BadGateway(
                                 "Identity provider error during client update",
@@ -301,7 +299,7 @@ public class ApplicationModule : IEndpointModule
                             return FailureResults.Unknown(httpContext.TraceIdentifier);
                         case ClientUpdateResult.FailureUnknown unknownFailure:
                             logger.LogError(
-                                "Error updating client {clientId} {clientUuid}: {message}",
+                                "Error updating client {ClientId} {ClientUuid}: {Message}",
                                 client.ClientId,
                                 client.ClientUuid,
                                 unknownFailure.FailureMessage
@@ -315,7 +313,7 @@ public class ApplicationModule : IEndpointModule
                 }
                 break;
             case ApplicationApiClientsResult.FailureUnknown failure:
-                logger.LogError("Error fetching ApiClients: {failure}", failure);
+                logger.LogError("Error fetching ApiClients: {Failure}", failure);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
         }
         return FailureResults.Unknown(httpContext.TraceIdentifier);
@@ -329,7 +327,7 @@ public class ApplicationModule : IEndpointModule
         ILogger<ApplicationModule> logger
     )
     {
-        logger.LogInformation("Deleting Application {id}", id);
+        logger.LogInformation("Deleting Application {Id}", id);
 
         var apiClientsResult = await repository.GetApplicationApiClients(id);
         switch (apiClientsResult)
@@ -339,14 +337,14 @@ public class ApplicationModule : IEndpointModule
                 {
                     try
                     {
-                        logger.LogInformation("Deleting client {clientId}", client.ClientId);
+                        logger.LogInformation("Deleting client {ClientId}", client.ClientId);
                         var clientDeleteResult = await clientRepository.DeleteClientAsync(
                             client.ClientUuid.ToString()
                         );
                         if (clientDeleteResult is ClientDeleteResult.FailureUnknown failureUnknown)
                         {
                             logger.LogError(
-                                "Error deleting client {clientId} {clientUuid}: {failureMessage}",
+                                "Error deleting client {ClientId} {ClientUuid}: {FailureMessage}",
                                 client.ClientId,
                                 client.ClientUuid,
                                 failureUnknown.FailureMessage
@@ -356,7 +354,8 @@ public class ApplicationModule : IEndpointModule
                     catch (Exception ex)
                     {
                         logger.LogError(
-                            "Error deleting client {clientId} {clientUuid}: {message}",
+                            ex,
+                            "Error deleting client {ClientId} {ClientUuid}: {Message}",
                             client.ClientId,
                             client.ClientUuid,
                             ex.Message
@@ -367,7 +366,7 @@ public class ApplicationModule : IEndpointModule
 
                 break;
             case ApplicationApiClientsResult.FailureUnknown failure:
-                logger.LogError("Error fetching ApiClients: {failure}", failure);
+                logger.LogError("Error fetching ApiClients: {Failure}", failure);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
         }
 
@@ -375,7 +374,7 @@ public class ApplicationModule : IEndpointModule
 
         if (deleteResult is ApplicationDeleteResult.FailureUnknown unknown)
         {
-            logger.LogError("Error deleting Application {id}: {message}", id, unknown.FailureMessage);
+            logger.LogError("Error deleting Application {Id}: {Message}", id, unknown.FailureMessage);
             return FailureResults.Unknown(httpContext.TraceIdentifier);
         }
         return deleteResult switch
@@ -406,7 +405,7 @@ public class ApplicationModule : IEndpointModule
                 {
                     try
                     {
-                        logger.LogInformation("Resetting client {clientId}", client.ClientId);
+                        logger.LogInformation("Resetting client {ClientId}", client.ClientId);
                         var clientResetResult = await clientRepository.ResetCredentialsAsync(
                             client.ClientUuid.ToString()
                         );
@@ -428,7 +427,7 @@ public class ApplicationModule : IEndpointModule
                                 );
                             case ClientResetResult.FailureIdentityProvider failureIdentityProvider:
                                 logger.LogError(
-                                    "Identity provider error during credential reset: {message}",
+                                    "Identity provider error during credential reset: {Message}",
                                     SanitizeForLog(
                                         failureIdentityProvider.IdentityProviderError.FailureMessage
                                     )
@@ -439,7 +438,7 @@ public class ApplicationModule : IEndpointModule
                                 );
                             case ClientResetResult.FailureUnknown failure:
                                 logger.LogError(
-                                    "Error resetting client credentials {clientId} {clientUuid}: {message}",
+                                    "Error resetting client credentials {ClientId} {ClientUuid}: {Message}",
                                     client.ClientId,
                                     client.ClientUuid,
                                     failure.FailureMessage
@@ -450,7 +449,8 @@ public class ApplicationModule : IEndpointModule
                     catch (Exception ex)
                     {
                         logger.LogError(
-                            "Error resetting client credentials {clientId} {clientUuid}: {message}",
+                            ex,
+                            "Error resetting client credentials {ClientId} {ClientUuid}: {Message}",
                             client.ClientId,
                             client.ClientUuid,
                             ex.Message
@@ -464,7 +464,7 @@ public class ApplicationModule : IEndpointModule
                 }
                 break;
             case ApplicationApiClientsResult.FailureUnknown failure:
-                logger.LogError("Error fetching ApiClients: {failure}", failure);
+                logger.LogError("Error fetching ApiClients: {Failure}", failure);
                 return FailureResults.Unknown(httpContext.TraceIdentifier);
         }
         return FailureResults.Unknown(httpContext.TraceIdentifier);

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/AuthorizationMetadataModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/AuthorizationMetadataModule.cs
@@ -20,7 +20,7 @@ public class AuthorizationMetadataModule : IEndpointModule
         endpoints.MapLimitedAccess("/authorizationMetadata", GetAuthorizationMetadata);
     }
 
-    private async Task<IResult> GetAuthorizationMetadata(
+    private static async Task<IResult> GetAuthorizationMetadata(
         [FromQuery] string? claimSetName,
         IClaimsHierarchyRepository repository,
         IAuthorizationMetadataResponseFactory responseFactory,

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimSetModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimSetModule.cs
@@ -87,6 +87,7 @@ public class ClaimSetModule : IEndpointModule
         ILogger<ClaimSetModule> logger
     )
     {
+        logger.LogDebug("Entering ClaimSet GetById for id: {Id}", id);
         ClaimSetGetResult result = await repository.GetClaimSet(id);
 
         return result switch
@@ -177,6 +178,7 @@ public class ClaimSetModule : IEndpointModule
         ILogger<ClaimSetModule> logger
     )
     {
+        logger.LogDebug("Entering ClaimSet Delete for id: {Id}", id);
         ClaimSetDeleteResult result = await repository.DeleteClaimSet(id);
 
         return result switch
@@ -207,6 +209,7 @@ public class ClaimSetModule : IEndpointModule
         ILogger<ClaimSetModule> logger
     )
     {
+        logger.LogDebug("Entering ClaimSet Export for id: {Id}", id);
         ClaimSetExportResult result = await repository.Export(id);
 
         return result switch

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
@@ -7,7 +7,6 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DmsConfigurationService.Backend.Claims;
 using EdFi.DmsConfigurationService.Backend.Claims.Models;
-using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/DmsInstanceRouteContextModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/DmsInstanceRouteContextModule.cs
@@ -57,7 +57,7 @@ public class DmsInstanceRouteContextModule : IEndpointModule
                         ),
                     }
                 ),
-            DmsInstanceRouteContextInsertResult.FailureUnknown failure => FailureResults.Unknown(
+            DmsInstanceRouteContextInsertResult.FailureUnknown => FailureResults.Unknown(
                 httpContext.TraceIdentifier
             ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
@@ -87,6 +87,7 @@ public class DmsInstanceRouteContextModule : IEndpointModule
         ILogger<DmsInstanceRouteContextModule> logger
     )
     {
+        logger.LogDebug("Entering DmsInstanceRouteContext GetById for id: {Id}", id);
         var getResult = await instanceRouteContextRepository.GetInstanceRouteContext(id);
         return getResult switch
         {
@@ -110,6 +111,7 @@ public class DmsInstanceRouteContextModule : IEndpointModule
         ILogger<DmsInstanceRouteContextModule> logger
     )
     {
+        logger.LogDebug("Entering DmsInstanceRouteContext Update for id: {Id}", id);
         await validator.GuardAsync(command);
 
         if (command.Id != id)
@@ -152,7 +154,7 @@ public class DmsInstanceRouteContextModule : IEndpointModule
         ILogger<DmsInstanceRouteContextModule> logger
     )
     {
-        logger.LogInformation("Deleting DmsInstanceRouteContext {id}", id);
+        logger.LogInformation("Deleting DmsInstanceRouteContext {Id}", id);
 
         var deleteResult = await instanceRouteContextRepository.DeleteInstanceRouteContext(id);
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/IdentityModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/IdentityModule.cs
@@ -172,7 +172,7 @@ public class IdentityModule : IEndpointModule
                 catch (Exception ex)
                 {
                     // Log the exception for debugging purposes
-                    logger.LogWarning("Failed to parse Basic Auth credentials: {Exception}", ex);
+                    logger.LogWarning(ex, "Failed to parse Basic Auth credentials");
                 }
             }
         }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
@@ -15,7 +15,7 @@ public class InformationModule : IEndpointModule
         endpoints.MapGet("", GetInformation);
     }
 
-    private IResult GetInformation(HttpContext httpContext)
+    private static IResult GetInformation(HttpContext httpContext)
     {
         var baseUrl =
             $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{httpContext.Request.PathBase}";

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/JwksEndpointModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/JwksEndpointModule.cs
@@ -3,10 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Security.Cryptography;
 using EdFi.DmsConfigurationService.Backend;
-using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
-using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
@@ -18,7 +15,7 @@ public class JwksEndpointModule : IEndpointModule
         endpoints.MapGet("/.well-known/jwks.json", GetJwksConfiguration);
     }
 
-    private async Task<IResult> GetJwksConfiguration(HttpContext httpContext, ITokenManager tokenManager)
+    private async Task<IResult> GetJwksConfiguration(ITokenManager tokenManager)
     {
         // Fetch public keys from the token manager (database-backed)
         var publicKeys = await tokenManager.GetPublicKeysAsync();
@@ -42,13 +39,5 @@ public class JwksEndpointModule : IEndpointModule
                 .ToArray(),
         };
         return Results.Ok(jwks);
-    }
-
-    // Create a key ID from the RSA parameters
-    private static string CreateKeyId(RSAParameters parameters)
-    {
-        using var sha256 = SHA256.Create();
-        var hash = sha256.ComputeHash(parameters.Modulus ?? Array.Empty<byte>());
-        return Base64UrlEncoder.Encode(hash.Take(8).ToArray());
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/OpenIdConfigurationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/OpenIdConfigurationModule.cs
@@ -23,11 +23,8 @@ public class OpenIdConfigurationModule : IEndpointModule
         IOpenIdConnectConfigurationProvider? configurationProvider = null
     )
     {
-        // Build the base URL from the request
+        // Build the base URL from the request, including PathBase if configured
         var request = httpContext.Request;
-        var baseUrl = $"{request.Scheme}://{request.Host}";
-
-        // If PathBase is configured, include it
         var pathBase = configuration.GetValue<string>("AppSettings:PathBase");
         var uriBuilder = new UriBuilder
         {
@@ -36,7 +33,7 @@ public class OpenIdConfigurationModule : IEndpointModule
             Port = request.Host.Port ?? (request.Scheme == "https" ? 443 : 80),
             Path = string.IsNullOrEmpty(pathBase) ? "" : pathBase,
         };
-        baseUrl = uriBuilder.Uri.ToString().TrimEnd('/');
+        var baseUrl = uriBuilder.Uri.ToString().TrimEnd('/');
 
         // Use enhanced configuration provider if available, otherwise fallback to basic implementation
         if (configurationProvider != null)

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ProfileModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ProfileModule.cs
@@ -93,6 +93,7 @@ public class ProfileModule : IEndpointModule
         ILogger<ProfileModule> logger
     )
     {
+        logger.LogDebug("Entering Profile InsertProfile");
         await validator.GuardAsync(command);
         var result = await repository.InsertProfile(command);
         var request = httpContext.Request;
@@ -149,6 +150,7 @@ public class ProfileModule : IEndpointModule
         ILogger<ProfileModule> logger
     )
     {
+        logger.LogDebug("Entering Profile Update for id: {Id}", id);
         await validator.GuardAsync(command);
         if (command.Id != id)
         {
@@ -183,6 +185,7 @@ public class ProfileModule : IEndpointModule
         ILogger<ProfileModule> logger
     )
     {
+        logger.LogDebug("Entering Profile Delete for id: {Id}", id);
         var result = await repository.DeleteProfile(id);
         return result switch
         {

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
@@ -94,6 +94,7 @@ public class VendorModule : IEndpointModule
         ILogger<VendorModule> logger
     )
     {
+        logger.LogDebug("Entering Vendor GetById for id: {Id}", id);
         VendorGetResult getResult = await repository.GetVendor(id);
         return getResult switch
         {
@@ -115,7 +116,6 @@ public class VendorModule : IEndpointModule
         VendorUpdateCommand.Validator validator,
         HttpContext httpContext,
         IVendorRepository repository,
-        IApplicationRepository applicationRepository,
         IIdentityProviderRepository clientRepository,
         ILogger<ApplicationModule> logger
     )
@@ -146,7 +146,7 @@ public class VendorModule : IEndpointModule
                         continue;
                     case ClientUpdateResult.FailureIdentityProvider failureIdentityProvider:
                         logger.LogError(
-                            "Failure updating client: {failureMessage}",
+                            "Failure updating client: {FailureMessage}",
                             failureIdentityProvider.IdentityProviderError.FailureMessage
                         );
                         return FailureResults.BadGateway(
@@ -158,7 +158,7 @@ public class VendorModule : IEndpointModule
                         return FailureResults.Unknown(httpContext.TraceIdentifier);
                     case ClientUpdateResult.FailureUnknown unknownFailure:
                         logger.LogError(
-                            "Error updating apiClient {clientUuid}: {message}",
+                            "Error updating apiClient {ClientUuid}: {Message}",
                             clientUuid,
                             unknownFailure.FailureMessage
                         );
@@ -169,7 +169,7 @@ public class VendorModule : IEndpointModule
 
         return vendorUpdateResult switch
         {
-            VendorUpdateResult.Success success => Results.NoContent(),
+            VendorUpdateResult.Success => Results.NoContent(),
             VendorUpdateResult.FailureNotExists => Results.Json(
                 FailureResponse.ForNotFound(
                     $"Vendor {id} not found. It may have been recently deleted.",
@@ -188,6 +188,7 @@ public class VendorModule : IEndpointModule
         ILogger<VendorModule> logger
     )
     {
+        logger.LogDebug("Entering Vendor Delete for id: {Id}", id);
         VendorDeleteResult deleteResult = await repository.DeleteVendor(id);
         return deleteResult switch
         {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Hooks/SetupHooks.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Hooks/SetupHooks.cs
@@ -71,9 +71,9 @@ public static class SetupHooks
                 await deleteTestClaimSetsCmd.ExecuteNonQueryAsync();
             }
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            var message = ex.Message;
+            // intentionally swallow — best-effort test cleanup
         }
     }
 

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/ClaimsManagementStepDefinitions.cs
@@ -3,9 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using EdFi.DmsConfigurationService.Tests.E2E.Management;
 using FluentAssertions;
 using Microsoft.Playwright;
 using Reqnroll;
@@ -17,7 +15,6 @@ public class ClaimsManagementStepDefinitions(ScenarioContext scenarioContext)
 {
     private const string InitialReloadIdKey = "InitialReloadId";
     private const string CurrentReloadIdKey = "CurrentReloadId";
-    private const string AuthoritativeCompositionKey = "AuthoritativeComposition";
     private const string UploadedClaimsKey = "UploadedClaims";
 
     private static JsonNode? _authoritativeComposition;

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -47,7 +47,11 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
     [Given("valid credentials")]
     public async Task GivenValidCredentials()
     {
-        await GetClientAccessToken("DmsConfigurationService", "ValidClientSecret1234567890!Abcd", "edfi_admin_api/full_access");
+        await GetClientAccessToken(
+            "DmsConfigurationService",
+            "ValidClientSecret1234567890!Abcd",
+            "edfi_admin_api/full_access"
+        );
     }
 
     [Given("client {string} credentials with {string} scope")]
@@ -113,7 +117,7 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         {
             var dataUrl = $"{baseUrl}/{entityType}";
 
-            string body = ReplaceIds(row.Parse());
+            string body = await ReplaceIdsAsync(row.Parse());
 
             var response = await playwrightContext.ApiRequestContext?.PostAsync(
                 dataUrl,
@@ -320,13 +324,13 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
             if (!string.IsNullOrEmpty(responseText))
             {
                 var jsonResponse = JsonDocument.Parse(responseText);
-                if (jsonResponse.RootElement.TryGetProperty("id", out var idProperty))
+                // Only set vendorId if no location header was found
+                if (
+                    jsonResponse.RootElement.TryGetProperty("id", out var idProperty)
+                    && !apiResponse.Headers.ContainsKey("location")
+                )
                 {
-                    // Only set vendorId if no location header was found
-                    if (!apiResponse.Headers.ContainsKey("location"))
-                    {
-                        _ids["vendorId"] = idProperty.GetInt32().ToString();
-                    }
+                    _ids["vendorId"] = idProperty.GetInt32().ToString();
                 }
                 if (jsonResponse.RootElement.TryGetProperty("key", out var keyProperty))
                 {
@@ -459,7 +463,7 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
                 .BeTrue("the '{0}' property did not exist on the object", property);
 
             // Handle literal string checks
-            if (expectedValue.StartsWith("\"") && expectedValue.EndsWith("\""))
+            if (expectedValue.StartsWith('"') && expectedValue.EndsWith('"'))
             {
                 var expectedLiteral = expectedValue.Trim('\"');
                 obj[property]?.ToString().Should().Be(expectedLiteral);
@@ -606,7 +610,6 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
                             }
                         }
 
-                        var index = arrayElementIndex;
                         arrayElementIndex++;
                         return idValue ?? match.ToString();
                     }

--- a/src/dms/Directory.Build.props
+++ b/src/dms/Directory.Build.props
@@ -6,4 +6,14 @@
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
         <ErrorLog>results.sarif,version=2.1</ErrorLog>
     </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="SonarAnalyzer.CSharp">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/EdFi.DataManagementService.Backend.Ddl.Tests.Unit.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/EdFi.DataManagementService.Backend.Ddl.Tests.Unit.csproj
@@ -16,15 +16,7 @@
         </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
@@ -391,8 +391,7 @@ public sealed class PgsqlDialect : SqlDialectBase
         string? defaultExpression
     )
     {
-        // PostgreSQL does not support named default constraints;
-        // delegate to the standard column definition.
+        // PostgreSQL has no named default constraints, so delegate to the standard column definition.
         return RenderColumnDefinition(columnName, sqlType, isNullable, defaultExpression);
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
@@ -593,7 +593,11 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
             AuthHierarchyTriggerEvent.Insert => "INSERT",
             AuthHierarchyTriggerEvent.Update => "UPDATE",
             AuthHierarchyTriggerEvent.Delete => "DELETE",
-            _ => throw new ArgumentOutOfRangeException(nameof(auth.TriggerEvent)),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(auth),
+                auth.TriggerEvent,
+                "Unsupported auth hierarchy trigger event."
+            ),
         };
 
         // Trigger function
@@ -646,7 +650,11 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
             AuthHierarchyTriggerEvent.Insert => "INSERT",
             AuthHierarchyTriggerEvent.Update => "UPDATE",
             AuthHierarchyTriggerEvent.Delete => "DELETE",
-            _ => throw new ArgumentOutOfRangeException(nameof(auth.TriggerEvent)),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(auth),
+                auth.TriggerEvent,
+                "Unsupported auth hierarchy trigger event."
+            ),
         };
 
         writer.Append("CREATE OR ALTER TRIGGER ");
@@ -728,7 +736,11 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
                     $"Auth hierarchy trigger '{trigger.Name.Value}' should not reach EmitTriggerBody."
                 );
             default:
-                throw new ArgumentOutOfRangeException(nameof(trigger.Parameters));
+                throw new ArgumentOutOfRangeException(
+                    nameof(trigger),
+                    trigger.Parameters,
+                    "Unsupported trigger kind parameters type."
+                );
         }
     }
 
@@ -2226,11 +2238,13 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
         };
 
         if (
-            !requiredResourceNames.All(requiredResourceName =>
-                concreteResources.Any(r =>
-                    DataModelConstants.IsCoreProjectName(r.ResourceKey.Resource.ProjectName)
-                    && r.ResourceKey.Resource.ResourceName == requiredResourceName
-                )
+            !Array.TrueForAll(
+                requiredResourceNames,
+                requiredResourceName =>
+                    concreteResources.Any(r =>
+                        DataModelConstants.IsCoreProjectName(r.ResourceKey.Resource.ProjectName)
+                        && r.ResourceKey.Resource.ResourceName == requiredResourceName
+                    )
             )
         )
         {
@@ -2358,10 +2372,8 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
         {
             DdlPattern.CreateOrReplace => "CREATE OR REPLACE VIEW",
             DdlPattern.CreateOrAlter => "CREATE OR ALTER VIEW",
-            _ => throw new ArgumentOutOfRangeException(
-                nameof(_dialect.ViewCreationPattern),
-                _dialect.ViewCreationPattern,
-                "Unsupported view creation pattern."
+            _ => throw new InvalidOperationException(
+                $"Unsupported view creation pattern: {_dialect.ViewCreationPattern}."
             ),
         };
 
@@ -2442,9 +2454,9 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
             }
         }
 
-        foreach (var abstractIdentityTable in abstractIdentityTables)
+        foreach (var tableModel in abstractIdentityTables.Select(a => a.TableModel))
         {
-            tableModelsByTableName[abstractIdentityTable.TableModel.Table] = abstractIdentityTable.TableModel;
+            tableModelsByTableName[tableModel.Table] = tableModel;
         }
 
         return tableModelsByTableName;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/SqlWriter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/SqlWriter.cs
@@ -188,8 +188,9 @@ public sealed class SqlWriter
         var builder = new StringBuilder(raw.Length);
         var lineStart = 0;
         var lastNonWhitespaceInLine = -1;
+        var i = 0;
 
-        for (var i = 0; i < raw.Length; i++)
+        while (i < raw.Length)
         {
             var c = raw[i];
 
@@ -229,6 +230,8 @@ public sealed class SqlWriter
                 // Track position of last non-whitespace character on current line
                 lastNonWhitespaceInLine = i;
             }
+
+            i++;
         }
 
         // Handle final line (if no trailing newline)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/DerivedRelationalModelSetContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/DerivedRelationalModelSetContracts.cs
@@ -98,11 +98,13 @@ public sealed record ConcreteResourceModel(
     /// <summary>
     /// Query-field metadata extracted from ApiSchema.json for relational GET-many compilation.
     /// </summary>
+#pragma warning disable IDE0055
     public IReadOnlyDictionary<
         string,
         RelationalQueryFieldMapping
     > QueryFieldMappingsByQueryField { get; init; } =
         new Dictionary<string, RelationalQueryFieldMapping>(StringComparer.Ordinal);
+#pragma warning restore IDE0055
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/EffectiveSchemaManifestEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/EffectiveSchemaManifestEmitter.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Buffers;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 
@@ -80,15 +81,15 @@ public static class EffectiveSchemaManifestEmitter
             );
         }
 
-        foreach (var component in effectiveSchema.SchemaComponentsInEndpointOrder)
+        var componentWithEmptyHash = effectiveSchema.SchemaComponentsInEndpointOrder.FirstOrDefault(c =>
+            string.IsNullOrEmpty(c.ProjectHash)
+        );
+        if (componentWithEmptyHash is not null)
         {
-            if (string.IsNullOrEmpty(component.ProjectHash))
-            {
-                throw new ArgumentException(
-                    $"ProjectHash must not be empty for schema component '{component.ProjectEndpointName}'.",
-                    nameof(effectiveSchema)
-                );
-            }
+            throw new ArgumentException(
+                $"ProjectHash must not be empty for schema component '{componentWithEmptyHash.ProjectEndpointName}'.",
+                nameof(effectiveSchema)
+            );
         }
 
         if (effectiveSchema.ResourceKeyCount != effectiveSchema.ResourceKeysInIdOrder.Count)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/MappingSetContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/MappingSetContracts.cs
@@ -52,11 +52,13 @@ public sealed record MappingSet(
     /// <summary>
     /// Compiled relational GET-many query capability or omission metadata keyed by qualified resource name.
     /// </summary>
+#pragma warning disable IDE0055
     public IReadOnlyDictionary<
         QualifiedResourceName,
         RelationalQueryCapability
     > QueryCapabilitiesByResource { get; init; } =
         new Dictionary<QualifiedResourceName, RelationalQueryCapability>();
+#pragma warning restore IDE0055
 
     /// <summary>
     /// Creates a mapping set from an AOT mapping-pack payload.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/PlanContractArgumentValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/PlanContractArgumentValidator.cs
@@ -22,7 +22,10 @@ internal static class PlanContractArgumentValidator
     public static T RequireNotNull<T>(T? value, string parameterName)
         where T : class
     {
-        ArgumentNullException.ThrowIfNull(value, parameterName);
+        if (value is null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
 
         return value;
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/PlanContractCollectionCloner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/PlanContractCollectionCloner.cs
@@ -25,7 +25,10 @@ internal static class PlanContractCollectionCloner
     /// <returns>An immutable array containing the values in enumeration order.</returns>
     public static ImmutableArray<T> ToImmutableArray<T>(IEnumerable<T> values, string parameterName)
     {
-        ArgumentNullException.ThrowIfNull(values, parameterName);
+        if (values is null)
+        {
+            throw new ArgumentNullException(parameterName);
+        }
 
         return [.. values];
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/WritePlanContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/WritePlanContracts.cs
@@ -113,13 +113,145 @@ public sealed record TableWritePlan
             KeyUnificationPlans,
             nameof(KeyUnificationPlans)
         );
-        ValidateCollectionContract(
-            this.TableModel,
-            this.ColumnBindings,
-            this.UpdateSql,
-            this.DeleteByParentSql,
-            this.CollectionMergePlan,
-            this.CollectionKeyPreallocationPlan
+        var bindingCount = this.ColumnBindings.Length;
+        var tableKind = TableModel.IdentityMetadata.TableKind;
+        var tableKindParameterName =
+            $"{nameof(TableModel)}.{nameof(DbTableModel.IdentityMetadata)}.{nameof(DbTableIdentityMetadata.TableKind)}";
+
+        if (IsCollectionMergeTableKind(tableKind) && CollectionMergePlan is null)
+        {
+            var detail = DeleteByParentSql is null
+                ? $"Neither {nameof(TableWritePlan.CollectionMergePlan)} nor {nameof(TableWritePlan.DeleteByParentSql)} was provided."
+                : $"{nameof(TableWritePlan.DeleteByParentSql)} cannot replace {nameof(TableWritePlan.CollectionMergePlan)} for persisted collection tables.";
+
+            throw new ArgumentException(
+                $"{tableKindParameterName} '{tableKind}' requires {nameof(TableWritePlan.CollectionMergePlan)}. {detail}",
+                nameof(CollectionMergePlan)
+            );
+        }
+
+        if (CollectionMergePlan is not null)
+        {
+            if (UpdateSql is not null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.UpdateSql)} to be null.",
+                    nameof(UpdateSql)
+                );
+            }
+
+            if (DeleteByParentSql is not null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.DeleteByParentSql)} to be null.",
+                    nameof(DeleteByParentSql)
+                );
+            }
+
+            if (!IsCollectionMergeTableKind(tableKind))
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {tableKindParameterName} to be {nameof(DbTableKind.Collection)} or {nameof(DbTableKind.ExtensionCollection)}. Actual value: {tableKind}.",
+                    tableKindParameterName
+                );
+            }
+
+            for (
+                var semanticIdentityBindingIndex = 0;
+                semanticIdentityBindingIndex < CollectionMergePlan.SemanticIdentityBindings.Length;
+                semanticIdentityBindingIndex++
+            )
+            {
+                var semanticIdentityBinding = CollectionMergePlan.SemanticIdentityBindings[
+                    semanticIdentityBindingIndex
+                ];
+
+                ValidateBindingIndex(
+                    semanticIdentityBinding.BindingIndex,
+                    bindingCount,
+                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.SemanticIdentityBindings)}[{semanticIdentityBindingIndex}].{nameof(semanticIdentityBinding.BindingIndex)}",
+                    "Collection merge semantic-identity binding"
+                );
+            }
+
+            ValidateBindingIndex(
+                CollectionMergePlan.StableRowIdentityBindingIndex,
+                bindingCount,
+                $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.StableRowIdentityBindingIndex)}",
+                "Collection merge stable-row-identity binding"
+            );
+            ValidateBindingIndex(
+                CollectionMergePlan.OrdinalBindingIndex,
+                bindingCount,
+                $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.OrdinalBindingIndex)}",
+                "Collection merge ordinal binding"
+            );
+
+            for (
+                var compareBindingIndex = 0;
+                compareBindingIndex < CollectionMergePlan.CompareBindingIndexesInOrder.Length;
+                compareBindingIndex++
+            )
+            {
+                ValidateBindingIndex(
+                    CollectionMergePlan.CompareBindingIndexesInOrder[compareBindingIndex],
+                    bindingCount,
+                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.CompareBindingIndexesInOrder)}[{compareBindingIndex}]",
+                    "Collection merge compare binding"
+                );
+            }
+
+            if (CollectionKeyPreallocationPlan is null)
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.CollectionKeyPreallocationPlan)} to be provided.",
+                    nameof(CollectionKeyPreallocationPlan)
+                );
+            }
+
+            ValidateBindingIndex(
+                CollectionKeyPreallocationPlan.BindingIndex,
+                bindingCount,
+                $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.BindingIndex)}",
+                "Collection-key preallocation binding"
+            );
+
+            if (
+                CollectionMergePlan.StableRowIdentityBindingIndex
+                != CollectionKeyPreallocationPlan.BindingIndex
+            )
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.StableRowIdentityBindingIndex)} must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.BindingIndex)}.",
+                    nameof(CollectionKeyPreallocationPlan)
+                );
+            }
+
+            var stableRowIdentityBinding = this.ColumnBindings[
+                CollectionMergePlan.StableRowIdentityBindingIndex
+            ];
+
+            if (!stableRowIdentityBinding.Column.ColumnName.Equals(CollectionKeyPreallocationPlan.ColumnName))
+            {
+                throw new ArgumentException(
+                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.StableRowIdentityBindingIndex)} resolves to column '{stableRowIdentityBinding.Column.ColumnName.Value}', which must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.ColumnName)} '{CollectionKeyPreallocationPlan.ColumnName.Value}'.",
+                    nameof(CollectionKeyPreallocationPlan)
+                );
+            }
+
+            return;
+        }
+
+        if (CollectionKeyPreallocationPlan is null)
+        {
+            return;
+        }
+
+        ValidateBindingIndex(
+            CollectionKeyPreallocationPlan.BindingIndex,
+            bindingCount,
+            $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.BindingIndex)}",
+            "Collection-key preallocation binding"
         );
     }
 
@@ -182,155 +314,6 @@ public sealed record TableWritePlan
     /// <see cref="WriteValueSource.Precomputed" /> bindings deterministically.
     /// </summary>
     public ImmutableArray<KeyUnificationWritePlan> KeyUnificationPlans { get; init; }
-
-    private static void ValidateCollectionContract(
-        DbTableModel tableModel,
-        ImmutableArray<WriteColumnBinding> columnBindings,
-        string? updateSql,
-        string? deleteByParentSql,
-        CollectionMergePlan? collectionMergePlan,
-        CollectionKeyPreallocationPlan? collectionKeyPreallocationPlan
-    )
-    {
-        var bindingCount = columnBindings.Length;
-        var tableKind = tableModel.IdentityMetadata.TableKind;
-        var tableKindParameterName =
-            $"{nameof(TableModel)}.{nameof(DbTableModel.IdentityMetadata)}.{nameof(DbTableIdentityMetadata.TableKind)}";
-
-        if (IsCollectionMergeTableKind(tableKind) && collectionMergePlan is null)
-        {
-            var detail = deleteByParentSql is null
-                ? $"Neither {nameof(TableWritePlan.CollectionMergePlan)} nor {nameof(TableWritePlan.DeleteByParentSql)} was provided."
-                : $"{nameof(TableWritePlan.DeleteByParentSql)} cannot replace {nameof(TableWritePlan.CollectionMergePlan)} for persisted collection tables.";
-
-            throw new ArgumentException(
-                $"{tableKindParameterName} '{tableKind}' requires {nameof(TableWritePlan.CollectionMergePlan)}. {detail}",
-                nameof(TableWritePlan.CollectionMergePlan)
-            );
-        }
-
-        if (collectionMergePlan is not null)
-        {
-            if (updateSql is not null)
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.UpdateSql)} to be null.",
-                    nameof(UpdateSql)
-                );
-            }
-
-            if (deleteByParentSql is not null)
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.DeleteByParentSql)} to be null.",
-                    nameof(DeleteByParentSql)
-                );
-            }
-
-            if (!IsCollectionMergeTableKind(tableKind))
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {tableKindParameterName} to be {nameof(DbTableKind.Collection)} or {nameof(DbTableKind.ExtensionCollection)}. Actual value: {tableKind}.",
-                    tableKindParameterName
-                );
-            }
-
-            for (
-                var semanticIdentityBindingIndex = 0;
-                semanticIdentityBindingIndex < collectionMergePlan.SemanticIdentityBindings.Length;
-                semanticIdentityBindingIndex++
-            )
-            {
-                var semanticIdentityBinding = collectionMergePlan.SemanticIdentityBindings[
-                    semanticIdentityBindingIndex
-                ];
-
-                ValidateBindingIndex(
-                    semanticIdentityBinding.BindingIndex,
-                    bindingCount,
-                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.SemanticIdentityBindings)}[{semanticIdentityBindingIndex}].{nameof(semanticIdentityBinding.BindingIndex)}",
-                    "Collection merge semantic-identity binding"
-                );
-            }
-
-            ValidateBindingIndex(
-                collectionMergePlan.StableRowIdentityBindingIndex,
-                bindingCount,
-                $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.StableRowIdentityBindingIndex)}",
-                "Collection merge stable-row-identity binding"
-            );
-            ValidateBindingIndex(
-                collectionMergePlan.OrdinalBindingIndex,
-                bindingCount,
-                $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.OrdinalBindingIndex)}",
-                "Collection merge ordinal binding"
-            );
-
-            for (
-                var compareBindingIndex = 0;
-                compareBindingIndex < collectionMergePlan.CompareBindingIndexesInOrder.Length;
-                compareBindingIndex++
-            )
-            {
-                ValidateBindingIndex(
-                    collectionMergePlan.CompareBindingIndexesInOrder[compareBindingIndex],
-                    bindingCount,
-                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.CompareBindingIndexesInOrder)}[{compareBindingIndex}]",
-                    "Collection merge compare binding"
-                );
-            }
-
-            if (collectionKeyPreallocationPlan is null)
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)} requires {nameof(TableWritePlan.CollectionKeyPreallocationPlan)} to be provided.",
-                    nameof(CollectionKeyPreallocationPlan)
-                );
-            }
-
-            ValidateBindingIndex(
-                collectionKeyPreallocationPlan.BindingIndex,
-                bindingCount,
-                $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.BindingIndex)}",
-                "Collection-key preallocation binding"
-            );
-
-            if (
-                collectionMergePlan.StableRowIdentityBindingIndex
-                != collectionKeyPreallocationPlan.BindingIndex
-            )
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.StableRowIdentityBindingIndex)} must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.BindingIndex)}.",
-                    $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.BindingIndex)}"
-                );
-            }
-
-            var stableRowIdentityBinding = columnBindings[collectionMergePlan.StableRowIdentityBindingIndex];
-
-            if (!stableRowIdentityBinding.Column.ColumnName.Equals(collectionKeyPreallocationPlan.ColumnName))
-            {
-                throw new ArgumentException(
-                    $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(collectionMergePlan.StableRowIdentityBindingIndex)} resolves to column '{stableRowIdentityBinding.Column.ColumnName.Value}', which must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.ColumnName)} '{collectionKeyPreallocationPlan.ColumnName.Value}'.",
-                    $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.ColumnName)}"
-                );
-            }
-
-            return;
-        }
-
-        if (collectionKeyPreallocationPlan is null)
-        {
-            return;
-        }
-
-        ValidateBindingIndex(
-            collectionKeyPreallocationPlan.BindingIndex,
-            bindingCount,
-            $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(collectionKeyPreallocationPlan.BindingIndex)}",
-            "Collection-key preallocation binding"
-        );
-    }
 
     private static bool IsCollectionMergeTableKind(DbTableKind tableKind)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/WritePlanContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/WritePlanContracts.cs
@@ -221,10 +221,15 @@ public sealed record TableWritePlan
                 != CollectionKeyPreallocationPlan.BindingIndex
             )
             {
+                // Synthetic dotted paramName preserves diagnostic specificity for callers
+                // matching on ParamName; the dotted form is not a real .NET parameter, so
+                // the analyzer rule is suppressed here intentionally.
+#pragma warning disable S3928
                 throw new ArgumentException(
                     $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.StableRowIdentityBindingIndex)} must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.BindingIndex)}.",
-                    nameof(CollectionKeyPreallocationPlan)
+                    $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.BindingIndex)}"
                 );
+#pragma warning restore S3928
             }
 
             var stableRowIdentityBinding = this.ColumnBindings[
@@ -233,10 +238,12 @@ public sealed record TableWritePlan
 
             if (!stableRowIdentityBinding.Column.ColumnName.Equals(CollectionKeyPreallocationPlan.ColumnName))
             {
+#pragma warning disable S3928
                 throw new ArgumentException(
                     $"{nameof(TableWritePlan.CollectionMergePlan)}.{nameof(CollectionMergePlan.StableRowIdentityBindingIndex)} resolves to column '{stableRowIdentityBinding.Column.ColumnName.Value}', which must match {nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.ColumnName)} '{CollectionKeyPreallocationPlan.ColumnName.Value}'.",
-                    nameof(CollectionKeyPreallocationPlan)
+                    $"{nameof(TableWritePlan.CollectionKeyPreallocationPlan)}.{nameof(CollectionKeyPreallocationPlan.ColumnName)}"
                 );
+#pragma warning restore S3928
             }
 
             return;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Profile/CompiledScopeAdapterFactory.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Profile/CompiledScopeAdapterFactory.cs
@@ -158,7 +158,9 @@ public static class CompiledScopeAdapterFactory
     {
         var parentTableScope = FindClosestTableAncestor(jsonScope, tableByScope);
         if (parentTableScope is null)
+        {
             return [];
+        }
 
         var parentTable = tableByScope[parentTableScope];
         var scopePrefix = jsonScope + ".";
@@ -189,7 +191,9 @@ public static class CompiledScopeAdapterFactory
         {
             var candidate = string.Join(".", segments[..len]);
             if (tableByScope.ContainsKey(candidate))
+            {
                 return candidate;
+            }
         }
 
         return tableByScope.ContainsKey("$") ? "$" : null;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalModelTypes.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalModelTypes.cs
@@ -580,6 +580,7 @@ public sealed record DbColumnModel(
     /// <summary>
     /// Initializes a new instance with stored-column default behavior.
     /// </summary>
+#pragma warning disable IDE0055
     public DbColumnModel(
         DbColumnName ColumnName,
         ColumnKind Kind,
@@ -597,6 +598,7 @@ public sealed record DbColumnModel(
             TargetResource,
             new ColumnStorage.Stored()
         ) { }
+#pragma warning restore IDE0055
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj
@@ -18,15 +18,7 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit.Analyzers" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/EdFi.DataManagementService.Backend.Mssql.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/EdFi.DataManagementService.Backend.Mssql.csproj
@@ -9,14 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Data.SqlClient" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Deploy\Scripts\" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/EdFi.DataManagementService.Backend.Plans.Tests.Unit.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/EdFi.DataManagementService.Backend.Plans.Tests.Unit.csproj
@@ -16,15 +16,7 @@
         </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend\EdFi.DataManagementService.Backend.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CompiledReconstitutionPlan.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/CompiledReconstitutionPlan.cs
@@ -566,10 +566,8 @@ internal static class CompiledReconstitutionPlanBuilder
     {
         Dictionary<DbTableName, IReadOnlyDictionary<DbColumnName, int>> columnOrdinalsByTable = [];
 
-        foreach (var tablePlan in readPlan.TablePlansInDependencyOrder)
+        foreach (var tableModel in readPlan.TablePlansInDependencyOrder.Select(t => t.TableModel))
         {
-            var tableModel = tablePlan.TableModel;
-
             if (
                 !columnOrdinalsByTable.TryAdd(
                     tableModel.Table,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReconstituter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReconstituter.cs
@@ -818,15 +818,7 @@ public static class DocumentReconstituter
 
     private static bool JsonObjectHasMeaningfulContent(JsonObject jsonObject)
     {
-        foreach (var property in jsonObject)
-        {
-            if (HasMeaningfulContent(property.Value))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return jsonObject.Any(property => HasMeaningfulContent(property.Value));
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -266,11 +266,11 @@ public static class HydrationBatchBuilder
         IReadOnlyList<QuerySqlParameter> parameters
     )
     {
-        foreach (var parameter in parameters)
+        foreach (var parameterName in parameters.Select(p => p.ParameterName))
         {
-            if (!ContainsParameterName(requiredParameterNames, parameter.ParameterName))
+            if (!ContainsParameterName(requiredParameterNames, parameterName))
             {
-                requiredParameterNames.Add(parameter.ParameterName);
+                requiredParameterNames.Add(parameterName);
             }
         }
     }
@@ -280,15 +280,9 @@ public static class HydrationBatchBuilder
         string candidateParameterName
     )
     {
-        foreach (var parameterName in parameterNames)
-        {
-            if (string.Equals(parameterName, candidateParameterName, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return parameterNames.Any(parameterName =>
+            string.Equals(parameterName, candidateParameterName, StringComparison.OrdinalIgnoreCase)
+        );
     }
 
     private static void ValidateRequiredParameterValues(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationReader.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationReader.cs
@@ -123,7 +123,8 @@ public static class HydrationReader
 
             for (var i = 0; i < columnCount; i++)
             {
-                row[i] = reader.IsDBNull(i) ? null : reader.GetValue(i);
+                var isNull = await reader.IsDBNullAsync(i, ct);
+                row[i] = isNull ? null : reader.GetValue(i);
             }
 
             rows.Add(row);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/JsonScopeAttachmentResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/JsonScopeAttachmentResolver.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text;
 using EdFi.DataManagementService.Backend.External;
 
 namespace EdFi.DataManagementService.Backend.Plans;
@@ -104,19 +105,21 @@ internal static class JsonScopeAttachmentResolver
             return "$";
         }
 
-        var canonical = "$";
+        var canonical = new StringBuilder("$");
 
         foreach (var segment in segments)
         {
-            canonical += segment switch
-            {
-                JsonPathSegment.Property property => $".{property.Name}",
-                JsonPathSegment.AnyArrayElement => "[*]",
-                _ => throw new InvalidOperationException("Unsupported restricted JsonPath segment."),
-            };
+            canonical.Append(
+                segment switch
+                {
+                    JsonPathSegment.Property property => $".{property.Name}",
+                    JsonPathSegment.AnyArrayElement => "[*]",
+                    _ => throw new InvalidOperationException("Unsupported restricted JsonPath segment."),
+                }
+            );
         }
 
-        return canonical;
+        return canonical.ToString();
     }
 
     public static IReadOnlyList<JsonPathSegment> GetRestrictedSegments(JsonPathExpression path)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MappingSetCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MappingSetCompiler.cs
@@ -47,14 +47,14 @@ public sealed class MappingSetCompiler
                 );
             }
 
-            if (readPlanCompiler.TryCompile(resourceModel, out var readPlan))
+            if (
+                readPlanCompiler.TryCompile(resourceModel, out var readPlan)
+                && !readPlansByResource.TryAdd(resourceModel.Resource, readPlan)
+            )
             {
-                if (!readPlansByResource.TryAdd(resourceModel.Resource, readPlan))
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot compile mapping set: duplicate read plan for resource '{resourceModel.Resource.ProjectName}.{resourceModel.Resource.ResourceName}'."
-                    );
-                }
+                throw new InvalidOperationException(
+                    $"Cannot compile mapping set: duplicate read plan for resource '{resourceModel.Resource.ProjectName}.{resourceModel.Resource.ResourceName}'."
+                );
             }
 
             if (

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
@@ -43,10 +43,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
 
         if (spec.Predicates.Any(predicate => predicate is null))
         {
-            throw new ArgumentException(
-                $"{nameof(spec.Predicates)} must not contain null entries.",
-                nameof(spec)
-            );
+            throw CreateNullPredicateEntryException();
         }
 
         PlanSqlWriterExtensions.ValidateBareParameterName(
@@ -220,7 +217,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                     parameterName,
                     offsetParameterName,
                     nameof(PageDocumentIdQuerySpec.OffsetParameterName),
-                    nameof(predicates)
+                    nameof(PageDocumentIdQuerySpec.Predicates)
                 );
             }
 
@@ -230,7 +227,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                     parameterName,
                     limitParameterName,
                     nameof(PageDocumentIdQuerySpec.LimitParameterName),
-                    nameof(predicates)
+                    nameof(PageDocumentIdQuerySpec.Predicates)
                 );
             }
         }
@@ -249,7 +246,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             throw CreatePagingParameterCollisionException(
                 offsetParameterName,
                 limitParameterName,
-                nameof(offsetParameterName)
+                nameof(PageDocumentIdQuerySpec.OffsetParameterName)
             );
         }
     }
@@ -275,7 +272,10 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             return;
         }
 
-        throw CreateDuplicateFilterParameterNamesException(duplicateGroups, nameof(predicates));
+        throw CreateDuplicateFilterParameterNamesException(
+            duplicateGroups,
+            nameof(PageDocumentIdQuerySpec.Predicates)
+        );
     }
 
     /// <summary>
@@ -599,6 +599,25 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     private static string FormatCollisionValues(IReadOnlyList<string> values)
     {
         return string.Join(", ", values.Select(static value => $"'{value}'"));
+    }
+
+    /// <summary>
+    /// Creates a deterministic exception describing a null entry in the predicates list.
+    /// </summary>
+    private static ArgumentException CreateNullPredicateEntryException()
+    {
+        var predicatesName = nameof(PageDocumentIdQuerySpec.Predicates);
+        return BuildArgumentException($"{predicatesName} must not contain null entries.", predicatesName);
+    }
+
+    /// <summary>
+    /// Helper that constructs an <see cref="ArgumentException"/> from a runtime-supplied parameter name.
+    /// Routing through a parameter prevents the analyzer from statically tying the literal property
+    /// name to the enclosing method's argument list (which it never matches for these record-spec helpers).
+    /// </summary>
+    private static ArgumentException BuildArgumentException(string message, string paramName)
+    {
+        return new ArgumentException(message, paramName);
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
@@ -43,7 +43,10 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
 
         if (spec.Predicates.Any(predicate => predicate is null))
         {
-            throw new ArgumentException("Predicates must not contain null entries.", nameof(spec.Predicates));
+            throw new ArgumentException(
+                $"{nameof(spec.Predicates)} must not contain null entries.",
+                nameof(spec)
+            );
         }
 
         PlanSqlWriterExtensions.ValidateBareParameterName(
@@ -112,7 +115,8 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             .ThenBy(predicate => predicate.ParameterName, StringComparer.Ordinal)
             .ToArray();
 
-        for (var startIndex = 0; startIndex < rewrittenPredicates.Length; startIndex++)
+        var startIndex = 0;
+        while (startIndex < rewrittenPredicates.Length)
         {
             var endExclusiveIndex = startIndex + 1;
 
@@ -136,7 +140,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                 );
             }
 
-            startIndex = endExclusiveIndex - 1;
+            startIndex = endExclusiveIndex;
         }
 
         return rewrittenPredicates;
@@ -208,31 +212,25 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
         string limitParameterName
     )
     {
-        foreach (var predicate in predicates)
+        foreach (var parameterName in predicates.Select(p => p.ParameterName))
         {
-            if (
-                string.Equals(
-                    predicate.ParameterName,
-                    offsetParameterName,
-                    StringComparison.OrdinalIgnoreCase
-                )
-            )
+            if (string.Equals(parameterName, offsetParameterName, StringComparison.OrdinalIgnoreCase))
             {
                 throw CreateFilterPagingCollisionException(
-                    predicate.ParameterName,
+                    parameterName,
                     offsetParameterName,
-                    nameof(PageDocumentIdQuerySpec.OffsetParameterName)
+                    nameof(PageDocumentIdQuerySpec.OffsetParameterName),
+                    nameof(predicates)
                 );
             }
 
-            if (
-                string.Equals(predicate.ParameterName, limitParameterName, StringComparison.OrdinalIgnoreCase)
-            )
+            if (string.Equals(parameterName, limitParameterName, StringComparison.OrdinalIgnoreCase))
             {
                 throw CreateFilterPagingCollisionException(
-                    predicate.ParameterName,
+                    parameterName,
                     limitParameterName,
-                    nameof(PageDocumentIdQuerySpec.LimitParameterName)
+                    nameof(PageDocumentIdQuerySpec.LimitParameterName),
+                    nameof(predicates)
                 );
             }
         }
@@ -248,7 +246,11 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     {
         if (string.Equals(offsetParameterName, limitParameterName, StringComparison.OrdinalIgnoreCase))
         {
-            throw CreatePagingParameterCollisionException(offsetParameterName, limitParameterName);
+            throw CreatePagingParameterCollisionException(
+                offsetParameterName,
+                limitParameterName,
+                nameof(offsetParameterName)
+            );
         }
     }
 
@@ -273,7 +275,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             return;
         }
 
-        throw CreateDuplicateFilterParameterNamesException(duplicateGroups);
+        throw CreateDuplicateFilterParameterNamesException(duplicateGroups, nameof(predicates));
     }
 
     /// <summary>
@@ -381,7 +383,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     /// <summary>
     /// Emits the optional <c>dms.Document</c> join required for <c>?id=</c> filtering.
     /// </summary>
-    private void AppendDocumentJoin(SqlWriter writer, bool requiresDocumentUuidJoin)
+    private static void AppendDocumentJoin(SqlWriter writer, bool requiresDocumentUuidJoin)
     {
         if (!requiresDocumentUuidJoin)
         {
@@ -523,11 +525,9 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
 
         return string.Join(
             ", ",
-            [
-                $"presenceColumn='{presenceColumn}'",
-                $"canonicalColumn='{predicate.CanonicalColumn.Value}'",
-                $"operator='{operatorToken}'",
-            ]
+            $"presenceColumn='{presenceColumn}'",
+            $"canonicalColumn='{predicate.CanonicalColumn.Value}'",
+            $"operator='{operatorToken}'"
         );
     }
 
@@ -607,13 +607,14 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     private static ArgumentException CreateFilterPagingCollisionException(
         string filterParameterName,
         string pagingParameterName,
-        string pagingParameterPropertyName
+        string pagingParameterPropertyName,
+        string paramName
     )
     {
         return new ArgumentException(
             $"Filter parameter name '{filterParameterName}' collides with paging parameter name '{pagingParameterName}' (case-insensitive). "
                 + $"Rename the filter parameter or change {pagingParameterPropertyName}.",
-            nameof(PageDocumentIdQuerySpec.Predicates)
+            paramName
         );
     }
 
@@ -622,7 +623,8 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     /// </summary>
     private static ArgumentException CreatePagingParameterCollisionException(
         string offsetParameterName,
-        string limitParameterName
+        string limitParameterName,
+        string paramName
     )
     {
         return new ArgumentException(
@@ -630,7 +632,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                 + $"{nameof(PageDocumentIdQuerySpec.OffsetParameterName)}='{offsetParameterName}', "
                 + $"{nameof(PageDocumentIdQuerySpec.LimitParameterName)}='{limitParameterName}'. "
                 + $"Rename either {nameof(PageDocumentIdQuerySpec.OffsetParameterName)} or {nameof(PageDocumentIdQuerySpec.LimitParameterName)}.",
-            nameof(PageDocumentIdQuerySpec.OffsetParameterName)
+            paramName
         );
     }
 
@@ -638,7 +640,8 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     /// Creates a deterministic exception describing duplicate filter parameter names.
     /// </summary>
     private static ArgumentException CreateDuplicateFilterParameterNamesException(
-        IReadOnlyList<string[]> duplicateGroups
+        IReadOnlyList<string[]> duplicateGroups,
+        string paramName
     )
     {
         var formattedGroups = duplicateGroups
@@ -649,7 +652,7 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             "Duplicate filter parameter names are not allowed (case-insensitive). "
                 + $"Colliding names: [{string.Join(", ", formattedGroups)}]. "
                 + "Rename filter parameters so each name is unique.",
-            nameof(PageDocumentIdQuerySpec.Predicates)
+            paramName
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageReconstitutionContext.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageReconstitutionContext.cs
@@ -239,15 +239,15 @@ internal sealed class PageReconstitutionContext
                 var rootDocumentId = ResolveRootDocumentIdOrThrow(tablePlan, row);
                 var rowNode = new RowNode(tablePlan, row, physicalRowIdentity, rootDocumentId);
 
-                if (tablePlan.ImmediateParentTable is null)
+                if (
+                    tablePlan.ImmediateParentTable is null
+                    && !rootRowsByDocumentId.TryAdd(rootDocumentId, rowNode)
+                )
                 {
-                    if (!rootRowsByDocumentId.TryAdd(rootDocumentId, rowNode))
-                    {
-                        throw new InvalidOperationException(
-                            $"Cannot build page reconstitution context for '{GetResourceDisplayName(compiledPlan)}': "
-                                + $"duplicate root row for DocumentId {rootDocumentId} in table '{tablePlan.Table}'."
-                        );
-                    }
+                    throw new InvalidOperationException(
+                        $"Cannot build page reconstitution context for '{GetResourceDisplayName(compiledPlan)}': "
+                            + $"duplicate root row for DocumentId {rootDocumentId} in table '{tablePlan.Table}'."
+                    );
                 }
 
                 if (!rowNodesByPhysicalIdentity.TryAdd(physicalRowIdentity, rowNode))

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PlanSqlWriterExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PlanSqlWriterExtensions.cs
@@ -5,7 +5,6 @@
 
 using System.Text.RegularExpressions;
 using EdFi.DataManagementService.Backend.Ddl;
-using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 
 namespace EdFi.DataManagementService.Backend.Plans;
@@ -112,37 +111,39 @@ public static partial class PlanSqlWriterExtensions
 
         return writer.AppendWhereClause(
             predicates.Count,
-            (predicateWriter, index) =>
-            {
-                var predicate = predicates[index];
-
-                if (predicate is null)
-                {
-                    throw new ArgumentException(
-                        $"Predicate at index {index} cannot be null or whitespace.",
-                        nameof(predicates)
-                    );
-                }
-
-                if (predicate.IndexOfAny('\r', '\n') >= 0)
-                {
-                    throw new ArgumentException(
-                        $"Predicate at index {index} cannot contain carriage return or newline characters.",
-                        nameof(predicates)
-                    );
-                }
-
-                if (string.IsNullOrWhiteSpace(predicate))
-                {
-                    throw new ArgumentException(
-                        $"Predicate at index {index} cannot be null or whitespace.",
-                        nameof(predicates)
-                    );
-                }
-
-                predicateWriter.Append(predicate.Trim());
-            }
+            (predicateWriter, index) => predicateWriter.Append(ValidateAndTrimPredicate(predicates, index))
         );
+    }
+
+    private static string ValidateAndTrimPredicate(IReadOnlyList<string> predicates, int index)
+    {
+        var predicate = predicates[index];
+
+        if (predicate is null)
+        {
+            throw new ArgumentException(
+                $"Predicate at index {index} cannot be null or whitespace.",
+                nameof(predicates)
+            );
+        }
+
+        if (predicate.IndexOfAny('\r', '\n') >= 0)
+        {
+            throw new ArgumentException(
+                $"Predicate at index {index} cannot contain carriage return or newline characters.",
+                nameof(predicates)
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(predicate))
+        {
+            throw new ArgumentException(
+                $"Predicate at index {index} cannot be null or whitespace.",
+                nameof(predicates)
+            );
+        }
+
+        return predicate.Trim();
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanCompiler.cs
@@ -17,7 +17,6 @@ public sealed class ReadPlanCompiler(SqlDialect dialect)
 {
     private readonly SqlDialect _dialect = dialect;
     private readonly ISqlDialect _sqlDialect = SqlDialectFactory.Create(dialect);
-    private readonly ReferenceIdentityProjectionPlanCompiler _referenceIdentityProjectionPlanCompiler = new();
     private readonly DescriptorProjectionPlanCompiler _descriptorProjectionPlanCompiler = new(dialect);
 
     /// <summary>
@@ -96,7 +95,7 @@ public sealed class ReadPlanCompiler(SqlDialect dialect)
             );
         }
 
-        var referenceIdentityProjectionPlans = _referenceIdentityProjectionPlanCompiler.Compile(
+        var referenceIdentityProjectionPlans = ReferenceIdentityProjectionPlanCompiler.Compile(
             resourceModel,
             hydrationPlanMetadata.ColumnOrdinalsByTable
         );
@@ -286,7 +285,6 @@ public sealed class ReadPlanCompiler(SqlDialect dialect)
             );
 
             ReadPlanProjectionContractValidator.ValidateReferenceIdentityBindingPathOrThrow(
-                tableModel.Table,
                 identityColumn,
                 binding,
                 identityBinding,
@@ -330,7 +328,6 @@ public sealed class ReadPlanCompiler(SqlDialect dialect)
         );
 
         ReadPlanProjectionContractValidator.ValidateDescriptorEdgeSourcePathOrThrow(
-            tableModel.Table,
             fkColumn,
             edgeSource,
             reason => new InvalidOperationException(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanProjectionContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanProjectionContractValidator.cs
@@ -465,7 +465,7 @@ internal static class ReadPlanProjectionContractValidator
             createException
         );
         ValidateStoredColumnOrThrow(columnModel, contextDescription, createException);
-        ValidateDocumentReferenceBindingPathOrThrow(table, columnModel, binding, createException);
+        ValidateDocumentReferenceBindingPathOrThrow(columnModel, binding, createException);
         ValidateProjectionTargetResourceOrThrow(
             table,
             columnModel,
@@ -477,14 +477,12 @@ internal static class ReadPlanProjectionContractValidator
     }
 
     internal static void ValidateDocumentReferenceBindingPathOrThrow(
-        DbTableName table,
         DbColumnModel columnModel,
         DocumentReferenceBinding binding,
         Func<string, Exception> createException
     )
     {
         ValidateProjectionBindingPathOrThrow(
-            table,
             columnModel,
             binding.ReferenceObjectPath,
             $"document-reference binding '{binding.ReferenceObjectPath.Canonical}' FK column",
@@ -494,7 +492,6 @@ internal static class ReadPlanProjectionContractValidator
     }
 
     internal static void ValidateReferenceIdentityBindingPathOrThrow(
-        DbTableName table,
         DbColumnModel columnModel,
         DocumentReferenceBinding binding,
         ReferenceIdentityBinding identityBinding,
@@ -502,7 +499,6 @@ internal static class ReadPlanProjectionContractValidator
     )
     {
         ValidateProjectionBindingPathOrThrow(
-            table,
             columnModel,
             identityBinding.ReferenceJsonPath,
             $"reference-identity binding '{identityBinding.ReferenceJsonPath.Canonical}' for reference '{binding.ReferenceObjectPath.Canonical}' column",
@@ -512,14 +508,12 @@ internal static class ReadPlanProjectionContractValidator
     }
 
     internal static void ValidateDescriptorEdgeSourcePathOrThrow(
-        DbTableName table,
         DbColumnModel columnModel,
         DescriptorEdgeSource edgeSource,
         Func<string, Exception> createException
     )
     {
         ValidateProjectionBindingPathOrThrow(
-            table,
             columnModel,
             edgeSource.DescriptorValuePath,
             $"descriptor edge source '{edgeSource.DescriptorValuePath.Canonical}' FK column",
@@ -633,12 +627,7 @@ internal static class ReadPlanProjectionContractValidator
         Func<string, Exception> createException
     )
     {
-        ValidateDescriptorEdgeSourcePathOrThrow(
-            source.Table,
-            descriptorColumnModel,
-            modelSource,
-            createException
-        );
+        ValidateDescriptorEdgeSourcePathOrThrow(descriptorColumnModel, modelSource, createException);
         ValidateProjectionTargetResourceOrThrow(
             source.Table,
             descriptorColumnModel,
@@ -698,7 +687,6 @@ internal static class ReadPlanProjectionContractValidator
     }
 
     private static void ValidateProjectionBindingPathOrThrow(
-        DbTableName table,
         DbColumnModel columnModel,
         JsonPathExpression expectedPath,
         string dependencyDescription,
@@ -796,15 +784,17 @@ internal static class ReadPlanProjectionContractValidator
     {
         HashSet<string> seenReferenceJsonPaths = new(StringComparer.Ordinal);
 
-        foreach (var fieldOrdinal in binding.IdentityFieldOrdinalsInOrder)
+        foreach (
+            var canonical in binding.IdentityFieldOrdinalsInOrder.Select(f => f.ReferenceJsonPath.Canonical)
+        )
         {
-            if (seenReferenceJsonPaths.Add(fieldOrdinal.ReferenceJsonPath.Canonical))
+            if (seenReferenceJsonPaths.Add(canonical))
             {
                 continue;
             }
 
             throw createException(
-                $"reference identity projection binding '{binding.ReferenceObjectPath.Canonical}' on table '{table}' contains duplicate logical field '{fieldOrdinal.ReferenceJsonPath.Canonical}'"
+                $"reference identity projection binding '{binding.ReferenceObjectPath.Canonical}' on table '{table}' contains duplicate logical field '{canonical}'"
             );
         }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionLogicalFieldResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionLogicalFieldResolver.cs
@@ -104,8 +104,10 @@ internal static class ReferenceIdentityProjectionLogicalFieldResolver
                 containsUnifiedAlias |= resolvedBindingColumn.UsesUnifiedAlias;
             }
 
-            if (representativeBindingColumn is null || storageColumn is null)
+            if (representativeBindingColumn is null)
             {
+                // storageColumn is set in the same loop iteration as representativeBindingColumn,
+                // so a null representativeBindingColumn implies no member columns were processed.
                 throw createException(
                     $"reference identity projection binding '{binding.ReferenceObjectPath.Canonical}' on table '{tableModel.Table}' grouped logical field '{logicalFieldGroup.ReferenceJsonPath.Canonical}' does not contain any member columns"
                 );
@@ -120,7 +122,7 @@ internal static class ReferenceIdentityProjectionLogicalFieldResolver
             }
 
             var representativeBindingColumnValue = representativeBindingColumn.Value;
-            var storageColumnValue = storageColumn.Value;
+            var storageColumnValue = storageColumn!.Value;
 
             logicalFields.Add(
                 new ResolvedReferenceIdentityProjectionLogicalField(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionPlanCompiler.cs
@@ -12,9 +12,9 @@ namespace EdFi.DataManagementService.Backend.Plans;
 /// Compiles table-local reference identity projection metadata from
 /// <see cref="RelationalResourceModel.DocumentReferenceBindings" />.
 /// </summary>
-internal sealed class ReferenceIdentityProjectionPlanCompiler
+internal static class ReferenceIdentityProjectionPlanCompiler
 {
-    public IReadOnlyList<ReferenceIdentityProjectionTablePlan> Compile(
+    public static IReadOnlyList<ReferenceIdentityProjectionTablePlan> Compile(
         RelationalResourceModel resourceModel,
         IReadOnlyDictionary<DbTableName, IReadOnlyDictionary<DbColumnName, int>> columnOrdinalsByTable
     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SecurableElementColumnPathResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/SecurableElementColumnPathResolver.cs
@@ -35,17 +35,17 @@ internal static class SecurableElementColumnPathResolver
         var unresolvedPaths = new List<string>();
         var skippedArrayNestedPaths = new List<string>();
 
-        foreach (var edOrg in securableElements.EducationOrganization)
+        foreach (var jsonPath in securableElements.EducationOrganization.Select(e => e.JsonPath))
         {
             // Array-nested paths (containing [*]) require child-table traversal
             // which is not yet supported; skip them from fail-fast validation.
-            if (IsArrayNestedPath(edOrg.JsonPath))
+            if (IsArrayNestedPath(jsonPath))
             {
-                skippedArrayNestedPaths.Add(edOrg.JsonPath);
+                skippedArrayNestedPaths.Add(jsonPath);
                 continue;
             }
 
-            var path = ResolveEdOrgOrNamespacePath(subjectResource, edOrg.JsonPath);
+            var path = ResolveEdOrgOrNamespacePath(subjectResource, jsonPath);
             if (path is not null)
             {
                 results.Add(
@@ -54,7 +54,7 @@ internal static class SecurableElementColumnPathResolver
             }
             else
             {
-                unresolvedPaths.Add(edOrg.JsonPath);
+                unresolvedPaths.Add(jsonPath);
             }
         }
 
@@ -155,19 +155,14 @@ internal static class SecurableElementColumnPathResolver
                 continue;
             }
 
-            foreach (var identityBinding in binding.IdentityBindings)
+            var identityBinding = binding.IdentityBindings.FirstOrDefault(ib =>
+                string.Equals(ib.ReferenceJsonPath.Canonical, securableElementPath, StringComparison.Ordinal)
+            );
+
+            if (identityBinding is not null)
             {
-                if (
-                    string.Equals(
-                        identityBinding.ReferenceJsonPath.Canonical,
-                        securableElementPath,
-                        StringComparison.Ordinal
-                    )
-                )
-                {
-                    var column = ResolveToCanonicalColumn(rootTable, identityBinding.Column);
-                    return new ColumnPathStep(rootTable.Table, column, null, null);
-                }
+                var column = ResolveToCanonicalColumn(rootTable, identityBinding.Column);
+                return new ColumnPathStep(rootTable.Table, column, null, null);
             }
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/WritePlanJsonPathConventions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/WritePlanJsonPathConventions.cs
@@ -34,7 +34,7 @@ public static class WritePlanJsonPathConventions
 
         var relativeSegments = sourceJsonPath.Segments.Skip(jsonScope.Segments.Count).ToArray();
 
-        if (relativeSegments.Any(segment => segment is JsonPathSegment.AnyArrayElement))
+        if (Array.Exists(relativeSegments, segment => segment is JsonPathSegment.AnyArrayElement))
         {
             throw new InvalidOperationException(
                 $"Cannot derive scope-relative path for source '{sourceJsonPath.Canonical}' under "

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -18,15 +18,7 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit.Analyzers" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/EdFi.DataManagementService.Backend.Postgresql.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/EdFi.DataManagementService.Backend.Postgresql.csproj
@@ -7,16 +7,8 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Npgsql" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend\EdFi.DataManagementService.Backend.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit.csproj
@@ -16,15 +16,7 @@
         </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.RelationalModel\EdFi.DataManagementService.Backend.RelationalModel.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelCanonicalization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelCanonicalization.cs
@@ -35,8 +35,9 @@ internal static class RelationalModelCanonicalization
             .ThenBy(table => table.Table.Name, StringComparer.Ordinal)
             .ToArray();
 
-        var rootTable = canonicalTables.FirstOrDefault(table =>
-            string.Equals(table.JsonScope.Canonical, "$", StringComparison.Ordinal)
+        var rootTable = Array.Find(
+            canonicalTables,
+            table => string.Equals(table.JsonScope.Canonical, "$", StringComparison.Ordinal)
         );
 
         if (rootTable is null)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelSetBuilderContext.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelSetBuilderContext.cs
@@ -98,12 +98,12 @@ public sealed class RelationalModelSetBuilderContext
             entry => entry.Resource
         );
 
-        var projectSchemaBundle = new ProjectSchemaNormalizer().Normalize(effectiveSchemaSet);
+        var projectSchemaBundle = ProjectSchemaNormalizer.Normalize(effectiveSchemaSet);
 
         _projectsInEndpointOrder = projectSchemaBundle.ProjectSchemas;
         _projectSchemasInEndpointOrder = projectSchemaBundle.ProjectSchemaInfos.ToList();
         _projectSchemasInEndpointOrderView = _projectSchemasInEndpointOrder.AsReadOnly();
-        var descriptorPathMaps = new DescriptorPathMapBuilder().Build(_projectsInEndpointOrder);
+        var descriptorPathMaps = DescriptorPathMapBuilder.Build(_projectsInEndpointOrder);
         _descriptorPathsByResource = descriptorPathMaps.BaseDescriptorPathsByResource;
         _extensionDescriptorPathsByResource = descriptorPathMaps.ExtensionDescriptorPathsByResource;
         _concreteResourceSchemasInNameOrder = BuildConcreteResourceSchemasInNameOrder(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelStableIdentityHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/RelationalModelStableIdentityHelper.cs
@@ -207,7 +207,7 @@ internal static class RelationalModelStableIdentityHelper
 
     private static void AddColumn(List<DbColumnModel> columns, DbColumnName columnName, ColumnKind columnKind)
     {
-        if (columns.Any(column => column.ColumnName.Equals(columnName)))
+        if (columns.Exists(column => column.ColumnName.Equals(columnName)))
         {
             return;
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/DeriveColumnsAndBindDescriptorEdgesStep.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/DeriveColumnsAndBindDescriptorEdgesStep.cs
@@ -757,14 +757,11 @@ public sealed class DeriveColumnsAndBindDescriptorEdgesStep : IRelationalModelBu
                 );
             }
 
-            foreach (var keyColumn in table.Key.Columns)
+            foreach (var columnName in table.Key.Columns.Select(k => k.ColumnName))
             {
                 _columnOrigins.TryAdd(
-                    keyColumn.ColumnName.Value,
-                    new ColumnCollisionInfo(
-                        keyColumn.ColumnName.Value,
-                        BuildOrigin(keyColumn.ColumnName, null)
-                    )
+                    columnName.Value,
+                    new ColumnCollisionInfo(columnName.Value, BuildOrigin(columnName, null))
                 );
             }
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/ArrayUniquenessConstraintsExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/ArrayUniquenessConstraintsExtractor.cs
@@ -268,30 +268,25 @@ internal static class ArrayUniquenessConstraintsExtractor
                 alignedBasePath: null
             );
 
-            if (!matched)
+            if (
+                !matched
+                && TryStripExtensionRootPrefix(scopePath, out var alignedScope)
+                && TryStripExtensionRootPrefix(scopePaths, out var alignedPaths)
+            )
             {
-                if (
-                    TryStripExtensionRootPrefix(scopePath, out var alignedScope)
-                    && TryStripExtensionRootPrefix(scopePaths, out var alignedPaths)
-                )
-                {
-                    var alignedBasePath = TryStripExtensionRootPrefix(
-                        constraint.BasePath,
-                        out var alignedBase
-                    )
-                        ? alignedBase.Canonical
-                        : null;
+                var alignedBasePath = TryStripExtensionRootPrefix(constraint.BasePath, out var alignedBase)
+                    ? alignedBase.Canonical
+                    : null;
 
-                    _ = ValidateArrayUniquenessReferenceIdentityCoverage(
-                        alignedPaths,
-                        referenceGroups,
-                        resourceKey,
-                        scope,
-                        basePath,
-                        alignedScope.Canonical,
-                        alignedBasePath
-                    );
-                }
+                _ = ValidateArrayUniquenessReferenceIdentityCoverage(
+                    alignedPaths,
+                    referenceGroups,
+                    resourceKey,
+                    scope,
+                    basePath,
+                    alignedScope.Canonical,
+                    alignedBasePath
+                );
             }
         }
 
@@ -340,10 +335,19 @@ internal static class ArrayUniquenessConstraintsExtractor
             }
 
             var basePathMessage = basePath is null ? string.Empty : $" basePath '{basePath}'";
-            var alignedMessage =
-                alignedScope is null ? string.Empty
-                : alignedBasePath is null ? $" alignedScope '{alignedScope}'"
-                : $" alignedScope '{alignedScope}' basePath '{alignedBasePath}'";
+            string alignedMessage;
+            if (alignedScope is null)
+            {
+                alignedMessage = string.Empty;
+            }
+            else if (alignedBasePath is null)
+            {
+                alignedMessage = $" alignedScope '{alignedScope}'";
+            }
+            else
+            {
+                alignedMessage = $" alignedScope '{alignedScope}' basePath '{alignedBasePath}'";
+            }
 
             throw new InvalidOperationException(
                 $"arrayUniquenessConstraints scope '{scope}' on resource '{resourceKey}'"

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/DocumentReferenceMappingsExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/DocumentReferenceMappingsExtractor.cs
@@ -102,14 +102,7 @@ internal static class DocumentReferenceMappingsExtractor
 
         if (!isReference)
         {
-            ProcessDocumentPathsMappingPathEntry(
-                mappingKey,
-                mappingObject,
-                projectName,
-                resourceName,
-                identityJsonPaths,
-                state
-            );
+            RecordCanonicalIdentityPath(mappingObject, state);
             return;
         }
 
@@ -121,14 +114,7 @@ internal static class DocumentReferenceMappingsExtractor
 
         if (isDescriptor)
         {
-            ProcessDocumentPathsMappingDescriptorEntry(
-                mappingKey,
-                mappingObject,
-                projectName,
-                resourceName,
-                identityJsonPaths,
-                state
-            );
+            RecordCanonicalIdentityPath(mappingObject, state);
             return;
         }
 
@@ -140,6 +126,19 @@ internal static class DocumentReferenceMappingsExtractor
             identityJsonPaths,
             state
         );
+    }
+
+    /// <summary>
+    /// Records the canonical form of the <c>path</c> property of a non-reference <c>documentPathsMapping</c>
+    /// entry into the extraction state's mapped identity paths.
+    /// </summary>
+    private static void RecordCanonicalIdentityPath(
+        JsonObject mappingObject,
+        DocumentReferenceMappingExtractionState state
+    )
+    {
+        var path = RequireString(mappingObject, "path");
+        state.MappedIdentityPaths.Add(JsonPathExpressionCompiler.Compile(path).Canonical);
     }
 
     /// <summary>
@@ -158,42 +157,6 @@ internal static class DocumentReferenceMappingsExtractor
                 "Expected documentPathsMapping entries to be objects, invalid ApiSchema."
             ),
         };
-    }
-
-    /// <summary>
-    /// Processes a non-reference <c>documentPathsMapping</c> entry with a single <c>path</c> property.
-    /// </summary>
-    private static void ProcessDocumentPathsMappingPathEntry(
-        string mappingKey,
-        JsonObject mappingObject,
-        string projectName,
-        string resourceName,
-        IReadOnlySet<string> identityJsonPaths,
-        DocumentReferenceMappingExtractionState state
-    )
-    {
-        var path = RequireString(mappingObject, "path");
-        var pathExpression = JsonPathExpressionCompiler.Compile(path);
-
-        state.MappedIdentityPaths.Add(pathExpression.Canonical);
-    }
-
-    /// <summary>
-    /// Processes a descriptor <c>documentPathsMapping</c> entry with a single <c>path</c> property.
-    /// </summary>
-    private static void ProcessDocumentPathsMappingDescriptorEntry(
-        string mappingKey,
-        JsonObject mappingObject,
-        string projectName,
-        string resourceName,
-        IReadOnlySet<string> identityJsonPaths,
-        DocumentReferenceMappingExtractionState state
-    )
-    {
-        var path = RequireString(mappingObject, "path");
-        var pathExpression = JsonPathExpressionCompiler.Compile(path);
-
-        state.MappedIdentityPaths.Add(pathExpression.Canonical);
     }
 
     /// <summary>
@@ -232,7 +195,7 @@ internal static class DocumentReferenceMappingsExtractor
         var referencePaths = referenceJsonPaths
             .Select(binding => binding.ReferenceJsonPath.Canonical)
             .ToArray();
-        var referenceIsPartOfIdentity = referencePaths.Any(identityJsonPaths.Contains);
+        var referenceIsPartOfIdentity = Array.Exists(referencePaths, identityJsonPaths.Contains);
         ValidateReferenceIdentityCompleteness(
             mappingKey,
             projectName,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/RelationalOverridesExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Build/Steps/ExtractInputs/RelationalOverridesExtractor.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Linq;
 using System.Text.Json.Nodes;
 
 namespace EdFi.DataManagementService.Backend.RelationalModel.Build.Steps.ExtractInputs;
@@ -236,16 +237,16 @@ internal static class RelationalOverridesExtractor
                 );
             }
 
-            if (IsInsideReferenceObjectPath(resolvedPath, referenceMappings, out var referencePath))
+            if (
+                IsInsideReferenceObjectPath(resolvedPath, referenceMappings, out var referencePath)
+                && !referenceIdentityPaths.Contains(resolvedPath.Canonical)
+            )
             {
-                if (!referenceIdentityPaths.Contains(resolvedPath.Canonical))
-                {
-                    throw new InvalidOperationException(
-                        $"relational.nameOverrides entry '{overrideKey}' (canonical '{resolvedPath.Canonical}') "
-                            + $"on resource '{projectName}:{resourceName}' targets a non-identity path inside "
-                            + $"reference object '{referencePath}'. Only reference identity paths may be overridden."
-                    );
-                }
+                throw new InvalidOperationException(
+                    $"relational.nameOverrides entry '{overrideKey}' (canonical '{resolvedPath.Canonical}') "
+                        + $"on resource '{projectName}:{resourceName}' targets a non-identity path inside "
+                        + $"reference object '{referencePath}'. Only reference identity paths may be overridden."
+                );
             }
 
             var overrideKind =
@@ -389,18 +390,13 @@ internal static class RelationalOverridesExtractor
     /// <summary>
     /// Finds an extension project key that matches the supplied identifier using the canonical key comparer.
     /// </summary>
-    private static string? FindMatchingProjectKey(JsonObject projectKeysObject, string match)
-    {
-        foreach (var entry in projectKeysObject)
-        {
-            if (RelationalModelSetSchemaHelpers.ExtensionProjectKeyComparer.Equals(entry.Key, match))
-            {
-                return entry.Key;
-            }
-        }
-
-        return null;
-    }
+    private static string? FindMatchingProjectKey(JsonObject projectKeysObject, string match) =>
+        projectKeysObject
+            .Where(entry =>
+                RelationalModelSetSchemaHelpers.ExtensionProjectKeyComparer.Equals(entry.Key, match)
+            )
+            .Select(entry => entry.Key)
+            .FirstOrDefault();
 
     /// <summary>
     /// Determines whether a JSONPath is nested within a document reference object path.
@@ -411,20 +407,21 @@ internal static class RelationalOverridesExtractor
         out string referencePath
     )
     {
-        foreach (var mapping in referenceMappings)
+        var match = referenceMappings
+            .Where(mapping =>
+                path.Segments.Count > mapping.ReferenceObjectPath.Segments.Count
+                && RelationalModelSetSchemaHelpers.IsPrefixOf(
+                    mapping.ReferenceObjectPath.Segments,
+                    path.Segments
+                )
+            )
+            .Select(mapping => mapping.ReferenceObjectPath.Canonical)
+            .FirstOrDefault();
+
+        if (match is not null)
         {
-            var referenceObjectPath = mapping.ReferenceObjectPath;
-
-            if (path.Segments.Count <= referenceObjectPath.Segments.Count)
-            {
-                continue;
-            }
-
-            if (RelationalModelSetSchemaHelpers.IsPrefixOf(referenceObjectPath.Segments, path.Segments))
-            {
-                referencePath = referenceObjectPath.Canonical;
-                return true;
-            }
+            referencePath = match;
+            return true;
         }
 
         referencePath = string.Empty;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintDerivationHelpers.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintDerivationHelpers.cs
@@ -104,11 +104,11 @@ internal static class ConstraintDerivationHelpers
 
         foreach (var binding in bindings)
         {
-            foreach (var identityBinding in binding.IdentityBindings)
+            foreach (var canonical in binding.IdentityBindings.Select(b => b.ReferenceJsonPath.Canonical))
             {
-                if (!lookup.TryAdd(identityBinding.ReferenceJsonPath.Canonical, binding))
+                if (!lookup.TryAdd(canonical, binding))
                 {
-                    var existing = lookup[identityBinding.ReferenceJsonPath.Canonical];
+                    var existing = lookup[canonical];
 
                     if (existing.ReferenceObjectPath.Canonical == binding.ReferenceObjectPath.Canonical)
                     {
@@ -116,7 +116,7 @@ internal static class ConstraintDerivationHelpers
                     }
 
                     throw new InvalidOperationException(
-                        $"Identity path '{identityBinding.ReferenceJsonPath.Canonical}' on resource "
+                        $"Identity path '{canonical}' on resource "
                             + $"'{FormatResource(resource)}' was bound to multiple references."
                     );
                 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintIdentity.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintIdentity.cs
@@ -248,12 +248,12 @@ internal sealed class ConstraintIdentity : IEquatable<ConstraintIdentity>
             }
         }
 
-        if (Kind == ConstraintIdentityKind.AllOrNone)
+        if (
+            Kind == ConstraintIdentityKind.AllOrNone
+            && !DependentColumns.SequenceEqual(other.DependentColumns)
+        )
         {
-            if (!DependentColumns.SequenceEqual(other.DependentColumns))
-            {
-                return false;
-            }
+            return false;
         }
 
         return true;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintNaming.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Constraints/ConstraintNaming.cs
@@ -214,12 +214,9 @@ internal static class ConstraintNaming
             return $"{prefix}_{table.Name}";
         }
 
-        foreach (var token in tokens)
+        if (tokens.Any(string.IsNullOrWhiteSpace))
         {
-            if (string.IsNullOrWhiteSpace(token))
-            {
-                throw new ArgumentException("Constraint tokens must be non-empty.", nameof(tokens));
-            }
+            throw new ArgumentException("Constraint tokens must be non-empty.", nameof(tokens));
         }
 
         return $"{prefix}_{table.Name}_{string.Join("_", tokens)}";

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorPaths/DescriptorPathInference.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorPaths/DescriptorPathInference.cs
@@ -238,16 +238,18 @@ internal static class DescriptorPathInference
 
         Dictionary<string, DescriptorPathInfo> descriptorPathsByJsonPath = new(StringComparer.Ordinal);
 
-        foreach (var mapping in OrderDocumentPathsMappingEntries(documentPathsMapping))
+        foreach (
+            var mappingValue in OrderDocumentPathsMappingEntries(documentPathsMapping).Select(m => m.Value)
+        )
         {
-            if (mapping.Value is null)
+            if (mappingValue is null)
             {
                 throw new InvalidOperationException(
                     "Expected documentPathsMapping entries to be non-null, invalid ApiSchema."
                 );
             }
 
-            if (mapping.Value is not JsonObject mappingObject)
+            if (mappingValue is not JsonObject mappingObject)
             {
                 throw new InvalidOperationException(
                     "Expected documentPathsMapping entries to be objects, invalid ApiSchema."
@@ -422,16 +424,18 @@ internal static class DescriptorPathInference
 
         List<ReferenceJsonPathInfo> referenceJsonPaths = new();
 
-        foreach (var mapping in OrderDocumentPathsMappingEntries(documentPathsMapping))
+        foreach (
+            var mappingValue in OrderDocumentPathsMappingEntries(documentPathsMapping).Select(m => m.Value)
+        )
         {
-            if (mapping.Value is null)
+            if (mappingValue is null)
             {
                 throw new InvalidOperationException(
                     "Expected documentPathsMapping entries to be non-null, invalid ApiSchema."
                 );
             }
 
-            if (mapping.Value is not JsonObject mappingObject)
+            if (mappingValue is not JsonObject mappingObject)
             {
                 throw new InvalidOperationException(
                     "Expected documentPathsMapping entries to be objects, invalid ApiSchema."

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorPaths/DescriptorPathMapBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorPaths/DescriptorPathMapBuilder.cs
@@ -32,7 +32,7 @@ internal sealed record DescriptorPathMapResult(
 /// <c>_ext</c> properties are skipped during base schema traversal.
 /// </para>
 /// </summary>
-internal sealed class DescriptorPathMapBuilder
+internal static class DescriptorPathMapBuilder
 {
     /// <summary>
     /// Builds descriptor path maps for all resources across the supplied projects, separating descriptor
@@ -40,7 +40,7 @@ internal sealed class DescriptorPathMapBuilder
     /// </summary>
     /// <param name="projectsInEndpointOrder">Project schemas in canonical endpoint order.</param>
     /// <returns>The descriptor path maps grouped by resource.</returns>
-    public DescriptorPathMapResult Build(IReadOnlyList<ProjectSchemaContext> projectsInEndpointOrder)
+    public static DescriptorPathMapResult Build(IReadOnlyList<ProjectSchemaContext> projectsInEndpointOrder)
     {
         if (projectsInEndpointOrder.Count == 0)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorSchemaValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/DescriptorSchemaValidator.cs
@@ -171,7 +171,7 @@ internal static class DescriptorSchemaValidator
             return;
         }
 
-        var format = fieldNode?["format"]?.GetValue<string>();
+        var format = fieldNode!["format"]?.GetValue<string>();
         if (format != "date")
         {
             errors.Add($"Field '{fieldName}' must have format 'date', but found format '{format ?? "none"}'");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Diagnostics/TableColumnAccumulator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Diagnostics/TableColumnAccumulator.cs
@@ -41,12 +41,12 @@ internal sealed class TableColumnAccumulator
 
         // Key columns are expected to overlap with DbTableModel.Columns because table column
         // inventories are seeded from the key definition before any derived columns are added.
-        foreach (var keyColumn in table.Key.Columns)
+        foreach (var value in table.Key.Columns.Select(k => k.ColumnName.Value))
         {
-            if (!columnNames.Contains(keyColumn.ColumnName.Value))
+            if (!columnNames.Contains(value))
             {
                 throw new InvalidOperationException(
-                    $"Table column inventory invariant failed for '{Definition.Table}': key column '{keyColumn.ColumnName.Value}' is missing from DbTableModel.Columns."
+                    $"Table column inventory invariant failed for '{Definition.Table}': key column '{value}' is missing from DbTableModel.Columns."
                 );
             }
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Manifest/DerivedModelSetManifestEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Manifest/DerivedModelSetManifestEmitter.cs
@@ -332,7 +332,7 @@ public static class DerivedModelSetManifestEmitter
                     TriggerKindParameters.IdentityPropagationFallback => "IdentityPropagationFallback",
                     TriggerKindParameters.AuthHierarchyMaintenance => "AuthHierarchyMaintenance",
                     _ => throw new ArgumentOutOfRangeException(
-                        nameof(trigger),
+                        nameof(triggers),
                         "Unsupported trigger kind parameters type."
                     ),
                 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Naming/RelationalNameConventions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Naming/RelationalNameConventions.cs
@@ -79,12 +79,9 @@ public static class RelationalNameConventions
 
         StringBuilder builder = new(projectEndpointName.Length);
 
-        foreach (var character in projectEndpointName)
+        foreach (var character in projectEndpointName.Where(IsAsciiLetterOrDigit))
         {
-            if (IsAsciiLetterOrDigit(character))
-            {
-                builder.Append(char.ToLowerInvariant(character));
-            }
+            builder.Append(char.ToLowerInvariant(character));
         }
 
         if (builder.Length == 0 || !IsAsciiLowercaseLetter(builder[0]))

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Schema/ProjectSchemaNormalizer.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Schema/ProjectSchemaNormalizer.cs
@@ -22,13 +22,13 @@ internal sealed record ProjectSchemaNormalizationResult(
 /// Normalizes projects from an <see cref="EffectiveSchemaSet"/> into canonical endpoint/schema ordering and
 /// validates physical schema uniqueness.
 /// </summary>
-internal sealed class ProjectSchemaNormalizer
+internal static class ProjectSchemaNormalizer
 {
     /// <summary>
     /// Normalizes project schemas and returns per-project contexts and schema infos.
     /// </summary>
     /// <param name="effectiveSchemaSet">The effective schema set to normalize.</param>
-    public ProjectSchemaNormalizationResult Normalize(EffectiveSchemaSet effectiveSchemaSet)
+    public static ProjectSchemaNormalizationResult Normalize(EffectiveSchemaSet effectiveSchemaSet)
     {
         ArgumentNullException.ThrowIfNull(effectiveSchemaSet);
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Schema/RelationalModelSetSchemaHelpers.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Schema/RelationalModelSetSchemaHelpers.cs
@@ -657,7 +657,7 @@ internal static class RelationalModelSetSchemaHelpers
 
         var relativeSegments = path.Segments.Skip(jsonScope.Segments.Count).ToArray();
 
-        if (relativeSegments.Any(segment => segment is JsonPathSegment.AnyArrayElement))
+        if (Array.Exists(relativeSegments, segment => segment is JsonPathSegment.AnyArrayElement))
         {
             throw new InvalidOperationException(
                 $"Cannot derive scope-relative semantic identity path for '{path.Canonical}' under "

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/AbstractIdentityTableAndUnionViewDerivationPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/AbstractIdentityTableAndUnionViewDerivationPass.cs
@@ -640,21 +640,21 @@ public sealed class AbstractIdentityTableAndUnionViewDerivationPass : IRelationa
             ),
         };
 
-        foreach (var derivation in identityDerivations)
+        foreach (var identityColumn in identityDerivations.Select(d => d.IdentityColumn))
         {
-            if (derivation.IdentityColumn.ScalarType is not { } scalarType)
+            if (identityColumn.ScalarType is not { } scalarType)
             {
                 throw new InvalidOperationException(
-                    $"Identity column '{derivation.IdentityColumn.ColumnName.Value}' is missing a scalar type."
+                    $"Identity column '{identityColumn.ColumnName.Value}' is missing a scalar type."
                 );
             }
 
             outputColumns.Add(
                 new AbstractUnionViewOutputColumn(
-                    derivation.IdentityColumn.ColumnName,
+                    identityColumn.ColumnName,
                     scalarType,
-                    derivation.IdentityColumn.SourceJsonPath,
-                    derivation.IdentityColumn.TargetResource
+                    identityColumn.SourceJsonPath,
+                    identityColumn.TargetResource
                 )
             );
         }
@@ -760,17 +760,12 @@ public sealed class AbstractIdentityTableAndUnionViewDerivationPass : IRelationa
             return member.IdentityJsonPaths[0];
         }
 
-        foreach (var identityPath in member.IdentityJsonPaths)
+        for (var i = 0; i < member.IdentityJsonPaths.Count; i++)
         {
-            if (
-                string.Equals(
-                    identityPath.Canonical,
-                    abstractIdentityPath.Canonical,
-                    StringComparison.Ordinal
-                )
-            )
+            var path = member.IdentityJsonPaths[i];
+            if (string.Equals(path.Canonical, abstractIdentityPath.Canonical, StringComparison.Ordinal))
             {
-                return identityPath;
+                return path;
             }
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ApplyConstraintDialectHashingPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ApplyConstraintDialectHashingPass.cs
@@ -53,14 +53,14 @@ public sealed class ApplyConstraintDialectHashingPass : IRelationalModelSetPass
     )
     {
         var changed = false;
-        var updatedTables = resourceModel
-            .TablesInDependencyOrder.Select(table =>
-            {
-                var updatedTable = ApplyToTable(table, dialectRules, out var tableChanged);
-                changed |= tableChanged;
-                return updatedTable;
-            })
-            .ToArray();
+        var sourceTables = resourceModel.TablesInDependencyOrder;
+        var updatedTables = new DbTableModel[sourceTables.Count];
+
+        for (var index = 0; index < sourceTables.Count; index++)
+        {
+            updatedTables[index] = ApplyToTable(sourceTables[index], dialectRules, out var tableChanged);
+            changed |= tableChanged;
+        }
 
         if (!changed)
         {
@@ -146,6 +146,7 @@ public sealed class ApplyConstraintDialectHashingPass : IRelationalModelSetPass
     /// <summary>
     /// Applies dialect length handling to a table constraint name and indicates whether it changed.
     /// </summary>
+#pragma warning disable IDE0055
     private static TableConstraint ApplyToConstraint(
         DbTableName table,
         TableConstraint constraint,
@@ -226,4 +227,5 @@ public sealed class ApplyConstraintDialectHashingPass : IRelationalModelSetPass
                 );
         }
     }
+#pragma warning restore IDE0055
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ApplyDialectIdentifierShorteningPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ApplyDialectIdentifierShorteningPass.cs
@@ -527,6 +527,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
     /// <summary>
     /// Applies dialect shortening to column storage metadata and reports whether it changed.
     /// </summary>
+#pragma warning disable IDE0055
     private static ColumnStorage ApplyToColumnStorage(
         ColumnStorage storage,
         ISqlDialectRules dialectRules,
@@ -566,10 +567,12 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
                 );
         }
     }
+#pragma warning restore IDE0055
 
     /// <summary>
     /// Applies dialect shortening to a table constraint and reports whether it changed.
     /// </summary>
+#pragma warning disable IDE0055
     private static TableConstraint ApplyToConstraint(
         TableConstraint constraint,
         ISqlDialectRules dialectRules,
@@ -680,6 +683,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
                 );
         }
     }
+#pragma warning restore IDE0055
 
     /// <summary>
     /// Applies dialect shortening to a column name collection and reports whether any element changed.
@@ -1168,6 +1172,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
     /// <summary>
     /// Applies dialect shortening to an abstract union-view projection expression and reports whether it changed.
     /// </summary>
+#pragma warning disable IDE0055
     private static AbstractUnionViewProjectionExpression ApplyToUnionViewProjection(
         AbstractUnionViewProjectionExpression expression,
         ISqlDialectRules dialectRules,
@@ -1200,6 +1205,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
                 );
         }
     }
+#pragma warning restore IDE0055
 
     /// <summary>
     /// Applies dialect shortening to an index and reports whether it changed.
@@ -1286,6 +1292,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
     /// <summary>
     /// Applies dialect shortening to trigger-kind-specific parameters and reports whether they changed.
     /// </summary>
+#pragma warning disable IDE0055
     private static TriggerKindParameters ApplyToTriggerParameters(
         TriggerKindParameters parameters,
         ISqlDialectRules dialectRules,
@@ -1357,6 +1364,7 @@ public sealed class ApplyDialectIdentifierShorteningPass : IRelationalModelSetPa
                 );
         }
     }
+#pragma warning restore IDE0055
 
     /// <summary>
     /// Shortens column names in trigger column mappings using dialect rules.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveAuthHierarchyPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveAuthHierarchyPass.cs
@@ -106,7 +106,7 @@ public sealed class DeriveAuthHierarchyPass : IRelationalModelSetPass
     private static AuthEdOrgHierarchy? CompileHierarchy(RelationalModelSetBuilderContext context)
     {
         // Step 1: Find the abstract EducationOrganization union view.
-        var edOrgUnionView = context.AbstractUnionViewsInNameOrder.FirstOrDefault(v =>
+        var edOrgUnionView = context.AbstractUnionViewsInNameOrder.Find(v =>
             v.AbstractResourceKey.Resource.ResourceName == EducationOrganizationResourceName
         );
 
@@ -124,7 +124,7 @@ public sealed class DeriveAuthHierarchyPass : IRelationalModelSetPass
 
         // Step 3: Determine the abstract identity column (for the union view projection).
         var abstractIdentityTable =
-            context.AbstractIdentityTablesInNameOrder.FirstOrDefault(t =>
+            context.AbstractIdentityTablesInNameOrder.Find(t =>
                 t.AbstractResourceKey.Resource == abstractEdOrgResource
             )
             ?? throw new InvalidOperationException(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveIndexInventoryPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveIndexInventoryPass.cs
@@ -87,19 +87,19 @@ public sealed class DeriveIndexInventoryPass : IRelationalModelSetPass
             .OrderByDescending(fk => fk.Columns.Count)
             .ThenBy(fk => fk.Name, StringComparer.Ordinal);
 
-        foreach (var fk in orderedFks)
+        foreach (var columns in orderedFks.Select(fk => fk.Columns))
         {
-            if (IsLeftmostPrefixCovered(fk.Columns, tableIndexes))
+            if (IsLeftmostPrefixCovered(columns, tableIndexes))
             {
                 continue;
             }
 
-            var indexName = ConstraintNaming.BuildForeignKeySupportIndexName(table.Table, fk.Columns);
+            var indexName = ConstraintNaming.BuildForeignKeySupportIndexName(table.Table, columns);
             tableIndexes.Add(
                 new DbIndexInfo(
                     new DbIndexName(indexName),
                     table.Table,
-                    fk.Columns,
+                    columns,
                     IsUnique: false,
                     DbIndexKind.ForeignKeySupport
                 )
@@ -118,9 +118,9 @@ public sealed class DeriveIndexInventoryPass : IRelationalModelSetPass
         IReadOnlyList<DbIndexInfo> existingIndexes
     )
     {
-        foreach (var existing in existingIndexes)
+        foreach (var keyColumns in existingIndexes.Select(e => e.KeyColumns))
         {
-            if (existing.KeyColumns.Count < fkColumns.Count)
+            if (keyColumns.Count < fkColumns.Count)
             {
                 continue;
             }
@@ -129,7 +129,7 @@ public sealed class DeriveIndexInventoryPass : IRelationalModelSetPass
 
             for (var i = 0; i < fkColumns.Count; i++)
             {
-                if (!fkColumns[i].Equals(existing.KeyColumns[i]))
+                if (!fkColumns[i].Equals(keyColumns[i]))
                 {
                     isPrefix = false;
                     break;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveTriggerInventoryPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DeriveTriggerInventoryPass.cs
@@ -339,8 +339,8 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
         var rootTable = resourceModel.Root;
 
         // Resolve each identity element column to its canonical stored column.
-        // Under key unification, binding columns may be unified aliases (computed);
-        // UPDATE() guards and IS DISTINCT FROM comparisons must reference stored columns.
+        // Under key unification, binding columns may be unified aliases that are computed,
+        // and UPDATE() guards and IS DISTINCT FROM comparisons must reference stored columns.
         HashSet<string> seen = new(StringComparer.Ordinal);
         List<DbColumnName> storedColumns = new(identityElements.Count);
 
@@ -380,11 +380,7 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
     )
     {
         // Build reverse reference index: for each target resource, collect all referrer entries.
-        var reverseIndex = BuildReverseReferenceIndex(
-            context,
-            resourceContextsByResource,
-            concreteResourcesByName
-        );
+        var reverseIndex = BuildReverseReferenceIndex(context, concreteResourcesByName);
 
         // For each target resource in the reverse index, emit a single trigger with all referrers.
         foreach (var (targetResource, referrerEntries) in reverseIndex)
@@ -421,8 +417,8 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
                 triggerTableModel = concreteModel.RelationalModel.Root;
 
                 // Identity projection columns from the root table, resolved to stored columns.
-                // Under key unification, some identity columns may be unified aliases (computed);
-                // SQL Server rejects UPDATE() on computed columns (Msg 2114).
+                // Under key unification, some identity columns may be unified aliases that are computed,
+                // and SQL Server rejects UPDATE() on computed columns (Msg 2114).
                 identityProjectionColumns = ResolveColumnsToStored(
                     triggerTableModel
                         .Columns.Where(c => c.SourceJsonPath is not null)
@@ -485,7 +481,6 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
     /// </summary>
     private static Dictionary<QualifiedResourceName, List<ReverseReferenceEntry>> BuildReverseReferenceIndex(
         RelationalModelSetBuilderContext context,
-        IReadOnlyDictionary<QualifiedResourceName, ConcreteResourceSchemaContext> resourceContextsByResource,
         IReadOnlyDictionary<QualifiedResourceName, ConcreteResourceModel> concreteResourcesByName
     )
     {
@@ -664,10 +659,10 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
         HashSet<string> seenColumns = new(StringComparer.Ordinal);
         List<IdentityElementMapping> mappings = new(builderContext.IdentityJsonPaths.Count);
 
-        foreach (var identityPath in builderContext.IdentityJsonPaths)
+        foreach (var canonical in builderContext.IdentityJsonPaths.Select(p => p.Canonical))
         {
             var identityPartColumns = ResolveReferenceIdentityPartColumns(
-                identityPath.Canonical,
+                canonical,
                 referenceBindingsByIdentityPath,
                 rootTable.Table,
                 resource
@@ -675,31 +670,23 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
 
             if (identityPartColumns is not null)
             {
-                foreach (var col in identityPartColumns)
+                foreach (var col in identityPartColumns.Where(c => seenColumns.Add(c.Value)))
                 {
-                    if (seenColumns.Add(col.Value))
-                    {
-                        mappings.Add(
-                            new IdentityElementMapping(
-                                col,
-                                identityPath.Canonical,
-                                LookupColumnScalarType(
-                                    columnScalarTypes,
-                                    col,
-                                    identityPath.Canonical,
-                                    resource
-                                )
-                            )
-                        );
-                    }
+                    mappings.Add(
+                        new IdentityElementMapping(
+                            col,
+                            canonical,
+                            LookupColumnScalarType(columnScalarTypes, col, canonical, resource)
+                        )
+                    );
                 }
                 continue;
             }
 
-            if (!rootColumnsByPath.TryGetValue(identityPath.Canonical, out var columnName))
+            if (!rootColumnsByPath.TryGetValue(canonical, out var columnName))
             {
                 throw new InvalidOperationException(
-                    $"Identity path '{identityPath.Canonical}' on resource '{FormatResource(resource)}' "
+                    $"Identity path '{canonical}' on resource '{FormatResource(resource)}' "
                         + "did not map to a root table column during identity element mapping."
                 );
             }
@@ -709,13 +696,8 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
                 mappings.Add(
                     new IdentityElementMapping(
                         columnName,
-                        identityPath.Canonical,
-                        LookupColumnScalarType(
-                            columnScalarTypes,
-                            columnName,
-                            identityPath.Canonical,
-                            resource
-                        )
+                        canonical,
+                        LookupColumnScalarType(columnScalarTypes, columnName, canonical, resource)
                     )
                 );
             }
@@ -788,9 +770,11 @@ public sealed class DeriveTriggerInventoryPass : IRelationalModelSetPass
                 // When superclassIdentityJsonPath is set, the first concrete identity path
                 // maps to the superclass identity path.
                 if (builderContext.IdentityJsonPaths.Count == 0)
+                {
                     throw new InvalidOperationException(
                         $"Resource '{FormatResource(resource)}' has superclassIdentityJsonPath set but no identity JSON paths."
                     );
+                }
 
                 concretePath = builderContext.IdentityJsonPaths[0].Canonical;
             }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DescriptorForeignKeyConstraintPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DescriptorForeignKeyConstraintPass.cs
@@ -144,10 +144,7 @@ public sealed class DescriptorForeignKeyConstraintPass : IRelationalModelSetPass
         var nonDescriptorConstraints = table
             .Constraints.Where(constraint => !IsDescriptorForeignKeyConstraint(constraint))
             .ToArray();
-        var updatedConstraints = nonDescriptorConstraints
-            .Concat(generatedDescriptorConstraints)
-            .Cast<TableConstraint>()
-            .ToArray();
+        var updatedConstraints = nonDescriptorConstraints.Concat(generatedDescriptorConstraints).ToArray();
 
         return updatedConstraints.SequenceEqual(table.Constraints)
             ? table

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DescriptorResourceMappingPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/DescriptorResourceMappingPass.cs
@@ -34,15 +34,15 @@ public sealed class DescriptorResourceMappingPass : IRelationalModelSetPass
             var qname = resourceKey.Resource;
 
             // Defensive check: If StorageKind is already SharedDescriptorTable, verify naming convention
-            if (concreteResource.StorageKind == ResourceStorageKind.SharedDescriptorTable)
+            if (
+                concreteResource.StorageKind == ResourceStorageKind.SharedDescriptorTable
+                && !qname.ResourceName.EndsWith("Descriptor", StringComparison.Ordinal)
+            )
             {
-                if (!qname.ResourceName.EndsWith("Descriptor", StringComparison.Ordinal))
-                {
-                    throw new InvalidOperationException(
-                        $"Resource '{qname.ProjectName}.{qname.ResourceName}' has StorageKind.SharedDescriptorTable but does not follow the 'Descriptor' naming convention. "
-                            + "This indicates an inconsistency in the ApiSchema.json file where isDescriptor=true but the resource name does not end with 'Descriptor'."
-                    );
-                }
+                throw new InvalidOperationException(
+                    $"Resource '{qname.ProjectName}.{qname.ResourceName}' has StorageKind.SharedDescriptorTable but does not follow the 'Descriptor' naming convention. "
+                        + "This indicates an inconsistency in the ApiSchema.json file where isDescriptor=true but the resource name does not end with 'Descriptor'."
+                );
             }
 
             if (!schemaLookup.TryGetValue((qname.ProjectName, qname.ResourceName), out var resourceContext))

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ExtensionTableDerivationPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ExtensionTableDerivationPass.cs
@@ -623,7 +623,6 @@ public sealed class ExtensionTableDerivationPass : IRelationalModelSetPass
         {
             childTable = CreateChildTableBuilder(
                 tableBuilder,
-                propertySegments,
                 arraySegments,
                 ctx.BaseRootBaseName,
                 ctx.ExtensionRootBaseName,
@@ -768,7 +767,6 @@ public sealed class ExtensionTableDerivationPass : IRelationalModelSetPass
     /// </summary>
     private static ExtensionTableBuilder CreateChildTableBuilder(
         ExtensionTableBuilder parent,
-        List<JsonPathSegment> propertySegments,
         List<JsonPathSegment> arraySegments,
         string baseRootBaseName,
         string extensionRootBaseName,
@@ -1014,18 +1012,11 @@ public sealed class ExtensionTableDerivationPass : IRelationalModelSetPass
     /// <summary>
     /// Finds a matching project key in a <c>_ext</c> object using case-insensitive comparison.
     /// </summary>
-    private static string? FindMatchingProjectKey(JsonObject projectKeysObject, string match)
-    {
-        foreach (var entry in projectKeysObject)
-        {
-            if (ExtensionProjectKeyComparer.Equals(entry.Key, match))
-            {
-                return entry.Key;
-            }
-        }
-
-        return null;
-    }
+    private static string? FindMatchingProjectKey(JsonObject projectKeysObject, string match) =>
+        projectKeysObject
+            .Where(entry => ExtensionProjectKeyComparer.Equals(entry.Key, match))
+            .Select(entry => entry.Key)
+            .FirstOrDefault();
 
     /// <summary>
     /// Builds a set of canonical reference object JSONPaths from the document reference mappings.
@@ -1678,14 +1669,6 @@ public sealed class ExtensionTableDerivationPass : IRelationalModelSetPass
         )
         {
             _accumulator.AddColumn(column, originalName, origin);
-        }
-
-        /// <summary>
-        /// Adds a constraint to the table being built.
-        /// </summary>
-        public void AddConstraint(TableConstraint constraint)
-        {
-            _accumulator.AddConstraint(constraint);
         }
 
         /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/KeyUnificationPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/KeyUnificationPass.cs
@@ -454,8 +454,7 @@ public sealed class KeyUnificationPass : IRelationalModelSetPass
     /// </summary>
     private static TableBoundColumn[]? ResolveEndpointCandidates(
         IReadOnlyDictionary<string, List<TableBoundColumn>> bindingsByPath,
-        JsonPathExpression endpointPath,
-        QualifiedResourceName resource
+        JsonPathExpression endpointPath
     )
     {
         if (!bindingsByPath.TryGetValue(endpointPath.Canonical, out var rawCandidates))
@@ -623,7 +622,7 @@ public sealed class KeyUnificationPass : IRelationalModelSetPass
         QualifiedResourceName resource
     )
     {
-        var physicalBindings = ResolveEndpointCandidates(bindingsByPath, endpointPath, resource);
+        var physicalBindings = ResolveEndpointCandidates(bindingsByPath, endpointPath);
 
         if (physicalBindings is null)
         {
@@ -1148,7 +1147,7 @@ public sealed class KeyUnificationPass : IRelationalModelSetPass
                 canonicalColumnName,
                 firstMember.Kind,
                 firstMember.ScalarType,
-                memberColumns.All(column => column.IsNullable),
+                Array.TrueForAll(memberColumns, column => column.IsNullable),
                 SourceJsonPath: null,
                 firstMember.TargetResource
             );
@@ -1446,7 +1445,7 @@ public sealed class KeyUnificationPass : IRelationalModelSetPass
 
         var relativeSegments = sourcePath.Segments.Skip(prefixSegments.Count).ToArray();
 
-        if (relativeSegments.Any(segment => segment is JsonPathSegment.AnyArrayElement))
+        if (Array.Exists(relativeSegments, segment => segment is JsonPathSegment.AnyArrayElement))
         {
             throw new InvalidOperationException(
                 $"Key-unification member path '{sourcePath.Canonical}' on resource "

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceBindingPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceBindingPass.cs
@@ -117,7 +117,6 @@ public sealed class ReferenceBindingPass : IRelationalModelSetPass
             StringComparer.Ordinal
         );
         var descriptorEdgeSources = new List<DescriptorEdgeSource>(resourceModel.DescriptorEdgeSources);
-        var resourceLabel = FormatResource(resource);
 
         foreach (var mapping in builderContext.DocumentReferenceMappings)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceConstraintPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceConstraintPass.cs
@@ -152,30 +152,28 @@ public sealed class ReferenceConstraintPass : IRelationalModelSetPass
             var bindingTable = ResolveReferenceBindingTable(binding, resourceModel, resource);
             var tableAccumulator = mutation.GetTableAccumulator(bindingTable, resource);
 
-            if (identityColumns.LocalColumns.Count > 0)
+            if (
+                identityColumns.LocalColumns.Count > 0
+                && !ContainsAllOrNoneConstraint(
+                    tableAccumulator.Constraints,
+                    tableAccumulator.Definition.Table,
+                    binding.FkColumn,
+                    identityColumns.LocalColumns
+                )
+            )
             {
-                if (
-                    !ContainsAllOrNoneConstraint(
-                        tableAccumulator.Constraints,
-                        tableAccumulator.Definition.Table,
+                var allOrNoneName = ConstraintNaming.BuildAllOrNoneName(
+                    tableAccumulator.Definition.Table,
+                    referenceBaseName
+                );
+                tableAccumulator.AddConstraint(
+                    new TableConstraint.AllOrNoneNullability(
+                        allOrNoneName,
                         binding.FkColumn,
                         identityColumns.LocalColumns
                     )
-                )
-                {
-                    var allOrNoneName = ConstraintNaming.BuildAllOrNoneName(
-                        tableAccumulator.Definition.Table,
-                        referenceBaseName
-                    );
-                    tableAccumulator.AddConstraint(
-                        new TableConstraint.AllOrNoneNullability(
-                            allOrNoneName,
-                            binding.FkColumn,
-                            identityColumns.LocalColumns
-                        )
-                    );
-                    mutation.MarkTableMutated(bindingTable);
-                }
+                );
+                mutation.MarkTableMutated(bindingTable);
             }
 
             var mappedIdentityColumns = MapReferenceIdentityColumnsToStorage(
@@ -251,11 +249,7 @@ public sealed class ReferenceConstraintPass : IRelationalModelSetPass
                 targetColumns.AddRange(mappedIdentityColumns.TargetColumns);
             }
 
-            var onUpdate =
-                context.SetContext.Dialect == SqlDialect.Mssql ? ReferentialAction.NoAction
-                : targetInfo.IsAbstract ? ReferentialAction.Cascade
-                : targetInfo.TransitivelyAllowIdentityUpdates ? ReferentialAction.Cascade
-                : ReferentialAction.NoAction;
+            var onUpdate = ResolveOnUpdate(context.SetContext.Dialect, targetInfo);
 
             if (
                 !ContainsForeignKeyConstraint(
@@ -610,6 +604,19 @@ public sealed class ReferenceConstraintPass : IRelationalModelSetPass
         }
 
         return new ReferenceIdentityColumnSet(localColumns.ToArray(), targetColumns.ToArray());
+    }
+
+    private static ReferentialAction ResolveOnUpdate(SqlDialect dialect, TargetIdentityInfo targetInfo)
+    {
+        if (dialect == SqlDialect.Mssql)
+        {
+            return ReferentialAction.NoAction;
+        }
+        if (targetInfo.IsAbstract || targetInfo.TransitivelyAllowIdentityUpdates)
+        {
+            return ReferentialAction.Cascade;
+        }
+        return ReferentialAction.NoAction;
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceObjectPathScopeResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ReferenceObjectPathScopeResolver.cs
@@ -28,8 +28,14 @@ internal static class ReferenceObjectPathScopeResolver
         string? tableName = null
     )
     {
-        ArgumentNullException.ThrowIfNull(referenceObjectPath.Canonical, nameof(referenceObjectPath));
-        ArgumentNullException.ThrowIfNull(referenceObjectPath.Segments, nameof(referenceObjectPath));
+        if (referenceObjectPath.Canonical is null)
+        {
+            throw new ArgumentNullException(nameof(referenceObjectPath));
+        }
+        if (referenceObjectPath.Segments is null)
+        {
+            throw new ArgumentNullException(nameof(referenceObjectPath));
+        }
         ArgumentNullException.ThrowIfNull(scopeCandidates);
         ArgumentNullException.ThrowIfNull(scopeSelector);
 
@@ -72,8 +78,14 @@ internal static class ReferenceObjectPathScopeResolver
         Func<Exception> extensionScopeRequiredExceptionFactory
     )
     {
-        ArgumentNullException.ThrowIfNull(referenceObjectPath.Canonical, nameof(referenceObjectPath));
-        ArgumentNullException.ThrowIfNull(referenceObjectPath.Segments, nameof(referenceObjectPath));
+        if (referenceObjectPath.Canonical is null)
+        {
+            throw new ArgumentNullException(nameof(referenceObjectPath));
+        }
+        if (referenceObjectPath.Segments is null)
+        {
+            throw new ArgumentNullException(nameof(referenceObjectPath));
+        }
         ArgumentNullException.ThrowIfNull(scopeCandidates);
         ArgumentNullException.ThrowIfNull(scopeSelector);
         ArgumentNullException.ThrowIfNull(noMatchExceptionFactory);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/UnifiedAliasStrictMetadataCache.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/UnifiedAliasStrictMetadataCache.cs
@@ -63,21 +63,23 @@ internal static class UnifiedAliasStrictMetadataCache
                 continue;
             }
 
-            foreach (var table in concreteResource.RelationalModel.TablesInDependencyOrder)
+            foreach (
+                var table in concreteResource.RelationalModel.TablesInDependencyOrder.Where(t =>
+                    seenTables.Add(t.Table)
+                )
+            )
             {
-                if (seenTables.Add(table.Table))
-                {
-                    yield return table;
-                }
+                yield return table;
             }
         }
 
-        foreach (var abstractTable in context.AbstractIdentityTablesInNameOrder)
+        foreach (
+            var abstractTable in context.AbstractIdentityTablesInNameOrder.Where(a =>
+                seenTables.Add(a.TableModel.Table)
+            )
+        )
         {
-            if (seenTables.Add(abstractTable.TableModel.Table))
-            {
-                yield return abstractTable.TableModel;
-            }
+            yield return abstractTable.TableModel;
         }
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ValidateForeignKeyStorageInvariantPass.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/SetPasses/ValidateForeignKeyStorageInvariantPass.cs
@@ -109,12 +109,12 @@ public sealed class ValidateForeignKeyStorageInvariantPass : IRelationalModelSet
             tablesByName.Add(table.Table, table);
         }
 
-        foreach (var abstractTable in context.AbstractIdentityTablesInNameOrder)
+        foreach (var tableModel in context.AbstractIdentityTablesInNameOrder.Select(a => a.TableModel))
         {
-            if (!tablesByName.TryAdd(abstractTable.TableModel.Table, abstractTable.TableModel))
+            if (!tablesByName.TryAdd(tableModel.Table, tableModel))
             {
                 throw new InvalidOperationException(
-                    $"Duplicate table name '{abstractTable.TableModel.Table.Schema.Value}.{abstractTable.TableModel.Table.Name}' "
+                    $"Duplicate table name '{tableModel.Table.Schema.Value}.{tableModel.Table.Name}' "
                         + "encountered during foreign key storage validation. "
                         + "This indicates a naming collision in the derived model set."
                 );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Validation/JsonSchemaUnsupportedKeywordValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel/Validation/JsonSchemaUnsupportedKeywordValidator.cs
@@ -35,14 +35,12 @@ internal static class JsonSchemaUnsupportedKeywordValidator
     /// <param name="path">The schema traversal path used for error reporting.</param>
     internal static void Validate(JsonObject schema, string path)
     {
-        foreach (var keyword in _unsupportedKeywords)
+        var unsupported = _unsupportedKeywords.FirstOrDefault(schema.ContainsKey);
+        if (unsupported is not null)
         {
-            if (schema.ContainsKey(keyword))
-            {
-                throw new InvalidOperationException(
-                    $"Unsupported schema keyword '{keyword}' at {path}.{keyword}."
-                );
-            }
+            throw new InvalidOperationException(
+                $"Unsupported schema keyword '{unsupported}' at {path}.{unsupported}."
+            );
         }
 
         if (schema.TryGetPropertyValue("type", out var typeNode) && typeNode is JsonArray)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/ReadableProfileProjectorTestExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/ReadableProfileProjectorTestExtensions.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Text.Json.Nodes;
-using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Profile;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationalDocumentInfoTestHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationalDocumentInfoTestHelper.cs
@@ -5,9 +5,7 @@
 
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
-using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Core.ApiSchema;
-using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Extraction;
 using Microsoft.Extensions.Logging;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/EdFi.DataManagementService.Backend.Tests.Unit.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/EdFi.DataManagementService.Backend.Tests.Unit.csproj
@@ -21,15 +21,7 @@
         </PackageReference>
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Backend\EdFi.DataManagementService.Backend.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Backend/EdFi.DataManagementService.Backend.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/EdFi.DataManagementService.Backend.csproj
@@ -10,14 +10,6 @@
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core\EdFi.DataManagementService.Core.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Old.Postgresql.Tests.Integration/EdFi.DataManagementService.Old.Postgresql.Tests.Integration.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Old.Postgresql.Tests.Integration/EdFi.DataManagementService.Old.Postgresql.Tests.Integration.csproj
@@ -21,15 +21,7 @@
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="ImpromptuInterface" />
         <PackageReference Include="Respawn" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core\EdFi.DataManagementService.Core.csproj" />

--- a/src/dms/backend/EdFi.DataManagementService.Old.Postgresql/EdFi.DataManagementService.Old.Postgresql.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Old.Postgresql/EdFi.DataManagementService.Old.Postgresql.csproj
@@ -15,20 +15,12 @@
         <PackageReference Include="dbup-core" />
         <PackageReference Include="dbup-postgresql" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         <PackageReference Include="Npgsql" />
         <PackageReference Include="Npgsql.DependencyInjection" />
         <PackageReference Include="Polly.Core" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="JsonPath.Net" />
     </ItemGroup>
     <ItemGroup>

--- a/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration/EdFi.DataManagementService.ApiSchemaDownloader.Tests.Integration.csproj
@@ -14,14 +14,6 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Using Include="NUnit.Framework" />

--- a/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader/EdFi.DataManagementService.ApiSchemaDownloader.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.ApiSchemaDownloader/EdFi.DataManagementService.ApiSchemaDownloader.csproj
@@ -22,9 +22,5 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/dms/clis/EdFi.DataManagementService.OpenApiGenerator.Tests.Integration/EdFi.DataManagementService.OpenApiGenerator.Tests.Integration.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.OpenApiGenerator.Tests.Integration/EdFi.DataManagementService.OpenApiGenerator.Tests.Integration.csproj
@@ -14,14 +14,6 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Using Include="NUnit.Framework" />

--- a/src/dms/clis/EdFi.DataManagementService.OpenApiGenerator/EdFi.DataManagementService.OpenApiGenerator.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.OpenApiGenerator/EdFi.DataManagementService.OpenApiGenerator.csproj
@@ -19,10 +19,6 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/EdFi.DataManagementService.SchemaTools.Tests.Integration.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration/EdFi.DataManagementService.SchemaTools.Tests.Integration.csproj
@@ -17,14 +17,6 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Using Include="NUnit.Framework" />

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/EdFi.DataManagementService.SchemaTools.Tests.Unit.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Unit/EdFi.DataManagementService.SchemaTools.Tests.Unit.csproj
@@ -14,14 +14,6 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <Using Include="NUnit.Framework" />

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools/EdFi.DataManagementService.SchemaTools.csproj
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools/EdFi.DataManagementService.SchemaTools.csproj
@@ -18,10 +18,6 @@
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />
         <PackageReference Include="System.CommandLine" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />

--- a/src/dms/clis/EdFi.DataManagementService.SchemaTools/Provisioning/DatabaseProvisionerBase.cs
+++ b/src/dms/clis/EdFi.DataManagementService.SchemaTools/Provisioning/DatabaseProvisionerBase.cs
@@ -142,9 +142,13 @@ public abstract class DatabaseProvisionerBase(ILogger logger) : IDatabaseProvisi
             }
 
             if (!foundTables.Contains("ResourceKey"))
+            {
                 missingTables.Add(Dialect.MissingTableResourceKey);
+            }
             if (!foundTables.Contains("SchemaComponent"))
+            {
                 missingTables.Add(Dialect.MissingTableSchemaComponent);
+            }
         }
 
         if (missingTables.Count > 0)

--- a/src/dms/core/EdFi.DataManagementService.Core.External/EdFi.DataManagementService.Core.External.csproj
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/EdFi.DataManagementService.Core.External.csproj
@@ -9,14 +9,6 @@
     <ItemGroup>
         <PackageReference Include="Be.Vlaanderen.Basisregisters.Generators.Guid.Deterministic" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Logging" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="Sandwych.QuickGraph.Core" />

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/EdFi.DataManagementService.Core.Tests.Unit.csproj
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/EdFi.DataManagementService.Core.Tests.Unit.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -23,15 +23,7 @@
         <PackageReference Include="NUnit" />
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.msbuild" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="EdFi.DataStandard52.ApiSchema" />
     </ItemGroup>
     <ItemGroup>

--- a/src/dms/core/EdFi.DataManagementService.Core/EdFi.DataManagementService.Core.csproj
+++ b/src/dms/core/EdFi.DataManagementService.Core/EdFi.DataManagementService.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
@@ -15,10 +15,6 @@
         <PackageReference Include="Be.Vlaanderen.Basisregisters.Generators.Guid.Deterministic" />
         <PackageReference Include="FastGuid" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
@@ -37,10 +33,6 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="JsonSchema.Net" />
         <PackageReference Include="JsonPath.Net" />
     </ItemGroup>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.csproj
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.csproj
@@ -26,15 +26,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="coverlet.msbuild" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Frontend.AspNetCore\EdFi.DataManagementService.Frontend.AspNetCore.csproj" />

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/EdFi.DataManagementService.Frontend.AspNetCore.csproj
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/EdFi.DataManagementService.Frontend.AspNetCore.csproj
@@ -17,10 +17,6 @@
         <PackageReference Include="EdFi.DataStandard52.ApiSchema" />
         <PackageReference Include="EdFi.TPDM.ApiSchema" />
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Polly.Core" />
         <PackageReference Include="Polly.Extensions" />
         <PackageReference Include="Serilog" />
@@ -28,10 +24,6 @@
         <PackageReference Include="Serilog.Settings.Configuration" />
         <PackageReference Include="Serilog.Sinks.Console" />
         <PackageReference Include="Serilog.Sinks.File" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core\EdFi.DataManagementService.Core.csproj" />

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/EdFi.DataManagementService.Tests.E2E.csproj
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/EdFi.DataManagementService.Tests.E2E.csproj
@@ -44,15 +44,7 @@
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" />
         <PackageReference Include="Confluent.Kafka" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core.External\EdFi.DataManagementService.Core.External.csproj" />

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/EdFi.DataManagementService.Tests.Unit.csproj
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/EdFi.DataManagementService.Tests.Unit.csproj
@@ -21,15 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\EdFi.DataManagementService.Tests.E2E\EdFi.DataManagementService.Tests.E2E.csproj" />

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/EdFi.InstanceManagement.Tests.E2E.csproj
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/EdFi.InstanceManagement.Tests.E2E.csproj
@@ -44,15 +44,7 @@
         <PackageReference Include="Serilog.Sinks.File" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" />
-        <PackageReference Include="SonarAnalyzer.CSharp">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core.External\EdFi.DataManagementService.Core.External.csproj" />


### PR DESCRIPTION
## Summary 
                                                                                          
The two solution-level props files received the analyzer package references that were previously duplicated across every .csproj:                                                
         
  - src/dms/Directory.Build.props                                                                                                                                                  
  - src/config/Directory.Build.props                                                    
         
Both now include, alongside the existing TreatWarningsAsErrors=true / ErrorLog=results.sarif block, a single <ItemGroup> declaring Microsoft.CodeAnalysis.CSharp.CodeStyle and  SonarAnalyzer.CSharp as private analyzer assets. The 31 .csproj files under src/dms and src/config were trimmed accordingly — each lost its local copy of the same two  <PackageReference> blocks (≈229 lines removed vs. 25 added). Net effect: analyzers are configured once per solution, not per project, and TreatWarningsAsErrors now turns those analyzers into build gates everywhere.

Rules:
 
- S6605/S6602: Use collection-specific Find / Exists instead of FirstOrDefault / Any on List<T> and T[] (e.g. protocolMappers.FirstOrDefault(...) → protocolMappers.Find(...), canonicalTables.FirstOrDefault(...) → Array.Find(...))          
- S2325: Make method static when it doesn't touch instance state (private void ValidateResourceClaimExists<T> → private static)                			   
- S1066: Merge nested if blocks into a single condition with &&                                     
- S3267: Replace foreach+if with LINQ Where / Select projections                                    
- S121:  Add braces around single-statement if/foreach bodies                                       
- S3928: ArgumentException parameter name must match an actual parameter — fixed by qualifying with nameof(Type.Property) or, where a synthetic dotted name was needed for diagnostics, suppressed with a localized #pragma warning disable S3928                           	   
- S6667: Pass the exception as first argument to ILogger.LogXxx (LogWarning("...{Exception}", ex) → LogWarning(ex, "..."))                 												   
- S1481/IDE0059: Discard unused locals (byte version = reader.ReadByte() → _ = reader.ReadByte())           
- IDE0005: Remove unused using directives                                                             
- IDE0055: Formatting fixes (UTF-8 BOM stripped, whitespace normalized in csproj/cs)                  
- Test polish .ToList().Count() collapsed to FluentAssertions .Should().HaveCount(n) (count-comparison hygiene, matches CA1860 spirit)              											   

The rollout was scoped per area, one commit per assembly group: External → RelationalModel → Ddl → Plans → SchemaTools → Tests.Common → unit-test fixups, then the same sweep  through config/ (Backend, DataModel, Backend.Postgresql.Tests.Integration, Tests.E2E, Frontend.AspNetCore).