### PR TITLE
[DMS-1073] CMS info endpoint exposes CI-stamped build number

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -335,6 +335,7 @@ jobs:
     outputs:
       hash-code: ${{ steps.hash-code.outputs.hash-code }}
       dms-version: ${{ steps.versions.outputs.dms-v }}
+      assembly-version: ${{ steps.versions.outputs.cs-assembly-version }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -355,10 +356,47 @@ jobs:
       - name: Publish Config .NET Assemblies
         run: |
           $packageVersion = "${{ steps.versions.outputs.dms-semver }}" -replace "cs-v", ""
+          $assemblyVersion = "${{ steps.versions.outputs.cs-assembly-version }}"
 
           ./build-config.ps1 -Command BuildAndPublish `
               -Configuration Release `
-              -DmsCSVersion $packageVersion
+              -DmsCSVersion $packageVersion `
+              -DmsCSAssemblyVersion $assemblyVersion
+
+      - name: Verify Config DLL Version Stamp
+        run: |
+          $publishDir = "src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/publish"
+          $dllName = "EdFi.DmsConfigurationService.Frontend.AspNetCore.dll"
+
+          $dll = Get-ChildItem -Path $publishDir -Filter $dllName -Recurse | Select-Object -First 1
+          if ($null -eq $dll) {
+            Write-Error "DLL not found: $dllName under $publishDir"
+            exit 1
+          }
+
+          $expectedVersion = "${{ steps.versions.outputs.cs-assembly-version }}"
+          $semver = "${{ steps.versions.outputs.dms-semver }}" -replace "cs-v", ""
+          $normalizedAssemblyVersion = $expectedVersion
+
+          $assemblyName = [System.Reflection.AssemblyName]::GetAssemblyName($dll.FullName)
+          $dllAssemblyVersion = $assemblyName.Version.ToString()
+
+          $fileVersionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($dll.FullName)
+          $fileVersion = $fileVersionInfo.FileVersion
+          $productVersion = $fileVersionInfo.ProductVersion
+
+          Write-Output "Full semver:                  $semver"
+          Write-Output "Normalized assembly version:  $normalizedAssemblyVersion"
+          Write-Output "DLL assembly version:         $dllAssemblyVersion"
+          Write-Output "FileVersionInfo.FileVersion:  $fileVersion"
+          Write-Output "FileVersionInfo.ProductVersion: $productVersion"
+
+          if ($dllAssemblyVersion -ne $expectedVersion) {
+            Write-Error "Assembly version mismatch: expected '$expectedVersion' but DLL reports '$dllAssemblyVersion'"
+            exit 1
+          }
+
+          Write-Output "Assembly version stamp verified: $dllAssemblyVersion"
 
       - name: Create Config NuGet Package
         run: |
@@ -568,6 +606,7 @@ jobs:
     name: Publish Config to Docker Hub
     runs-on: ubuntu-latest
     needs:
+      - pack-cs
       - publish-package-cs
     steps:
       - name: Wait 20s
@@ -593,6 +632,7 @@ jobs:
           fi
 
           SEMVERSION=${PACKAGEVERSION:7}  # strip off the leading 'cs-pre-'
+
           echo "DMSTAGS=$DMSTAGS" >> $GITHUB_OUTPUT
           echo "VERSION=$SEMVERSION" >> $GITHUB_OUTPUT
 
@@ -617,7 +657,9 @@ jobs:
           context: "{{defaultContext}}:src/config"
           cache-from: type=registry,ref=${{ env.CONFIG_IMAGE_NAME }}:pre
           cache-to: type=inline
-          build-args: VERSION=${{ steps.prepare-tags.outputs.VERSION }}
+          build-args: |
+            VERSION=${{ steps.prepare-tags.outputs.VERSION }}
+            ASSEMBLY_VERSION=${{ needs.pack-cs.outputs.assembly-version }}
           file: Nuget.Dockerfile
           tags: ${{ steps.prepare-tags.outputs.DMSTAGS }}
           labels: ${{ steps.metadatamanagementservice.outputs.labels }}

--- a/build-config.ps1
+++ b/build-config.ps1
@@ -47,11 +47,18 @@ param(
     [ValidateSet("Clean", "Restore", "Build", "BuildAndPublish", "UnitTest", "E2ETest", "IntegrationTest", "Coverage", "Package", "Push", "DockerBuild", "DockerRun", "Run")]
     $Command = "Build",
 
-    # Assembly and package version number for the DMS Configuration Service. The
-    # current package number is configured in the build automation tool and
+    # Full semantic version for the DMS Configuration Service (e.g. "0.7.1-alpha.0.83").
+    # When non-empty, forwarded to MSBuild as /p:Version and /p:InformationalVersion.
+    # The current package number is configured in the build automation tool and
     # passed to this script.
     [string]
     $DmsCSVersion = "0.1",
+
+    # Normalized four-part assembly version (Major.Minor.Patch.Height, e.g. "0.7.1.83").
+    # When non-empty, forwarded to MSBuild as /p:AssemblyVersion and /p:FileVersion.
+    # Derived from $DmsCSVersion by the CI pipeline for prerelease builds.
+    [string]
+    $DmsCSAssemblyVersion = "",
 
     # .NET project build configuration, defaults to "Debug". Options are: Debug, Release.
     [string]
@@ -137,8 +144,20 @@ function SetDMSAssemblyInfo {
 
 function Compile {
     Invoke-Execute {
+        $versionArgs = @()
+        if (-not [string]::IsNullOrEmpty($DmsCSVersion))
+        {
+            $versionArgs += "/p:Version=$DmsCSVersion"
+            $versionArgs += "/p:InformationalVersion=$DmsCSVersion"
+            $versionArgs += "/p:VersionPrefix=$DmsCSVersion"
+        }
+        if (-not [string]::IsNullOrEmpty($DmsCSAssemblyVersion))
+        {
+            $versionArgs += "/p:AssemblyVersion=$DmsCSAssemblyVersion"
+            $versionArgs += "/p:FileVersion=$DmsCSAssemblyVersion"
+        }
 
-        dotnet build $defaultSolution -c $Configuration --nologo --no-restore
+        dotnet build $defaultSolution -c $Configuration --nologo --no-restore @versionArgs
     }
 }
 
@@ -146,7 +165,20 @@ function PublishApi {
     Invoke-Execute {
         $project = "$applicationRoot/$projectName/"
         $outputPath = "$project/publish"
-        dotnet publish $project -c $Configuration -o $outputPath --nologo
+        $versionArgs = @()
+        if (-not [string]::IsNullOrEmpty($DmsCSVersion))
+        {
+            $versionArgs += "/p:Version=$DmsCSVersion"
+            $versionArgs += "/p:InformationalVersion=$DmsCSVersion"
+            $versionArgs += "/p:VersionPrefix=$DmsCSVersion"
+        }
+        if (-not [string]::IsNullOrEmpty($DmsCSAssemblyVersion))
+        {
+            $versionArgs += "/p:AssemblyVersion=$DmsCSAssemblyVersion"
+            $versionArgs += "/p:FileVersion=$DmsCSAssemblyVersion"
+        }
+
+        dotnet publish $project -c $Configuration -o $outputPath --nologo @versionArgs
     }
 }
 
@@ -364,8 +396,20 @@ $dockerTagBase = "local"
 $dockerTagDMS = "$($dockerTagBase)/dms-configuration-service"
 
 function DockerBuild {
+    $versionArgs = @()
+    if (-not [string]::IsNullOrEmpty($DmsCSVersion))
+    {
+        $versionArgs += "--build-arg"
+        $versionArgs += "VERSION=$DmsCSVersion"
+    }
+    if (-not [string]::IsNullOrEmpty($DmsCSAssemblyVersion))
+    {
+        $versionArgs += "--build-arg"
+        $versionArgs += "ASSEMBLY_VERSION=$DmsCSAssemblyVersion"
+    }
+
     Push-Location src/config/
-    &docker buildx build -t $dockerTagDMS -f Dockerfile . --build-context parentdir=../
+    &docker buildx build -t $dockerTagDMS -f Dockerfile . --build-context parentdir=../ @versionArgs
     Pop-Location
 }
 

--- a/package-helpers.psm1
+++ b/package-helpers.psm1
@@ -30,8 +30,12 @@ function Get-VersionNumber {
     $dmsSemver = "$projectPrefix-v$($version)"
     "dms-semver=$dmsSemver" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
+    $assemblyVersion = Convert-ToAssemblyVersion $version
+    "$projectPrefix-assembly-version=$assemblyVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
     Write-Output "dms-v is set to: $version"
     Write-Output "dms-semver is set to: $dmsSemver"
+    Write-Output "$projectPrefix-assembly-version is set to: $assemblyVersion"
 }
 
 <#
@@ -133,4 +137,56 @@ function InstallCredentialHandler {
     Write-Host "The artifacts-credprovider was successfully installed" -ForegroundColor Green
 }
 
-Export-ModuleMember -Function Get-VersionNumber, Invoke-Promote, InstallCredentialHandler
+<#
+.SYNOPSIS
+Converts a MinVer-style semantic version string to a four-part assembly version.
+
+.DESCRIPTION
+Takes a MinVer-style semver (e.g. '0.7.1-alpha.0.83') and returns a four-part
+numeric version suitable for use as an assembly/file version (e.g. '0.7.1.83').
+
+Rules:
+  - Split on '-'; the first part supplies Major.Minor.Patch.
+  - If a pre-release tail is present, the last numeric segment of that tail
+    becomes the fourth part (build height). If no numeric segment exists, 0 is used.
+  - If there is no pre-release tail, the fourth part is 0.
+
+.PARAMETER Version
+The MinVer-style semver string to convert.
+
+.EXAMPLE
+Convert-ToAssemblyVersion '0.7.1-alpha.0.83'
+# Returns: 0.7.1.83
+
+.EXAMPLE
+Convert-ToAssemblyVersion '1.2.3'
+# Returns: 1.2.3.0
+#>
+function Convert-ToAssemblyVersion {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Version
+    )
+
+    $parts = $Version -split '-', 2
+    $mmp = $parts[0]
+
+    if ($parts.Length -gt 1) {
+        $prerelease = $parts[1]
+        $numericSegments = $prerelease -split '\.' | Where-Object { $_ -match '^\d+$' }
+        if ($numericSegments) {
+            $height = @($numericSegments)[-1]
+        }
+        else {
+            $height = 0
+        }
+    }
+    else {
+        $height = 0
+    }
+
+    return "$mmp.$height"
+}
+
+Export-ModuleMember -Function Get-VersionNumber, Invoke-Promote, InstallCredentialHandler, Convert-ToAssemblyVersion

--- a/src/config/Dockerfile
+++ b/src/config/Dockerfile
@@ -28,8 +28,19 @@ COPY backend/EdFi.DmsConfigurationService.Backend.Mssql/ ./backend/EdFi.DmsConfi
 COPY backend/EdFi.DmsConfigurationService.Backend.Postgresql/ ./backend/EdFi.DmsConfigurationService.Backend.Postgresql/
 COPY datamodel/EdFi.DmsConfigurationService.DataModel/ ./datamodel/EdFi.DmsConfigurationService.DataModel/
 
-RUN dotnet publish frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj \
-    -c Release --no-restore --self-contained false -o /app/Frontend
+ARG VERSION=""
+ARG ASSEMBLY_VERSION=""
+
+RUN version_args=""; \
+    if [ -n "$VERSION" ]; then \
+        version_args="$version_args /p:Version=$VERSION /p:InformationalVersion=$VERSION"; \
+    fi; \
+    if [ -n "$ASSEMBLY_VERSION" ]; then \
+        version_args="$version_args /p:AssemblyVersion=$ASSEMBLY_VERSION /p:FileVersion=$ASSEMBLY_VERSION"; \
+    fi; \
+    dotnet publish frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj \
+        -c Release --no-restore --self-contained false -o /app/Frontend \
+        $version_args
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0.3-alpine3.23@sha256:258b939d6d684ff05ad7ea16782b4bee55260de4acc6f99bec897fd11de7640c AS runtimebase
 

--- a/src/config/Nuget.Dockerfile
+++ b/src/config/Nuget.Dockerfile
@@ -12,11 +12,13 @@ RUN apk --no-cache add postgresql16-client
 FROM runtimebase AS setup
 
 ARG VERSION=0.0.0
+ARG ASSEMBLY_VERSION=0.0.0.0
 ENV ASPNETCORE_HTTP_PORTS=8080
 
 WORKDIR /app
 
 RUN echo "Tag Version:" $VERSION
+RUN echo "Assembly Version:" $ASSEMBLY_VERSION
 
 RUN wget -O /app/EdFi.DmsConfigurationService.zip "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_apis/packaging/feeds/EdFi/nuget/packages/EdFi.DmsConfigurationService/versions/${VERSION}/content" && \
     unzip /app/EdFi.DmsConfigurationService.zip -d /app/ && \

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Information/ApiInformation.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Information/ApiInformation.cs
@@ -7,11 +7,18 @@ namespace EdFi.DmsConfigurationService.DataModel.Model.Information;
 
 public class ApiInformation
 {
-    public ApiInformation(string version, string applicationName, string informationalVersion, ApiUrls urls)
+    public ApiInformation(
+        string version,
+        string applicationName,
+        string informationalVersion,
+        string build,
+        ApiUrls urls
+    )
     {
         Version = version;
         ApplicationName = applicationName;
         InformationalVersion = informationalVersion;
+        Build = build;
         Urls = urls;
     }
 
@@ -20,6 +27,8 @@ public class ApiInformation
     public string ApplicationName { get; }
 
     public string InformationalVersion { get; }
+
+    public string Build { get; }
 
     public ApiUrls Urls { get; }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
@@ -5,6 +5,7 @@
 
 using System.Net;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -55,8 +56,37 @@ public class InformationModuleTests
         jsonDoc.RootElement.TryGetProperty("version", out _).Should().BeTrue();
         jsonDoc.RootElement.TryGetProperty("applicationName", out _).Should().BeTrue();
         jsonDoc.RootElement.TryGetProperty("informationalVersion", out _).Should().BeTrue();
+        jsonDoc.RootElement.TryGetProperty("build", out var build).Should().BeTrue();
+        build.GetString().Should().NotBeNullOrEmpty();
         jsonDoc.RootElement.TryGetProperty("urls", out var urls).Should().BeTrue();
         urls.TryGetProperty("openApiMetadata", out _).Should().BeTrue();
+    }
+
+    [Test]
+    public async Task It_should_return_a_four_part_build_version()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/");
+        var content = await response.Content.ReadAsStringAsync();
+        var jsonDoc = JsonDocument.Parse(content);
+
+        // Assert
+        jsonDoc.RootElement.TryGetProperty("build", out var build).Should().BeTrue();
+        var buildValue = build.GetString();
+        buildValue.Should().NotBeNullOrEmpty();
+        Regex
+            .IsMatch(buildValue!, @"^\d+\.\d+\.\d+\.\d+$")
+            .Should()
+            .BeTrue(
+                because: $"build value '{buildValue}' should match the four-part numeric version pattern"
+            );
     }
 
     [Test]

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
@@ -24,6 +24,7 @@ public class InformationModule : IEndpointModule
             ApiVersionDetails.Version,
             ApiVersionDetails.ApplicationName,
             ApiVersionDetails.InformationalVersion,
+            ApiVersionDetails.Build,
             urls
         );
         return Results.Ok(response);

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Metadata.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Metadata.feature
@@ -12,12 +12,14 @@ Feature: Metadata endpoints
                       "version": "{*}",
                       "applicationName": "Ed-Fi Alliance DMS Configuration Service",
                       "informationalVersion": "{*}",
+                      "build": "{*}",
                       "urls": {
                           "openApiMetadata": "{*}"
                       }
                   }
                   """
               And the response contains metadata URLs
+              And the response body field "build" is non-empty and matches pattern "^\d+\.\d+\.\d+\.\d+$"
 
         Scenario: 02 Get OpenAPI specification
              When a GET request is made to "/metadata/specifications"

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/MetadataStepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/MetadataStepDefinitions.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
 using EdFi.DmsConfigurationService.Tests.E2E.Management;
 using FluentAssertions;
 using Reqnroll;
@@ -234,6 +235,24 @@ public class MetadataStepDefinitions(PlaywrightContext playwrightContext, Scenar
             var response = await _playwrightContext.ApiRequestContext!.GetAsync(url);
             response.Status.Should().Be(200, $"Metadata URL '{urlField}' at '{url}' should be accessible");
         }
+    }
+
+    [Then(@"the response body field {string} is non-empty and matches pattern {string}")]
+    public async Task ThenTheResponseBodyFieldIsNonEmptyAndMatchesPattern(string fieldName, string pattern)
+    {
+        var apiResponse = GetLastApiResponse();
+        string responseJsonString = await apiResponse.TextAsync();
+        JsonDocument responseJsonDoc = JsonDocument.Parse(responseJsonString);
+        JsonNode responseJson = JsonNode.Parse(responseJsonDoc.RootElement.ToString())!;
+
+        responseJson[fieldName].Should().NotBeNull($"Response should contain '{fieldName}' field");
+
+        var fieldValue = responseJson[fieldName]!.ToString();
+        fieldValue.Should().NotBeNullOrEmpty($"Field '{fieldName}' should not be empty");
+        Regex
+            .IsMatch(fieldValue, pattern)
+            .Should()
+            .BeTrue($"Field '{fieldName}' value '{fieldValue}' should match pattern '{pattern}'");
     }
 
     private Microsoft.Playwright.IAPIResponse GetLastApiResponse()


### PR DESCRIPTION
## Summary
- Adds a `build` field to the CMS `GET /` API information response, surfaced from `Assembly.GetExecutingAssembly().GetName().Version`.
- Wires CI version flow end-to-end: workflow computes a four-part assembly version from the MinVer semver via a new `Convert-ToAssemblyVersion` helper, forwards both values through `build-config.ps1` to MSBuild as `/p:Version`, `/p:InformationalVersion`, `/p:AssemblyVersion`, `/p:FileVersion`, and a post-publish step verifies the published DLL was actually stamped.
- Stamps the source `Dockerfile` via `ARG VERSION` / `ARG ASSEMBLY_VERSION` (empty defaults preserve local/PR behavior); `Nuget.Dockerfile` echoes `ASSEMBLY_VERSION` for diagnostics on the release path.

## Test plan
- [x] Unit: `InformationModuleTests` asserts `build` is non-empty and matches `^\d+\.\d+\.\d+\.\d+$` (241 tests pass)
- [x] Local stamped publish: `build-config.ps1 BuildAndPublish -DmsCSVersion 0.7.1-alpha.0.83 -DmsCSAssemblyVersion 0.7.1.83` → DLL `AssemblyVersion=0.7.1.83`, `FileVersion=0.7.1.83`, `ProductVersion=0.7.1-alpha.0.83+<sha>`
- [x] Source Dockerfile build with stamping args → in-image DLL stamped `0.7.1.83`
- [x] Source Dockerfile build with no args → falls back to MSBuild default (unchanged from prior behavior)
- [x] Release workflow wiring verified: `pack-cs` outputs `assembly-version`; `docker-publish-cs` declares `needs: [pack-cs, ...]`; both `VERSION` and `ASSEMBLY_VERSION` build-args forwarded
- [ ] CMS E2E `Metadata.feature` runtime assertion (covered by GitHub Actions on this PR)