### PR TITLE
[DMS-1121] ReferentialIdentity trigger formatting parity for DateTime and decimal

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/identity-propagation.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/identity-propagation.json
@@ -4,12 +4,12 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "b21b92e6554ad108168f4c2dff1e27fe601a9d68d1ec8d246d2df0e66f73c123",
+      "normalized_sql_sha256": "8fb90c533639bd5d1b1e511a8584dd278cb9bcb63d75cb1620178f496f192eb8",
       "statement_count": 83
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "6c8680185d8b01b951509f556d76533e54e592fd7cbe056ea906de28e0a68733",
+      "normalized_sql_sha256": "6609fa3c0c9ed31933f4a28257db4a2be293f013b7c2a3f59093a5b603816b4a",
       "statement_count": 64
     }
   ]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/mssql/identity-propagation.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/mssql/identity-propagation.sql
@@ -133,7 +133,7 @@ BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
         WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 2;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.schoolReference.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max)) + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.entryDate=' + CONVERT(nvarchar(10), i.[EntryDate], 23) + N'#' + N'$.entryTimestamp=' + CONVERT(nvarchar(19), i.[EntryTimestamp], 126) + N'#' + N'$.isActive=' + CASE WHEN i.[IsActive] = 1 THEN N'true' ELSE N'false' END), i.[DocumentId], 2
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.schoolReference.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max)) + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.entryDate=' + CONVERT(nvarchar(10), i.[EntryDate], 23) + N'#' + N'$.entryTimestamp=' + CONVERT(nvarchar(19), i.[EntryTimestamp], 126) + N'Z' + N'#' + N'$.isActive=' + CASE WHEN i.[IsActive] = 1 THEN N'true' ELSE N'false' END), i.[DocumentId], 2
         FROM inserted i;
     END
     ELSE IF (UPDATE([SchoolId]) OR UPDATE([StudentUniqueId]) OR UPDATE([EntryDate]) OR UPDATE([EntryTimestamp]) OR UPDATE([IsActive]))
@@ -146,7 +146,7 @@ BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
         WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 2;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.schoolReference.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max)) + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.entryDate=' + CONVERT(nvarchar(10), i.[EntryDate], 23) + N'#' + N'$.entryTimestamp=' + CONVERT(nvarchar(19), i.[EntryTimestamp], 126) + N'#' + N'$.isActive=' + CASE WHEN i.[IsActive] = 1 THEN N'true' ELSE N'false' END), i.[DocumentId], 2
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.schoolReference.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max)) + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.entryDate=' + CONVERT(nvarchar(10), i.[EntryDate], 23) + N'#' + N'$.entryTimestamp=' + CONVERT(nvarchar(19), i.[EntryTimestamp], 126) + N'Z' + N'#' + N'$.isActive=' + CASE WHEN i.[IsActive] = 1 THEN N'true' ELSE N'false' END), i.[DocumentId], 2
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/pgsql/identity-propagation.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/pgsql/identity-propagation.sql
@@ -92,7 +92,7 @@ BEGIN
         DELETE FROM "dms"."ReferentialIdentity"
         WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 2;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudentSchoolAssociation' || '$.schoolReference.schoolId=' || NEW."SchoolId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentUniqueId"::text || '#' || '$.entryDate=' || NEW."EntryDate"::text || '#' || '$.entryTimestamp=' || to_char(NEW."EntryTimestamp", 'YYYY-MM-DD"T"HH24:MI:SS') || '#' || '$.isActive=' || NEW."IsActive"::text), NEW."DocumentId", 2);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudentSchoolAssociation' || '$.schoolReference.schoolId=' || NEW."SchoolId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentUniqueId"::text || '#' || '$.entryDate=' || NEW."EntryDate"::text || '#' || '$.entryTimestamp=' || to_char(NEW."EntryTimestamp" AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') || '#' || '$.isActive=' || NEW."IsActive"::text), NEW."DocumentId", 2);
     END IF;
     RETURN NEW;
 END;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/ddl.manifest.json
@@ -1,16 +1,16 @@
 {
-  "effective_schema_hash": "944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874",
+  "effective_schema_hash": "9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3",
   "relational_mapping_version": "v1",
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "79ca37590574eb1119963798075de95a4164578953d57d6fa431542b91fb8b04",
-      "statement_count": 143
+      "normalized_sql_sha256": "9a529b89994ce54abf43b2b7c988600f72ce273b603885791ffae627514525ae",
+      "statement_count": 160
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "b7c4d5ddb32127d36a76d87bcca8cef392098c99ac5c1301c58494bdee4e21d2",
-      "statement_count": 149
+      "normalized_sql_sha256": "ad5a494744176b4f77a5729bb9fa9e42527defcbec769178360759056fea7d38",
+      "statement_count": 178
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/effective-schema.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/effective-schema.manifest.json
@@ -1,69 +1,87 @@
 {
   "api_schema_format_version": "1.0.0",
   "relational_mapping_version": "v1",
-  "effective_schema_hash": "944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874",
-  "resource_key_count": 9,
-  "resource_key_seed_hash": "ad599c265d1176cee04b8add1d0e42f19fe7fe9a6f4089154b38b249334bed95",
+  "effective_schema_hash": "9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3",
+  "resource_key_count": 12,
+  "resource_key_seed_hash": "cf22bda16c6555c3f9f4f106f8ba65c2461e58fc300892b4fbb958648ba026d1",
   "schema_components": [
     {
       "project_endpoint_name": "ed-fi",
       "project_name": "Ed-Fi",
       "project_version": "5.0.0",
       "is_extension_project": false,
-      "project_hash": "c8817887d5bc51bd4c383008fe396cb7b1af0d7924ce48bdcbcd67a256815350"
+      "project_hash": "c0e134d83d997f1c7efb3ad496fab6afee4617d745704322cf5b7e2911f35ac9"
     }
   ],
   "resource_keys": [
     {
       "resource_key_id": 1,
       "project_name": "Ed-Fi",
-      "resource_name": "EdOrgDependentChildResource",
+      "resource_name": "DateTimeKeyResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 2,
       "project_name": "Ed-Fi",
-      "resource_name": "EdOrgDependentResource",
+      "resource_name": "DecimalKeyResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 3,
       "project_name": "Ed-Fi",
-      "resource_name": "EducationOrganization",
+      "resource_name": "DecimalRefResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 4,
       "project_name": "Ed-Fi",
-      "resource_name": "KeyUnifiedResource",
+      "resource_name": "EdOrgDependentChildResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 5,
       "project_name": "Ed-Fi",
-      "resource_name": "ResourceA",
+      "resource_name": "EdOrgDependentResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 6,
       "project_name": "Ed-Fi",
-      "resource_name": "ResourceB",
+      "resource_name": "EducationOrganization",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 7,
       "project_name": "Ed-Fi",
-      "resource_name": "School",
+      "resource_name": "KeyUnifiedResource",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 8,
       "project_name": "Ed-Fi",
-      "resource_name": "Student",
+      "resource_name": "ResourceA",
       "resource_version": "5.0.0"
     },
     {
       "resource_key_id": 9,
+      "project_name": "Ed-Fi",
+      "resource_name": "ResourceB",
+      "resource_version": "5.0.0"
+    },
+    {
+      "resource_key_id": 10,
+      "project_name": "Ed-Fi",
+      "resource_name": "School",
+      "resource_version": "5.0.0"
+    },
+    {
+      "resource_key_id": 11,
+      "project_name": "Ed-Fi",
+      "resource_name": "Student",
+      "resource_version": "5.0.0"
+    },
+    {
+      "resource_key_id": 12,
       "project_name": "Ed-Fi",
       "resource_name": "StudentSchoolAssociation",
       "resource_version": "5.0.0"

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/mssql.sql
@@ -9,9 +9,9 @@ IF OBJECT_ID(N'dms.EffectiveSchema', N'U') IS NOT NULL
 BEGIN
     SELECT @preflight_stored_hash = [EffectiveSchemaHash] FROM [dms].[EffectiveSchema]
     WHERE [EffectiveSchemaSingletonId] = 1;
-    IF @preflight_stored_hash IS NOT NULL AND @preflight_stored_hash <> N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874'
+    IF @preflight_stored_hash IS NOT NULL AND @preflight_stored_hash <> N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3'
     BEGIN
-        DECLARE @preflight_msg nvarchar(500) = CONCAT(N'EffectiveSchemaHash mismatch: database has ''', @preflight_stored_hash, N''' but expected ''', N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874', N'''');
+        DECLARE @preflight_msg nvarchar(500) = CONCAT(N'EffectiveSchemaHash mismatch: database has ''', @preflight_stored_hash, N''' but expected ''', N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3', N'''');
         THROW 50000, @preflight_msg, 1;
     END
 END
@@ -440,6 +440,37 @@ IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'edfi')
 IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'auth')
     EXEC('CREATE SCHEMA [auth]');
 
+IF OBJECT_ID(N'edfi.DateTimeKeyResource', N'U') IS NULL
+CREATE TABLE [edfi].[DateTimeKeyResource]
+(
+    [DocumentId] bigint NOT NULL,
+    [EventTimestamp] datetime2(7) NOT NULL,
+    CONSTRAINT [PK_DateTimeKeyResource] PRIMARY KEY ([DocumentId]),
+    CONSTRAINT [UX_DateTimeKeyResource_NK] UNIQUE ([EventTimestamp])
+);
+
+IF OBJECT_ID(N'edfi.DecimalKeyResource', N'U') IS NULL
+CREATE TABLE [edfi].[DecimalKeyResource]
+(
+    [DocumentId] bigint NOT NULL,
+    [DecimalKey] decimal(9,2) NOT NULL,
+    CONSTRAINT [PK_DecimalKeyResource] PRIMARY KEY ([DocumentId]),
+    CONSTRAINT [UX_DecimalKeyResource_NK] UNIQUE ([DecimalKey]),
+    CONSTRAINT [UX_DecimalKeyResource_RefKey] UNIQUE ([DocumentId], [DecimalKey])
+);
+
+IF OBJECT_ID(N'edfi.DecimalRefResource', N'U') IS NULL
+CREATE TABLE [edfi].[DecimalRefResource]
+(
+    [DocumentId] bigint NOT NULL,
+    [DecimalKeyReference_DocumentId] bigint NOT NULL,
+    [DecimalKeyReference_DecimalKey] decimal(9,2) NOT NULL,
+    [RefResourceId] nvarchar(64) NOT NULL,
+    CONSTRAINT [PK_DecimalRefResource] PRIMARY KEY ([DocumentId]),
+    CONSTRAINT [UX_DecimalRefResource_NK] UNIQUE ([RefResourceId], [DecimalKeyReference_DocumentId]),
+    CONSTRAINT [CK_DecimalRefResource_DecimalKeyReference_AllNone] CHECK (([DecimalKeyReference_DocumentId] IS NULL AND [DecimalKeyReference_DecimalKey] IS NULL) OR ([DecimalKeyReference_DocumentId] IS NOT NULL AND [DecimalKeyReference_DecimalKey] IS NOT NULL))
+);
+
 IF OBJECT_ID(N'edfi.EdOrgDependentChildResource', N'U') IS NULL
 CREATE TABLE [edfi].[EdOrgDependentChildResource]
 (
@@ -563,6 +594,50 @@ CREATE TABLE [edfi].[EducationOrganizationIdentity]
     CONSTRAINT [UX_EducationOrganizationIdentity_NK] UNIQUE ([EducationOrganizationId]),
     CONSTRAINT [UX_EducationOrganizationIdentity_RefKey] UNIQUE ([DocumentId], [EducationOrganizationId])
 );
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DateTimeKeyResource_Document' AND parent_object_id = OBJECT_ID(N'edfi.DateTimeKeyResource')
+)
+ALTER TABLE [edfi].[DateTimeKeyResource]
+ADD CONSTRAINT [FK_DateTimeKeyResource_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DecimalKeyResource_Document' AND parent_object_id = OBJECT_ID(N'edfi.DecimalKeyResource')
+)
+ALTER TABLE [edfi].[DecimalKeyResource]
+ADD CONSTRAINT [FK_DecimalKeyResource_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DecimalRefResource_DecimalKeyReference_RefKey' AND parent_object_id = OBJECT_ID(N'edfi.DecimalRefResource')
+)
+ALTER TABLE [edfi].[DecimalRefResource]
+ADD CONSTRAINT [FK_DecimalRefResource_DecimalKeyReference_RefKey]
+FOREIGN KEY ([DecimalKeyReference_DocumentId], [DecimalKeyReference_DecimalKey])
+REFERENCES [edfi].[DecimalKeyResource] ([DocumentId], [DecimalKey])
+ON DELETE NO ACTION
+ON UPDATE NO ACTION;
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.foreign_keys
+    WHERE name = N'FK_DecimalRefResource_Document' AND parent_object_id = OBJECT_ID(N'edfi.DecimalRefResource')
+)
+ALTER TABLE [edfi].[DecimalRefResource]
+ADD CONSTRAINT [FK_DecimalRefResource_Document]
+FOREIGN KEY ([DocumentId])
+REFERENCES [dms].[Document] ([DocumentId])
+ON DELETE CASCADE
+ON UPDATE NO ACTION;
 
 IF NOT EXISTS (
     SELECT 1 FROM sys.foreign_keys
@@ -752,6 +827,14 @@ IF NOT EXISTS (
     SELECT 1 FROM sys.indexes i
     JOIN sys.tables t ON i.object_id = t.object_id
     JOIN sys.schemas s ON t.schema_id = s.schema_id
+    WHERE s.name = N'edfi' AND t.name = N'DecimalRefResource' AND i.name = N'IX_DecimalRefResource_DecimalKeyReference_DocumentId_DecimalKeyReference_DecimalKey'
+)
+CREATE INDEX [IX_DecimalRefResource_DecimalKeyReference_DocumentId_DecimalKeyReference_DecimalKey] ON [edfi].[DecimalRefResource] ([DecimalKeyReference_DocumentId], [DecimalKeyReference_DecimalKey]);
+
+IF NOT EXISTS (
+    SELECT 1 FROM sys.indexes i
+    JOIN sys.tables t ON i.object_id = t.object_id
+    JOIN sys.schemas s ON t.schema_id = s.schema_id
     WHERE s.name = N'edfi' AND t.name = N'EdOrgDependentChildResource' AND i.name = N'IX_EdOrgDependentChildResource_EdOrgDependentResourceReference_DocumentId'
 )
 CREATE INDEX [IX_EdOrgDependentChildResource_EdOrgDependentResourceReference_DocumentId] ON [edfi].[EdOrgDependentChildResource] ([EdOrgDependentResourceReference_DocumentId]);
@@ -811,8 +894,8 @@ FROM [edfi].[School]
 ;
 
 GO
-CREATE OR ALTER TRIGGER [edfi].[TR_EdOrgDependentChildResource_ReferentialIdentity]
-ON [edfi].[EdOrgDependentChildResource]
+CREATE OR ALTER TRIGGER [edfi].[TR_DateTimeKeyResource_ReferentialIdentity]
+ON [edfi].[DateTimeKeyResource]
 AFTER INSERT, UPDATE
 AS
 BEGIN
@@ -822,7 +905,196 @@ BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
         WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 1;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentChildResource' AS nvarchar(max)) + N'$.edOrgDependentChildResourceId=' + i.[EdOrgDependentChildResourceId] + N'#' + N'$.edOrgDependentResourceReference.edOrgDependentResourceId=' + i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] + N'#' + N'$.edOrgDependentResourceReference.educationOrganizationId=' + CAST(i.[EdOrgDependentResourceReference_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 1
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDateTimeKeyResource' AS nvarchar(max)) + N'$.eventTimestamp=' + CONVERT(nvarchar(19), i.[EventTimestamp], 126) + N'Z'), i.[DocumentId], 1
+        FROM inserted i;
+    END
+    ELSE IF (UPDATE([EventTimestamp]))
+    BEGIN
+        DECLARE @changedDocs TABLE ([DocumentId] bigint NOT NULL);
+        INSERT INTO @changedDocs ([DocumentId])
+        SELECT i.[DocumentId]
+        FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
+        WHERE (i.[EventTimestamp] <> d.[EventTimestamp] OR (i.[EventTimestamp] IS NULL AND d.[EventTimestamp] IS NOT NULL) OR (i.[EventTimestamp] IS NOT NULL AND d.[EventTimestamp] IS NULL));
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 1;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDateTimeKeyResource' AS nvarchar(max)) + N'$.eventTimestamp=' + CONVERT(nvarchar(19), i.[EventTimestamp], 126) + N'Z'), i.[DocumentId], 1
+        FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_DateTimeKeyResource_Stamp]
+ON [edfi].[DateTimeKeyResource]
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    ;WITH affectedDocs AS (
+        SELECT i.[DocumentId]
+        FROM inserted i
+        LEFT JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE del.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[EventTimestamp] <> del.[EventTimestamp] OR (i.[EventTimestamp] IS NULL AND del.[EventTimestamp] IS NOT NULL) OR (i.[EventTimestamp] IS NOT NULL AND del.[EventTimestamp] IS NULL))
+        UNION
+        SELECT del.[DocumentId]
+        FROM deleted del
+        LEFT JOIN inserted i ON i.[DocumentId] = del.[DocumentId]
+        WHERE i.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[EventTimestamp] <> del.[EventTimestamp] OR (i.[EventTimestamp] IS NULL AND del.[EventTimestamp] IS NOT NULL) OR (i.[EventTimestamp] IS NOT NULL AND del.[EventTimestamp] IS NULL))
+    )
+    UPDATE d
+    SET d.[ContentVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[ContentLastModifiedAt] = sysutcdatetime()
+    FROM [dms].[Document] d
+    INNER JOIN affectedDocs a ON d.[DocumentId] = a.[DocumentId];
+    IF EXISTS (SELECT 1 FROM deleted) AND (UPDATE([EventTimestamp]))
+    BEGIN
+        UPDATE d
+        SET d.[IdentityVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[IdentityLastModifiedAt] = sysutcdatetime()
+        FROM [dms].[Document] d
+        INNER JOIN inserted i ON d.[DocumentId] = i.[DocumentId]
+        INNER JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE (i.[EventTimestamp] <> del.[EventTimestamp] OR (i.[EventTimestamp] IS NULL AND del.[EventTimestamp] IS NOT NULL) OR (i.[EventTimestamp] IS NOT NULL AND del.[EventTimestamp] IS NULL));
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_DecimalKeyResource_ReferentialIdentity]
+ON [edfi].[DecimalKeyResource]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 2;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDecimalKeyResource' AS nvarchar(max)) + N'$.decimalKey=' + CASE WHEN CHARINDEX(N'.', CAST(i.[DecimalKey] AS nvarchar(max))) = 0 THEN CAST(i.[DecimalKey] AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max))))) ELSE LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max)))) + 1) END END), i.[DocumentId], 2
+        FROM inserted i;
+    END
+    ELSE IF (UPDATE([DecimalKey]))
+    BEGIN
+        DECLARE @changedDocs TABLE ([DocumentId] bigint NOT NULL);
+        INSERT INTO @changedDocs ([DocumentId])
+        SELECT i.[DocumentId]
+        FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
+        WHERE (i.[DecimalKey] <> d.[DecimalKey] OR (i.[DecimalKey] IS NULL AND d.[DecimalKey] IS NOT NULL) OR (i.[DecimalKey] IS NOT NULL AND d.[DecimalKey] IS NULL));
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 2;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDecimalKeyResource' AS nvarchar(max)) + N'$.decimalKey=' + CASE WHEN CHARINDEX(N'.', CAST(i.[DecimalKey] AS nvarchar(max))) = 0 THEN CAST(i.[DecimalKey] AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max))))) ELSE LEFT(CAST(i.[DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKey] AS nvarchar(max)))) + 1) END END), i.[DocumentId], 2
+        FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_DecimalKeyResource_Stamp]
+ON [edfi].[DecimalKeyResource]
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    ;WITH affectedDocs AS (
+        SELECT i.[DocumentId]
+        FROM inserted i
+        LEFT JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE del.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[DecimalKey] <> del.[DecimalKey] OR (i.[DecimalKey] IS NULL AND del.[DecimalKey] IS NOT NULL) OR (i.[DecimalKey] IS NOT NULL AND del.[DecimalKey] IS NULL))
+        UNION
+        SELECT del.[DocumentId]
+        FROM deleted del
+        LEFT JOIN inserted i ON i.[DocumentId] = del.[DocumentId]
+        WHERE i.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[DecimalKey] <> del.[DecimalKey] OR (i.[DecimalKey] IS NULL AND del.[DecimalKey] IS NOT NULL) OR (i.[DecimalKey] IS NOT NULL AND del.[DecimalKey] IS NULL))
+    )
+    UPDATE d
+    SET d.[ContentVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[ContentLastModifiedAt] = sysutcdatetime()
+    FROM [dms].[Document] d
+    INNER JOIN affectedDocs a ON d.[DocumentId] = a.[DocumentId];
+    IF EXISTS (SELECT 1 FROM deleted) AND (UPDATE([DecimalKey]))
+    BEGIN
+        UPDATE d
+        SET d.[IdentityVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[IdentityLastModifiedAt] = sysutcdatetime()
+        FROM [dms].[Document] d
+        INNER JOIN inserted i ON d.[DocumentId] = i.[DocumentId]
+        INNER JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE (i.[DecimalKey] <> del.[DecimalKey] OR (i.[DecimalKey] IS NULL AND del.[DecimalKey] IS NOT NULL) OR (i.[DecimalKey] IS NOT NULL AND del.[DecimalKey] IS NULL));
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_DecimalRefResource_ReferentialIdentity]
+ON [edfi].[DecimalRefResource]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 3;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDecimalRefResource' AS nvarchar(max)) + N'$.refResourceId=' + i.[RefResourceId] + N'#' + N'$.decimalKeyReference.decimalKey=' + CASE WHEN CHARINDEX(N'.', CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) = 0 THEN CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))))) ELSE LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)))) + 1) END END), i.[DocumentId], 3
+        FROM inserted i;
+    END
+    ELSE IF (UPDATE([RefResourceId]) OR UPDATE([DecimalKeyReference_DecimalKey]))
+    BEGIN
+        DECLARE @changedDocs TABLE ([DocumentId] bigint NOT NULL);
+        INSERT INTO @changedDocs ([DocumentId])
+        SELECT i.[DocumentId]
+        FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
+        WHERE (CAST(i.[RefResourceId] AS varbinary(max)) <> CAST(d.[RefResourceId] AS varbinary(max)) OR (i.[RefResourceId] IS NULL AND d.[RefResourceId] IS NOT NULL) OR (i.[RefResourceId] IS NOT NULL AND d.[RefResourceId] IS NULL)) OR (i.[DecimalKeyReference_DecimalKey] <> d.[DecimalKeyReference_DecimalKey] OR (i.[DecimalKeyReference_DecimalKey] IS NULL AND d.[DecimalKeyReference_DecimalKey] IS NOT NULL) OR (i.[DecimalKeyReference_DecimalKey] IS NOT NULL AND d.[DecimalKeyReference_DecimalKey] IS NULL));
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 3;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiDecimalRefResource' AS nvarchar(max)) + N'$.refResourceId=' + i.[RefResourceId] + N'#' + N'$.decimalKeyReference.decimalKey=' + CASE WHEN CHARINDEX(N'.', CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) = 0 THEN CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))))) ELSE LEFT(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)), LEN(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.[DecimalKeyReference_DecimalKey] AS nvarchar(max)))) + 1) END END), i.[DocumentId], 3
+        FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_DecimalRefResource_Stamp]
+ON [edfi].[DecimalRefResource]
+AFTER INSERT, UPDATE, DELETE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    ;WITH affectedDocs AS (
+        SELECT i.[DocumentId]
+        FROM inserted i
+        LEFT JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE del.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[DecimalKeyReference_DocumentId] <> del.[DecimalKeyReference_DocumentId] OR (i.[DecimalKeyReference_DocumentId] IS NULL AND del.[DecimalKeyReference_DocumentId] IS NOT NULL) OR (i.[DecimalKeyReference_DocumentId] IS NOT NULL AND del.[DecimalKeyReference_DocumentId] IS NULL)) OR (i.[DecimalKeyReference_DecimalKey] <> del.[DecimalKeyReference_DecimalKey] OR (i.[DecimalKeyReference_DecimalKey] IS NULL AND del.[DecimalKeyReference_DecimalKey] IS NOT NULL) OR (i.[DecimalKeyReference_DecimalKey] IS NOT NULL AND del.[DecimalKeyReference_DecimalKey] IS NULL)) OR (CAST(i.[RefResourceId] AS varbinary(max)) <> CAST(del.[RefResourceId] AS varbinary(max)) OR (i.[RefResourceId] IS NULL AND del.[RefResourceId] IS NOT NULL) OR (i.[RefResourceId] IS NOT NULL AND del.[RefResourceId] IS NULL))
+        UNION
+        SELECT del.[DocumentId]
+        FROM deleted del
+        LEFT JOIN inserted i ON i.[DocumentId] = del.[DocumentId]
+        WHERE i.[DocumentId] IS NULL OR (i.[DocumentId] <> del.[DocumentId] OR (i.[DocumentId] IS NULL AND del.[DocumentId] IS NOT NULL) OR (i.[DocumentId] IS NOT NULL AND del.[DocumentId] IS NULL)) OR (i.[DecimalKeyReference_DocumentId] <> del.[DecimalKeyReference_DocumentId] OR (i.[DecimalKeyReference_DocumentId] IS NULL AND del.[DecimalKeyReference_DocumentId] IS NOT NULL) OR (i.[DecimalKeyReference_DocumentId] IS NOT NULL AND del.[DecimalKeyReference_DocumentId] IS NULL)) OR (i.[DecimalKeyReference_DecimalKey] <> del.[DecimalKeyReference_DecimalKey] OR (i.[DecimalKeyReference_DecimalKey] IS NULL AND del.[DecimalKeyReference_DecimalKey] IS NOT NULL) OR (i.[DecimalKeyReference_DecimalKey] IS NOT NULL AND del.[DecimalKeyReference_DecimalKey] IS NULL)) OR (CAST(i.[RefResourceId] AS varbinary(max)) <> CAST(del.[RefResourceId] AS varbinary(max)) OR (i.[RefResourceId] IS NULL AND del.[RefResourceId] IS NOT NULL) OR (i.[RefResourceId] IS NOT NULL AND del.[RefResourceId] IS NULL))
+    )
+    UPDATE d
+    SET d.[ContentVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[ContentLastModifiedAt] = sysutcdatetime()
+    FROM [dms].[Document] d
+    INNER JOIN affectedDocs a ON d.[DocumentId] = a.[DocumentId];
+    IF EXISTS (SELECT 1 FROM deleted) AND (UPDATE([RefResourceId]) OR UPDATE([DecimalKeyReference_DecimalKey]))
+    BEGIN
+        UPDATE d
+        SET d.[IdentityVersion] = NEXT VALUE FOR [dms].[ChangeVersionSequence], d.[IdentityLastModifiedAt] = sysutcdatetime()
+        FROM [dms].[Document] d
+        INNER JOIN inserted i ON d.[DocumentId] = i.[DocumentId]
+        INNER JOIN deleted del ON del.[DocumentId] = i.[DocumentId]
+        WHERE (CAST(i.[RefResourceId] AS varbinary(max)) <> CAST(del.[RefResourceId] AS varbinary(max)) OR (i.[RefResourceId] IS NULL AND del.[RefResourceId] IS NOT NULL) OR (i.[RefResourceId] IS NOT NULL AND del.[RefResourceId] IS NULL)) OR (i.[DecimalKeyReference_DecimalKey] <> del.[DecimalKeyReference_DecimalKey] OR (i.[DecimalKeyReference_DecimalKey] IS NULL AND del.[DecimalKeyReference_DecimalKey] IS NOT NULL) OR (i.[DecimalKeyReference_DecimalKey] IS NOT NULL AND del.[DecimalKeyReference_DecimalKey] IS NULL));
+    END
+END;
+GO
+
+CREATE OR ALTER TRIGGER [edfi].[TR_EdOrgDependentChildResource_ReferentialIdentity]
+ON [edfi].[EdOrgDependentChildResource]
+AFTER INSERT, UPDATE
+AS
+BEGIN
+    SET NOCOUNT ON;
+    IF NOT EXISTS (SELECT 1 FROM deleted)
+    BEGIN
+        DELETE FROM [dms].[ReferentialIdentity]
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 4;
+        INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentChildResource' AS nvarchar(max)) + N'$.edOrgDependentChildResourceId=' + i.[EdOrgDependentChildResourceId] + N'#' + N'$.edOrgDependentResourceReference.edOrgDependentResourceId=' + i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] + N'#' + N'$.edOrgDependentResourceReference.educationOrganizationId=' + CAST(i.[EdOrgDependentResourceReference_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 4
         FROM inserted i;
     END
     ELSE IF (UPDATE([EdOrgDependentChildResourceId]) OR UPDATE([EdOrgDependentResourceReference_EdOrgDependentResourceId]) OR UPDATE([EdOrgDependentResourceReference_EducationOrganizationId]))
@@ -833,9 +1105,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[EdOrgDependentChildResourceId] AS varbinary(max)) <> CAST(d.[EdOrgDependentChildResourceId] AS varbinary(max)) OR (i.[EdOrgDependentChildResourceId] IS NULL AND d.[EdOrgDependentChildResourceId] IS NOT NULL) OR (i.[EdOrgDependentChildResourceId] IS NOT NULL AND d.[EdOrgDependentChildResourceId] IS NULL)) OR (CAST(i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] AS varbinary(max)) <> CAST(d.[EdOrgDependentResourceReference_EdOrgDependentResourceId] AS varbinary(max)) OR (i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] IS NULL AND d.[EdOrgDependentResourceReference_EdOrgDependentResourceId] IS NOT NULL) OR (i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] IS NOT NULL AND d.[EdOrgDependentResourceReference_EdOrgDependentResourceId] IS NULL)) OR (i.[EdOrgDependentResourceReference_EducationOrganizationId] <> d.[EdOrgDependentResourceReference_EducationOrganizationId] OR (i.[EdOrgDependentResourceReference_EducationOrganizationId] IS NULL AND d.[EdOrgDependentResourceReference_EducationOrganizationId] IS NOT NULL) OR (i.[EdOrgDependentResourceReference_EducationOrganizationId] IS NOT NULL AND d.[EdOrgDependentResourceReference_EducationOrganizationId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 1;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 4;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentChildResource' AS nvarchar(max)) + N'$.edOrgDependentChildResourceId=' + i.[EdOrgDependentChildResourceId] + N'#' + N'$.edOrgDependentResourceReference.edOrgDependentResourceId=' + i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] + N'#' + N'$.edOrgDependentResourceReference.educationOrganizationId=' + CAST(i.[EdOrgDependentResourceReference_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 1
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentChildResource' AS nvarchar(max)) + N'$.edOrgDependentChildResourceId=' + i.[EdOrgDependentChildResourceId] + N'#' + N'$.edOrgDependentResourceReference.edOrgDependentResourceId=' + i.[EdOrgDependentResourceReference_EdOrgDependentResourceId] + N'#' + N'$.edOrgDependentResourceReference.educationOrganizationId=' + CAST(i.[EdOrgDependentResourceReference_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 4
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -908,9 +1180,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 2;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 5;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentResource' AS nvarchar(max)) + N'$.edOrgDependentResourceId=' + i.[EdOrgDependentResourceId] + N'#' + N'$.educationOrganizationReference.educationOrganizationId=' + CAST(i.[EducationOrganization_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 2
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentResource' AS nvarchar(max)) + N'$.edOrgDependentResourceId=' + i.[EdOrgDependentResourceId] + N'#' + N'$.educationOrganizationReference.educationOrganizationId=' + CAST(i.[EducationOrganization_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 5
         FROM inserted i;
     END
     ELSE IF (UPDATE([EdOrgDependentResourceId]) OR UPDATE([EducationOrganization_EducationOrganizationId]))
@@ -921,9 +1193,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[EdOrgDependentResourceId] AS varbinary(max)) <> CAST(d.[EdOrgDependentResourceId] AS varbinary(max)) OR (i.[EdOrgDependentResourceId] IS NULL AND d.[EdOrgDependentResourceId] IS NOT NULL) OR (i.[EdOrgDependentResourceId] IS NOT NULL AND d.[EdOrgDependentResourceId] IS NULL)) OR (i.[EducationOrganization_EducationOrganizationId] <> d.[EducationOrganization_EducationOrganizationId] OR (i.[EducationOrganization_EducationOrganizationId] IS NULL AND d.[EducationOrganization_EducationOrganizationId] IS NOT NULL) OR (i.[EducationOrganization_EducationOrganizationId] IS NOT NULL AND d.[EducationOrganization_EducationOrganizationId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 2;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 5;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentResource' AS nvarchar(max)) + N'$.edOrgDependentResourceId=' + i.[EdOrgDependentResourceId] + N'#' + N'$.educationOrganizationReference.educationOrganizationId=' + CAST(i.[EducationOrganization_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 2
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEdOrgDependentResource' AS nvarchar(max)) + N'$.edOrgDependentResourceId=' + i.[EdOrgDependentResourceId] + N'#' + N'$.educationOrganizationReference.educationOrganizationId=' + CAST(i.[EducationOrganization_EducationOrganizationId] AS nvarchar(max))), i.[DocumentId], 5
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -996,9 +1268,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 4;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 7;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiKeyUnifiedResource' AS nvarchar(max)) + N'$.keyUnifiedResourceId=' + i.[KeyUnifiedResourceId] + N'#' + N'$.resourceAReference.resourceAId=' + i.[ResourceAReference_ResourceAId] + N'#' + N'$.resourceAReference.studentUniqueId=' + i.[ResourceAReference_StudentUniqueId] + N'#' + N'$.resourceBReference.resourceBId=' + i.[ResourceBReference_ResourceBId] + N'#' + N'$.resourceBReference.studentUniqueId=' + i.[ResourceBReference_StudentUniqueId]), i.[DocumentId], 4
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiKeyUnifiedResource' AS nvarchar(max)) + N'$.keyUnifiedResourceId=' + i.[KeyUnifiedResourceId] + N'#' + N'$.resourceAReference.resourceAId=' + i.[ResourceAReference_ResourceAId] + N'#' + N'$.resourceAReference.studentUniqueId=' + i.[ResourceAReference_StudentUniqueId] + N'#' + N'$.resourceBReference.resourceBId=' + i.[ResourceBReference_ResourceBId] + N'#' + N'$.resourceBReference.studentUniqueId=' + i.[ResourceBReference_StudentUniqueId]), i.[DocumentId], 7
         FROM inserted i;
     END
     ELSE IF (UPDATE([KeyUnifiedResourceId]) OR UPDATE([ResourceAReference_ResourceAId]) OR UPDATE([StudentUniqueId_Unified]) OR UPDATE([ResourceBReference_ResourceBId]))
@@ -1009,9 +1281,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[KeyUnifiedResourceId] AS varbinary(max)) <> CAST(d.[KeyUnifiedResourceId] AS varbinary(max)) OR (i.[KeyUnifiedResourceId] IS NULL AND d.[KeyUnifiedResourceId] IS NOT NULL) OR (i.[KeyUnifiedResourceId] IS NOT NULL AND d.[KeyUnifiedResourceId] IS NULL)) OR (CAST(i.[ResourceAReference_ResourceAId] AS varbinary(max)) <> CAST(d.[ResourceAReference_ResourceAId] AS varbinary(max)) OR (i.[ResourceAReference_ResourceAId] IS NULL AND d.[ResourceAReference_ResourceAId] IS NOT NULL) OR (i.[ResourceAReference_ResourceAId] IS NOT NULL AND d.[ResourceAReference_ResourceAId] IS NULL)) OR (CAST(i.[StudentUniqueId_Unified] AS varbinary(max)) <> CAST(d.[StudentUniqueId_Unified] AS varbinary(max)) OR (i.[StudentUniqueId_Unified] IS NULL AND d.[StudentUniqueId_Unified] IS NOT NULL) OR (i.[StudentUniqueId_Unified] IS NOT NULL AND d.[StudentUniqueId_Unified] IS NULL)) OR (CAST(i.[ResourceBReference_ResourceBId] AS varbinary(max)) <> CAST(d.[ResourceBReference_ResourceBId] AS varbinary(max)) OR (i.[ResourceBReference_ResourceBId] IS NULL AND d.[ResourceBReference_ResourceBId] IS NOT NULL) OR (i.[ResourceBReference_ResourceBId] IS NOT NULL AND d.[ResourceBReference_ResourceBId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 4;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 7;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiKeyUnifiedResource' AS nvarchar(max)) + N'$.keyUnifiedResourceId=' + i.[KeyUnifiedResourceId] + N'#' + N'$.resourceAReference.resourceAId=' + i.[ResourceAReference_ResourceAId] + N'#' + N'$.resourceAReference.studentUniqueId=' + i.[ResourceAReference_StudentUniqueId] + N'#' + N'$.resourceBReference.resourceBId=' + i.[ResourceBReference_ResourceBId] + N'#' + N'$.resourceBReference.studentUniqueId=' + i.[ResourceBReference_StudentUniqueId]), i.[DocumentId], 4
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiKeyUnifiedResource' AS nvarchar(max)) + N'$.keyUnifiedResourceId=' + i.[KeyUnifiedResourceId] + N'#' + N'$.resourceAReference.resourceAId=' + i.[ResourceAReference_ResourceAId] + N'#' + N'$.resourceAReference.studentUniqueId=' + i.[ResourceAReference_StudentUniqueId] + N'#' + N'$.resourceBReference.resourceBId=' + i.[ResourceBReference_ResourceBId] + N'#' + N'$.resourceBReference.studentUniqueId=' + i.[ResourceBReference_StudentUniqueId]), i.[DocumentId], 7
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1084,9 +1356,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 5;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 8;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceA' AS nvarchar(max)) + N'$.resourceAId=' + i.[ResourceAId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 5
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceA' AS nvarchar(max)) + N'$.resourceAId=' + i.[ResourceAId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 8
         FROM inserted i;
     END
     ELSE IF (UPDATE([ResourceAId]) OR UPDATE([StudentReference_StudentUniqueId]))
@@ -1097,9 +1369,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[ResourceAId] AS varbinary(max)) <> CAST(d.[ResourceAId] AS varbinary(max)) OR (i.[ResourceAId] IS NULL AND d.[ResourceAId] IS NOT NULL) OR (i.[ResourceAId] IS NOT NULL AND d.[ResourceAId] IS NULL)) OR (CAST(i.[StudentReference_StudentUniqueId] AS varbinary(max)) <> CAST(d.[StudentReference_StudentUniqueId] AS varbinary(max)) OR (i.[StudentReference_StudentUniqueId] IS NULL AND d.[StudentReference_StudentUniqueId] IS NOT NULL) OR (i.[StudentReference_StudentUniqueId] IS NOT NULL AND d.[StudentReference_StudentUniqueId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 5;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 8;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceA' AS nvarchar(max)) + N'$.resourceAId=' + i.[ResourceAId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 5
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceA' AS nvarchar(max)) + N'$.resourceAId=' + i.[ResourceAId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 8
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1172,9 +1444,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 6;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 9;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceB' AS nvarchar(max)) + N'$.resourceBId=' + i.[ResourceBId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 6
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceB' AS nvarchar(max)) + N'$.resourceBId=' + i.[ResourceBId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 9
         FROM inserted i;
     END
     ELSE IF (UPDATE([ResourceBId]) OR UPDATE([StudentReference_StudentUniqueId]))
@@ -1185,9 +1457,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[ResourceBId] AS varbinary(max)) <> CAST(d.[ResourceBId] AS varbinary(max)) OR (i.[ResourceBId] IS NULL AND d.[ResourceBId] IS NOT NULL) OR (i.[ResourceBId] IS NOT NULL AND d.[ResourceBId] IS NULL)) OR (CAST(i.[StudentReference_StudentUniqueId] AS varbinary(max)) <> CAST(d.[StudentReference_StudentUniqueId] AS varbinary(max)) OR (i.[StudentReference_StudentUniqueId] IS NULL AND d.[StudentReference_StudentUniqueId] IS NOT NULL) OR (i.[StudentReference_StudentUniqueId] IS NOT NULL AND d.[StudentReference_StudentUniqueId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 6;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 9;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceB' AS nvarchar(max)) + N'$.resourceBId=' + i.[ResourceBId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 6
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiResourceB' AS nvarchar(max)) + N'$.resourceBId=' + i.[ResourceBId] + N'#' + N'$.studentReference.studentUniqueId=' + i.[StudentReference_StudentUniqueId]), i.[DocumentId], 9
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1324,14 +1596,14 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 7;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 10;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiSchool' AS nvarchar(max)) + N'$.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 7
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiSchool' AS nvarchar(max)) + N'$.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 10
         FROM inserted i;
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 3;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 6;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEducationOrganization' AS nvarchar(max)) + N'$.educationOrganizationId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 3
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEducationOrganization' AS nvarchar(max)) + N'$.educationOrganizationId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 6
         FROM inserted i;
     END
     ELSE IF (UPDATE([SchoolId]))
@@ -1342,14 +1614,14 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (i.[SchoolId] <> d.[SchoolId] OR (i.[SchoolId] IS NULL AND d.[SchoolId] IS NOT NULL) OR (i.[SchoolId] IS NOT NULL AND d.[SchoolId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 7;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 10;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiSchool' AS nvarchar(max)) + N'$.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 7
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiSchool' AS nvarchar(max)) + N'$.schoolId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 10
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 3;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 6;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEducationOrganization' AS nvarchar(max)) + N'$.educationOrganizationId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 3
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiEducationOrganization' AS nvarchar(max)) + N'$.educationOrganizationId=' + CAST(i.[SchoolId] AS nvarchar(max))), i.[DocumentId], 6
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1430,9 +1702,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 8;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 11;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 8
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 11
         FROM inserted i;
     END
     ELSE IF (UPDATE([StudentUniqueId]))
@@ -1443,9 +1715,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(d.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND d.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND d.[StudentUniqueId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 8;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 11;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 8
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudent' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId]), i.[DocumentId], 11
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1493,9 +1765,9 @@ BEGIN
     IF NOT EXISTS (SELECT 1 FROM deleted)
     BEGIN
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 9;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM inserted) AND [ResourceKeyId] = 12;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.schoolReference.schoolId=' + CAST(i.[SchoolReference_SchoolId] AS nvarchar(max))), i.[DocumentId], 9
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.schoolReference.schoolId=' + CAST(i.[SchoolReference_SchoolId] AS nvarchar(max))), i.[DocumentId], 12
         FROM inserted i;
     END
     ELSE IF (UPDATE([StudentUniqueId]) OR UPDATE([SchoolReference_SchoolId]))
@@ -1506,9 +1778,9 @@ BEGIN
         FROM inserted i INNER JOIN deleted d ON d.[DocumentId] = i.[DocumentId]
         WHERE (CAST(i.[StudentUniqueId] AS varbinary(max)) <> CAST(d.[StudentUniqueId] AS varbinary(max)) OR (i.[StudentUniqueId] IS NULL AND d.[StudentUniqueId] IS NOT NULL) OR (i.[StudentUniqueId] IS NOT NULL AND d.[StudentUniqueId] IS NULL)) OR (i.[SchoolReference_SchoolId] <> d.[SchoolReference_SchoolId] OR (i.[SchoolReference_SchoolId] IS NULL AND d.[SchoolReference_SchoolId] IS NOT NULL) OR (i.[SchoolReference_SchoolId] IS NOT NULL AND d.[SchoolReference_SchoolId] IS NULL));
         DELETE FROM [dms].[ReferentialIdentity]
-        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 9;
+        WHERE [DocumentId] IN (SELECT [DocumentId] FROM @changedDocs) AND [ResourceKeyId] = 12;
         INSERT INTO [dms].[ReferentialIdentity] ([ReferentialId], [DocumentId], [ResourceKeyId])
-        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.schoolReference.schoolId=' + CAST(i.[SchoolReference_SchoolId] AS nvarchar(max))), i.[DocumentId], 9
+        SELECT [dms].[uuidv5]('edf1edf1-3df1-3df1-3df1-3df1edf1edf1', CAST(N'Ed-FiStudentSchoolAssociation' AS nvarchar(max)) + N'$.studentUniqueId=' + i.[StudentUniqueId] + N'#' + N'$.schoolReference.schoolId=' + CAST(i.[SchoolReference_SchoolId] AS nvarchar(max))), i.[DocumentId], 12
         FROM inserted i INNER JOIN @changedDocs cd ON cd.[DocumentId] = i.[DocumentId];
     END
 END;
@@ -1554,31 +1826,40 @@ GO
 -- ResourceKey seed inserts (insert-if-missing)
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 1)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (1, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0');
+    VALUES (1, N'Ed-Fi', N'DateTimeKeyResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 2)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (2, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0');
+    VALUES (2, N'Ed-Fi', N'DecimalKeyResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 3)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (3, N'Ed-Fi', N'EducationOrganization', N'5.0.0');
+    VALUES (3, N'Ed-Fi', N'DecimalRefResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 4)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (4, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0');
+    VALUES (4, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 5)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (5, N'Ed-Fi', N'ResourceA', N'5.0.0');
+    VALUES (5, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 6)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (6, N'Ed-Fi', N'ResourceB', N'5.0.0');
+    VALUES (6, N'Ed-Fi', N'EducationOrganization', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 7)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (7, N'Ed-Fi', N'School', N'5.0.0');
+    VALUES (7, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 8)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (8, N'Ed-Fi', N'Student', N'5.0.0');
+    VALUES (8, N'Ed-Fi', N'ResourceA', N'5.0.0');
 IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 9)
     INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
-    VALUES (9, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0');
+    VALUES (9, N'Ed-Fi', N'ResourceB', N'5.0.0');
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 10)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (10, N'Ed-Fi', N'School', N'5.0.0');
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 11)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (11, N'Ed-Fi', N'Student', N'5.0.0');
+IF NOT EXISTS (SELECT 1 FROM [dms].[ResourceKey] WHERE [ResourceKeyId] = 12)
+    INSERT INTO [dms].[ResourceKey] ([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
+    VALUES (12, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0');
 
 -- ResourceKey full-table validation (count + content)
 DECLARE @actual_count integer;
@@ -1586,9 +1867,9 @@ DECLARE @mismatched_count integer;
 DECLARE @rk_mismatched_ids nvarchar(max);
 
 SELECT @actual_count = COUNT(*) FROM [dms].[ResourceKey];
-IF @actual_count <> 9
+IF @actual_count <> 12
 BEGIN
-    DECLARE @rk_count_msg nvarchar(200) = CONCAT(N'dms.ResourceKey count mismatch: expected 9, found ', CAST(@actual_count AS nvarchar(10)));
+    DECLARE @rk_count_msg nvarchar(200) = CONCAT(N'dms.ResourceKey count mismatch: expected 12, found ', CAST(@actual_count AS nvarchar(10)));
     THROW 50000, @rk_count_msg, 1;
 END
 
@@ -1596,15 +1877,18 @@ SELECT @mismatched_count = COUNT(*)
 FROM [dms].[ResourceKey] rk
 WHERE NOT EXISTS (
     SELECT 1 FROM (VALUES
-        (1, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0'),
-        (2, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0'),
-        (3, N'Ed-Fi', N'EducationOrganization', N'5.0.0'),
-        (4, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0'),
-        (5, N'Ed-Fi', N'ResourceA', N'5.0.0'),
-        (6, N'Ed-Fi', N'ResourceB', N'5.0.0'),
-        (7, N'Ed-Fi', N'School', N'5.0.0'),
-        (8, N'Ed-Fi', N'Student', N'5.0.0'),
-        (9, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0')
+        (1, N'Ed-Fi', N'DateTimeKeyResource', N'5.0.0'),
+        (2, N'Ed-Fi', N'DecimalKeyResource', N'5.0.0'),
+        (3, N'Ed-Fi', N'DecimalRefResource', N'5.0.0'),
+        (4, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0'),
+        (5, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0'),
+        (6, N'Ed-Fi', N'EducationOrganization', N'5.0.0'),
+        (7, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0'),
+        (8, N'Ed-Fi', N'ResourceA', N'5.0.0'),
+        (9, N'Ed-Fi', N'ResourceB', N'5.0.0'),
+        (10, N'Ed-Fi', N'School', N'5.0.0'),
+        (11, N'Ed-Fi', N'Student', N'5.0.0'),
+        (12, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0')
     ) AS expected([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
     WHERE expected.[ResourceKeyId] = rk.[ResourceKeyId]
     AND expected.[ProjectName] = rk.[ProjectName]
@@ -1619,15 +1903,18 @@ BEGIN
         FROM [dms].[ResourceKey] rk
         WHERE NOT EXISTS (
             SELECT 1 FROM (VALUES
-                (1, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0'),
-                (2, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0'),
-                (3, N'Ed-Fi', N'EducationOrganization', N'5.0.0'),
-                (4, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0'),
-                (5, N'Ed-Fi', N'ResourceA', N'5.0.0'),
-                (6, N'Ed-Fi', N'ResourceB', N'5.0.0'),
-                (7, N'Ed-Fi', N'School', N'5.0.0'),
-                (8, N'Ed-Fi', N'Student', N'5.0.0'),
-                (9, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0')
+                (1, N'Ed-Fi', N'DateTimeKeyResource', N'5.0.0'),
+                (2, N'Ed-Fi', N'DecimalKeyResource', N'5.0.0'),
+                (3, N'Ed-Fi', N'DecimalRefResource', N'5.0.0'),
+                (4, N'Ed-Fi', N'EdOrgDependentChildResource', N'5.0.0'),
+                (5, N'Ed-Fi', N'EdOrgDependentResource', N'5.0.0'),
+                (6, N'Ed-Fi', N'EducationOrganization', N'5.0.0'),
+                (7, N'Ed-Fi', N'KeyUnifiedResource', N'5.0.0'),
+                (8, N'Ed-Fi', N'ResourceA', N'5.0.0'),
+                (9, N'Ed-Fi', N'ResourceB', N'5.0.0'),
+                (10, N'Ed-Fi', N'School', N'5.0.0'),
+                (11, N'Ed-Fi', N'Student', N'5.0.0'),
+                (12, N'Ed-Fi', N'StudentSchoolAssociation', N'5.0.0')
             ) AS expected([ResourceKeyId], [ProjectName], [ResourceName], [ResourceVersion])
             WHERE expected.[ResourceKeyId] = rk.[ResourceKeyId]
             AND expected.[ProjectName] = rk.[ProjectName]
@@ -1643,7 +1930,7 @@ END
 -- EffectiveSchema singleton insert-if-missing
 IF NOT EXISTS (SELECT 1 FROM [dms].[EffectiveSchema] WHERE [EffectiveSchemaSingletonId] = 1)
     INSERT INTO [dms].[EffectiveSchema] ([EffectiveSchemaSingletonId], [ApiSchemaFormatVersion], [EffectiveSchemaHash], [ResourceKeyCount], [ResourceKeySeedHash])
-    VALUES (1, N'1.0.0', N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874', 9, 0xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95);
+    VALUES (1, N'1.0.0', N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3', 12, 0xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1);
 
 -- EffectiveSchema validation (ApiSchemaFormatVersion + ResourceKeyCount + ResourceKeySeedHash)
 DECLARE @es_stored_api_schema_format_version nvarchar(255);
@@ -1659,29 +1946,29 @@ BEGIN
     BEGIN
         THROW 50000, N'dms.EffectiveSchema.ApiSchemaFormatVersion must not be empty.', 1;
     END
-    IF @es_stored_count <> 9
+    IF @es_stored_count <> 12
     BEGIN
-        DECLARE @es_count_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeyCount mismatch: expected 9, found ', CAST(@es_stored_count AS nvarchar(10)));
+        DECLARE @es_count_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeyCount mismatch: expected 12, found ', CAST(@es_stored_count AS nvarchar(10)));
         THROW 50000, @es_count_msg, 1;
     END
-    IF @es_stored_hash <> 0xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95
+    IF @es_stored_hash <> 0xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1
     BEGIN
-        DECLARE @es_hash_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored ', CONVERT(nvarchar(66), @es_stored_hash, 1), N' but expected ', CONVERT(nvarchar(66), 0xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95, 1));
+        DECLARE @es_hash_msg nvarchar(200) = CONCAT(N'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored ', CONVERT(nvarchar(66), @es_stored_hash, 1), N' but expected ', CONVERT(nvarchar(66), 0xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1, 1));
         THROW 50000, @es_hash_msg, 1;
     END
 END
 
 -- SchemaComponent seed inserts (insert-if-missing)
-IF NOT EXISTS (SELECT 1 FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874' AND [ProjectEndpointName] = N'ed-fi')
+IF NOT EXISTS (SELECT 1 FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3' AND [ProjectEndpointName] = N'ed-fi')
     INSERT INTO [dms].[SchemaComponent] ([EffectiveSchemaHash], [ProjectEndpointName], [ProjectName], [ProjectVersion], [IsExtensionProject])
-    VALUES (N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874', N'ed-fi', N'Ed-Fi', N'5.0.0', 0);
+    VALUES (N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3', N'ed-fi', N'Ed-Fi', N'5.0.0', 0);
 
 -- SchemaComponent exact-match validation (count + content)
 DECLARE @sc_actual_count integer;
 DECLARE @sc_mismatched_count integer;
 DECLARE @sc_mismatched_names nvarchar(max);
 
-SELECT @sc_actual_count = COUNT(*) FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874';
+SELECT @sc_actual_count = COUNT(*) FROM [dms].[SchemaComponent] WHERE [EffectiveSchemaHash] = N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3';
 IF @sc_actual_count <> 1
 BEGIN
     DECLARE @sc_count_msg nvarchar(200) = CONCAT(N'dms.SchemaComponent count mismatch: expected 1, found ', CAST(@sc_actual_count AS nvarchar(10)));
@@ -1690,7 +1977,7 @@ END
 
 SELECT @sc_mismatched_count = COUNT(*)
 FROM [dms].[SchemaComponent] sc
-WHERE sc.[EffectiveSchemaHash] = N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874'
+WHERE sc.[EffectiveSchemaHash] = N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3'
 AND NOT EXISTS (
     SELECT 1 FROM (VALUES
         (N'ed-fi', N'Ed-Fi', N'5.0.0', 0)
@@ -1706,7 +1993,7 @@ BEGIN
     FROM (
         SELECT TOP 10 sc.[ProjectEndpointName]
         FROM [dms].[SchemaComponent] sc
-        WHERE sc.[EffectiveSchemaHash] = N'944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874'
+        WHERE sc.[EffectiveSchemaHash] = N'9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3'
         AND NOT EXISTS (
             SELECT 1 FROM (VALUES
                 (N'ed-fi', N'Ed-Fi', N'5.0.0', 0)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
@@ -10,8 +10,8 @@ BEGIN
     IF to_regclass('"dms"."EffectiveSchema"') IS NOT NULL THEN
         SELECT "EffectiveSchemaHash" INTO _stored_hash FROM "dms"."EffectiveSchema"
         WHERE "EffectiveSchemaSingletonId" = 1;
-        IF _stored_hash IS NOT NULL AND _stored_hash <> '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874' THEN
-            RAISE EXCEPTION 'EffectiveSchemaHash mismatch: database has ''%'' but expected ''%''', _stored_hash, '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874';
+        IF _stored_hash IS NOT NULL AND _stored_hash <> '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3' THEN
+            RAISE EXCEPTION 'EffectiveSchemaHash mismatch: database has ''%'' but expected ''%''', _stored_hash, '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3';
         END IF;
     END IF;
 END $$;
@@ -456,6 +456,34 @@ CREATE TRIGGER "TR_Document_Journal"
 CREATE SCHEMA IF NOT EXISTS "edfi";
 CREATE SCHEMA IF NOT EXISTS "auth";
 
+CREATE TABLE IF NOT EXISTS "edfi"."DateTimeKeyResource"
+(
+    "DocumentId" bigint NOT NULL,
+    "EventTimestamp" timestamp with time zone NOT NULL,
+    CONSTRAINT "PK_DateTimeKeyResource" PRIMARY KEY ("DocumentId"),
+    CONSTRAINT "UX_DateTimeKeyResource_NK" UNIQUE ("EventTimestamp")
+);
+
+CREATE TABLE IF NOT EXISTS "edfi"."DecimalKeyResource"
+(
+    "DocumentId" bigint NOT NULL,
+    "DecimalKey" numeric(9,2) NOT NULL,
+    CONSTRAINT "PK_DecimalKeyResource" PRIMARY KEY ("DocumentId"),
+    CONSTRAINT "UX_DecimalKeyResource_NK" UNIQUE ("DecimalKey"),
+    CONSTRAINT "UX_DecimalKeyResource_RefKey" UNIQUE ("DocumentId", "DecimalKey")
+);
+
+CREATE TABLE IF NOT EXISTS "edfi"."DecimalRefResource"
+(
+    "DocumentId" bigint NOT NULL,
+    "DecimalKeyReference_DocumentId" bigint NOT NULL,
+    "DecimalKeyReference_DecimalKey" numeric(9,2) NOT NULL,
+    "RefResourceId" varchar(64) NOT NULL,
+    CONSTRAINT "PK_DecimalRefResource" PRIMARY KEY ("DocumentId"),
+    CONSTRAINT "UX_DecimalRefResource_NK" UNIQUE ("RefResourceId", "DecimalKeyReference_DocumentId"),
+    CONSTRAINT "CK_DecimalRefResource_DecimalKeyReference_AllNone" CHECK (("DecimalKeyReference_DocumentId" IS NULL AND "DecimalKeyReference_DecimalKey" IS NULL) OR ("DecimalKeyReference_DocumentId" IS NOT NULL AND "DecimalKeyReference_DecimalKey" IS NOT NULL))
+);
+
 CREATE TABLE IF NOT EXISTS "edfi"."EdOrgDependentChildResource"
 (
     "DocumentId" bigint NOT NULL,
@@ -569,6 +597,74 @@ CREATE TABLE IF NOT EXISTS "edfi"."EducationOrganizationIdentity"
     CONSTRAINT "UX_EducationOrganizationIdentity_NK" UNIQUE ("EducationOrganizationId"),
     CONSTRAINT "UX_EducationOrganizationIdentity_RefKey" UNIQUE ("DocumentId", "EducationOrganizationId")
 );
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DateTimeKeyResource_Document'
+        AND conrelid = to_regclass('"edfi"."DateTimeKeyResource"')
+    )
+    THEN
+        ALTER TABLE "edfi"."DateTimeKeyResource"
+        ADD CONSTRAINT "FK_DateTimeKeyResource_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DecimalKeyResource_Document'
+        AND conrelid = to_regclass('"edfi"."DecimalKeyResource"')
+    )
+    THEN
+        ALTER TABLE "edfi"."DecimalKeyResource"
+        ADD CONSTRAINT "FK_DecimalKeyResource_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DecimalRefResource_DecimalKeyReference_RefKey'
+        AND conrelid = to_regclass('"edfi"."DecimalRefResource"')
+    )
+    THEN
+        ALTER TABLE "edfi"."DecimalRefResource"
+        ADD CONSTRAINT "FK_DecimalRefResource_DecimalKeyReference_RefKey"
+        FOREIGN KEY ("DecimalKeyReference_DocumentId", "DecimalKeyReference_DecimalKey")
+        REFERENCES "edfi"."DecimalKeyResource" ("DocumentId", "DecimalKey")
+        ON DELETE NO ACTION
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'FK_DecimalRefResource_Document'
+        AND conrelid = to_regclass('"edfi"."DecimalRefResource"')
+    )
+    THEN
+        ALTER TABLE "edfi"."DecimalRefResource"
+        ADD CONSTRAINT "FK_DecimalRefResource_Document"
+        FOREIGN KEY ("DocumentId")
+        REFERENCES "dms"."Document" ("DocumentId")
+        ON DELETE CASCADE
+        ON UPDATE NO ACTION;
+    END IF;
+END $$;
 
 DO $$
 BEGIN
@@ -844,6 +940,8 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS "IX_EducationOrganizationIdToEducationOrganizationId_Target" ON "auth"."EducationOrganizationIdToEducationOrganizationId" ("TargetEducationOrganizationId") INCLUDE ("SourceEducationOrganizationId");
 
+CREATE INDEX IF NOT EXISTS "IX_DecimalRefResource_DecimalKeyReference_DocumentId_1972800496" ON "edfi"."DecimalRefResource" ("DecimalKeyReference_DocumentId", "DecimalKeyReference_DecimalKey");
+
 CREATE INDEX IF NOT EXISTS "IX_EdOrgDependentChildResource_EdOrgDependentResourc_42d6c19595" ON "edfi"."EdOrgDependentChildResource" ("EdOrgDependentResourceReference_DocumentId", "EdOrgDependentResourceReference_EdOrgDependentResourceId", "EdOrgDependentResourceReference_EducationOrganizationId");
 
 CREATE INDEX IF NOT EXISTS "IX_EdOrgDependentResource_EducationOrganization_Docu_abaf527b99" ON "edfi"."EdOrgDependentResource" ("EducationOrganization_DocumentId", "EducationOrganization_EducationOrganizationId");
@@ -863,14 +961,167 @@ SELECT "DocumentId" AS "DocumentId", "SchoolId" AS "EducationOrganizationId", 'E
 FROM "edfi"."School"
 ;
 
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DateTimeKeyResource_ReferentialIdentity"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'INSERT' OR (OLD."EventTimestamp" IS DISTINCT FROM NEW."EventTimestamp") THEN
+        DELETE FROM "dms"."ReferentialIdentity"
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 1;
+        INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiDateTimeKeyResource' || '$.eventTimestamp=' || to_char(NEW."EventTimestamp" AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')), NEW."DocumentId", 1);
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DateTimeKeyResource_ReferentialIdentity" ON "edfi"."DateTimeKeyResource";
+CREATE TRIGGER "TR_DateTimeKeyResource_ReferentialIdentity"
+AFTER INSERT OR UPDATE ON "edfi"."DateTimeKeyResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DateTimeKeyResource_ReferentialIdentity"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DateTimeKeyResource_Stamp"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = OLD."DocumentId";
+        RETURN OLD;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NOT (OLD."DocumentId" IS DISTINCT FROM NEW."DocumentId" OR OLD."EventTimestamp" IS DISTINCT FROM NEW."EventTimestamp") THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    IF TG_OP = 'UPDATE' AND (OLD."EventTimestamp" IS DISTINCT FROM NEW."EventTimestamp") THEN
+        UPDATE "dms"."Document"
+        SET "IdentityVersion" = nextval('"dms"."ChangeVersionSequence"'), "IdentityLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DateTimeKeyResource_Stamp" ON "edfi"."DateTimeKeyResource";
+CREATE TRIGGER "TR_DateTimeKeyResource_Stamp"
+BEFORE INSERT OR UPDATE OR DELETE ON "edfi"."DateTimeKeyResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DateTimeKeyResource_Stamp"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DecimalKeyResource_ReferentialIdentity"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'INSERT' OR (OLD."DecimalKey" IS DISTINCT FROM NEW."DecimalKey") THEN
+        DELETE FROM "dms"."ReferentialIdentity"
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 2;
+        INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiDecimalKeyResource' || '$.decimalKey=' || regexp_replace(regexp_replace(NEW."DecimalKey"::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')), NEW."DocumentId", 2);
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DecimalKeyResource_ReferentialIdentity" ON "edfi"."DecimalKeyResource";
+CREATE TRIGGER "TR_DecimalKeyResource_ReferentialIdentity"
+AFTER INSERT OR UPDATE ON "edfi"."DecimalKeyResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DecimalKeyResource_ReferentialIdentity"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DecimalKeyResource_Stamp"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = OLD."DocumentId";
+        RETURN OLD;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NOT (OLD."DocumentId" IS DISTINCT FROM NEW."DocumentId" OR OLD."DecimalKey" IS DISTINCT FROM NEW."DecimalKey") THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    IF TG_OP = 'UPDATE' AND (OLD."DecimalKey" IS DISTINCT FROM NEW."DecimalKey") THEN
+        UPDATE "dms"."Document"
+        SET "IdentityVersion" = nextval('"dms"."ChangeVersionSequence"'), "IdentityLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DecimalKeyResource_Stamp" ON "edfi"."DecimalKeyResource";
+CREATE TRIGGER "TR_DecimalKeyResource_Stamp"
+BEFORE INSERT OR UPDATE OR DELETE ON "edfi"."DecimalKeyResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DecimalKeyResource_Stamp"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DecimalRefResource_ReferentialIdentity"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'INSERT' OR (OLD."RefResourceId" IS DISTINCT FROM NEW."RefResourceId" OR OLD."DecimalKeyReference_DecimalKey" IS DISTINCT FROM NEW."DecimalKeyReference_DecimalKey") THEN
+        DELETE FROM "dms"."ReferentialIdentity"
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 3;
+        INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiDecimalRefResource' || '$.refResourceId=' || NEW."RefResourceId"::text || '#' || '$.decimalKeyReference.decimalKey=' || regexp_replace(regexp_replace(NEW."DecimalKeyReference_DecimalKey"::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')), NEW."DocumentId", 3);
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DecimalRefResource_ReferentialIdentity" ON "edfi"."DecimalRefResource";
+CREATE TRIGGER "TR_DecimalRefResource_ReferentialIdentity"
+AFTER INSERT OR UPDATE ON "edfi"."DecimalRefResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DecimalRefResource_ReferentialIdentity"();
+
+CREATE OR REPLACE FUNCTION "edfi"."TF_TR_DecimalRefResource_Stamp"()
+RETURNS TRIGGER AS $func$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = OLD."DocumentId";
+        RETURN OLD;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NOT (OLD."DocumentId" IS DISTINCT FROM NEW."DocumentId" OR OLD."DecimalKeyReference_DocumentId" IS DISTINCT FROM NEW."DecimalKeyReference_DocumentId" OR OLD."DecimalKeyReference_DecimalKey" IS DISTINCT FROM NEW."DecimalKeyReference_DecimalKey" OR OLD."RefResourceId" IS DISTINCT FROM NEW."RefResourceId") THEN
+        RETURN NEW;
+    END IF;
+    IF TG_OP = 'UPDATE' THEN
+        UPDATE "dms"."Document"
+        SET "ContentVersion" = nextval('"dms"."ChangeVersionSequence"'), "ContentLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    IF TG_OP = 'UPDATE' AND (OLD."RefResourceId" IS DISTINCT FROM NEW."RefResourceId" OR OLD."DecimalKeyReference_DecimalKey" IS DISTINCT FROM NEW."DecimalKeyReference_DecimalKey") THEN
+        UPDATE "dms"."Document"
+        SET "IdentityVersion" = nextval('"dms"."ChangeVersionSequence"'), "IdentityLastModifiedAt" = now()
+        WHERE "DocumentId" = NEW."DocumentId";
+    END IF;
+    RETURN NEW;
+END;
+$func$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "TR_DecimalRefResource_Stamp" ON "edfi"."DecimalRefResource";
+CREATE TRIGGER "TR_DecimalRefResource_Stamp"
+BEFORE INSERT OR UPDATE OR DELETE ON "edfi"."DecimalRefResource"
+FOR EACH ROW
+EXECUTE FUNCTION "edfi"."TF_TR_DecimalRefResource_Stamp"();
+
 CREATE OR REPLACE FUNCTION "edfi"."TF_TR_EdOrgDependentChildResource_ReferentialIdentity"()
 RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."EdOrgDependentChildResourceId" IS DISTINCT FROM NEW."EdOrgDependentChildResourceId" OR OLD."EdOrgDependentResourceReference_EdOrgDependentResourceId" IS DISTINCT FROM NEW."EdOrgDependentResourceReference_EdOrgDependentResourceId" OR OLD."EdOrgDependentResourceReference_EducationOrganizationId" IS DISTINCT FROM NEW."EdOrgDependentResourceReference_EducationOrganizationId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 1;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 4;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEdOrgDependentChildResource' || '$.edOrgDependentChildResourceId=' || NEW."EdOrgDependentChildResourceId"::text || '#' || '$.edOrgDependentResourceReference.edOrgDependentResourceId=' || NEW."EdOrgDependentResourceReference_EdOrgDependentResourceId"::text || '#' || '$.edOrgDependentResourceReference.educationOrganizationId=' || NEW."EdOrgDependentResourceReference_EducationOrganizationId"::text), NEW."DocumentId", 1);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEdOrgDependentChildResource' || '$.edOrgDependentChildResourceId=' || NEW."EdOrgDependentChildResourceId"::text || '#' || '$.edOrgDependentResourceReference.edOrgDependentResourceId=' || NEW."EdOrgDependentResourceReference_EdOrgDependentResourceId"::text || '#' || '$.edOrgDependentResourceReference.educationOrganizationId=' || NEW."EdOrgDependentResourceReference_EducationOrganizationId"::text), NEW."DocumentId", 4);
     END IF;
     RETURN NEW;
 END;
@@ -919,9 +1170,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."EdOrgDependentResourceId" IS DISTINCT FROM NEW."EdOrgDependentResourceId" OR OLD."EducationOrganization_EducationOrganizationId" IS DISTINCT FROM NEW."EducationOrganization_EducationOrganizationId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 2;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 5;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEdOrgDependentResource' || '$.edOrgDependentResourceId=' || NEW."EdOrgDependentResourceId"::text || '#' || '$.educationOrganizationReference.educationOrganizationId=' || NEW."EducationOrganization_EducationOrganizationId"::text), NEW."DocumentId", 2);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEdOrgDependentResource' || '$.edOrgDependentResourceId=' || NEW."EdOrgDependentResourceId"::text || '#' || '$.educationOrganizationReference.educationOrganizationId=' || NEW."EducationOrganization_EducationOrganizationId"::text), NEW."DocumentId", 5);
     END IF;
     RETURN NEW;
 END;
@@ -970,9 +1221,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."KeyUnifiedResourceId" IS DISTINCT FROM NEW."KeyUnifiedResourceId" OR OLD."ResourceAReference_ResourceAId" IS DISTINCT FROM NEW."ResourceAReference_ResourceAId" OR OLD."StudentUniqueId_Unified" IS DISTINCT FROM NEW."StudentUniqueId_Unified" OR OLD."ResourceBReference_ResourceBId" IS DISTINCT FROM NEW."ResourceBReference_ResourceBId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 4;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 7;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiKeyUnifiedResource' || '$.keyUnifiedResourceId=' || NEW."KeyUnifiedResourceId"::text || '#' || '$.resourceAReference.resourceAId=' || NEW."ResourceAReference_ResourceAId"::text || '#' || '$.resourceAReference.studentUniqueId=' || NEW."ResourceAReference_StudentUniqueId"::text || '#' || '$.resourceBReference.resourceBId=' || NEW."ResourceBReference_ResourceBId"::text || '#' || '$.resourceBReference.studentUniqueId=' || NEW."ResourceBReference_StudentUniqueId"::text), NEW."DocumentId", 4);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiKeyUnifiedResource' || '$.keyUnifiedResourceId=' || NEW."KeyUnifiedResourceId"::text || '#' || '$.resourceAReference.resourceAId=' || NEW."ResourceAReference_ResourceAId"::text || '#' || '$.resourceAReference.studentUniqueId=' || NEW."ResourceAReference_StudentUniqueId"::text || '#' || '$.resourceBReference.resourceBId=' || NEW."ResourceBReference_ResourceBId"::text || '#' || '$.resourceBReference.studentUniqueId=' || NEW."ResourceBReference_StudentUniqueId"::text), NEW."DocumentId", 7);
     END IF;
     RETURN NEW;
 END;
@@ -1021,9 +1272,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."ResourceAId" IS DISTINCT FROM NEW."ResourceAId" OR OLD."StudentReference_StudentUniqueId" IS DISTINCT FROM NEW."StudentReference_StudentUniqueId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 5;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 8;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiResourceA' || '$.resourceAId=' || NEW."ResourceAId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentReference_StudentUniqueId"::text), NEW."DocumentId", 5);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiResourceA' || '$.resourceAId=' || NEW."ResourceAId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentReference_StudentUniqueId"::text), NEW."DocumentId", 8);
     END IF;
     RETURN NEW;
 END;
@@ -1072,9 +1323,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."ResourceBId" IS DISTINCT FROM NEW."ResourceBId" OR OLD."StudentReference_StudentUniqueId" IS DISTINCT FROM NEW."StudentReference_StudentUniqueId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 6;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 9;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiResourceB' || '$.resourceBId=' || NEW."ResourceBId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentReference_StudentUniqueId"::text), NEW."DocumentId", 6);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiResourceB' || '$.resourceBId=' || NEW."ResourceBId"::text || '#' || '$.studentReference.studentUniqueId=' || NEW."StudentReference_StudentUniqueId"::text), NEW."DocumentId", 9);
     END IF;
     RETURN NEW;
 END;
@@ -1172,13 +1423,13 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."SchoolId" IS DISTINCT FROM NEW."SchoolId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 7;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 10;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiSchool' || '$.schoolId=' || NEW."SchoolId"::text), NEW."DocumentId", 7);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiSchool' || '$.schoolId=' || NEW."SchoolId"::text), NEW."DocumentId", 10);
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 3;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 6;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEducationOrganization' || '$.educationOrganizationId=' || NEW."SchoolId"::text), NEW."DocumentId", 3);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiEducationOrganization' || '$.educationOrganizationId=' || NEW."SchoolId"::text), NEW."DocumentId", 6);
     END IF;
     RETURN NEW;
 END;
@@ -1227,9 +1478,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."StudentUniqueId" IS DISTINCT FROM NEW."StudentUniqueId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 8;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 11;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudent' || '$.studentUniqueId=' || NEW."StudentUniqueId"::text), NEW."DocumentId", 8);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudent' || '$.studentUniqueId=' || NEW."StudentUniqueId"::text), NEW."DocumentId", 11);
     END IF;
     RETURN NEW;
 END;
@@ -1278,9 +1529,9 @@ RETURNS TRIGGER AS $func$
 BEGIN
     IF TG_OP = 'INSERT' OR (OLD."StudentUniqueId" IS DISTINCT FROM NEW."StudentUniqueId" OR OLD."SchoolReference_SchoolId" IS DISTINCT FROM NEW."SchoolReference_SchoolId") THEN
         DELETE FROM "dms"."ReferentialIdentity"
-        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 9;
+        WHERE "DocumentId" = NEW."DocumentId" AND "ResourceKeyId" = 12;
         INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
-        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudentSchoolAssociation' || '$.studentUniqueId=' || NEW."StudentUniqueId"::text || '#' || '$.schoolReference.schoolId=' || NEW."SchoolReference_SchoolId"::text), NEW."DocumentId", 9);
+        VALUES ("dms"."uuidv5"('edf1edf1-3df1-3df1-3df1-3df1edf1edf1'::uuid, 'Ed-FiStudentSchoolAssociation' || '$.studentUniqueId=' || NEW."StudentUniqueId"::text || '#' || '$.schoolReference.schoolId=' || NEW."SchoolReference_SchoolId"::text), NEW."DocumentId", 12);
     END IF;
     RETURN NEW;
 END;
@@ -1330,31 +1581,40 @@ EXECUTE FUNCTION "edfi"."TF_TR_StudentSchoolAssociation_Stamp"();
 
 -- ResourceKey seed inserts (insert-if-missing)
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (1, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0')
+VALUES (1, 'Ed-Fi', 'DateTimeKeyResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (2, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0')
+VALUES (2, 'Ed-Fi', 'DecimalKeyResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (3, 'Ed-Fi', 'EducationOrganization', '5.0.0')
+VALUES (3, 'Ed-Fi', 'DecimalRefResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (4, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0')
+VALUES (4, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (5, 'Ed-Fi', 'ResourceA', '5.0.0')
+VALUES (5, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (6, 'Ed-Fi', 'ResourceB', '5.0.0')
+VALUES (6, 'Ed-Fi', 'EducationOrganization', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (7, 'Ed-Fi', 'School', '5.0.0')
+VALUES (7, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (8, 'Ed-Fi', 'Student', '5.0.0')
+VALUES (8, 'Ed-Fi', 'ResourceA', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
-VALUES (9, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
+VALUES (9, 'Ed-Fi', 'ResourceB', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (10, 'Ed-Fi', 'School', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (11, 'Ed-Fi', 'Student', '5.0.0')
+ON CONFLICT ("ResourceKeyId") DO NOTHING;
+INSERT INTO "dms"."ResourceKey" ("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
+VALUES (12, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
 ON CONFLICT ("ResourceKeyId") DO NOTHING;
 
 -- ResourceKey full-table validation (count + content)
@@ -1365,23 +1625,26 @@ DECLARE
     _mismatched_ids text;
 BEGIN
     SELECT COUNT(*) INTO _actual_count FROM "dms"."ResourceKey";
-    IF _actual_count <> 9 THEN
-        RAISE EXCEPTION 'dms.ResourceKey count mismatch: expected 9, found %', _actual_count;
+    IF _actual_count <> 12 THEN
+        RAISE EXCEPTION 'dms.ResourceKey count mismatch: expected 12, found %', _actual_count;
     END IF;
 
     SELECT COUNT(*) INTO _mismatched_count
     FROM "dms"."ResourceKey" rk
     WHERE NOT EXISTS (
         SELECT 1 FROM (VALUES
-            (1::smallint, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0'),
-            (2::smallint, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0'),
-            (3::smallint, 'Ed-Fi', 'EducationOrganization', '5.0.0'),
-            (4::smallint, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0'),
-            (5::smallint, 'Ed-Fi', 'ResourceA', '5.0.0'),
-            (6::smallint, 'Ed-Fi', 'ResourceB', '5.0.0'),
-            (7::smallint, 'Ed-Fi', 'School', '5.0.0'),
-            (8::smallint, 'Ed-Fi', 'Student', '5.0.0'),
-            (9::smallint, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
+            (1::smallint, 'Ed-Fi', 'DateTimeKeyResource', '5.0.0'),
+            (2::smallint, 'Ed-Fi', 'DecimalKeyResource', '5.0.0'),
+            (3::smallint, 'Ed-Fi', 'DecimalRefResource', '5.0.0'),
+            (4::smallint, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0'),
+            (5::smallint, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0'),
+            (6::smallint, 'Ed-Fi', 'EducationOrganization', '5.0.0'),
+            (7::smallint, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0'),
+            (8::smallint, 'Ed-Fi', 'ResourceA', '5.0.0'),
+            (9::smallint, 'Ed-Fi', 'ResourceB', '5.0.0'),
+            (10::smallint, 'Ed-Fi', 'School', '5.0.0'),
+            (11::smallint, 'Ed-Fi', 'Student', '5.0.0'),
+            (12::smallint, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
         ) AS expected("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
         WHERE expected."ResourceKeyId" = rk."ResourceKeyId"
         AND expected."ProjectName" = rk."ProjectName"
@@ -1395,15 +1658,18 @@ BEGIN
             FROM "dms"."ResourceKey" rk
             WHERE NOT EXISTS (
                 SELECT 1 FROM (VALUES
-                    (1::smallint, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0'),
-                    (2::smallint, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0'),
-                    (3::smallint, 'Ed-Fi', 'EducationOrganization', '5.0.0'),
-                    (4::smallint, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0'),
-                    (5::smallint, 'Ed-Fi', 'ResourceA', '5.0.0'),
-                    (6::smallint, 'Ed-Fi', 'ResourceB', '5.0.0'),
-                    (7::smallint, 'Ed-Fi', 'School', '5.0.0'),
-                    (8::smallint, 'Ed-Fi', 'Student', '5.0.0'),
-                    (9::smallint, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
+                    (1::smallint, 'Ed-Fi', 'DateTimeKeyResource', '5.0.0'),
+                    (2::smallint, 'Ed-Fi', 'DecimalKeyResource', '5.0.0'),
+                    (3::smallint, 'Ed-Fi', 'DecimalRefResource', '5.0.0'),
+                    (4::smallint, 'Ed-Fi', 'EdOrgDependentChildResource', '5.0.0'),
+                    (5::smallint, 'Ed-Fi', 'EdOrgDependentResource', '5.0.0'),
+                    (6::smallint, 'Ed-Fi', 'EducationOrganization', '5.0.0'),
+                    (7::smallint, 'Ed-Fi', 'KeyUnifiedResource', '5.0.0'),
+                    (8::smallint, 'Ed-Fi', 'ResourceA', '5.0.0'),
+                    (9::smallint, 'Ed-Fi', 'ResourceB', '5.0.0'),
+                    (10::smallint, 'Ed-Fi', 'School', '5.0.0'),
+                    (11::smallint, 'Ed-Fi', 'Student', '5.0.0'),
+                    (12::smallint, 'Ed-Fi', 'StudentSchoolAssociation', '5.0.0')
                 ) AS expected("ResourceKeyId", "ProjectName", "ResourceName", "ResourceVersion")
                 WHERE expected."ResourceKeyId" = rk."ResourceKeyId"
                 AND expected."ProjectName" = rk."ProjectName"
@@ -1419,7 +1685,7 @@ END $$;
 
 -- EffectiveSchema singleton insert-if-missing
 INSERT INTO "dms"."EffectiveSchema" ("EffectiveSchemaSingletonId", "ApiSchemaFormatVersion", "EffectiveSchemaHash", "ResourceKeyCount", "ResourceKeySeedHash")
-VALUES (1, '1.0.0', '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874', 9, '\xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95'::bytea)
+VALUES (1, '1.0.0', '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3', 12, '\xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1'::bytea)
 ON CONFLICT ("EffectiveSchemaSingletonId") DO NOTHING;
 
 -- EffectiveSchema validation (ApiSchemaFormatVersion + ResourceKeyCount + ResourceKeySeedHash)
@@ -1436,18 +1702,18 @@ BEGIN
         IF _stored_api_schema_format_version IS NULL OR btrim(_stored_api_schema_format_version) = '' THEN
             RAISE EXCEPTION 'dms.EffectiveSchema.ApiSchemaFormatVersion must not be empty.';
         END IF;
-        IF _stored_count <> 9 THEN
-            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeyCount mismatch: expected 9, found %', _stored_count;
+        IF _stored_count <> 12 THEN
+            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeyCount mismatch: expected 12, found %', _stored_count;
         END IF;
-        IF _stored_hash <> '\xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95'::bytea THEN
-            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored % but expected %', encode(_stored_hash, 'hex'), encode('\xAD599C265D1176CEE04B8ADD1D0E42F19FE7FE9A6F4089154B38B249334BED95'::bytea, 'hex');
+        IF _stored_hash <> '\xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1'::bytea THEN
+            RAISE EXCEPTION 'dms.EffectiveSchema ResourceKeySeedHash mismatch: stored % but expected %', encode(_stored_hash, 'hex'), encode('\xCF22BDA16C6555C3F9F4F106F8BA65C2461E58FC300892B4FBB958648BA026D1'::bytea, 'hex');
         END IF;
     END IF;
 END $$;
 
 -- SchemaComponent seed inserts (insert-if-missing)
 INSERT INTO "dms"."SchemaComponent" ("EffectiveSchemaHash", "ProjectEndpointName", "ProjectName", "ProjectVersion", "IsExtensionProject")
-VALUES ('944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874', 'ed-fi', 'Ed-Fi', '5.0.0', false)
+VALUES ('9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3', 'ed-fi', 'Ed-Fi', '5.0.0', false)
 ON CONFLICT ("EffectiveSchemaHash", "ProjectEndpointName") DO NOTHING;
 
 -- SchemaComponent exact-match validation (count + content)
@@ -1457,14 +1723,14 @@ DECLARE
     _mismatched_count integer;
     _mismatched_names text;
 BEGIN
-    SELECT COUNT(*) INTO _actual_count FROM "dms"."SchemaComponent" WHERE "EffectiveSchemaHash" = '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874';
+    SELECT COUNT(*) INTO _actual_count FROM "dms"."SchemaComponent" WHERE "EffectiveSchemaHash" = '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3';
     IF _actual_count <> 1 THEN
         RAISE EXCEPTION 'dms.SchemaComponent count mismatch: expected 1, found %', _actual_count;
     END IF;
 
     SELECT COUNT(*) INTO _mismatched_count
     FROM "dms"."SchemaComponent" sc
-    WHERE sc."EffectiveSchemaHash" = '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874'
+    WHERE sc."EffectiveSchemaHash" = '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3'
     AND NOT EXISTS (
         SELECT 1 FROM (VALUES
             ('ed-fi', 'Ed-Fi', '5.0.0', false)
@@ -1479,7 +1745,7 @@ BEGIN
         FROM (
             SELECT sc."ProjectEndpointName" AS name
             FROM "dms"."SchemaComponent" sc
-            WHERE sc."EffectiveSchemaHash" = '944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874'
+            WHERE sc."EffectiveSchemaHash" = '9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3'
             AND NOT EXISTS (
                 SELECT 1 FROM (VALUES
                     ('ed-fi', 'Ed-Fi', '5.0.0', false)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/relational-model.mssql.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/relational-model.mssql.manifest.json
@@ -1,6 +1,6 @@
 {
   "dialect": "mssql",
-  "effective_schema_hash": "944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874",
+  "effective_schema_hash": "9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3",
   "relational_mapping_version": "v1",
   "projects": [
     {
@@ -12,6 +12,24 @@
     }
   ],
   "resources": [
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DateTimeKeyResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalKeyResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalRefResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
     {
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentChildResource",
@@ -239,6 +257,105 @@
       ],
       "include_columns": [
         "SourceEducationOrganizationId"
+      ]
+    },
+    {
+      "name": "PK_DateTimeKeyResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DateTimeKeyResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "EventTimestamp"
+      ]
+    },
+    {
+      "name": "PK_DecimalKeyResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DecimalKeyResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "UX_DecimalKeyResource_RefKey",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId",
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "IX_DecimalRefResource_DecimalKeyReference_DocumentId_DecimalKeyReference_DecimalKey",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "DecimalKeyReference_DocumentId",
+        "DecimalKeyReference_DecimalKey"
+      ]
+    },
+    {
+      "name": "PK_DecimalRefResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DecimalRefResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DocumentId"
       ]
     },
     {
@@ -632,6 +749,123 @@
   ],
   "triggers": [
     {
+      "name": "TR_DateTimeKeyResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "EventTimestamp"
+      ],
+      "resource_key_id": 1,
+      "project_name": "Ed-Fi",
+      "resource_name": "DateTimeKeyResource",
+      "identity_elements": [
+        {
+          "column": "EventTimestamp",
+          "identity_json_path": "$.eventTimestamp"
+        }
+      ]
+    },
+    {
+      "name": "TR_DateTimeKeyResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "EventTimestamp"
+      ]
+    },
+    {
+      "name": "TR_DecimalKeyResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "DecimalKey"
+      ],
+      "resource_key_id": 2,
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalKeyResource",
+      "identity_elements": [
+        {
+          "column": "DecimalKey",
+          "identity_json_path": "$.decimalKey"
+        }
+      ]
+    },
+    {
+      "name": "TR_DecimalKeyResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "TR_DecimalRefResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DecimalKey"
+      ],
+      "resource_key_id": 3,
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalRefResource",
+      "identity_elements": [
+        {
+          "column": "RefResourceId",
+          "identity_json_path": "$.refResourceId"
+        },
+        {
+          "column": "DecimalKeyReference_DecimalKey",
+          "identity_json_path": "$.decimalKeyReference.decimalKey"
+        }
+      ]
+    },
+    {
+      "name": "TR_DecimalRefResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DecimalKey"
+      ]
+    },
+    {
       "name": "TR_EdOrgDependentChildResource_ReferentialIdentity",
       "table": {
         "schema": "edfi",
@@ -646,7 +880,7 @@
         "EdOrgDependentResourceReference_EdOrgDependentResourceId",
         "EdOrgDependentResourceReference_EducationOrganizationId"
       ],
-      "resource_key_id": 1,
+      "resource_key_id": 4,
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentChildResource",
       "identity_elements": [
@@ -729,7 +963,7 @@
         "EdOrgDependentResourceId",
         "EducationOrganization_EducationOrganizationId"
       ],
-      "resource_key_id": 2,
+      "resource_key_id": 5,
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentResource",
       "identity_elements": [
@@ -803,7 +1037,7 @@
         "StudentUniqueId_Unified",
         "ResourceBReference_ResourceBId"
       ],
-      "resource_key_id": 4,
+      "resource_key_id": 7,
       "project_name": "Ed-Fi",
       "resource_name": "KeyUnifiedResource",
       "identity_elements": [
@@ -895,7 +1129,7 @@
         "ResourceAId",
         "StudentReference_StudentUniqueId"
       ],
-      "resource_key_id": 5,
+      "resource_key_id": 8,
       "project_name": "Ed-Fi",
       "resource_name": "ResourceA",
       "identity_elements": [
@@ -973,7 +1207,7 @@
         "ResourceBId",
         "StudentReference_StudentUniqueId"
       ],
-      "resource_key_id": 6,
+      "resource_key_id": 9,
       "project_name": "Ed-Fi",
       "resource_name": "ResourceB",
       "identity_elements": [
@@ -1099,7 +1333,7 @@
       "identity_projection_columns": [
         "SchoolId"
       ],
-      "resource_key_id": 7,
+      "resource_key_id": 10,
       "project_name": "Ed-Fi",
       "resource_name": "School",
       "identity_elements": [
@@ -1109,7 +1343,7 @@
         }
       ],
       "superclass_alias": {
-        "resource_key_id": 3,
+        "resource_key_id": 6,
         "project_name": "Ed-Fi",
         "resource_name": "EducationOrganization",
         "identity_elements": [
@@ -1190,7 +1424,7 @@
       "identity_projection_columns": [
         "StudentUniqueId"
       ],
-      "resource_key_id": 8,
+      "resource_key_id": 11,
       "project_name": "Ed-Fi",
       "resource_name": "Student",
       "identity_elements": [
@@ -1228,7 +1462,7 @@
         "StudentUniqueId",
         "SchoolReference_SchoolId"
       ],
-      "resource_key_id": 9,
+      "resource_key_id": 12,
       "project_name": "Ed-Fi",
       "resource_name": "StudentSchoolAssociation",
       "identity_elements": [
@@ -1259,6 +1493,376 @@
     }
   ],
   "resource_details": [
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DateTimeKeyResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DateTimeKeyResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "EventTimestamp",
+              "kind": "Scalar",
+              "type": {
+                "kind": "DateTime"
+              },
+              "is_nullable": false,
+              "source_path": "$.eventTimestamp",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DateTimeKeyResource_NK",
+              "columns": [
+                "EventTimestamp"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DateTimeKeyResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DecimalKeyResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DecimalKeyResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKey",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Decimal",
+                "precision": 9,
+                "scale": 2
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKey",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalKeyResource_NK",
+              "columns": [
+                "DecimalKey"
+              ]
+            },
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalKeyResource_RefKey",
+              "columns": [
+                "DocumentId",
+                "DecimalKey"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalKeyResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DecimalRefResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DecimalRefResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKeyReference_DocumentId",
+              "kind": "DocumentFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKeyReference",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKeyReference_DecimalKey",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Decimal",
+                "precision": 9,
+                "scale": 2
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKeyReference.decimalKey",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "RefResourceId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 64
+              },
+              "is_nullable": false,
+              "source_path": "$.refResourceId",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalRefResource_NK",
+              "columns": [
+                "RefResourceId",
+                "DecimalKeyReference_DocumentId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalRefResource_DecimalKeyReference_RefKey",
+              "columns": [
+                "DecimalKeyReference_DocumentId",
+                "DecimalKeyReference_DecimalKey"
+              ],
+              "target_table": {
+                "schema": "edfi",
+                "name": "DecimalKeyResource"
+              },
+              "target_columns": [
+                "DocumentId",
+                "DecimalKey"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalRefResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "AllOrNoneNullability",
+              "name": "CK_DecimalRefResource_DecimalKeyReference_AllNone",
+              "fk_column": "DecimalKeyReference_DocumentId",
+              "dependent_columns": [
+                "DecimalKeyReference_DecimalKey"
+              ]
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [
+        {
+          "is_identity_component": true,
+          "reference_object_path": "$.decimalKeyReference",
+          "table": {
+            "schema": "edfi",
+            "name": "DecimalRefResource"
+          },
+          "fk_column": "DecimalKeyReference_DocumentId",
+          "target_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "DecimalKeyResource"
+          },
+          "identity_bindings": [
+            {
+              "identity_json_path": "$.decimalKey",
+              "reference_json_path": "$.decimalKeyReference.decimalKey",
+              "column": "DecimalKeyReference_DecimalKey"
+            }
+          ]
+        }
+      ],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
     {
       "resource": {
         "project_name": "Ed-Fi",

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/relational-model.pgsql.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/relational-model.pgsql.manifest.json
@@ -1,6 +1,6 @@
 {
   "dialect": "pgsql",
-  "effective_schema_hash": "944f17699511435162631bce81c2e9847f454da6852158449af8f3da6c4a8874",
+  "effective_schema_hash": "9060f2839ae31d81b6d2b460c1517a6a7378d2daaae2962a6a26051f437780d3",
   "relational_mapping_version": "v1",
   "projects": [
     {
@@ -12,6 +12,24 @@
     }
   ],
   "resources": [
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DateTimeKeyResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalKeyResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
+    {
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalRefResource",
+      "storage_kind": "RelationalTables",
+      "physical_schema": "edfi"
+    },
     {
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentChildResource",
@@ -239,6 +257,105 @@
       ],
       "include_columns": [
         "SourceEducationOrganizationId"
+      ]
+    },
+    {
+      "name": "PK_DateTimeKeyResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DateTimeKeyResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "EventTimestamp"
+      ]
+    },
+    {
+      "name": "PK_DecimalKeyResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DecimalKeyResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "UX_DecimalKeyResource_RefKey",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId",
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "IX_DecimalRefResource_DecimalKeyReference_DocumentId_1972800496",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "ForeignKeySupport",
+      "is_unique": false,
+      "key_columns": [
+        "DecimalKeyReference_DocumentId",
+        "DecimalKeyReference_DecimalKey"
+      ]
+    },
+    {
+      "name": "PK_DecimalRefResource",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "PrimaryKey",
+      "is_unique": true,
+      "key_columns": [
+        "DocumentId"
+      ]
+    },
+    {
+      "name": "UX_DecimalRefResource_NK",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "UniqueConstraint",
+      "is_unique": true,
+      "key_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DocumentId"
       ]
     },
     {
@@ -642,6 +759,123 @@
   ],
   "triggers": [
     {
+      "name": "TR_DateTimeKeyResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "EventTimestamp"
+      ],
+      "resource_key_id": 1,
+      "project_name": "Ed-Fi",
+      "resource_name": "DateTimeKeyResource",
+      "identity_elements": [
+        {
+          "column": "EventTimestamp",
+          "identity_json_path": "$.eventTimestamp"
+        }
+      ]
+    },
+    {
+      "name": "TR_DateTimeKeyResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DateTimeKeyResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "EventTimestamp"
+      ]
+    },
+    {
+      "name": "TR_DecimalKeyResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "DecimalKey"
+      ],
+      "resource_key_id": 2,
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalKeyResource",
+      "identity_elements": [
+        {
+          "column": "DecimalKey",
+          "identity_json_path": "$.decimalKey"
+        }
+      ]
+    },
+    {
+      "name": "TR_DecimalKeyResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalKeyResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "DecimalKey"
+      ]
+    },
+    {
+      "name": "TR_DecimalRefResource_ReferentialIdentity",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "ReferentialIdentityMaintenance",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DecimalKey"
+      ],
+      "resource_key_id": 3,
+      "project_name": "Ed-Fi",
+      "resource_name": "DecimalRefResource",
+      "identity_elements": [
+        {
+          "column": "RefResourceId",
+          "identity_json_path": "$.refResourceId"
+        },
+        {
+          "column": "DecimalKeyReference_DecimalKey",
+          "identity_json_path": "$.decimalKeyReference.decimalKey"
+        }
+      ]
+    },
+    {
+      "name": "TR_DecimalRefResource_Stamp",
+      "table": {
+        "schema": "edfi",
+        "name": "DecimalRefResource"
+      },
+      "kind": "DocumentStamping",
+      "key_columns": [
+        "DocumentId"
+      ],
+      "identity_projection_columns": [
+        "RefResourceId",
+        "DecimalKeyReference_DecimalKey"
+      ]
+    },
+    {
       "name": "TR_EdOrgDependentChildResource_ReferentialIdentity",
       "table": {
         "schema": "edfi",
@@ -656,7 +890,7 @@
         "EdOrgDependentResourceReference_EdOrgDependentResourceId",
         "EdOrgDependentResourceReference_EducationOrganizationId"
       ],
-      "resource_key_id": 1,
+      "resource_key_id": 4,
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentChildResource",
       "identity_elements": [
@@ -704,7 +938,7 @@
         "EdOrgDependentResourceId",
         "EducationOrganization_EducationOrganizationId"
       ],
-      "resource_key_id": 2,
+      "resource_key_id": 5,
       "project_name": "Ed-Fi",
       "resource_name": "EdOrgDependentResource",
       "identity_elements": [
@@ -749,7 +983,7 @@
         "StudentUniqueId_Unified",
         "ResourceBReference_ResourceBId"
       ],
-      "resource_key_id": 4,
+      "resource_key_id": 7,
       "project_name": "Ed-Fi",
       "resource_name": "KeyUnifiedResource",
       "identity_elements": [
@@ -806,7 +1040,7 @@
         "ResourceAId",
         "StudentReference_StudentUniqueId"
       ],
-      "resource_key_id": 5,
+      "resource_key_id": 8,
       "project_name": "Ed-Fi",
       "resource_name": "ResourceA",
       "identity_elements": [
@@ -849,7 +1083,7 @@
         "ResourceBId",
         "StudentReference_StudentUniqueId"
       ],
-      "resource_key_id": 6,
+      "resource_key_id": 9,
       "project_name": "Ed-Fi",
       "resource_name": "ResourceB",
       "identity_elements": [
@@ -944,7 +1178,7 @@
       "identity_projection_columns": [
         "SchoolId"
       ],
-      "resource_key_id": 7,
+      "resource_key_id": 10,
       "project_name": "Ed-Fi",
       "resource_name": "School",
       "identity_elements": [
@@ -954,7 +1188,7 @@
         }
       ],
       "superclass_alias": {
-        "resource_key_id": 3,
+        "resource_key_id": 6,
         "project_name": "Ed-Fi",
         "resource_name": "EducationOrganization",
         "identity_elements": [
@@ -992,7 +1226,7 @@
       "identity_projection_columns": [
         "StudentUniqueId"
       ],
-      "resource_key_id": 8,
+      "resource_key_id": 11,
       "project_name": "Ed-Fi",
       "resource_name": "Student",
       "identity_elements": [
@@ -1030,7 +1264,7 @@
         "StudentUniqueId",
         "SchoolReference_SchoolId"
       ],
-      "resource_key_id": 9,
+      "resource_key_id": 12,
       "project_name": "Ed-Fi",
       "resource_name": "StudentSchoolAssociation",
       "identity_elements": [
@@ -1061,6 +1295,376 @@
     }
   ],
   "resource_details": [
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DateTimeKeyResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DateTimeKeyResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "EventTimestamp",
+              "kind": "Scalar",
+              "type": {
+                "kind": "DateTime"
+              },
+              "is_nullable": false,
+              "source_path": "$.eventTimestamp",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DateTimeKeyResource_NK",
+              "columns": [
+                "EventTimestamp"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DateTimeKeyResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DecimalKeyResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DecimalKeyResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKey",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Decimal",
+                "precision": 9,
+                "scale": 2
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKey",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalKeyResource_NK",
+              "columns": [
+                "DecimalKey"
+              ]
+            },
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalKeyResource_RefKey",
+              "columns": [
+                "DocumentId",
+                "DecimalKey"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalKeyResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
+    {
+      "resource": {
+        "project_name": "Ed-Fi",
+        "resource_name": "DecimalRefResource"
+      },
+      "physical_schema": "edfi",
+      "storage_kind": "RelationalTables",
+      "tables": [
+        {
+          "schema": "edfi",
+          "name": "DecimalRefResource",
+          "scope": "$",
+          "key_columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart"
+            }
+          ],
+          "columns": [
+            {
+              "name": "DocumentId",
+              "kind": "ParentKeyPart",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": null,
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKeyReference_DocumentId",
+              "kind": "DocumentFk",
+              "type": {
+                "kind": "Int64"
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKeyReference",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "DecimalKeyReference_DecimalKey",
+              "kind": "Scalar",
+              "type": {
+                "kind": "Decimal",
+                "precision": 9,
+                "scale": 2
+              },
+              "is_nullable": false,
+              "source_path": "$.decimalKeyReference.decimalKey",
+              "storage": {
+                "kind": "Stored"
+              }
+            },
+            {
+              "name": "RefResourceId",
+              "kind": "Scalar",
+              "type": {
+                "kind": "String",
+                "max_length": 64
+              },
+              "is_nullable": false,
+              "source_path": "$.refResourceId",
+              "storage": {
+                "kind": "Stored"
+              }
+            }
+          ],
+          "key_unification_classes": [],
+          "identity_metadata": {
+            "table_kind": "Root",
+            "physical_row_identity_columns": [
+              "DocumentId"
+            ],
+            "root_scope_locator_columns": [
+              "DocumentId"
+            ],
+            "immediate_parent_scope_locator_columns": [],
+            "semantic_identity_bindings": []
+          },
+          "descriptor_fk_deduplications": [],
+          "constraints": [
+            {
+              "kind": "Unique",
+              "name": "UX_DecimalRefResource_NK",
+              "columns": [
+                "RefResourceId",
+                "DecimalKeyReference_DocumentId"
+              ]
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalRefResource_DecimalKeyReference_RefKey",
+              "columns": [
+                "DecimalKeyReference_DocumentId",
+                "DecimalKeyReference_DecimalKey"
+              ],
+              "target_table": {
+                "schema": "edfi",
+                "name": "DecimalKeyResource"
+              },
+              "target_columns": [
+                "DocumentId",
+                "DecimalKey"
+              ],
+              "on_delete": "NoAction",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "ForeignKey",
+              "name": "FK_DecimalRefResource_Document",
+              "columns": [
+                "DocumentId"
+              ],
+              "target_table": {
+                "schema": "dms",
+                "name": "Document"
+              },
+              "target_columns": [
+                "DocumentId"
+              ],
+              "on_delete": "Cascade",
+              "on_update": "NoAction"
+            },
+            {
+              "kind": "AllOrNoneNullability",
+              "name": "CK_DecimalRefResource_DecimalKeyReference_AllNone",
+              "fk_column": "DecimalKeyReference_DocumentId",
+              "dependent_columns": [
+                "DecimalKeyReference_DecimalKey"
+              ]
+            }
+          ]
+        }
+      ],
+      "key_unification_equality_constraints": {
+        "applied": [],
+        "redundant": [],
+        "ignored": [],
+        "ignored_by_reason": {},
+        "skipped": []
+      },
+      "document_reference_bindings": [
+        {
+          "is_identity_component": true,
+          "reference_object_path": "$.decimalKeyReference",
+          "table": {
+            "schema": "edfi",
+            "name": "DecimalRefResource"
+          },
+          "fk_column": "DecimalKeyReference_DocumentId",
+          "target_resource": {
+            "project_name": "Ed-Fi",
+            "resource_name": "DecimalKeyResource"
+          },
+          "identity_bindings": [
+            {
+              "identity_json_path": "$.decimalKey",
+              "reference_json_path": "$.decimalKeyReference.decimalKey",
+              "column": "DecimalKeyReference_DecimalKey"
+            }
+          ]
+        }
+      ],
+      "descriptor_edge_sources": [],
+      "extension_sites": []
+    },
     {
       "resource": {
         "project_name": "Ed-Fi",

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/inputs/ApiSchema.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/inputs/ApiSchema.json
@@ -5,7 +5,7 @@
     "projectEndpointName": "ed-fi",
     "projectVersion": "5.0.0",
     "isExtensionProject": false,
-    "description": "Referential-identity fixture - Student, School (subclass), and StudentSchoolAssociation with references",
+    "description": "Referential-identity fixture - Student, School (subclass), StudentSchoolAssociation with references, plus decimal/datetime/decimal-reference resources",
     "abstractResources": {
       "EducationOrganization": {
         "identityJsonPaths": [
@@ -21,7 +21,10 @@
       "resourcebs": "resourceBs",
       "keyunifiedresources": "keyUnifiedResources",
       "edorgdependentresources": "edOrgDependentResources",
-      "edorgdependentchildresources": "edOrgDependentChildResources"
+      "edorgdependentchildresources": "edOrgDependentChildResources",
+      "decimalkeyresources": "decimalKeyResources",
+      "datetimekeyresources": "dateTimeKeyResources",
+      "decimalrefresources": "decimalRefResources"
     },
     "educationOrganizationHierarchy": {
       "EducationOrganization": {},
@@ -39,7 +42,10 @@
       "ResourceB": "resourceBs",
       "KeyUnifiedResource": "keyUnifiedResources",
       "EdOrgDependentResource": "edOrgDependentResources",
-      "EdOrgDependentChildResource": "edOrgDependentChildResources"
+      "EdOrgDependentChildResource": "edOrgDependentChildResources",
+      "DecimalKeyResource": "decimalKeyResources",
+      "DateTimeKeyResource": "dateTimeKeyResources",
+      "DecimalRefResource": "decimalRefResources"
     },
     "resourceSchemas": {
       "students": {
@@ -529,6 +535,153 @@
             }
           },
           "required": ["edOrgDependentChildResourceId", "edOrgDependentResourceReference"]
+        }
+      },
+      "decimalKeyResources": {
+        "resourceName": "DecimalKeyResource",
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": [
+          "$.decimalKey"
+        ],
+        "numericJsonPaths": [
+          "$.decimalKey"
+        ],
+        "dateTimeJsonPaths": [],
+        "documentPathsMapping": {
+          "DecimalKey": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.decimalKey"
+          }
+        },
+        "decimalPropertyValidationInfos": [
+          {
+            "path": "$.decimalKey",
+            "totalDigits": 9,
+            "decimalPlaces": 2
+          }
+        ],
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "decimalKey": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "decimalKey"
+          ]
+        }
+      },
+      "dateTimeKeyResources": {
+        "resourceName": "DateTimeKeyResource",
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": [
+          "$.eventTimestamp"
+        ],
+        "numericJsonPaths": [],
+        "dateTimeJsonPaths": [
+          "$.eventTimestamp"
+        ],
+        "documentPathsMapping": {
+          "EventTimestamp": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.eventTimestamp"
+          }
+        },
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "eventTimestamp": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          "required": [
+            "eventTimestamp"
+          ]
+        }
+      },
+      "decimalRefResources": {
+        "resourceName": "DecimalRefResource",
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSubclass": false,
+        "isSchoolYearEnumeration": false,
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": [
+          "$.refResourceId",
+          "$.decimalKeyReference.decimalKey"
+        ],
+        "numericJsonPaths": [
+          "$.decimalKeyReference.decimalKey"
+        ],
+        "dateTimeJsonPaths": [],
+        "decimalPropertyValidationInfos": [
+          {
+            "path": "$.decimalKeyReference.decimalKey",
+            "totalDigits": 9,
+            "decimalPlaces": 2
+          }
+        ],
+        "documentPathsMapping": {
+          "RefResourceId": {
+            "isReference": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "path": "$.refResourceId"
+          },
+          "DecimalKeyReference": {
+            "isReference": true,
+            "isDescriptor": false,
+            "isPartOfIdentity": true,
+            "isRequired": true,
+            "projectName": "Ed-Fi",
+            "resourceName": "DecimalKeyResource",
+            "referenceJsonPaths": [
+              {
+                "identityJsonPath": "$.decimalKey",
+                "referenceJsonPath": "$.decimalKeyReference.decimalKey",
+                "type": "number"
+              }
+            ]
+          }
+        },
+        "jsonSchemaForInsert": {
+          "type": "object",
+          "properties": {
+            "refResourceId": {
+              "type": "string",
+              "maxLength": 64
+            },
+            "decimalKeyReference": {
+              "type": "object",
+              "properties": {
+                "decimalKey": {
+                  "type": "number"
+                }
+              },
+              "required": ["decimalKey"]
+            }
+          },
+          "required": ["refResourceId", "decimalKeyReference"]
         }
       }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
@@ -1159,23 +1159,39 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
         {
             case ScalarKind.DateTime:
                 // PG timestamp::text gives 'YYYY-MM-DD HH:MM:SS' (space, no T).
-                // Use to_char for ISO 8601 with T separator.
+                // Use to_char with AT TIME ZONE 'UTC' to produce the ISO 8601 form with T
+                // separator and a literal Z suffix, independent of the session timezone.
                 //
-                // No AT TIME ZONE 'UTC' conversion: the PG column type is timestamptz, which
-                // stores UTC internally but displays in the session timezone. The trigger fires
-                // in the same session as the INSERT/UPDATE, so to_char always reproduces the
-                // original literal that was inserted — matching what Core's ReferentialIdCalculator
-                // hashes from the raw JSON string. Adding AT TIME ZONE 'UTC' here would break
-                // parity because the C# path does not normalize to UTC before hashing.
-                // The DMS application must use a consistent session timezone (UTC recommended).
-                // See also EmitMssqlColumnToNvarchar (datetime2 is timezone-naive, no issue).
+                // Core normalizes incoming DateTime values to UTC before persistence:
+                // JsonHelpers.TryNormalizeDateTimeString parses with
+                // DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal
+                // and emits yyyy-MM-ddTHH:mm:ssZ. AT TIME ZONE 'UTC' here ensures the
+                // trigger reproduces that canonical UTC form regardless of the session
+                // timezone, so the trigger-computed ReferentialId always matches what
+                // Core's ReferentialIdCalculator hashes.
+                // Precedent: PostgresqlReferenceLookupCommandBuilder uses the same form.
                 writer.Append("to_char(NEW.");
                 writer.Append(quoted);
-                writer.Append(", 'YYYY-MM-DD\"T\"HH24:MI:SS')");
+                writer.Append(" AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')");
+                break;
+
+            case ScalarKind.Decimal:
+                // Decimal columns carry column-scale trailing zeros (e.g., decimal(9,2) renders
+                // 1.50, 2.00) that Core never hashes — IdentityValueCanonicalizer strips them.
+                // Use two nested regexp_replace calls to strip trailing fractional zeros and then
+                // a trailing decimal point so the trigger output matches the Core canonical form.
+                //   regexp_replace(NEW.col::text, '(\.[0-9]*?)0+$', '\1') strips trailing zeros
+                //   after the decimal: 1.50 → 1.5, 2.00 → 2., 100 → 100 (no decimal, unchanged).
+                //   The outer regexp_replace(..., '\.$', '') then drops any resulting lone decimal
+                //   point: 2. → 2, 100 → 100 (unchanged).
+                // Cases verified: 1.50→1.5, 2.00→2, 100.00→100, 1.5→1.5, 100→100, 0→0, -1.50→-1.5.
+                writer.Append("regexp_replace(regexp_replace(NEW.");
+                writer.Append(quoted);
+                writer.Append("""::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')""");
                 break;
 
             default:
-                // String, Int32, Int64, Date, Time, Decimal, Boolean — ::text is deterministic.
+                // String, Int32, Int64, Date, Time, Boolean — ::text is deterministic.
                 writer.Append("NEW.");
                 writer.Append(quoted);
                 writer.Append("::text");
@@ -1357,12 +1373,14 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
                 break;
 
             case ScalarKind.DateTime:
-                // ISO 8601: YYYY-MM-DDTHH:mm:ss (CONVERT style 126, truncated to 19 chars).
+                // ISO 8601: YYYY-MM-DDTHH:mm:ssZ (CONVERT style 126, truncated to 19 chars, with UTC Z suffix).
                 // Truncation to whole seconds matches PG to_char() which also omits fractional
-                // seconds, ensuring cross-engine identity hash parity.
+                // seconds, ensuring cross-engine identity hash parity. datetime2 is timezone-naive
+                // because Core normalizes incoming offsets to UTC before persistence, so appending
+                // the literal Z suffix is sufficient.
                 writer.Append("CONVERT(nvarchar(19), i.");
                 writer.Append(quoted);
-                writer.Append(", 126)");
+                writer.Append(", 126) + N'Z'");
                 break;
 
             case ScalarKind.Time:
@@ -1380,8 +1398,38 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
                 writer.Append(" = 1 THEN N'true' ELSE N'false' END");
                 break;
 
+            case ScalarKind.Decimal:
+                // Trim trailing fractional zeros and a trailing decimal point to match Core's
+                // canonical decimal form (no exponent, no trailing zeros, no trailing decimal
+                // point). Uses deterministic CAST/CHARINDEX/PATINDEX/LEFT/REVERSE — no FORMAT().
+                // Example transformations: 1.50 → 1.5, 2.00 → 2, 100.00 → 100, 1.5 → 1.5.
+                writer.Append("CASE WHEN CHARINDEX(N'.', CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max))) = 0 THEN CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max))))) ELSE LEFT(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
+                writer.Append(quoted);
+                writer.Append(" AS nvarchar(max)))) + 1) END END");
+                break;
+
             default:
-                // Int32, Int64, Decimal — CAST is deterministic and matches Core/PG formatting.
+                // Int32, Int64 — CAST is deterministic and matches Core/PG formatting.
                 writer.Append("CAST(i.");
                 writer.Append(quoted);
                 writer.Append(" AS nvarchar(max))");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/RelationalModelDdlEmitter.cs
@@ -1149,54 +1149,13 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
 
     /// <summary>
     /// Emits a type-aware text conversion for an identity column value in PostgreSQL.
-    /// Uses <c>::text</c> for most types (already ISO-stable) but explicit <c>to_char()</c>
-    /// for <see cref="ScalarKind.DateTime"/> where <c>::text</c> omits the ISO 8601 T separator.
+    /// Delegates to <see cref="DialectIdentityTextFormatter.PgsqlColumnToText"/> so the
+    /// trigger and the runtime reference-lookup verification SQL share one source of truth.
     /// </summary>
     private void EmitPgsqlColumnToText(SqlWriter writer, DbColumnName column, RelationalScalarType scalarType)
     {
-        var quoted = Quote(column);
-        switch (scalarType.Kind)
-        {
-            case ScalarKind.DateTime:
-                // PG timestamp::text gives 'YYYY-MM-DD HH:MM:SS' (space, no T).
-                // Use to_char with AT TIME ZONE 'UTC' to produce the ISO 8601 form with T
-                // separator and a literal Z suffix, independent of the session timezone.
-                //
-                // Core normalizes incoming DateTime values to UTC before persistence:
-                // JsonHelpers.TryNormalizeDateTimeString parses with
-                // DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal
-                // and emits yyyy-MM-ddTHH:mm:ssZ. AT TIME ZONE 'UTC' here ensures the
-                // trigger reproduces that canonical UTC form regardless of the session
-                // timezone, so the trigger-computed ReferentialId always matches what
-                // Core's ReferentialIdCalculator hashes.
-                // Precedent: PostgresqlReferenceLookupCommandBuilder uses the same form.
-                writer.Append("to_char(NEW.");
-                writer.Append(quoted);
-                writer.Append(" AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')");
-                break;
-
-            case ScalarKind.Decimal:
-                // Decimal columns carry column-scale trailing zeros (e.g., decimal(9,2) renders
-                // 1.50, 2.00) that Core never hashes — IdentityValueCanonicalizer strips them.
-                // Use two nested regexp_replace calls to strip trailing fractional zeros and then
-                // a trailing decimal point so the trigger output matches the Core canonical form.
-                //   regexp_replace(NEW.col::text, '(\.[0-9]*?)0+$', '\1') strips trailing zeros
-                //   after the decimal: 1.50 → 1.5, 2.00 → 2., 100 → 100 (no decimal, unchanged).
-                //   The outer regexp_replace(..., '\.$', '') then drops any resulting lone decimal
-                //   point: 2. → 2, 100 → 100 (unchanged).
-                // Cases verified: 1.50→1.5, 2.00→2, 100.00→100, 1.5→1.5, 100→100, 0→0, -1.50→-1.5.
-                writer.Append("regexp_replace(regexp_replace(NEW.");
-                writer.Append(quoted);
-                writer.Append("""::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')""");
-                break;
-
-            default:
-                // String, Int32, Int64, Date, Time, Boolean — ::text is deterministic.
-                writer.Append("NEW.");
-                writer.Append(quoted);
-                writer.Append("::text");
-                break;
-        }
+        var columnExpression = $"NEW.{Quote(column)}";
+        writer.Append(DialectIdentityTextFormatter.PgsqlColumnToText(columnExpression, scalarType));
     }
 
     private void EmitMssqlReferentialIdentityBody(
@@ -1347,8 +1306,8 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
 
     /// <summary>
     /// Emits a type-aware nvarchar conversion for an identity column value in MSSQL.
-    /// Uses deterministic CONVERT styles for temporal types to ensure cross-engine parity
-    /// with PostgreSQL and Core's <c>JsonValue.ToString()</c>.
+    /// Delegates to <see cref="DialectIdentityTextFormatter.MssqlColumnToNvarchar"/> so the
+    /// trigger and the runtime reference-lookup verification SQL share one source of truth.
     /// </summary>
     private void EmitMssqlColumnToNvarchar(
         SqlWriter writer,
@@ -1356,85 +1315,8 @@ public sealed class RelationalModelDdlEmitter(ISqlDialect dialect)
         RelationalScalarType scalarType
     )
     {
-        var quoted = Quote(column);
-        switch (scalarType.Kind)
-        {
-            case ScalarKind.String:
-                // Already nvarchar — no cast needed.
-                writer.Append("i.");
-                writer.Append(quoted);
-                break;
-
-            case ScalarKind.Date:
-                // ISO 8601: YYYY-MM-DD (CONVERT style 23).
-                writer.Append("CONVERT(nvarchar(10), i.");
-                writer.Append(quoted);
-                writer.Append(", 23)");
-                break;
-
-            case ScalarKind.DateTime:
-                // ISO 8601: YYYY-MM-DDTHH:mm:ssZ (CONVERT style 126, truncated to 19 chars, with UTC Z suffix).
-                // Truncation to whole seconds matches PG to_char() which also omits fractional
-                // seconds, ensuring cross-engine identity hash parity. datetime2 is timezone-naive
-                // because Core normalizes incoming offsets to UTC before persistence, so appending
-                // the literal Z suffix is sufficient.
-                writer.Append("CONVERT(nvarchar(19), i.");
-                writer.Append(quoted);
-                writer.Append(", 126) + N'Z'");
-                break;
-
-            case ScalarKind.Time:
-                // HH:mm:ss (CONVERT style 108).
-                writer.Append("CONVERT(nvarchar(8), i.");
-                writer.Append(quoted);
-                writer.Append(", 108)");
-                break;
-
-            case ScalarKind.Boolean:
-                // CAST(bit AS nvarchar) produces '1'/'0', but Core's JsonValue.ToString()
-                // and PG bool::text both produce 'true'/'false'. Use CASE to match.
-                writer.Append("CASE WHEN i.");
-                writer.Append(quoted);
-                writer.Append(" = 1 THEN N'true' ELSE N'false' END");
-                break;
-
-            case ScalarKind.Decimal:
-                // Trim trailing fractional zeros and a trailing decimal point to match Core's
-                // canonical decimal form (no exponent, no trailing zeros, no trailing decimal
-                // point). Uses deterministic CAST/CHARINDEX/PATINDEX/LEFT/REVERSE — no FORMAT().
-                // Example transformations: 1.50 → 1.5, 2.00 → 2, 100.00 → 100, 1.5 → 1.5.
-                writer.Append("CASE WHEN CHARINDEX(N'.', CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))) = 0 THEN CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)) ELSE CASE WHEN RIGHT(LEFT(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)))) + 1), 1) = N'.' THEN LEFT(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))))) ELSE LEFT(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)), LEN(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))) - PATINDEX('%[^0]%', REVERSE(CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max)))) + 1) END END");
-                break;
-
-            default:
-                // Int32, Int64 — CAST is deterministic and matches Core/PG formatting.
-                writer.Append("CAST(i.");
-                writer.Append(quoted);
-                writer.Append(" AS nvarchar(max))");
-                break;
-        }
+        var columnExpression = $"i.{Quote(column)}";
+        writer.Append(DialectIdentityTextFormatter.MssqlColumnToNvarchar(columnExpression, scalarType));
     }
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/DialectIdentityTextFormatter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/DialectIdentityTextFormatter.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.External;
+
+/// <summary>
+/// Single source of truth for converting an identity column value to its canonical
+/// text form inside generated SQL. Used by both ReferentialIdentity trigger emission
+/// (Backend.Ddl) and reference-lookup verification (Backend.Postgresql / Backend.Mssql)
+/// so the trigger-stored ReferentialId text and the runtime-computed verification key
+/// cannot drift.
+///
+/// Output must match Core's <c>IdentityValueCanonicalizer</c>: fixed-point decimals
+/// with no trailing fractional zeros, no trailing decimal point, ISO 8601 'Z'-suffixed
+/// UTC datetimes, and 'true'/'false' booleans.
+/// </summary>
+public static class DialectIdentityTextFormatter
+{
+    /// <summary>
+    /// Returns a PostgreSQL expression that converts <paramref name="columnExpression"/>
+    /// (e.g. <c>NEW."Foo"</c>, <c>s."Foo"</c>) to its canonical identity text form.
+    /// </summary>
+    public static string PgsqlColumnToText(string columnExpression, RelationalScalarType scalarType)
+    {
+        ArgumentNullException.ThrowIfNull(columnExpression);
+        ArgumentNullException.ThrowIfNull(scalarType);
+
+        return scalarType.Kind switch
+        {
+            // PG timestamp::text gives 'YYYY-MM-DD HH:MM:SS' (space, no T). Use to_char with
+            // AT TIME ZONE 'UTC' to produce ISO 8601 with the T separator and a literal Z,
+            // independent of the session timezone. Core normalizes incoming DateTime values
+            // to UTC before persistence, so AT TIME ZONE 'UTC' here reproduces that canonical
+            // UTC form.
+            ScalarKind.DateTime =>
+                $"to_char({columnExpression} AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')",
+
+            // Decimal columns carry column-scale trailing zeros (e.g. decimal(9,2) renders
+            // 1.50, 2.00) that Core never hashes. Two nested regexp_replace calls strip
+            // trailing fractional zeros and then a lone trailing decimal point so the SQL
+            // output matches Core's canonical decimal form.
+            //   regexp_replace(<col>::text, '(\.[0-9]*?)0+$', '\1')  → 1.50→1.5, 2.00→2.
+            //   outer regexp_replace(..., '\.$', '')                 → 2.→2, 100→100.
+            // Cases verified: 1.50→1.5, 2.00→2, 100.00→100, 1.5→1.5, 100→100, 0→0, -1.50→-1.5.
+            ScalarKind.Decimal =>
+                $"""regexp_replace(regexp_replace({columnExpression}::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')""",
+
+            // String, Int32, Int64, Date, Time, Boolean — ::text is deterministic.
+            _ => $"{columnExpression}::text",
+        };
+    }
+
+    /// <summary>
+    /// Returns a SQL Server expression that converts <paramref name="columnExpression"/>
+    /// (e.g. <c>i.[Foo]</c>, <c>s.[Foo]</c>) to its canonical identity nvarchar form.
+    /// </summary>
+    public static string MssqlColumnToNvarchar(string columnExpression, RelationalScalarType scalarType)
+    {
+        ArgumentNullException.ThrowIfNull(columnExpression);
+        ArgumentNullException.ThrowIfNull(scalarType);
+
+        return scalarType.Kind switch
+        {
+            // Already nvarchar — no cast needed.
+            ScalarKind.String => columnExpression,
+
+            // ISO 8601: YYYY-MM-DD (CONVERT style 23).
+            ScalarKind.Date => $"CONVERT(nvarchar(10), {columnExpression}, 23)",
+
+            // ISO 8601: YYYY-MM-DDTHH:mm:ssZ (CONVERT style 126, truncated to 19 chars,
+            // with UTC Z suffix). Truncation to whole seconds matches PG to_char()'s
+            // omission of fractional seconds. datetime2 is timezone-naive because Core
+            // normalizes incoming offsets to UTC before persistence, so appending Z is
+            // sufficient.
+            ScalarKind.DateTime => $"CONVERT(nvarchar(19), {columnExpression}, 126) + N'Z'",
+
+            // HH:mm:ss (CONVERT style 108).
+            ScalarKind.Time => $"CONVERT(nvarchar(8), {columnExpression}, 108)",
+
+            // CAST(bit AS nvarchar) produces '1'/'0', but Core's JsonValue.ToString() and
+            // PG bool::text both produce 'true'/'false'. Use CASE to match.
+            ScalarKind.Boolean => $"CASE WHEN {columnExpression} = 1 THEN N'true' ELSE N'false' END",
+
+            // Trim trailing fractional zeros and a trailing decimal point to match Core's
+            // canonical form. Deterministic CAST/CHARINDEX/PATINDEX/LEFT/REVERSE — no FORMAT().
+            // Example transformations: 1.50 → 1.5, 2.00 → 2, 100.00 → 100, 1.5 → 1.5.
+            ScalarKind.Decimal => BuildMssqlDecimalText(columnExpression),
+
+            // Int32, Int64 — CAST is deterministic and matches Core/PG formatting.
+            _ => $"CAST({columnExpression} AS nvarchar(max))",
+        };
+    }
+
+    private static string BuildMssqlDecimalText(string columnExpression)
+    {
+        var cast = $"CAST({columnExpression} AS nvarchar(max))";
+        return $"CASE WHEN CHARINDEX(N'.', {cast}) = 0 THEN {cast} "
+            + $"ELSE CASE WHEN RIGHT(LEFT({cast}, LEN({cast}) - PATINDEX('%[^0]%', REVERSE({cast})) + 1), 1) = N'.' "
+            + $"THEN LEFT({cast}, LEN({cast}) - PATINDEX('%[^0]%', REVERSE({cast}))) "
+            + $"ELSE LEFT({cast}, LEN({cast}) - PATINDEX('%[^0]%', REVERSE({cast})) + 1) END END";
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferentialIdentityTests.cs
@@ -924,6 +924,143 @@ public class MssqlReferentialIdentityTests
         );
     }
 
+    [Test]
+    public async Task DateTime_trigger_emits_utc_z_suffix()
+    {
+        // Arrange — plain UTC wall-clock literal; datetime2 is timezone-naive (no offset suffix)
+        var documentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DateTimeKeyResource");
+
+        // Act
+        await InsertDateTimeKeyResourceAsync(documentId, "2025-01-01T12:00:00");
+
+        // Assert — trigger must append Z so the ReferentialId matches the Core canonical form
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(1);
+
+        var expectedReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DateTimeKeyResource",
+            ("$.eventTimestamp", "2025-01-01T12:00:00Z")
+        );
+
+        ((Guid)referentialIds.Single()["ReferentialId"]!).Should().Be(expectedReferentialId);
+        ((long)referentialIds.Single()["DocumentId"]!).Should().Be(documentId);
+    }
+
+    [Test]
+    [TestCase("1.5", "1.5", TestName = "Single trailing zero stripped (1.50 stored as 1.5)")]
+    [TestCase("2.00", "2", TestName = "Fractional zeros and decimal point stripped (2.00 -> 2)")]
+    [TestCase("100.00", "100", TestName = "Integer trailing zeros preserved (100.00 -> 100)")]
+    public async Task Decimal_top_level_identity_trims_trailing_zeros(
+        string insertedValue,
+        string expectedCanonical
+    )
+    {
+        // Arrange
+        var documentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalKeyResource");
+
+        // Act
+        await InsertDecimalKeyResourceAsync(documentId, insertedValue);
+
+        // Assert
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(1);
+
+        var expectedReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DecimalKeyResource",
+            ("$.decimalKey", expectedCanonical)
+        );
+
+        ((Guid)referentialIds.Single()["ReferentialId"]!).Should().Be(expectedReferentialId);
+        ((long)referentialIds.Single()["DocumentId"]!).Should().Be(documentId);
+    }
+
+    [Test]
+    public async Task Decimal_reference_identity_trims_trailing_zeros()
+    {
+        // Arrange — insert DecimalKeyResource with decimalKey=1.50 (stored as decimal(9,2))
+        var decimalKeyDocumentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalKeyResource");
+        await InsertDecimalKeyResourceAsync(decimalKeyDocumentId, "1.50");
+
+        var refResourceId = "ref-dec-1";
+        var decimalRefDocumentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalRefResource");
+
+        // Act — insert DecimalRefResource referencing the DecimalKeyResource row
+        await InsertDecimalRefResourceAsync(
+            decimalRefDocumentId,
+            refResourceId,
+            decimalKeyDocumentId,
+            "1.50"
+        );
+
+        // Assert — DecimalRefResource RI: reference path $.decimalKeyReference.decimalKey canonical form
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(2);
+
+        var expectedDecimalRefReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DecimalRefResource",
+            ("$.refResourceId", refResourceId),
+            ("$.decimalKeyReference.decimalKey", "1.5")
+        );
+
+        var decimalRefRow = referentialIds.Single(r => (long)r["DocumentId"]! == decimalRefDocumentId);
+        ((Guid)decimalRefRow["ReferentialId"]!).Should().Be(expectedDecimalRefReferentialId);
+    }
+
+    private async Task InsertDateTimeKeyResourceAsync(long documentId, string eventTimestamp)
+    {
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [edfi].[DateTimeKeyResource] ([DocumentId], [EventTimestamp])
+            VALUES (@documentId, @eventTimestamp);
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@eventTimestamp", eventTimestamp)
+        );
+    }
+
+    private async Task InsertDecimalKeyResourceAsync(long documentId, string decimalKey)
+    {
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [edfi].[DecimalKeyResource] ([DocumentId], [DecimalKey])
+            VALUES (@documentId, @decimalKey);
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter(
+                "@decimalKey",
+                decimal.Parse(decimalKey, System.Globalization.CultureInfo.InvariantCulture)
+            )
+        );
+    }
+
+    private async Task InsertDecimalRefResourceAsync(
+        long documentId,
+        string refResourceId,
+        long decimalKeyReferenceDocumentId,
+        string decimalKeyReferenceDecimalKey
+    )
+    {
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [edfi].[DecimalRefResource] ([DocumentId], [RefResourceId], [DecimalKeyReference_DocumentId], [DecimalKeyReference_DecimalKey])
+            VALUES (@documentId, @refResourceId, @decimalKeyReferenceDocumentId, @decimalKeyReferenceDecimalKey);
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@refResourceId", refResourceId),
+            new SqlParameter("@decimalKeyReferenceDocumentId", decimalKeyReferenceDocumentId),
+            new SqlParameter(
+                "@decimalKeyReferenceDecimalKey",
+                decimal.Parse(
+                    decimalKeyReferenceDecimalKey,
+                    System.Globalization.CultureInfo.InvariantCulture
+                )
+            )
+        );
+    }
+
     private static IEnumerable<TestCaseData> CollationScenarios()
     {
         yield return new TestCaseData("STU001", "STU002").SetName("Plain value change");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/MssqlReferenceLookupSmallListStrategy.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/MssqlReferenceLookupSmallListStrategy.cs
@@ -198,18 +198,11 @@ internal sealed class MssqlReferenceLookupSmallListStrategy(IRelationalCommandEx
         ReferenceLookupVerificationElement identityElement
     )
     {
-        var quotedColumnName = QuoteIdentifier(identityElement.Column.Value);
-
-        return identityElement.ScalarType.Kind switch
-        {
-            ScalarKind.String => $"{sourceAlias}.{quotedColumnName}",
-            ScalarKind.Date => $"CONVERT(nvarchar(10), {sourceAlias}.{quotedColumnName}, 23)",
-            ScalarKind.DateTime => $"CONVERT(nvarchar(19), {sourceAlias}.{quotedColumnName}, 126) + N'Z'",
-            ScalarKind.Time => $"CONVERT(nvarchar(8), {sourceAlias}.{quotedColumnName}, 108)",
-            ScalarKind.Boolean =>
-                $"CASE WHEN {sourceAlias}.{quotedColumnName} = 1 THEN N'true' ELSE N'false' END",
-            _ => $"CAST({sourceAlias}.{quotedColumnName} AS nvarchar(max))",
-        };
+        var columnExpression = $"{sourceAlias}.{QuoteIdentifier(identityElement.Column.Value)}";
+        return DialectIdentityTextFormatter.MssqlColumnToNvarchar(
+            columnExpression,
+            identityElement.ScalarType
+        );
     }
 
     private static string QuoteTableName(DbTableName tableName) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlReferentialIdentityTests.cs
@@ -840,6 +840,131 @@ public class PostgresqlReferentialIdentityTests
         referentialIds.Should().BeEmpty();
     }
 
+    [Test]
+    public async Task DateTime_key_trigger_emits_utc_canonical_form_regardless_of_session_timezone()
+    {
+        // Arrange — document shell
+        var documentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DateTimeKeyResource");
+
+        // Act — open single connection with Eastern timezone, then insert
+        await using var connection = new NpgsqlConnection(_database.ConnectionString);
+        await connection.OpenAsync();
+
+        await using var transaction = await connection.BeginTransactionAsync();
+
+        await using var setTzCmd = connection.CreateCommand();
+        setTzCmd.Transaction = transaction;
+        setTzCmd.CommandText = "SET LOCAL TIME ZONE 'America/New_York'";
+        await setTzCmd.ExecuteNonQueryAsync();
+
+        await using var insertCmd = connection.CreateCommand();
+        insertCmd.Transaction = transaction;
+        insertCmd.CommandText = """
+            INSERT INTO "edfi"."DateTimeKeyResource" ("DocumentId", "EventTimestamp")
+            VALUES (@documentId, @eventTimestamp);
+            """;
+        insertCmd.Parameters.Add(new NpgsqlParameter("documentId", documentId));
+        insertCmd.Parameters.Add(
+            new NpgsqlParameter("eventTimestamp", NpgsqlTypes.NpgsqlDbType.TimestampTz)
+            {
+                Value = new DateTimeOffset(2025, 1, 1, 12, 0, 0, TimeSpan.Zero),
+            }
+        );
+        await insertCmd.ExecuteNonQueryAsync();
+
+        await transaction.CommitAsync();
+
+        // Assert — trigger must emit UTC form; Eastern session would yield '2025-01-01T07:00:00Z' without AT TIME ZONE fix
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(1);
+
+        var expectedReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DateTimeKeyResource",
+            ("$.eventTimestamp", "2025-01-01T12:00:00Z")
+        );
+        ((Guid)referentialIds.Single()["ReferentialId"]!).Should().Be(expectedReferentialId);
+        ((long)referentialIds.Single()["DocumentId"]!).Should().Be(documentId);
+    }
+
+    [Test]
+    [TestCase(1.5, "1.5", TestName = "Decimal_1point5_trims_single_trailing_zero")]
+    [TestCase(2.0, "2", TestName = "Decimal_2point00_trims_trailing_zeros_and_dot")]
+    [TestCase(100.0, "100", TestName = "Decimal_100point00_does_not_eat_integer_zeros")]
+    public async Task Decimal_key_trigger_emits_canonical_trimmed_form(
+        double rawValue,
+        string expectedCanonical
+    )
+    {
+        // Arrange
+        var documentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalKeyResource");
+
+        // Act
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "edfi"."DecimalKeyResource" ("DocumentId", "DecimalKey")
+            VALUES (@documentId, @decimalKey);
+            """,
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("decimalKey", (decimal)rawValue)
+        );
+
+        // Assert
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(1);
+
+        var expectedReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DecimalKeyResource",
+            ("$.decimalKey", expectedCanonical)
+        );
+        ((Guid)referentialIds.Single()["ReferentialId"]!).Should().Be(expectedReferentialId);
+        ((long)referentialIds.Single()["DocumentId"]!).Should().Be(documentId);
+    }
+
+    [Test]
+    public async Task Decimal_reference_trigger_emits_canonical_form_for_reference_identity_path()
+    {
+        // Arrange — insert a DecimalKeyResource with decimalKey = 1.50
+        var decimalKeyDocumentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalKeyResource");
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "edfi"."DecimalKeyResource" ("DocumentId", "DecimalKey")
+            VALUES (@documentId, @decimalKey);
+            """,
+            new NpgsqlParameter("documentId", decimalKeyDocumentId),
+            new NpgsqlParameter("decimalKey", 1.50m)
+        );
+
+        // Insert a DecimalRefResource referencing the above
+        var refResourceId = "ref-001";
+        var refDocumentId = await InsertDocumentAsync(Guid.NewGuid(), "Ed-Fi", "DecimalRefResource");
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "edfi"."DecimalRefResource" ("DocumentId", "RefResourceId", "DecimalKeyReference_DocumentId", "DecimalKeyReference_DecimalKey")
+            VALUES (@documentId, @refResourceId, @decimalKeyDocumentId, @decimalKey);
+            """,
+            new NpgsqlParameter("documentId", refDocumentId),
+            new NpgsqlParameter("refResourceId", refResourceId),
+            new NpgsqlParameter("decimalKeyDocumentId", decimalKeyDocumentId),
+            new NpgsqlParameter("decimalKey", 1.50m)
+        );
+
+        // Assert — DecimalRefResource's ReferentialId uses the canonical "1.5" form for decimalKey
+        var referentialIds = await QueryReferentialIdentityRowsAsync();
+        referentialIds.Should().HaveCount(2);
+
+        var expectedRefResourceReferentialId = ComputeReferentialId(
+            "Ed-Fi",
+            "DecimalRefResource",
+            ("$.refResourceId", refResourceId),
+            ("$.decimalKeyReference.decimalKey", "1.5")
+        );
+
+        var refRow = referentialIds.Single(r => (long)r["DocumentId"]! == refDocumentId);
+        ((Guid)refRow["ReferentialId"]!).Should().Be(expectedRefResourceReferentialId);
+    }
+
     private async Task<short> GetResourceKeyIdAsync(string projectName, string resourceName)
     {
         return await _database.ExecuteScalarAsync<short>(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlReferenceLookupCommandBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/PostgresqlReferenceLookupCommandBuilder.cs
@@ -159,14 +159,8 @@ internal static class PostgresqlReferenceLookupCommandBuilder
         ReferenceLookupVerificationElement identityElement
     )
     {
-        var quotedColumnName = QuoteIdentifier(identityElement.Column.Value);
-
-        return identityElement.ScalarType.Kind switch
-        {
-            ScalarKind.DateTime =>
-                $"""to_char({sourceAlias}.{quotedColumnName} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')""",
-            _ => $"{sourceAlias}.{quotedColumnName}::text",
-        };
+        var columnExpression = $"{sourceAlias}.{QuoteIdentifier(identityElement.Column.Value)}";
+        return DialectIdentityTextFormatter.PgsqlColumnToText(columnExpression, identityElement.ScalarType);
     }
 
     private static string QuoteTableName(DbTableName tableName) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/MssqlReferenceLookupSmallListStrategyTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/MssqlReferenceLookupSmallListStrategyTests.cs
@@ -219,6 +219,30 @@ public class Given_MssqlReferenceLookupSmallListStrategy
         command.CommandText.Should().Contain("CONVERT(nvarchar(19), source.[MeetingDateTime], 126) + N'Z'");
     }
 
+    [Test]
+    public void It_trims_decimal_identity_verification_keys_to_match_core_canonical_form()
+    {
+        // Without decimal trimming the lookup verification key would be e.g.
+        // "$.decimalKey=1.50", while Core's canonicalizer (and the trigger) emit
+        // "$.decimalKey=1.5". ReferenceResolver.EnsureLookupIntegrity does an
+        // ordinal string compare against the Core-built ExpectedVerificationIdentityKey,
+        // so the lookup SQL must apply the same trim or every decimal-keyed reference
+        // throws ReferenceLookupCorruptionException.
+        var command = MssqlReferenceLookupSmallListStrategy.BuildCommand(
+            new ReferenceLookupRequest(
+                MappingSet: RelationalAccessTestData.CreateMappingSet(_requestResource),
+                RequestResource: _requestResource,
+                Lookups: [RelationalAccessTestData.CreateDecimalKeyLookup(CreateReferentialId(6))]
+            )
+        );
+
+        command.CommandText.Should().Contain("FROM [edfi].[DecimalKeyResource] source");
+        command.CommandText.Should().Contain("CHARINDEX(N'.', CAST(source.[DecimalKey] AS nvarchar(max)))");
+        command
+            .CommandText.Should()
+            .Contain("PATINDEX('%[^0]%', REVERSE(CAST(source.[DecimalKey] AS nvarchar(max))))");
+    }
+
     private static ReferentialId CreateReferentialId(int seed)
     {
         var bytes = new byte[16];

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PostgresqlReferenceLookupCommandBuilderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/PostgresqlReferenceLookupCommandBuilderTests.cs
@@ -125,6 +125,32 @@ public class Given_PostgresqlReferenceLookupCommandBuilder
             );
     }
 
+    [Test]
+    public void It_trims_decimal_identity_verification_keys_to_match_core_canonical_form()
+    {
+        // Without decimal trimming the lookup verification key would be e.g.
+        // "$.decimalKey=1.50", while Core's canonicalizer (and the trigger) emit
+        // "$.decimalKey=1.5". ReferenceResolver.EnsureLookupIntegrity does an
+        // ordinal string compare against the Core-built ExpectedVerificationIdentityKey,
+        // so the lookup SQL must apply the same trim or every decimal-keyed reference
+        // throws ReferenceLookupCorruptionException.
+        var command = PostgresqlReferenceLookupCommandBuilder.Build(
+            new ReferenceLookupRequest(
+                MappingSet: RelationalAccessTestData.CreateMappingSet(_requestResource),
+                RequestResource: _requestResource,
+                Lookups: [RelationalAccessTestData.CreateDecimalKeyLookup(CreateReferentialId(5))]
+            )
+        );
+
+        command.CommandText.Should().Contain("FROM \"edfi\".\"DecimalKeyResource\" source");
+        command
+            .CommandText.Should()
+            .Contain(
+                @"regexp_replace(regexp_replace(source.""DecimalKey""::text, '(\.[0-9]*?)0+$', '\1'), '\.$', '')"
+            );
+        command.CommandText.Should().NotContain("source.\"DecimalKey\"::text |");
+    }
+
     private static ReferentialId CreateReferentialId(int seed)
     {
         var bytes = new byte[16];

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ReferenceResolverTests.cs
@@ -26,6 +26,7 @@ public class Given_ReferenceResolver
         "EducationOrganization"
     );
     private static readonly QualifiedResourceName _meetingResource = new("Ed-Fi", "Meeting");
+    private static readonly QualifiedResourceName _decimalKeyResource = new("Ed-Fi", "DecimalKeyResource");
     private static readonly QualifiedResourceName _schoolTypeDescriptorResource = new(
         "Ed-Fi",
         "SchoolTypeDescriptor"
@@ -268,6 +269,110 @@ public class Given_ReferenceResolver
             .SuccessfulDocumentReferencesByPath[new JsonPath("$.meetingReference")]
             .DocumentId.Should()
             .Be(404L);
+    }
+
+    [Test]
+    public async Task It_does_not_raise_corruption_for_matching_canonical_decimal_identity_verification_keys()
+    {
+        // Core canonicalizes decimal identity values to fixed-point with no trailing
+        // fractional zeros (e.g. "1.50" → "1.5"), and the trigger and lookup verification
+        // SQL must produce the same form. This test exercises the resolver path: when the
+        // adapter returns a canonical "$.decimalKey=1.5" key matching the request's
+        // ExpectedVerificationIdentityKey, EnsureLookupIntegrity must not throw.
+        const string CanonicalDecimalKey = "1.5";
+        var referentialId = new ReferentialId(Guid.NewGuid());
+        var adapter = new RecordingReferenceResolverAdapter([
+            [
+                new ReferenceLookupResult(
+                    ReferentialId: referentialId,
+                    DocumentId: 707,
+                    ResourceKeyId: 16,
+                    ReferentialIdentityResourceKeyId: 16,
+                    IsDescriptor: false,
+                    VerificationIdentityKey: $"$.decimalKey={CanonicalDecimalKey}"
+                ),
+            ],
+        ]);
+
+        var sut = new ReferenceResolver(adapter);
+
+        var result = await sut.ResolveAsync(
+            new ReferenceResolverRequest(
+                MappingSet: CreateMappingSet(),
+                RequestResource: _requestResource,
+                DocumentReferences:
+                [
+                    CreateDecimalKeyDocumentReference(
+                        referentialId,
+                        "$.decimalKeyReference",
+                        CanonicalDecimalKey
+                    ),
+                ],
+                DescriptorReferences: []
+            )
+        );
+
+        adapter.Requests.Should().ContainSingle();
+        adapter
+            .Requests[0]
+            .Lookups.Select(static lookup => lookup.ExpectedVerificationIdentityKey)
+            .Should()
+            .Equal($"$.decimalKey={CanonicalDecimalKey}");
+        result.InvalidDocumentReferences.Should().BeEmpty();
+        result
+            .SuccessfulDocumentReferencesByPath[new JsonPath("$.decimalKeyReference")]
+            .DocumentId.Should()
+            .Be(707L);
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_a_decimal_reference_lookup_returns_an_un_trimmed_verification_key()
+    {
+        // Regression guard for the verification-key parity contract: if the database side
+        // ever stops trimming trailing fractional zeros, EnsureLookupIntegrity must surface
+        // it as a corruption — silently mapping "$.decimalKey=1.50" onto a resolved
+        // "$.decimalKey=1.5" lookup would let mismatched references through.
+        const string CanonicalDecimalKey = "1.5";
+        const string UnTrimmedDecimalKey = "1.50";
+        var referentialId = new ReferentialId(Guid.NewGuid());
+        var adapter = new RecordingReferenceResolverAdapter([
+            [
+                new ReferenceLookupResult(
+                    ReferentialId: referentialId,
+                    DocumentId: 808,
+                    ResourceKeyId: 16,
+                    ReferentialIdentityResourceKeyId: 16,
+                    IsDescriptor: false,
+                    VerificationIdentityKey: $"$.decimalKey={UnTrimmedDecimalKey}"
+                ),
+            ],
+        ]);
+
+        var sut = new ReferenceResolver(adapter);
+
+        var act = async () =>
+            await sut.ResolveAsync(
+                new ReferenceResolverRequest(
+                    MappingSet: CreateMappingSet(),
+                    RequestResource: _requestResource,
+                    DocumentReferences:
+                    [
+                        CreateDecimalKeyDocumentReference(
+                            referentialId,
+                            "$.decimalKeyReference",
+                            CanonicalDecimalKey
+                        ),
+                    ],
+                    DescriptorReferences: []
+                )
+            );
+
+        var exception = await act.Should().ThrowAsync<ReferenceLookupCorruptionException>();
+        exception.Which.Message.Should().Contain("Reference lookup corruption detected");
+        exception.Which.Message.Should().Contain(referentialId.Value.ToString());
+        exception.Which.Message.Should().Contain("$.decimalKeyReference");
+        exception.Which.Message.Should().Contain($"$.decimalKey={CanonicalDecimalKey}");
+        exception.Which.Message.Should().Contain($"$.decimalKey={UnTrimmedDecimalKey}");
     }
 
     [Test]
@@ -889,12 +994,13 @@ public class Given_ReferenceResolver
             false
         );
         var meetingKey = new ResourceKeyEntry(15, _meetingResource, "1.0", false);
+        var decimalKeyResourceKey = new ResourceKeyEntry(16, _decimalKeyResource, "1.0", false);
         var educationOrganizationKey = new ResourceKeyEntry(30, _educationOrganizationResource, "1.0", true);
         var effectiveSchema = new EffectiveSchemaInfo(
             ApiSchemaFormatVersion: "1.0",
             RelationalMappingVersion: "v1",
             EffectiveSchemaHash: EffectiveSchemaHash,
-            ResourceKeyCount: 7,
+            ResourceKeyCount: 8,
             ResourceKeySeedHash: new byte[32],
             SchemaComponentsInEndpointOrder: [],
             ResourceKeysInIdOrder:
@@ -905,6 +1011,7 @@ public class Given_ReferenceResolver
                 schoolTypeDescriptorKey,
                 academicSubjectDescriptorKey,
                 meetingKey,
+                decimalKeyResourceKey,
                 educationOrganizationKey,
             ]
         );
@@ -952,6 +1059,11 @@ public class Given_ReferenceResolver
                     meetingKey,
                     ResourceStorageKind.RelationalTables,
                     CreateRelationalResourceModel(_meetingResource, "Meeting")
+                ),
+                new ConcreteResourceModel(
+                    decimalKeyResourceKey,
+                    ResourceStorageKind.RelationalTables,
+                    CreateRelationalResourceModel(_decimalKeyResource, "DecimalKeyResource")
                 ),
             ],
             AbstractIdentityTablesInNameOrder: [],
@@ -1045,6 +1157,24 @@ public class Given_ReferenceResolver
             ),
             DocumentIdentity: new DocumentIdentity([
                 new DocumentIdentityElement(new JsonPath("$.meetingDateTime"), meetingDateTime),
+            ]),
+            ReferentialId: referentialId,
+            Path: new JsonPath(path)
+        );
+
+    private static DocumentReference CreateDecimalKeyDocumentReference(
+        ReferentialId referentialId,
+        string path,
+        string canonicalDecimalKey
+    ) =>
+        new(
+            ResourceInfo: new BaseResourceInfo(
+                ProjectName: new ProjectName("Ed-Fi"),
+                ResourceName: new ResourceName("DecimalKeyResource"),
+                IsDescriptor: false
+            ),
+            DocumentIdentity: new DocumentIdentity([
+                new DocumentIdentityElement(new JsonPath("$.decimalKey"), canonicalDecimalKey),
             ]),
             ReferentialId: referentialId,
             Path: new JsonPath(path)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCommandAccessTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCommandAccessTests.cs
@@ -388,6 +388,7 @@ internal static class RelationalAccessTestData
         "EducationOrganization"
     );
     private static readonly QualifiedResourceName _meetingResource = new("Ed-Fi", "Meeting");
+    private static readonly QualifiedResourceName _decimalKeyResource = new("Ed-Fi", "DecimalKeyResource");
     private static readonly QualifiedResourceName _schoolTypeDescriptorResource = new(
         "Ed-Fi",
         "SchoolTypeDescriptor"
@@ -401,13 +402,14 @@ internal static class RelationalAccessTestData
         var localEducationAgencyKey = new ResourceKeyEntry(12, _localEducationAgencyResource, "1.0", false);
         var schoolTypeDescriptorKey = new ResourceKeyEntry(13, _schoolTypeDescriptorResource, "1.0", false);
         var meetingKey = new ResourceKeyEntry(14, _meetingResource, "1.0", false);
+        var decimalKeyKey = new ResourceKeyEntry(15, _decimalKeyResource, "1.0", false);
         var educationOrganizationKey = new ResourceKeyEntry(30, _educationOrganizationResource, "1.0", true);
 
         var effectiveSchema = new EffectiveSchemaInfo(
             ApiSchemaFormatVersion: "1.0",
             RelationalMappingVersion: "v1",
             EffectiveSchemaHash: EffectiveSchemaHash,
-            ResourceKeyCount: 6,
+            ResourceKeyCount: 7,
             ResourceKeySeedHash: new byte[32],
             SchemaComponentsInEndpointOrder: [],
             ResourceKeysInIdOrder:
@@ -417,6 +419,7 @@ internal static class RelationalAccessTestData
                 localEducationAgencyKey,
                 schoolTypeDescriptorKey,
                 meetingKey,
+                decimalKeyKey,
                 educationOrganizationKey,
             ]
         );
@@ -446,6 +449,11 @@ internal static class RelationalAccessTestData
                     meetingKey,
                     ResourceStorageKind.RelationalTables,
                     CreateRelationalResourceModel(_meetingResource, "Meeting")
+                ),
+                new ConcreteResourceModel(
+                    decimalKeyKey,
+                    ResourceStorageKind.RelationalTables,
+                    CreateRelationalResourceModel(_decimalKeyResource, "DecimalKeyResource")
                 ),
                 new ConcreteResourceModel(
                     schoolTypeDescriptorKey,
@@ -571,6 +579,17 @@ internal static class RelationalAccessTestData
             isDescriptor: false
         );
 
+    public static ReferenceLookupRequestEntry CreateDecimalKeyLookup(
+        ReferentialId referentialId,
+        string decimalKey = "1.5"
+    ) =>
+        CreateLookup(
+            _decimalKeyResource,
+            referentialId,
+            new DocumentIdentity([new DocumentIdentityElement(new JsonPath("$.decimalKey"), decimalKey)]),
+            isDescriptor: false
+        );
+
     public static DescriptorReference CreateDescriptorReference(
         ReferentialId referentialId,
         string uri,
@@ -658,6 +677,15 @@ internal static class RelationalAccessTestData
                 CreateIdentityColumn("LocalEducationAgencyId", "$.localEducationAgencyId", ScalarKind.Int32),
             ],
             "Meeting" => [CreateIdentityColumn("MeetingDateTime", "$.meetingDateTime", ScalarKind.DateTime)],
+            "DecimalKeyResource" =>
+            [
+                CreateIdentityColumn(
+                    "DecimalKey",
+                    "$.decimalKey",
+                    ScalarKind.Decimal,
+                    decimalPrecisionScale: (9, 2)
+                ),
+            ],
             _ => [],
         };
     }
@@ -665,12 +693,13 @@ internal static class RelationalAccessTestData
     private static DbColumnModel CreateIdentityColumn(
         string columnName,
         string jsonPath,
-        ScalarKind scalarKind
+        ScalarKind scalarKind,
+        (int Precision, int Scale)? decimalPrecisionScale = null
     ) =>
         new(
             new DbColumnName(columnName),
             ColumnKind.Scalar,
-            new RelationalScalarType(scalarKind),
+            new RelationalScalarType(scalarKind, Decimal: decimalPrecisionScale),
             IsNullable: false,
             SourceJsonPath: new JsonPathExpression(jsonPath, []),
             TargetResource: null

--- a/src/dms/backend/EdFi.DataManagementService.Old.Postgresql.Tests.Integration/UpsertTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Old.Postgresql.Tests.Integration/UpsertTests.cs
@@ -995,6 +995,7 @@ public class UpsertTests : DatabaseTest
                         "$.graduationPlanTypeDescriptor",
                         "$.graduationSchoolYear"
                       ],
+                      "numericJsonPaths": [],
                       "documentPathsMapping": {}
                     }
                     """
@@ -1015,6 +1016,7 @@ public class UpsertTests : DatabaseTest
                       "identityJsonPaths": [
                         "$.studentUniqueId"
                       ],
+                      "numericJsonPaths": [],
                       "documentPathsMapping": {
                         "GraduationPlan": {
                           "isDescriptor": false,

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityExtractorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityExtractorTests.cs
@@ -162,6 +162,94 @@ public class ExtractDocumentIdentityTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_Extracting_A_Decimal_Top_Level_Identity : ExtractDocumentIdentityTests
+    {
+        internal DocumentIdentity? documentIdentity;
+
+        [SetUp]
+        public void Setup()
+        {
+            ApiSchemaDocuments apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("Widget")
+                .WithIdentityJsonPaths(["$.widgetScore"])
+                .WithNumericJsonPaths(["$.widgetScore"])
+                .WithStartDocumentPathsMapping()
+                .WithDocumentPathScalar("WidgetScore", "$.widgetScore")
+                .WithEndDocumentPathsMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            ResourceSchema resourceSchema = BuildResourceSchema(apiSchemaDocuments, "widgets");
+
+            (documentIdentity, _) = resourceSchema.ExtractIdentities(
+                JsonNode.Parse(
+                    """
+                    {
+                        "widgetScore": 1.50
+                    }
+"""
+                )!,
+                NullLogger.Instance
+            );
+        }
+
+        [Test]
+        public void It_canonicalizes_the_decimal_identity_value()
+        {
+            documentIdentity!.DocumentIdentityElements.Should().HaveCount(1);
+            documentIdentity!.DocumentIdentityElements[0].IdentityJsonPath.Value.Should().Be("$.widgetScore");
+            documentIdentity!.DocumentIdentityElements[0].IdentityValue.Should().Be("1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Extracting_A_String_Top_Level_Identity_That_Is_Not_In_NumericJsonPaths
+        : ExtractDocumentIdentityTests
+    {
+        internal DocumentIdentity? documentIdentity;
+
+        [SetUp]
+        public void Setup()
+        {
+            ApiSchemaDocuments apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("Widget")
+                .WithIdentityJsonPaths(["$.widgetCode"])
+                .WithStartDocumentPathsMapping()
+                .WithDocumentPathScalar("WidgetCode", "$.widgetCode")
+                .WithEndDocumentPathsMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            ResourceSchema resourceSchema = BuildResourceSchema(apiSchemaDocuments, "widgets");
+
+            (documentIdentity, _) = resourceSchema.ExtractIdentities(
+                JsonNode.Parse(
+                    """
+                    {
+                        "widgetCode": "ABC-1.50"
+                    }
+"""
+                )!,
+                NullLogger.Instance
+            );
+        }
+
+        [Test]
+        public void It_passes_the_string_identity_value_through_unchanged()
+        {
+            documentIdentity!.DocumentIdentityElements.Should().HaveCount(1);
+            documentIdentity!.DocumentIdentityElements[0].IdentityJsonPath.Value.Should().Be("$.widgetCode");
+            documentIdentity!.DocumentIdentityElements[0].IdentityValue.Should().Be("ABC-1.50");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_Extracting_An_Identity_That_Includes_A_School_Year_Reference
         : ExtractDocumentIdentityTests
     {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityValueCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityValueCanonicalizerTests.cs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Extraction;
+
+[TestFixture]
+[Parallelizable]
+public class IdentityValueCanonicalizerTests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Integer_Value : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1");
+        }
+
+        [Test]
+        public void It_returns_the_integer_without_decimal_point()
+        {
+            _result.Should().Be("1");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Simple_Decimal : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1.5");
+        }
+
+        [Test]
+        public void It_returns_the_decimal_as_is()
+        {
+            _result.Should().Be("1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Trailing_Fractional_Zero : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1.50");
+        }
+
+        [Test]
+        public void It_strips_the_trailing_fractional_zero()
+        {
+            _result.Should().Be("1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Only_Fractional_Zeros : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("2.00");
+        }
+
+        [Test]
+        public void It_strips_the_decimal_point_and_fractional_zeros()
+        {
+            _result.Should().Be("2");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Scientific_Notation : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1e2");
+        }
+
+        [Test]
+        public void It_expands_to_fixed_point()
+        {
+            _result.Should().Be("100");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Scientific_Notation_Zero_Exponent
+        : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1.50e0");
+        }
+
+        [Test]
+        public void It_strips_the_exponent_and_trailing_fractional_zero()
+        {
+            _result.Should().Be("1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Negative_Exponent : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1.23e-1");
+        }
+
+        [Test]
+        public void It_moves_decimal_point_left_with_leading_zero()
+        {
+            _result.Should().Be("0.123");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Negative_Zero : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("-0.00");
+        }
+
+        [Test]
+        public void It_collapses_signed_zero_to_zero()
+        {
+            _result.Should().Be("0");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Negative_Decimal : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("-1.50");
+        }
+
+        [Test]
+        public void It_preserves_the_negative_sign_and_strips_trailing_zero()
+        {
+            _result.Should().Be("-1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CreateDocumentIdentityElement_With_Descriptor_Path : IdentityValueCanonicalizerTests
+    {
+        private DocumentIdentityElement _result = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                DocumentIdentity.DescriptorIdentityJsonPath,
+                "uri://ed-fi.org/StaffClassificationDescriptor#Kindergarten Teacher"
+            );
+        }
+
+        [Test]
+        public void It_lower_cases_the_descriptor_value()
+        {
+            _result
+                .IdentityValue.Should()
+                .Be("uri://ed-fi.org/staffclassificationdescriptor#kindergarten teacher");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CreateDocumentIdentityElement_With_Non_Numeric_Non_Descriptor_Path
+        : IdentityValueCanonicalizerTests
+    {
+        private DocumentIdentityElement _result = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                new JsonPath("$.sectionIdentifier"),
+                "MySection-ABC"
+            );
+        }
+
+        [Test]
+        public void It_passes_through_the_value_unchanged()
+        {
+            _result.IdentityValue.Should().Be("MySection-ABC");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CreateDocumentIdentityElement_With_Numeric_Path_And_Scientific_Notation
+        : IdentityValueCanonicalizerTests
+    {
+        private DocumentIdentityElement _result = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _result = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                "1e3",
+                isNumeric: true
+            );
+        }
+
+        [Test]
+        public void It_canonicalizes_the_numeric_value_to_fixed_point()
+        {
+            _result.IdentityValue.Should().Be("1000");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CreateDocumentIdentityElement_With_Numeric_Path_And_Descriptor_Suffix
+        : IdentityValueCanonicalizerTests
+    {
+        private DocumentIdentityElement _result = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            // A path ending in "Descriptor" is always treated as descriptor (lower-cased),
+            // even when isNumeric is true — descriptor path wins.
+            _result = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                new JsonPath("$.staffClassificationDescriptor"),
+                "uri://ed-fi.org/StaffClassificationDescriptor#Teacher",
+                isNumeric: true
+            );
+        }
+
+        [Test]
+        public void It_lower_cases_the_descriptor_value_ignoring_isNumeric()
+        {
+            _result.IdentityValue.Should().Be("uri://ed-fi.org/staffclassificationdescriptor#teacher");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_CreateDocumentIdentityElement_Default_IsNumeric_False : IdentityValueCanonicalizerTests
+    {
+        private DocumentIdentityElement _withDefault = null!;
+        private DocumentIdentityElement _withExplicitFalse = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _withDefault = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                new JsonPath("$.schoolYear"),
+                "2030"
+            );
+            _withExplicitFalse = IdentityValueCanonicalizer.CreateDocumentIdentityElement(
+                new JsonPath("$.schoolYear"),
+                "2030",
+                isNumeric: false
+            );
+        }
+
+        [Test]
+        public void It_passes_through_without_numeric_canonicalization_when_default()
+        {
+            _withDefault.IdentityValue.Should().Be("2030");
+        }
+
+        [Test]
+        public void It_passes_through_without_numeric_canonicalization_when_explicit_false()
+        {
+            _withExplicitFalse.IdentityValue.Should().Be("2030");
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityValueCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/IdentityValueCanonicalizerTests.cs
@@ -188,6 +188,30 @@ public class IdentityValueCanonicalizerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_CanonicalizeDecimal_With_Very_Small_Decimal : IdentityValueCanonicalizerTests
+    {
+        private string _result = string.Empty;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Smallest representable positive System.Decimal — historically risky because
+            // ToString("G29") would render this as "1E-28", diverging from the SQL trigger
+            // and lookup-verification expressions that emit fixed-point text.
+            _result = IdentityValueCanonicalizer.CanonicalizeDecimal("1e-28");
+        }
+
+        [Test]
+        public void It_emits_fixed_point_form_without_scientific_notation()
+        {
+            _result.Should().Be("0.0000000000000000000000000001");
+            _result.Should().NotContain("E");
+            _result.Should().NotContain("e");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_CreateDocumentIdentityElement_With_Descriptor_Path : IdentityValueCanonicalizerTests
     {
         private DocumentIdentityElement _result = null!;

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/ReferenceExtractorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Extraction/ReferenceExtractorTests.cs
@@ -1464,4 +1464,99 @@ public class ReferenceExtractorTests
             refArray.DocumentReferences.Should().HaveCount(3);
         }
     }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Extracting_A_Reference_Whose_Reference_Json_Path_Is_In_Numeric_Json_Paths
+        : ReferenceExtractorTests
+    {
+        private DocumentReference _documentReference = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            ApiSchemaDocuments apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("Order")
+                .WithNumericJsonPaths(["$.productReference.productPrice"])
+                .WithStartDocumentPathsMapping()
+                .WithDocumentPathReference(
+                    "Product",
+                    [new("$.productPrice", "$.productReference.productPrice")]
+                )
+                .WithEndDocumentPathsMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            ResourceSchema resourceSchema = BuildResourceSchema(apiSchemaDocuments, "orders");
+
+            _documentReference = ExtractSingleReference(
+                resourceSchema,
+                """
+                {
+                    "productReference": {
+                        "productPrice": 1.50
+                    }
+                }
+                """
+            );
+        }
+
+        [Test]
+        public void It_canonicalizes_the_decimal_reference_identity_value_using_the_reference_json_path()
+        {
+            var elements = _documentReference.DocumentIdentity.DocumentIdentityElements;
+            elements.Should().HaveCount(1);
+            elements[0].IdentityJsonPath.Value.Should().Be("$.productPrice");
+            elements[0].IdentityValue.Should().Be("1.5");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Extracting_A_Reference_Whose_Reference_Json_Path_Is_Not_In_Numeric_Json_Paths
+        : ReferenceExtractorTests
+    {
+        private DocumentReference _documentReference = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            ApiSchemaDocuments apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("Order")
+                .WithStartDocumentPathsMapping()
+                .WithDocumentPathReference(
+                    "Product",
+                    [new("$.productCode", "$.productReference.productCode")]
+                )
+                .WithEndDocumentPathsMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            ResourceSchema resourceSchema = BuildResourceSchema(apiSchemaDocuments, "orders");
+
+            _documentReference = ExtractSingleReference(
+                resourceSchema,
+                """
+                {
+                    "productReference": {
+                        "productCode": "ABC-1.50"
+                    }
+                }
+                """
+            );
+        }
+
+        [Test]
+        public void It_passes_the_string_reference_identity_value_through_unchanged()
+        {
+            var elements = _documentReference.DocumentIdentity.DocumentIdentityElements;
+            elements.Should().HaveCount(1);
+            elements[0].IdentityJsonPath.Value.Should().Be("$.productCode");
+            elements[0].IdentityValue.Should().Be("ABC-1.50");
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityExtractor.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityExtractor.cs
@@ -40,11 +40,16 @@ internal static class IdentityExtractor
         }
 
         // Build up documentIdentity in order
+        HashSet<string> numericJsonPathValues = resourceSchema
+            .NumericJsonPaths.Select(p => p.Value)
+            .ToHashSet(StringComparer.Ordinal);
+
         IEnumerable<DocumentIdentityElement> documentIdentityElements =
             resourceSchema.IdentityJsonPaths.Select(identityJsonPath =>
                 IdentityValueCanonicalizer.CreateDocumentIdentityElement(
                     identityJsonPath,
-                    documentBody.SelectRequiredNodeFromPathCoerceToString(identityJsonPath.Value, logger)
+                    documentBody.SelectRequiredNodeFromPathCoerceToString(identityJsonPath.Value, logger),
+                    numericJsonPathValues.Contains(identityJsonPath.Value)
                 )
             );
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityValueCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityValueCanonicalizer.cs
@@ -40,6 +40,11 @@ internal static class IdentityValueCanonicalizer
     /// then emits: fixed-point, no exponent, no leading '+', single leading '0' before the
     /// decimal point, no trailing fractional zeros, no trailing decimal point,
     /// and signed-zero collapsed to '0'.
+    ///
+    /// Output must match the SQL identity-text formatters in <c>DialectIdentityTextFormatter</c>
+    /// (PG <c>::text</c> + regexp trimming, MSSQL <c>CAST AS nvarchar(max)</c> + trim CASE).
+    /// Both DB engines render <c>numeric</c>/<c>decimal</c> in fixed-point form, so this
+    /// canonicalizer must also stay fixed-point — never scientific notation.
     /// </summary>
     internal static string CanonicalizeDecimal(string identityValue)
     {
@@ -60,8 +65,12 @@ internal static class IdentityValueCanonicalizer
             return "0";
         }
 
-        // G29 produces fixed-point with up to 29 significant digits, no exponent,
-        // no trailing fractional zeros, and no trailing decimal point.
-        return parsed.ToString("G29", CultureInfo.InvariantCulture);
+        // Fixed-point custom format: integer digits always shown, up to 28 fractional
+        // digits with trailing zeros and a lone trailing decimal point trimmed. 28 is the
+        // maximum scale of System.Decimal. The 'G' standard specifier is intentionally
+        // avoided because it can switch to scientific notation for very small decimals
+        // (e.g., 1e-28 → "1E-28" with G29), which would diverge from the trigger and
+        // lookup-verification SQL output.
+        return parsed.ToString("0.############################", CultureInfo.InvariantCulture);
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityValueCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Extraction/IdentityValueCanonicalizer.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
 using EdFi.DataManagementService.Core.External.Model;
 
 namespace EdFi.DataManagementService.Core.Extraction;
@@ -11,16 +12,56 @@ internal static class IdentityValueCanonicalizer
 {
     public static DocumentIdentityElement CreateDocumentIdentityElement(
         JsonPath identityJsonPath,
-        string identityValue
+        string identityValue,
+        bool isNumeric = false
     )
     {
-        return new(identityJsonPath, Canonicalize(identityJsonPath, identityValue));
+        return new(identityJsonPath, Canonicalize(identityJsonPath, identityValue, isNumeric));
     }
 
-    private static string Canonicalize(JsonPath identityJsonPath, string identityValue)
+    private static string Canonicalize(JsonPath identityJsonPath, string identityValue, bool isNumeric)
     {
-        return DocumentIdentity.IsDescriptorIdentityPath(identityJsonPath)
-            ? identityValue.ToLowerInvariant()
-            : identityValue;
+        if (DocumentIdentity.IsDescriptorIdentityPath(identityJsonPath))
+        {
+            return identityValue.ToLowerInvariant();
+        }
+
+        if (isNumeric)
+        {
+            return CanonicalizeDecimal(identityValue);
+        }
+
+        return identityValue;
+    }
+
+    /// <summary>
+    /// Canonicalizes a numeric identity-value string to a fixed-point decimal representation.
+    /// Parses the input as a decimal (supporting scientific notation and leading sign),
+    /// then emits: fixed-point, no exponent, no leading '+', single leading '0' before the
+    /// decimal point, no trailing fractional zeros, no trailing decimal point,
+    /// and signed-zero collapsed to '0'.
+    /// </summary>
+    internal static string CanonicalizeDecimal(string identityValue)
+    {
+        const NumberStyles styles =
+            NumberStyles.Float
+            | NumberStyles.AllowLeadingSign
+            | NumberStyles.AllowDecimalPoint
+            | NumberStyles.AllowExponent;
+
+        if (!decimal.TryParse(identityValue, styles, CultureInfo.InvariantCulture, out decimal parsed))
+        {
+            return identityValue;
+        }
+
+        // Collapse signed zero to positive zero
+        if (parsed == 0m)
+        {
+            return "0";
+        }
+
+        // G29 produces fixed-point with up to 29 significant digits, no exponent,
+        // no trailing fractional zeros, and no trailing decimal point.
+        return parsed.ToString("G29", CultureInfo.InvariantCulture);
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Extraction/ReferenceExtractor.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Extraction/ReferenceExtractor.cs
@@ -51,6 +51,9 @@ internal static class ReferenceExtractor
         List<DocumentReference> documentReferences = [];
         List<DocumentReferenceArray> documentReferenceArrays = [];
         List<WriteValidationFailure> validationFailures = [];
+        HashSet<string> numericJsonPathValues = resourceSchema
+            .NumericJsonPaths.Select(p => p.Value)
+            .ToHashSet(StringComparer.Ordinal);
 
         foreach (DocumentPath documentPath in resourceSchema.DocumentPaths)
         {
@@ -150,7 +153,8 @@ internal static class ReferenceExtractor
                         collectedIdentityElements[identityElementIndex] =
                             IdentityValueCanonicalizer.CreateDocumentIdentityElement(
                                 element.IdentityJsonPath,
-                                identityValue
+                                identityValue,
+                                numericJsonPathValues.Contains(element.ReferenceJsonPath.Value)
                             );
                         continue;
                     }


### PR DESCRIPTION
## Summary

Aligns Core, PostgreSQL, and SQL Server `ReferentialId` computation so the same identity values produce the same UUIDv5 across all three paths:

- **DateTime triggers** now emit `yyyy-MM-ddTHH:mm:ssZ` (PG: `to_char(... AT TIME ZONE 'UTC', '...Z')`; MSSQL: `CONVERT(nvarchar(19), ..., 126) + N'Z'`), matching `JsonHelpers.TryNormalizeDateTimeString`.
- **Decimal canonicalization** lives in a new `IdentityValueCanonicalizer.CanonicalizeDecimal` helper: parse → fixed-point `ToString("0.############################")`, never scientific notation, with trailing zeros and trailing decimal point trimmed and signed zero collapsed.
- **Reference-side decimal check** uses `element.ReferenceJsonPath` against the *current* resource's `NumericJsonPaths` (not the target's `IdentityJsonPath`), per D1 — without this, decimal references silently diverge.
- **Single source of truth for identity-text SQL.** New `DialectIdentityTextFormatter` (in `Backend.External`) emits the canonical PG/MSSQL conversion expression. Both `RelationalModelDdlEmitter` (trigger emission) and the runtime reference-lookup builders (`PostgresqlReferenceLookupCommandBuilder`, `MssqlReferenceLookupSmallListStrategy`) now route through it, so the trigger-stored ReferentialId text and the lookup-side verification key cannot drift.
- **Lookup-side decimal trim fix.** The lookup builders previously had no `Decimal` branch and defaulted to `::text` / `CAST AS nvarchar(max)`, which kept column-scale trailing zeros (e.g. `decimal(9,2)` → `1.50`) while the trigger emitted the trimmed form (`1.5`). Any decimal-keyed reference would have thrown `ReferenceLookupCorruptionException`. Routing the lookup through the shared formatter applies the same trim.
- Adds three resources to the `referential-identity` fixture (`DecimalKeyResource`, `DateTimeKeyResource`, `DecimalRefResource`) plus integration tests on both backends covering DateTime parity, decimal trim paths (`1.5`, `2.00`, `100.00`), and decimal-reference parity. Adds a `1e-28` regression test for the canonicalizer and happy-path / fail-closed coverage in `ReferenceResolverTests`.