### PR TITLE
[DMS-1082] CMS-INV-001: Investigate Feasibility of Resource Claim Metadata Endpoints

### DIFF
--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -1,0 +1,283 @@
+# DMS-1082 Spike: Resource Claims Endpoints in CMS
+
+## Purpose
+
+This spike documents the investigation behind the CMS resource claim endpoints and the implementation approach that should be used.
+
+It is intended to help the next developer understand:
+
+- why the endpoints are needed
+- how CMS data differs from the Admin API data model
+- what approach was used to bridge that gap
+- what risks remain with this shape of the solution
+
+It is also intended to give future implementation work enough context to avoid filling in contract gaps incorrectly. The executable story for this spike lives in `reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md`; this document explains why that story is shaped the way it is.
+
+The endpoints in scope are:
+
+- `GET /v2/resourceClaims`
+- `GET /v2/resourceClaims/{id}`
+- `GET /v2/resourceClaimActionAuthStrategies`
+
+## Why This Spike Exists
+
+The Ed-Fi Admin API exposes resource claim browsing endpoints that are used by tooling and administrators to inspect claim structure and authorization defaults. DMS authorization still follows the ODS/API resource-claim model: a request first needs the resource/action grant, and then any action-specific authorization strategy is evaluated against the data.
+
+CMS did not previously expose equivalent read endpoints. The spike was needed to answer two questions:
+
+1. Can the CMS data model support the same information in read form?
+2. If yes, what is the least risky way to expose it without changing the claims model or adding write paths?
+
+The answer is yes, but with important differences in how the data is stored and resolved.
+
+## Key Data-Model Difference
+
+The most important distinction is this:
+
+- In the Admin API, resource claims are represented as relational rows with a resource-claim table and integer identifiers.
+- In CMS, the claim structure is stored as a hierarchical JSON document.
+
+That difference changes the implementation shape completely.
+
+### CMS hierarchy JSON
+
+CMS stores the claims tree as a nested document. In the current CMS model, a claim node contains:
+
+- `name`, whose value is the full claim URI
+- optional `defaultAuthorization`
+- child `claims`
+- a `Parent` navigation property that is populated during deserialization
+
+This means the hierarchy already exists in memory as a tree, but it is not indexed as relational rows.
+
+### Resource claim metadata table
+
+The CMS also has persisted resource-claim metadata in `dmscs.ResourceClaim`.
+
+That table provides the values needed for the Admin API-compatible response shape, including:
+
+- a stable `long` id backed by the PostgreSQL `BIGINT` column
+- a display resource name
+- the claim URI used to match against the hierarchy document
+
+This table is what makes the CMS response contract possible without changing the hierarchy schema.
+
+The hierarchy remains the structural source of truth. The metadata table enriches hierarchy nodes; it does not decide which nodes are present in the tree response. A metadata row without a hierarchy node is therefore not returned by these read endpoints.
+
+## Why the Endpoints Make Sense
+
+These endpoints are justified because the information already exists in CMS, just not in the same form as the Admin API.
+
+The implementation is effectively a projection:
+
+- the hierarchy JSON provides structure
+- the resource-claim table provides the public-facing identifiers and display names
+- the claim-set metadata provides authorization-action and strategy details
+
+That makes the endpoints read-only projections over existing configuration, not a new domain model.
+
+## Approach Used
+
+The intended service implementation walks the claim hierarchy at runtime and joins each node with the corresponding metadata row from `dmscs.ResourceClaim`.
+
+That produces the response tree for:
+
+- `GET /v2/resourceClaims`
+- `GET /v2/resourceClaims/{id}`
+
+For the auth-strategy endpoint, the service:
+
+- traverses the same claim hierarchy
+- filters to claims that define default authorization
+- resolves action names from the existing claim-set action list
+- resolves authorization strategy names from the existing authorization-strategy list
+- emits a flat response shape for each claim with default authorization
+
+This is a reasonable approach because it reuses the existing configuration stores instead of introducing a parallel persistence model.
+
+## Implementation Contract Summary
+
+Use the companion story document for the final acceptance criteria. The core contract is:
+
+- `GET /v2/resourceClaims` returns a hierarchy of projected `ResourceClaimResponse` nodes.
+- `GET /v2/resourceClaims/{id}` searches the successfully projected hierarchy by metadata id and returns `404` only when the id is absent from that valid projection.
+- `GET /v2/resourceClaimActionAuthStrategies` returns a flat list for claims whose `DefaultAuthorization` contains at least one action.
+- `ResourceClaimResponse.Name` is the display resource name from `dmscs.ResourceClaim.ResourceName`, not the claim URI.
+- `ResourceClaimActionAuthStrategyResponse.ClaimName` is the full claim URI.
+- `ResourceClaimResponse.Id`, `ParentId`, `ResourceClaimActionAuthStrategyResponse.ResourceClaimId`, and `AuthStrategyId` should be `long` to match CMS persisted identifiers.
+- `ActionId` should remain `int`, matching the existing action repository model.
+- Missing lookup data is an integrity failure, not a reason to omit nodes or return zero ids.
+
+Example resource-claim node:
+
+```json
+{
+  "id": 42,
+  "name": "Student",
+  "parentId": 0,
+  "parentName": null,
+  "children": []
+}
+```
+
+Example action/auth-strategy item:
+
+```json
+{
+  "resourceClaimId": 42,
+  "resourceName": "Student",
+  "claimName": "http://ed-fi.org/identity/claims/ed-fi/student",
+  "authorizationStrategiesForActions": [
+    {
+      "actionId": 1,
+      "actionName": "Read",
+      "authorizationStrategies": [
+        {
+          "authStrategyId": 7,
+          "authStrategyName": "RelationshipsWithEdOrgsOnly"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Technical Tradeoffs
+
+### 1. Runtime join versus materialized claim table
+
+The chosen design performs the hierarchy-to-metadata match at request time.
+
+Benefits:
+
+- no schema change
+- no data migration
+- no extra write path
+- easy to reason about because the source of truth stays in CMS configuration
+
+Costs:
+
+- response quality depends on both the hierarchy JSON and the metadata table
+- the service can fail or return incomplete data if those sources drift
+- each request requires walking the tree and resolving lookup data in memory
+
+### 2. Exact match required between hierarchy and metadata
+
+The hierarchy and the resource-claim table must agree on the claim URI.
+
+This is the critical dependency in the current design.
+
+If the hierarchy contains a node that is not present in `dmscs.ResourceClaim`, the endpoint cannot safely infer the missing row. The same is true if the metadata exists but the hierarchy node is absent.
+
+That means this feature depends on data integrity across two sources, not one.
+
+Implementation consequence:
+
+- A hierarchy node without metadata must fail the projection.
+- A parent hierarchy node without metadata must fail the projection because child `ParentId` and `ParentName` cannot be produced reliably.
+- A metadata row without a hierarchy node may be ignored by these read endpoints because the hierarchy determines structure.
+- Duplicate metadata rows for the same claim URI should fail the projection.
+
+### 3. Tree traversal versus targeted lookup
+
+The single-claim endpoint is served by loading the hierarchy and searching it in memory.
+
+Benefits:
+
+- one service path for both list and single-item views
+- no need for a separate query shape
+- easy to test
+
+Costs:
+
+- the request still pays the cost of building the hierarchy projection
+- lookup is linear in the size of the projected tree
+
+For the current dataset size, that is acceptable. If the hierarchy grows substantially, this could become a performance concern.
+
+### 4. Graceful degradation versus explicit failure
+
+Projection-style APIs have a specific risk: missing supporting data can produce partial output if the service treats lookup failures as optional.
+
+That is dangerous because the API can look successful while silently omitting claim nodes or authorization information.
+
+For this feature, the safer behavior is to fail explicitly when required metadata cannot be resolved.
+
+Concrete examples of unsafe graceful degradation:
+
+- returning `200 OK` after skipping a hierarchy node whose claim URI is absent from `dmscs.ResourceClaim`
+- returning `200 OK` with `actionId: 0` because an action name did not resolve
+- returning `200 OK` with `authStrategyId: 0` because authorization strategies failed to load
+- returning an empty action/auth-strategy list because the authorization-strategy repository returned a failure
+
+Those cases should be service failures with useful logs, not successful responses.
+
+## Risks With This Approach
+
+### Risk: incomplete responses when metadata drifts
+
+If the hierarchy JSON and `dmscs.ResourceClaim` fall out of sync, the API can return an incomplete tree or miss claims entirely.
+
+This is the highest operational risk in the design.
+
+### Risk: misleading success on partial lookup failures
+
+If authorization strategies or action names cannot be resolved, the endpoint can return a `200 OK` with incomplete nested data unless the service handles that failure explicitly.
+
+That makes it harder for clients and operators to detect a data problem.
+
+### Risk: datastore-specific wiring
+
+The current CMS service wiring supports both `postgresql` and `mssql` values for `AppSettings:Datastore`, but the resource-claim schema and seed data currently exist only in the PostgreSQL deployment scripts.
+
+If the service is deployed against a datastore that does not have an equivalent table, seed data, repository implementation, and registration path, the new endpoints can fail at startup or runtime.
+
+This should be treated as a deployment constraint, not an incidental detail.
+
+The final implementation should choose one of these outcomes:
+
+- implement `IResourceClaimRepository` and deployment support for every CMS datastore supported by `main`
+- or document PostgreSQL-only support and gate endpoint/repository registration so unsupported datastores fail deliberately with a clear configuration error
+
+Leaving a PostgreSQL repository registered in common service wiring is not sufficient because it hides the deployment constraint and conflicts with the existing datastore selection pattern.
+
+### Risk: endpoint contract depends on source-data stability
+
+The API contract is only as stable as the persisted resource-claim metadata.
+
+If downstream consumers expect the identifiers, resource names, or hierarchy shape to be stable, the CMS must maintain consistent seed data and repository behavior.
+
+## What the Developer Should Take Away
+
+- CMS can support these endpoints without a schema redesign.
+- The key bridge is the match between hierarchy JSON and the resource-claim metadata table.
+- The implementation is justified because it exposes existing configuration in a read-only form.
+- The approach is workable, but it is not self-healing if the data sources drift.
+- The service should treat missing support data as an integrity problem, not a normal success path.
+
+## Implementation Guidance
+
+When working in this area, the next developer should keep these rules in mind:
+
+- preserve the hierarchy JSON as the structural source of truth
+- preserve the resource-claim table as the lookup source for response metadata
+- keep the endpoints read-only
+- fail explicitly when required lookup data is missing
+- make datastore support explicit in startup wiring
+- keep tests focused on both the success path and the failure path
+
+## Implementation Notes
+
+Implementation should start from the companion story and the current `main` code paths rather than assuming the service, module, or repository already exists. The important paths to compare are the endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, and `IClaimSetRepository.GetAuthorizationStrategies`.
+
+The service should validate the full projection before returning success. Missing hierarchy metadata, failed action lookup, failed authorization-strategy lookup, and datastore support gaps should surface through explicit result cases and endpoint mappings instead of becoming empty collections or zero-valued ids.
+
+The scope remains read-only. Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids to make the projection succeed.
+
+## Outcome
+
+The spike supports adding the endpoints because the necessary information already exists in CMS.
+
+The important caveat is that the implementation is a projection over two data sources, so correctness depends on them staying aligned.
+
+That is the main design risk to carry forward in maintenance and future changes.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -1,126 +1,105 @@
-# DMS-1082 Spike: Resource Claims Endpoints in CMS
+# DMS-1082 Architecture Brief: Resource Claims Endpoints in CMS
 
-## Purpose
+## 1. Summary
 
-This spike documents the investigation behind the CMS resource claim endpoints and the implementation approach that should be used.
+The Ed-Fi Admin API exposes resource claim browsing endpoints used by tooling and administrators to inspect claim structure and authorization defaults. DMS authorization follows the ODS/API resource-claim model: a request needs the resource/action grant first, and then the action-specific authorization strategy is evaluated.
 
-It is intended to help the next developer understand:
+CMS did not previously expose equivalent read endpoints. This spike confirmed that the necessary information already exists in CMS across two sources — the claims hierarchy JSON and the `dmscs.ResourceClaim` metadata table — and that read-only projections over those sources are sufficient to achieve Admin API parity without schema changes or new write paths.
 
-- why the endpoints are needed
-- how CMS data differs from the Admin API data model
-- what approach was used to bridge that gap
-- what risks remain with this shape of the solution
+The spike answered:
 
-It is also intended to give future implementation work enough context to avoid filling in contract gaps incorrectly. The executable story for this spike lives in `reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md`; this document explains why that story is shaped the way it is.
+1. Can the CMS data model support the same information in read form? **Yes.**
+2. What is the least risky way to expose it? **Runtime projection over existing configuration stores.**
 
-The endpoints in scope are:
+The executable story for this work is in `reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md`. The original tracking ticket for this feature area is [DMS-853](https://edfi.atlassian.net/browse/DMS-853); the spike (DMS-1082) and implementation story (DMS-1148) supersede it.
 
-- `GET /v2/resourceClaims`
-- `GET /v2/resourceClaims/{id}`
-- `GET /v2/resourceClaimActionAuthStrategies`
+The response and failure contracts in this document are normative and were verified against the ODS/Admin API source and published Admin API OpenAPI artifacts.
 
-## Why This Spike Exists
+---
 
-The Ed-Fi Admin API exposes resource claim browsing endpoints that are used by tooling and administrators to inspect claim structure and authorization defaults. DMS authorization still follows the ODS/API resource-claim model: a request first needs the resource/action grant, and then any action-specific authorization strategy is evaluated against the data.
+## 2. In-Scope Endpoints
 
-CMS did not previously expose equivalent read endpoints. The spike was needed to answer two questions:
+The following four endpoints are in scope:
 
-1. Can the CMS data model support the same information in read form?
-2. If yes, what is the least risky way to expose it without changing the claims model or adding write paths?
+| Route | Description |
+|---|---|
+| `GET /v2/resourceClaims` | Returns the full projected claim hierarchy as a collection of root nodes, each containing its full recursive subtree. |
+| `GET /v2/resourceClaims/{id}` | Returns the projected node matching the given `dmscs.ResourceClaim.Id`, including its full recursive subtree. Returns `404` when the requested id is absent. |
+| `GET /v2/resourceClaimActions` | Returns a flat list of resource claim actions resolved from claim-set metadata. |
+| `GET /v2/resourceClaimActionAuthStrategies` | Returns a flat list of resource claims with default authorization, including action and strategy details. |
 
-The answer is yes, but with important differences in how the data is stored and resolved.
+---
 
-## Key Data-Model Difference
+## 3. Out-of-Scope and Follow-Up Endpoints
 
-The most important distinction is this:
+| Route | Status |
+|---|---|
+| `POST /v2/resourceClaims`, `PUT`, `DELETE` | Out of scope. These endpoints are read-only projections; no write paths are added. |
+| `/v2/claimSets/{id}/resourceClaimActions/...` | Out of scope for this work. Not part of this parity set. |
+| Seed, bootstrap, or maintenance of resource-claim metadata rows | Explicitly out of scope. See Section 6. |
 
-- In the Admin API, resource claims are represented as relational rows with a resource-claim table and integer identifiers.
-- In CMS, the claim structure is stored as a hierarchical JSON document.
+---
 
-That difference changes the implementation shape completely.
+## 4. Parity Expectations
 
-### CMS hierarchy JSON
+### Route and response shape parity
 
-CMS stores the claims tree as a nested document. In the current CMS model, a claim node contains:
+These endpoints match the Admin API route surface and response shape. Divergences are explicit and listed in Section 5.
 
-- `name`, whose value is the full claim URI
-- optional `defaultAuthorization`
-- child `claims`
-- a `Parent` navigation property that is populated during deserialization
+### Hierarchy and collection semantics
 
-This means the hierarchy already exists in memory as a tree, but it is not indexed as relational rows.
+- `GET /v2/resourceClaims` returns a collection of **root nodes**. Each root node includes its full recursive subtree via nested `children` arrays.
+- `GET /v2/resourceClaims/{id}` returns the **selected node with its full recursive subtree**.
+- `GET /v2/resourceClaimActions` returns a flat list. No tree structure.
+- `GET /v2/resourceClaimActionAuthStrategies` returns a flat list with nested `authorizationStrategiesForActions` per item.
 
-### Resource claim metadata table
-
-The CMS also has persisted resource-claim metadata in `dmscs.ResourceClaim`.
-
-That table provides the values needed for the Admin API-compatible response shape, including:
-
-- a stable `long` id backed by the PostgreSQL `BIGINT` column
-- a display resource name
-- the claim URI used to match against the hierarchy document
-
-This table is what makes the CMS response contract possible without changing the hierarchy schema.
-
-The hierarchy remains the structural source of truth. The metadata table enriches hierarchy nodes; it does not decide which nodes are present in the tree response. A metadata row without a hierarchy node is therefore not returned by these read endpoints.
-
-## Why the Endpoints Make Sense
-
-These endpoints are justified because the information already exists in CMS, just not in the same form as the Admin API.
-
-The implementation is effectively a projection:
-
-- the hierarchy JSON provides structure
-- the resource-claim table provides the public-facing identifiers and display names
-- the claim-set metadata provides authorization-action and strategy details
-
-That makes the endpoints read-only projections over existing configuration, not a new domain model.
-
-## Approach Used
-
-The intended service implementation walks the claim hierarchy at runtime and joins each node with the corresponding metadata row from `dmscs.ResourceClaim`.
-
-That produces the response tree for:
-
-- `GET /v2/resourceClaims`
-- `GET /v2/resourceClaims/{id}`
-
-For the auth-strategy endpoint, the service:
-
-- traverses the same claim hierarchy
-- filters to claims that define default authorization
-- resolves action names from the existing claim-set action list
-- resolves authorization strategy names from the existing authorization-strategy list
-- emits a flat response shape for each claim with default authorization
-
-This is a reasonable approach because it reuses the existing configuration stores instead of introducing a parallel persistence model.
-
-## Implementation Contract Summary
-
-Use the companion story document for the final acceptance criteria. The core contract is:
-
-- `GET /v2/resourceClaims` returns a hierarchy of projected `ResourceClaimResponse` nodes.
-- `GET /v2/resourceClaims/{id}` searches the successfully projected hierarchy by metadata id and returns `404` only when the id is absent from that valid projection.
-- `GET /v2/resourceClaimActionAuthStrategies` returns a flat list for claims whose `DefaultAuthorization` contains at least one action.
-- `ResourceClaimResponse.Name` is the display resource name from `dmscs.ResourceClaim.ResourceName`, not the claim URI.
-- `ResourceClaimActionAuthStrategyResponse.ClaimName` is the full claim URI.
-- `ResourceClaimResponse.Id`, `ParentId`, `ResourceClaimActionAuthStrategyResponse.ResourceClaimId`, and `AuthStrategyId` should be `long` to match CMS persisted identifiers.
-- `ActionId` should remain `int`, matching the existing action repository model.
-- Missing lookup data is an integrity failure, not a reason to omit nodes or return zero ids.
-
-Example resource-claim node:
+Sample `resourceClaims` response node (normative contract):
 
 ```json
 {
-  "id": 42,
-  "name": "Student",
+  "id": 382,
+  "name": "epdm",
   "parentId": 0,
   "parentName": null,
-  "children": []
+  "children": [
+    {
+      "id": 386,
+      "name": "performanceEvaluation",
+      "parentId": 382,
+      "parentName": "epdm",
+      "children": [
+        {
+          "id": 387,
+          "name": "performanceEvaluation",
+          "parentId": 386,
+          "parentName": "performanceEvaluation",
+          "children": []
+        }
+      ]
+    }
+  ]
 }
 ```
 
-Example action/auth-strategy item:
+Sample `resourceClaimActions` response item (normative contract — verified against `management-api-2.3.0.yaml`):
+
+```json
+{
+  "resourceClaimId": 42,
+  "resourceName": "Student",
+  "claimName": "http://ed-fi.org/identity/claims/ed-fi/student",
+  "actions": [
+    { "name": "Create" },
+    { "name": "Read" },
+    { "name": "Update" },
+    { "name": "Delete" }
+  ]
+}
+```
+
+> **Note:** `actions` contains objects with only a `name` field. There is no `actionId` in this response shape. This differs from `resourceClaimActionAuthStrategies`, which does include `actionId` inside `authorizationStrategiesForActions`.
+
+Sample `resourceClaimActionAuthStrategies` response item (normative contract):
 
 ```json
 {
@@ -142,142 +121,162 @@ Example action/auth-strategy item:
 }
 ```
 
-## Technical Tradeoffs
+### Query parameter parity
 
-### 1. Runtime join versus materialized claim table
+All four endpoints support general query parameters:
 
-The chosen design performs the hierarchy-to-metadata match at request time.
+| Parameter | Type | Notes |
+|---|---|---|
+| `limit` | int | Maximum items to return |
+| `offset` | int | Pagination offset |
+| `orderBy` | string | Field name to sort by |
+| `direction` | string | `asc`/`ascending` or `desc`/`descending` |
 
-Benefits:
+Endpoint-specific filter parameters:
 
-- no schema change
-- no data migration
-- no extra write path
-- easy to reason about because the source of truth stays in CMS configuration
+| Endpoint | Filter Parameters |
+|---|---|
+| `GET /v2/resourceClaims` | `id` (long), `name` (string) |
+| `GET /v2/resourceClaimActions` | `resourceName` (string) |
+| `GET /v2/resourceClaimActionAuthStrategies` | `resourceName` (string) |
 
-Costs:
+DMS-1074 defines the shared CMS implementation pattern for Admin API-style query parameters such as `orderBy` and `direction`. These endpoints should reuse that implementation pattern rather than introducing a feature-specific variant here.
 
-- response quality depends on both the hierarchy JSON and the metadata table
-- the service can fail or return incomplete data if those sources drift
-- each request requires walking the tree and resolving lookup data in memory
+Admin API query behaviors intentionally not implemented must be listed as explicit omissions in the story acceptance criteria.
 
-### 2. Exact match required between hierarchy and metadata
+---
 
-The hierarchy and the resource-claim table must agree on the claim URI.
+## 5. Intentional CMS Divergences
 
-This is the critical dependency in the current design.
+These are accepted, deliberate differences from the Admin API. They are not compatibility gaps.
 
-If the hierarchy contains a node that is not present in `dmscs.ResourceClaim`, the endpoint cannot safely infer the missing row. The same is true if the metadata exists but the hierarchy node is absent.
+| Divergence | Rationale |
+|---|---|
+| Public and persisted IDs use `long` (`BIGINT`) | CMS uses `bigint` identifiers throughout. `ResourceClaimResponse.Id`, `ParentId`, `ResourceClaimActionAuthStrategyResponse.ResourceClaimId`, and `AuthStrategyId` are `long`. `ActionId` remains `int`, matching the existing action repository model. |
+| Authorization uses `MapSecuredGet` | These endpoints use the standard CMS secured GET pattern: `MapSecuredGet`, which applies `ReadOnlyOrAdminScopePolicy`. No new authorization model is introduced. |
 
-That means this feature depends on data integrity across two sources, not one.
+---
 
-Implementation consequence:
+## 6. Data and Metadata Assumptions
 
-- A hierarchy node without metadata must fail the projection.
-- A parent hierarchy node without metadata must fail the projection because child `ParentId` and `ParentName` cannot be produced reliably.
-- A metadata row without a hierarchy node may be ignored by these read endpoints because the hierarchy determines structure.
-- Duplicate metadata rows for the same claim URI should fail the projection.
+### The two-source dependency
 
-### 3. Tree traversal versus targeted lookup
+The CMS response contract depends on two sources staying aligned:
 
-The single-claim endpoint is served by loading the hierarchy and searching it in memory.
+1. **Claims hierarchy JSON** — the structural source of truth. Stored as a nested document. Provides claim URI, parent/child relationships, and `DefaultAuthorization` entries.
+2. **`dmscs.ResourceClaim` table** — the metadata source. Provides the stable `long` id, the display resource name (`ResourceName`), and the claim URI used to match against the hierarchy.
 
-Benefits:
+The hierarchy determines which nodes appear in the response. The metadata table enriches those nodes. A metadata row without a corresponding hierarchy node is not returned. A hierarchy node without a matching metadata row is a data integrity failure.
 
-- one service path for both list and single-item views
-- no need for a separate query shape
-- easy to test
+### Seed/bootstrap boundary
 
-Costs:
+Creating, seeding, or maintaining `dmscs.ResourceClaim` rows is **explicitly out of scope** for this spike and any direct implementation ticket derived from it. This applies to:
 
-- the request still pays the cost of building the hierarchy projection
-- lookup is linear in the size of the projected tree
+- base bootstrap metadata
+- extension claim metadata
+- custom claim metadata
+- homograph or dynamically composed claim metadata
 
-For the current dataset size, that is acceptable. If the hierarchy grows substantially, this could become a performance concern.
+The endpoints assume required metadata already exists. If it does not exist, the projection fails explicitly — it does not silently skip nodes or return partial results.
 
-### 4. Graceful degradation versus explicit failure
+### Matching policy
 
-Projection-style APIs have a specific risk: missing supporting data can produce partial output if the service treats lookup failures as optional.
+Hierarchy node to metadata row matching is by full claim URI, exact and case-sensitive, unless a different policy is explicitly documented in code and tests.
 
-That is dangerous because the API can look successful while silently omitting claim nodes or authorization information.
+---
 
-For this feature, the safer behavior is to fail explicitly when required metadata cannot be resolved.
+## 7. Authorization
 
-Concrete examples of unsafe graceful degradation:
+These endpoints use the standard CMS secured GET pattern for read endpoints. Endpoint registration should use `MapSecuredGet`, which applies `ReadOnlyOrAdminScopePolicy` along with the existing service policy requirement. No new authorization model is introduced for this feature area.
 
-- returning `200 OK` after skipping a hierarchy node whose claim URI is absent from `dmscs.ResourceClaim`
-- returning `200 OK` with `actionId: 0` because an action name did not resolve
-- returning `200 OK` with `authStrategyId: 0` because authorization strategies failed to load
-- returning an empty action/auth-strategy list because the authorization-strategy repository returned a failure
+---
 
-Those cases should be service failures with useful logs, not successful responses.
+## 8. Failure Contract
 
-## Risks With This Approach
+The public failure behavior should stay aligned with comparable CMS read endpoints while preserving the functional outcomes required for this feature area. This section defines externally visible behavior only. CMS may still enforce internal integrity checks, but those checks must not invent new public error categories unless the team explicitly accepts a divergence.
 
-### Risk: incomplete responses when metadata drifts
+### Public contract
 
-If the hierarchy JSON and `dmscs.ResourceClaim` fall out of sync, the API can return an incomplete tree or miss claims entirely.
+| Endpoint or Condition | API Behavior | Response Shape |
+|---|---|---|
+| `GET /v2/resourceClaims` success | `200 OK` | JSON array |
+| `GET /v2/resourceClaimActions` success | `200 OK` | JSON array |
+| `GET /v2/resourceClaimActionAuthStrategies` success | `200 OK` | JSON array |
+| Query filter matches no records | `200 OK` | Empty JSON array |
+| `GET /v2/resourceClaims/{id}` and id exists | `200 OK` | JSON object |
+| `GET /v2/resourceClaims/{id}` and id is absent | `404 Not Found` | Existing CMS not-found error body |
+| Unsupported `orderBy` value | Use the response defined by the DMS-1074 query-pattern implementation | Existing CMS validation error body |
+| Authorization failure | `401` or `403` | Existing CMS auth error body |
+| Unhandled server-side exception | `500 Internal Server Error` | Existing CMS unknown-error body |
 
-This is the highest operational risk in the design.
+### Response shape notes
 
-### Risk: misleading success on partial lookup failures
+- `404` for missing `resourceClaims/{id}` should use the same CMS not-found response structure as comparable endpoints.
+- `400` validation errors should use the same CMS validation response structure as comparable endpoints.
+- Generic `500` responses should use the same CMS unknown-error response structure as comparable endpoints.
 
-If authorization strategies or action names cannot be resolved, the endpoint can return a `200 OK` with incomplete nested data unless the service handles that failure explicitly.
+### Important constraint
 
-That makes it harder for clients and operators to detect a data problem.
+This spike should not define new public endpoint failures such as:
 
-### Risk: datastore-specific wiring
+- missing hierarchy row -> `404`
+- duplicate metadata row -> custom `500` contract
+- missing action lookup row -> custom `500` contract
+- missing authorization strategy lookup row -> custom `500` contract
 
-The current CMS service wiring supports both `postgresql` and `mssql` values for `AppSettings:Datastore`, but the resource-claim schema and seed data currently exist only in the PostgreSQL deployment scripts.
+Those may still be important CMS implementation concerns, but they belong in internal validation rules, implementation notes, or follow-up decisions unless the team intentionally chooses to diverge from existing CMS endpoint behavior.
 
-If the service is deployed against a datastore that does not have an equivalent table, seed data, repository implementation, and registration path, the new endpoints can fail at startup or runtime.
+Hierarchy repository failures should follow existing CMS patterns:
 
-This should be treated as a deployment constraint, not an incidental detail.
+- `FailureHierarchyNotFound` maps the same way it already does in `AuthorizationMetadataModule`: `404 Not Found`.
+- Other hierarchy or lookup integrity failures remain generic CMS `500` responses unless a broader CMS policy changes separately.
 
-The final implementation should choose one of these outcomes:
+---
 
-- implement `IResourceClaimRepository` and deployment support for every CMS datastore supported by `main`
-- or document PostgreSQL-only support and gate endpoint/repository registration so unsupported datastores fail deliberately with a clear configuration error
+## 9. Validation Items
 
-Leaving a PostgreSQL repository registered in common service wiring is not sufficient because it hides the deployment constraint and conflicts with the existing datastore selection pattern.
+These questions remain genuinely unresolved. They must be confirmed before or during implementation, and the findings must be recorded in the companion story or in this document.
 
-### Risk: endpoint contract depends on source-data stability
+1. **MSSQL datastore support** - The `dmscs.ResourceClaim` table and seed data currently exist only in the PostgreSQL deployment scripts. This spike scopes these endpoints to PostgreSQL only. MSSQL is unsupported for this feature area until equivalent repository and deployment support are added in later work. This spike does not attempt broader datastore-composition cleanup.
 
-The API contract is only as stable as the persisted resource-claim metadata.
+2. **Startup/health validation for unsupported configuration** - It is not yet confirmed whether missing metadata should produce a startup/health-check failure or a request-time failure inside CMS. This is an internal implementation decision, not part of the endpoint contract.
 
-If downstream consumers expect the identifiers, resource names, or hierarchy shape to be stable, the CMS must maintain consistent seed data and repository behavior.
+3. **`GET /v2/resourceClaimActions` response shape** - **Resolved.** Verified against `management-api-2.3.0.yaml`: the `actions` array contains `{ name: string }` objects only. There is no `actionId` in this response shape. See Section 4 for the normative sample.
 
-## What the Developer Should Take Away
+---
 
-- CMS can support these endpoints without a schema redesign.
-- The key bridge is the match between hierarchy JSON and the resource-claim metadata table.
-- The implementation is justified because it exposes existing configuration in a read-only form.
-- The approach is workable, but it is not self-healing if the data sources drift.
-- The service should treat missing support data as an integrity problem, not a normal success path.
+## 10. Deliverable
 
-## Implementation Guidance
+The output of this spike is the companion story `reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md` (Jira: DMS-1148), which contains the full acceptance criteria and task breakdown for implementation.
 
-When working in this area, the next developer should keep these rules in mind:
+---
 
-- preserve the hierarchy JSON as the structural source of truth
-- preserve the resource-claim table as the lookup source for response metadata
-- keep the endpoints read-only
-- fail explicitly when required lookup data is missing
-- make datastore support explicit in startup wiring
-- keep tests focused on both the success path and the failure path
+## Implementation Approach
 
-## Implementation Notes
+The intended service implementation walks the claim hierarchy at runtime and joins each node with the corresponding metadata row from `dmscs.ResourceClaim`.
 
-Implementation should start from the companion story and the current `main` code paths rather than assuming the service, module, or repository already exists. The important paths to compare are the endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, and `IClaimSetRepository.GetAuthorizationStrategies`.
+- `GET /v2/resourceClaims`: the service walks the hierarchy, projects each root node to `ResourceClaimResponse`, and includes the full recursive subtree.
+- `GET /v2/resourceClaims/{id}`: the service resolves the selected node by id and returns that node with its full recursive subtree.
+- `GET /v2/resourceClaimActions`: the service resolves action names through `IClaimSetRepository.GetActions` and projects a flat list.
+- `GET /v2/resourceClaimActionAuthStrategies`: the service traverses the hierarchy, filters to claims with `DefaultAuthorization`, resolves action names and authorization strategy names through the existing claim-set repository APIs, and emits a flat response.
 
-The service should validate the full projection before returning success. Missing hierarchy metadata, failed action lookup, failed authorization-strategy lookup, and datastore support gaps should surface through explicit result cases and endpoint mappings instead of becoming empty collections or zero-valued ids.
+This design reuses existing configuration stores without introducing a parallel persistence model or schema changes.
 
-The scope remains read-only. Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids to make the projection succeed.
+### Technical tradeoffs
 
-## Outcome
+**Runtime join versus materialized claim table.** The hierarchy-to-metadata match happens at request time. Benefits: no schema change, no data migration, no extra write path. Costs: response quality depends on both sources; each request walks the tree in memory.
 
-The spike supports adding the endpoints because the necessary information already exists in CMS.
+**Shared projection depth for list and single-item views.** The collection endpoint returns full recursive trees for root nodes, and the `{id}` endpoint returns the selected node with its full recursive subtree. Benefit: one consistent projection contract across both read endpoints. Cost: the single-item lookup may still need to project or traverse a larger portion of the hierarchy before locating the requested node.
 
-The important caveat is that the implementation is a projection over two data sources, so correctness depends on them staying aligned.
+**Exact-match dependency.** The hierarchy and `dmscs.ResourceClaim` must agree on the full claim URI. If they drift, the projection fails or returns incomplete data. This is the highest operational risk in the design and must be surfaced as an explicit failure, not a silent omission.
 
-That is the main design risk to carry forward in maintenance and future changes.
+### Implementation rules
+
+- Preserve the hierarchy JSON as the structural source of truth.
+- Preserve the resource-claim table as the metadata lookup source.
+- Keep all four endpoints read-only.
+- Fail explicitly when required lookup data is missing.
+- Treat PostgreSQL as the supported datastore path for this work; MSSQL support can be added later without changing the endpoint contract.
+- Reuse the shared query-parameter pattern defined by the DMS-1074 implementation instead of introducing a feature-specific filtering or sorting pattern here.
+- Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids.
+- Start from the companion story and the current `main` code paths. Key paths to examine: endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, `IClaimSetRepository.GetAuthorizationStrategies`.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -203,6 +203,8 @@ These endpoints should follow the current CMS tenant behavior of each dependency
 - the claims hierarchy remains the structural source used by these endpoints
 - `dmscs.ResourceClaim` provides the resource-claim metadata for this projection
 
+`dmscs.ResourceClaim` metadata is treated as global bootstrap metadata for this projection. Resource-claim metadata lookup must resolve the existing seeded rows where `TenantId IS NULL`; it must not require `TenantId = @TenantId` in multitenant requests. This does not introduce endpoint-specific tenant behavior for mutable tenant-owned CMS data. It reflects that `ResourceClaim` seed rows are global metadata and `ClaimName` is globally unique.
+
 ---
 
 ## 7. Authorization

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -183,6 +183,19 @@ The endpoints assume required metadata already exists. If it does not exist, the
 
 Hierarchy node to metadata row matching is by full claim URI, exact and case-sensitive, unless a different policy is explicitly documented in code and tests.
 
+### Tenant-scope policy
+
+These endpoints should follow the standard CMS tenant model already used by repositories such as `ClaimSetRepository`:
+
+- tenant scope is established per request by the existing tenant-resolution middleware
+- repository queries use the current `TenantContext`
+- when multi-tenancy is enabled, repository lookups are scoped by `TenantId`
+- when multi-tenancy is disabled, repository lookups use `TenantId IS NULL`
+
+No endpoint-specific tenant behavior is introduced for this feature area. The endpoint contract should not define a new "global plus tenant override" model unless CMS already supports it in the backing repository behavior.
+
+`dmscs.ResourceClaim` currently has a `TenantId` column, but it also retains a global unique constraint on `ClaimName`. That schema shape does not support tenant-specific duplicates of the same claim URI, so this spike does not define tenant override or duplicate-claim semantics for resource-claim metadata.
+
 ---
 
 ## 7. Authorization
@@ -235,11 +248,17 @@ Hierarchy repository failures should follow existing CMS patterns:
 
 ## 9. Validation Items
 
-These questions remain genuinely unresolved. They must be confirmed before or during implementation, and the findings must be recorded in the companion story or in this document.
+This section records implementation-boundary notes that remain relevant for planning. It is not an open question about public endpoint behavior unless explicitly stated.
 
 1. **MSSQL datastore support** - The `dmscs.ResourceClaim` table and seed data currently exist only in the PostgreSQL deployment scripts. This spike scopes these endpoints to PostgreSQL only. MSSQL is unsupported for this feature area until equivalent repository and deployment support are added in later work. This spike does not attempt broader datastore-composition cleanup.
 
-2. **Startup/health validation for unsupported configuration** - It is not yet confirmed whether missing metadata should produce a startup/health-check failure or a request-time failure inside CMS. This is an internal implementation decision, not part of the endpoint contract.
+2. **Startup versus request-time validation** - These endpoints should follow the existing CMS pattern:
+
+   - configuration validation failures remain startup concerns only where CMS already validates configuration during startup
+   - database deploy and initial claims bootstrap failures remain startup concerns only when those existing startup paths are enabled
+   - hierarchy lookup failures, duplicate hierarchy rows, metadata drift, and related repository or projection failures remain request-time concerns for read endpoints
+
+   This spike does not introduce new startup or health-check validation for resource-claim endpoint data integrity beyond existing CMS startup behavior.
 
 3. **`GET /v2/resourceClaimActions` response shape** - **Resolved.** Verified against `management-api-2.3.0.yaml`: the `actions` array contains `{ name: string }` objects only. There is no `actionId` in this response shape. See Section 4 for the normative sample.
 

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -204,14 +204,11 @@ Hierarchy node to metadata row matching is by full claim URI, exact and case-sen
 These endpoints should follow the current CMS tenant behavior of each dependency instead of introducing feature-specific tenant semantics:
 
 - tenant scope is established per request by the existing tenant-resolution middleware
-- tenant-aware repository lookups use the current `TenantContext`
-- `IClaimSetRepository.GetAuthorizationStrategies` follows its existing tenant-aware behavior: when multi-tenancy is enabled, it scopes lookup rows by `TenantId`; when multi-tenancy is disabled, it uses rows where `TenantId IS NULL`
-- `IClaimsHierarchyRepository` reads the single CMS claims hierarchy table; the current PostgreSQL schema does not carry a hierarchy `TenantId`
-- `dmscs.ResourceClaim` is global CMS configuration; the current PostgreSQL schema has no `TenantId` column and retains a unique `ClaimName` constraint
+- tenant-aware repository lookups continue to use their current tenant behavior
+- the claims hierarchy remains the structural source used by these endpoints
+- `dmscs.ResourceClaim` provides the resource-claim metadata for this projection
 
-No endpoint-specific tenant behavior is introduced for this feature area. The endpoint contract must not define a new "global plus tenant override" model unless CMS adds that behavior to the backing schema and repositories in separate work.
-
-This spike does not define support for tenant-specific duplicates of the same claim URI. Do not add a `TenantId` predicate, `TenantId` column, or duplicate-claim semantics to `dmscs.ResourceClaim` as part of DMS-1148.
+Resource-claim metadata lookup is by full claim URI, exact and case-sensitive. Tenant behavior follows the existing CMS dependencies; this story adds no endpoint-specific tenant behavior.
 
 ---
 
@@ -313,7 +310,7 @@ This design reuses existing configuration stores without introducing a parallel 
 - Keep all four endpoints read-only.
 - Fail explicitly when required lookup data is missing.
 - Treat PostgreSQL as the supported datastore path for this work; MSSQL support can be added later without changing the endpoint contract.
-- Treat `dmscs.ResourceClaim` as global CMS configuration in DMS-1148. Do not add tenant-specific resource-claim metadata behavior in this work.
+- Use `dmscs.ResourceClaim` as the metadata source in DMS-1148 without adding endpoint-specific tenant behavior in this work.
 - Reuse the current CMS query pattern implemented through `FrontendPagingQuery`, endpoint-specific frontend query DTOs, `PagingQueryValidator<T>`, and repository query models derived from `PagingQuery` instead of introducing a feature-specific filtering or sorting abstraction here.
 - Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids.
 - Start from the companion story and the current `main` code paths. Key paths to examine: endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, `IClaimSetRepository.GetAuthorizationStrategies`.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -57,25 +57,17 @@ Sample `resourceClaims` response node (normative contract):
 
 ```json
 {
-  "id": 382,
-  "name": "epdm",
+  "id": 4,
+  "name": "educationOrganizations",
   "parentId": 0,
   "parentName": null,
   "children": [
     {
-      "id": 386,
-      "name": "performanceEvaluation",
-      "parentId": 382,
-      "parentName": "epdm",
-      "children": [
-        {
-          "id": 387,
-          "name": "performanceEvaluation",
-          "parentId": 386,
-          "parentName": "performanceEvaluation",
-          "children": []
-        }
-      ]
+      "id": 229,
+      "name": "school",
+      "parentId": 4,
+      "parentName": "educationOrganizations",
+      "children": []
     }
   ]
 }
@@ -144,6 +136,13 @@ Endpoint-specific filter parameters:
 | `GET /v2/resourceClaimActions` | `resourceName` (string) |
 | `GET /v2/resourceClaimActionAuthStrategies` | `resourceName` (string) |
 
+Filter, sort, and paging semantics:
+
+- `GET /v2/resourceClaims` first builds the valid projected hierarchy. Without filters, the result collection contains the root nodes. With `id` or `name` filters, the result collection contains matching nodes from anywhere in the hierarchy, and each matching node still includes its full recursive subtree. The original `parentId` and `parentName` values are preserved.
+- For `GET /v2/resourceClaims`, `orderBy`, `direction`, `limit`, and `offset` apply to the top-level result collection after filtering. They do not page, sort, or remove descendant `children` within each returned subtree.
+- For `GET /v2/resourceClaimActions` and `GET /v2/resourceClaimActionAuthStrategies`, filters, sorting, and paging apply to the flat projected collection.
+- Required `orderBy` allowlists are `id`, `name`, `parentId`, and `parentName` for `resourceClaims`; `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActions`; and `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActionAuthStrategies`.
+
 Current CMS validation and paging behavior to mirror:
 
 - `offset` is optional and, when provided, must be greater than or equal to `0`
@@ -202,18 +201,17 @@ Hierarchy node to metadata row matching is by full claim URI, exact and case-sen
 
 ### Tenant-scope policy
 
-These endpoints should follow the standard CMS tenant model already used by repositories such as `ClaimSetRepository`:
+These endpoints should follow the current CMS tenant behavior of each dependency instead of introducing feature-specific tenant semantics:
 
 - tenant scope is established per request by the existing tenant-resolution middleware
-- repository queries use the current `TenantContext`
-- when multi-tenancy is enabled, repository lookups are scoped by `TenantId`
-- when multi-tenancy is disabled, repository lookups use `TenantId IS NULL`
+- tenant-aware repository lookups use the current `TenantContext`
+- `IClaimSetRepository.GetAuthorizationStrategies` follows its existing tenant-aware behavior: when multi-tenancy is enabled, it scopes lookup rows by `TenantId`; when multi-tenancy is disabled, it uses rows where `TenantId IS NULL`
+- `IClaimsHierarchyRepository` reads the single CMS claims hierarchy table; the current PostgreSQL schema does not carry a hierarchy `TenantId`
+- `dmscs.ResourceClaim` is global CMS configuration; the current PostgreSQL schema has no `TenantId` column and retains a unique `ClaimName` constraint
 
-No endpoint-specific tenant behavior is introduced for this feature area. The endpoint contract should not define a new "global plus tenant override" model unless CMS already supports it in the backing repository behavior.
+No endpoint-specific tenant behavior is introduced for this feature area. The endpoint contract must not define a new "global plus tenant override" model unless CMS adds that behavior to the backing schema and repositories in separate work.
 
-`dmscs.ResourceClaim` currently has a `TenantId` column, but it also retains a global unique constraint on `ClaimName`. That schema shape does not support tenant-specific duplicates of the same claim URI, so this spike does not define tenant override or duplicate-claim semantics for resource-claim metadata.
-
-`dmscs.ResourceClaim` rows are global configuration. The resource-claim metadata lookup does not filter by `TenantId`, regardless of whether multi-tenancy is enabled; it always queries rows where `TenantId IS NULL`. This is consistent with the global unique `ClaimName` constraint, which already prevents per-tenant duplicates, and with the fact that seeding is out of scope for this work (existing seed rows carry `TenantId IS NULL`).
+This spike does not define support for tenant-specific duplicates of the same claim URI. Do not add a `TenantId` predicate, `TenantId` column, or duplicate-claim semantics to `dmscs.ResourceClaim` as part of DMS-1148.
 
 ---
 
@@ -269,7 +267,7 @@ Hierarchy repository failures should follow existing CMS patterns:
 
 This section records implementation-boundary notes that remain relevant for planning. It is not an open question about public endpoint behavior unless explicitly stated.
 
-1. **MSSQL datastore support** - The `dmscs.ResourceClaim` table and seed data currently exist only in the PostgreSQL deployment scripts. This spike scopes these endpoints to PostgreSQL only. MSSQL is unsupported for this feature area until equivalent repository and deployment support are added in later work. This spike does not attempt broader datastore-composition cleanup.
+1. **MSSQL datastore support** - The `dmscs.ResourceClaim` table and seed data currently exist only in the PostgreSQL deployment scripts. This spike scopes these endpoints to PostgreSQL only. MSSQL is unsupported for this feature area until equivalent repository and deployment support are added in later work. The implementation must not silently route these endpoints to PostgreSQL-only repository code when CMS is configured for MSSQL. This spike does not attempt broader datastore-composition cleanup.
 
 2. **Startup versus request-time validation** - These endpoints should follow the existing CMS pattern:
 
@@ -306,7 +304,7 @@ This design reuses existing configuration stores without introducing a parallel 
 
 **Shared projection depth for list and single-item views.** The collection endpoint returns full recursive trees for root nodes, and the `{id}` endpoint returns the selected node with its full recursive subtree. Benefit: one consistent projection contract across both read endpoints. Cost: the single-item lookup may still need to project or traverse a larger portion of the hierarchy before locating the requested node.
 
-**Exact-match dependency.** The hierarchy and `dmscs.ResourceClaim` must agree on the full claim URI. If they drift, the projection fails or returns incomplete data. This is the highest operational risk in the design and must be surfaced as an explicit failure, not a silent omission.
+**Exact-match dependency.** The hierarchy and `dmscs.ResourceClaim` must agree on the full claim URI. If they drift, the projection fails explicitly. This is the highest operational risk in the design and must not become a silent omission or partial response.
 
 ### Implementation rules
 
@@ -315,6 +313,7 @@ This design reuses existing configuration stores without introducing a parallel 
 - Keep all four endpoints read-only.
 - Fail explicitly when required lookup data is missing.
 - Treat PostgreSQL as the supported datastore path for this work; MSSQL support can be added later without changing the endpoint contract.
+- Treat `dmscs.ResourceClaim` as global CMS configuration in DMS-1148. Do not add tenant-specific resource-claim metadata behavior in this work.
 - Reuse the current CMS query pattern implemented through `FrontendPagingQuery`, endpoint-specific frontend query DTOs, `PagingQueryValidator<T>`, and repository query models derived from `PagingQuery` instead of introducing a feature-specific filtering or sorting abstraction here.
 - Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids.
 - Start from the companion story and the current `main` code paths. Key paths to examine: endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, `IClaimSetRepository.GetAuthorizationStrategies`.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -138,14 +138,14 @@ Endpoint-specific filter parameters:
 
 Filter, sort, and paging semantics:
 
-- `GET /v2/resourceClaims` first builds the valid projected hierarchy. Without filters, the result collection contains the root nodes. With `id` or `name` filters, the result collection contains matching nodes from anywhere in the hierarchy, and each matching node still includes its full recursive subtree. The original `parentId` and `parentName` values are preserved.
+- `GET /v2/resourceClaims` first builds the valid projected hierarchy. Without filters, the result collection contains the root nodes. With `id` or `name` filters, the query applies those filters to the top-level root-node collection only. Matching root nodes retain their full recursive subtree, and the original `parentId` and `parentName` values are preserved.
 - For `GET /v2/resourceClaims`, `orderBy`, `direction`, `limit`, and `offset` apply to the top-level result collection after filtering. They do not page, sort, or remove descendant `children` within each returned subtree.
 - For `GET /v2/resourceClaimActions` and `GET /v2/resourceClaimActionAuthStrategies`, filters, sorting, and paging apply to the flat projected collection.
 - `name` and `resourceName` filters are case-insensitive.
 - When multiple filters are supplied, these endpoints follow the existing Config query-filter behavior.
-- Required `orderBy` allowlists are `id`, `name`, `parentId`, and `parentName` for `resourceClaims`; `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActions`; and `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActionAuthStrategies`.
+- Required `orderBy` allowlists are `name`, `parentName`, `parentId`, and `id` for `resourceClaims`; `resourceClaimId` and `resourceName` for `resourceClaimActions`; and `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActionAuthStrategies`.
 
-Current CMS validation and paging behavior should be reused as-is: optional `limit`/`offset`, validated `direction`, endpoint-specific `orderBy` allowlists, no implicit row cap when paging is omitted, and the existing default sort direction behavior. When `orderBy` is omitted, default ordering is determined by the current query-parameter implementation, which defaults to `id`.
+Current CMS validation and paging behavior should be reused as-is: optional `limit`/`offset`, validated `direction`, endpoint-specific `orderBy` allowlists, no implicit row cap when paging is omitted, and the existing default sort direction behavior. When `orderBy` is omitted, default ordering follows the current CMS query configuration for each endpoint: `name` for `resourceClaims`, `resourceClaimId` for `resourceClaimActions`, and `resourceClaimId` for `resourceClaimActionAuthStrategies`.
 
 Any Admin API query behavior intentionally not implemented should be listed as an explicit omission in the implementation story.
 
@@ -159,6 +159,9 @@ These are accepted, deliberate differences from the Admin API. They are not comp
 |---|---|
 | Public and persisted IDs use `long` (`BIGINT`) | CMS uses `bigint` identifiers throughout. `ResourceClaimResponse.Id`, `ParentId`, `ResourceClaimActionAuthStrategyResponse.ResourceClaimId`, and `AuthStrategyId` are `long`. `ActionId` remains `int`, matching the existing action repository model. |
 | Authorization uses `MapSecuredGet` | These endpoints use the standard CMS secured GET pattern: `MapSecuredGet`, which applies `ReadOnlyOrAdminScopePolicy`. No new authorization model is introduced. |
+| Query paging follows the existing CMS query pattern | CMS does not add an implicit row cap when `limit`/`offset` are omitted, and `orderBy` resolution follows the current endpoint query configuration. Any Admin API default-page-size behavior is intentionally not reproduced. |
+| `resourceClaims` list filters run before paging | CMS applies `id` and `name` filters to the root-node result collection before sorting and paging. Admin API v2 sorts and pages root nodes before applying those filters; that operation order is intentionally not reproduced. |
+| Query filters follow existing CMS matching rules | `name` and `resourceName` filters are case-insensitive, and `orderBy` matching follows the current CMS query implementation. This keeps the query contract aligned with the existing CMS stack rather than introducing endpoint-specific parsing rules. |
 
 ---
 

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -123,7 +123,9 @@ Sample `resourceClaimActionAuthStrategies` response item (normative contract):
 
 ### Query parameter parity
 
-All four endpoints support general query parameters:
+CMS already has an implemented query-parameter pattern for paged read endpoints. The resource-claim endpoints should follow that current pattern using a frontend query DTO bound with `[AsParameters]`, a feature-specific `PagingQueryValidator<T>`, and a repository query model derived from `PagingQuery`.
+
+All four endpoints support these general query parameters:
 
 | Parameter | Type | Notes |
 |---|---|---|
@@ -140,7 +142,20 @@ Endpoint-specific filter parameters:
 | `GET /v2/resourceClaimActions` | `resourceName` (string) |
 | `GET /v2/resourceClaimActionAuthStrategies` | `resourceName` (string) |
 
-DMS-1074 defines the shared CMS implementation pattern for Admin API-style query parameters such as `orderBy` and `direction`. These endpoints should reuse that implementation pattern rather than introducing a feature-specific variant here.
+Current CMS validation and paging behavior to mirror:
+
+- `offset` is optional and, when provided, must be greater than or equal to `0`
+- `limit` is optional and, when provided, must be greater than `0`
+- `direction` is optional and must be one of `asc`, `ascending`, `desc`, or `descending`
+- `orderBy` is optional and, when provided, must be validated against an endpoint-specific allowlist
+- when both `limit` and `offset` are omitted, the current `PagingQuery` implementation applies no implicit row cap
+- when `direction` is omitted, repository implementations default to ascending order unless a repository-specific behavior explicitly differs
+
+Implementation should follow the existing CMS code pattern used by modules such as `VendorModule`, `ClaimSetModule`, and `ProfileModule`:
+
+- frontend binding model in `FrontendQueryModels.cs`
+- validation in `PagingQueryValidators.cs`
+- repository paging contract in `PagingQuery.cs`
 
 Admin API query behaviors intentionally not implemented must be listed as explicit omissions in the story acceptance criteria.
 
@@ -218,7 +233,7 @@ The public failure behavior should stay aligned with comparable CMS read endpoin
 | Query filter matches no records | `200 OK` | Empty JSON array |
 | `GET /v2/resourceClaims/{id}` and id exists | `200 OK` | JSON object |
 | `GET /v2/resourceClaims/{id}` and id is absent | `404 Not Found` | Existing CMS not-found error body |
-| Unsupported `orderBy` value | Use the response defined by the DMS-1074 query-pattern implementation | Existing CMS validation error body |
+| Unsupported `orderBy` value | `400 Bad Request` | Existing CMS validation error body |
 | Authorization failure | `401` or `403` | Existing CMS auth error body |
 | Unhandled server-side exception | `500 Internal Server Error` | Existing CMS unknown-error body |
 
@@ -296,6 +311,6 @@ This design reuses existing configuration stores without introducing a parallel 
 - Keep all four endpoints read-only.
 - Fail explicitly when required lookup data is missing.
 - Treat PostgreSQL as the supported datastore path for this work; MSSQL support can be added later without changing the endpoint contract.
-- Reuse the shared query-parameter pattern defined by the DMS-1074 implementation instead of introducing a feature-specific filtering or sorting pattern here.
+- Reuse the current CMS query pattern implemented through `FrontendPagingQuery`, endpoint-specific frontend query DTOs, `PagingQueryValidator<T>`, and repository query models derived from `PagingQuery` instead of introducing a feature-specific filtering or sorting abstraction here.
 - Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids.
 - Start from the companion story and the current `main` code paths. Key paths to examine: endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, `IClaimSetRepository.GetAuthorizationStrategies`.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -115,7 +115,7 @@ Sample `resourceClaimActionAuthStrategies` response item (normative contract):
 
 ### Query parameter parity
 
-CMS already has an implemented query-parameter pattern for paged read endpoints. The resource-claim endpoints should follow that current pattern using a frontend query DTO bound with `[AsParameters]`, a feature-specific `PagingQueryValidator<T>`, and a repository query model derived from `PagingQuery`.
+CMS already has an implemented query-parameter pattern for paged read endpoints. The resource-claim endpoints should follow that pattern rather than introducing feature-specific paging, sorting, or validation plumbing.
 
 The three list endpoints (`GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies`) support these general query parameters:
 
@@ -141,24 +141,13 @@ Filter, sort, and paging semantics:
 - `GET /v2/resourceClaims` first builds the valid projected hierarchy. Without filters, the result collection contains the root nodes. With `id` or `name` filters, the result collection contains matching nodes from anywhere in the hierarchy, and each matching node still includes its full recursive subtree. The original `parentId` and `parentName` values are preserved.
 - For `GET /v2/resourceClaims`, `orderBy`, `direction`, `limit`, and `offset` apply to the top-level result collection after filtering. They do not page, sort, or remove descendant `children` within each returned subtree.
 - For `GET /v2/resourceClaimActions` and `GET /v2/resourceClaimActionAuthStrategies`, filters, sorting, and paging apply to the flat projected collection.
+- `name` and `resourceName` filters are case-insensitive.
+- When multiple filters are supplied, these endpoints follow the existing Config query-filter behavior.
 - Required `orderBy` allowlists are `id`, `name`, `parentId`, and `parentName` for `resourceClaims`; `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActions`; and `resourceClaimId`, `resourceName`, and `claimName` for `resourceClaimActionAuthStrategies`.
 
-Current CMS validation and paging behavior to mirror:
+Current CMS validation and paging behavior should be reused as-is: optional `limit`/`offset`, validated `direction`, endpoint-specific `orderBy` allowlists, no implicit row cap when paging is omitted, and the existing default sort direction behavior. When `orderBy` is omitted, default ordering is determined by the current query-parameter implementation, which defaults to `id`.
 
-- `offset` is optional and, when provided, must be greater than or equal to `0`
-- `limit` is optional and, when provided, must be greater than `0`
-- `direction` is optional and must be one of `asc`, `ascending`, `desc`, or `descending`
-- `orderBy` is optional and, when provided, must be validated against an endpoint-specific allowlist
-- when both `limit` and `offset` are omitted, the current `PagingQuery` implementation applies no implicit row cap
-- when `direction` is omitted, repository implementations default to ascending order unless a repository-specific behavior explicitly differs
-
-Implementation should follow the existing CMS code pattern used by modules such as `VendorModule`, `ClaimSetModule`, and `ProfileModule`:
-
-- frontend binding model in `FrontendQueryModels.cs`
-- validation in `PagingQueryValidators.cs`
-- repository paging contract in `PagingQuery.cs`
-
-Admin API query behaviors intentionally not implemented must be listed as explicit omissions in the story acceptance criteria.
+Any Admin API query behavior intentionally not implemented should be listed as an explicit omission in the implementation story.
 
 ---
 
@@ -184,6 +173,8 @@ The CMS response contract depends on two sources staying aligned:
 
 The hierarchy determines which nodes appear in the response. The metadata table enriches those nodes. A metadata row without a corresponding hierarchy node is not returned. A hierarchy node without a matching metadata row is a data integrity failure.
 
+The projection contract is complete-or-fail: once a request needs the projected hierarchy, every required hierarchy node must resolve to exactly one `dmscs.ResourceClaim` row by full claim URI. A response must not silently skip unresolved hierarchy nodes, omit unresolved descendants, or return a successful partial result because metadata is missing.
+
 ### Seed/bootstrap boundary
 
 Creating, seeding, or maintaining `dmscs.ResourceClaim` rows is **explicitly out of scope** for this spike and any direct implementation ticket derived from it. This applies to:
@@ -193,11 +184,15 @@ Creating, seeding, or maintaining `dmscs.ResourceClaim` rows is **explicitly out
 - custom claim metadata
 - homograph or dynamically composed claim metadata
 
-The endpoints assume required metadata already exists. If it does not exist, the projection fails explicitly — it does not silently skip nodes or return partial results.
+The endpoints assume required metadata already exists. If it does not exist, the projection fails explicitly - it does not silently skip nodes or return partial results.
+
+Before implementation is treated as ready, validate the current PostgreSQL seed data against the loaded claims hierarchy and record the result in implementation notes or tests. The useful evidence is simple: every claim URI present in the hierarchy has one matching `dmscs.ResourceClaim.ClaimName` row for the tenant scope under test. Known gaps must be documented as data limitations or fixed outside these read endpoints.
+
+Action and authorization-strategy lookup data is also complete-or-fail. If a `DefaultAuthorization` entry references an action or authorization strategy that cannot be resolved through the existing claim-set repository lookups, the endpoint must not return a successful partial response. It must fail using the existing CMS generic server-error response pattern for lookup or projection integrity failures.
 
 ### Matching policy
 
-Hierarchy node to metadata row matching is by full claim URI, exact and case-sensitive, unless a different policy is explicitly documented in code and tests.
+Hierarchy node to metadata row matching uses the exact full claim URI without casing normalization, unless a different policy is explicitly documented in code and tests.
 
 ### Tenant-scope policy
 
@@ -207,8 +202,6 @@ These endpoints should follow the current CMS tenant behavior of each dependency
 - tenant-aware repository lookups continue to use their current tenant behavior
 - the claims hierarchy remains the structural source used by these endpoints
 - `dmscs.ResourceClaim` provides the resource-claim metadata for this projection
-
-Resource-claim metadata lookup is by full claim URI, exact and case-sensitive. Tenant behavior follows the existing CMS dependencies; this story adds no endpoint-specific tenant behavior.
 
 ---
 
@@ -244,19 +237,14 @@ The public failure behavior should stay aligned with comparable CMS read endpoin
 
 ### Important constraint
 
-This spike should not define new public endpoint failures such as:
-
-- missing hierarchy row -> `404`
-- duplicate metadata row -> custom `500` contract
-- missing action lookup row -> custom `500` contract
-- missing authorization strategy lookup row -> custom `500` contract
-
-Those may still be important CMS implementation concerns, but they belong in internal validation rules, implementation notes, or follow-up decisions unless the team intentionally chooses to diverge from existing CMS endpoint behavior.
+This spike should not define new public endpoint failure categories for internal integrity issues such as missing metadata, duplicate lookup data, or missing action/authorization-strategy rows. Those concerns can be handled internally, logged, or tested as implementation failures, but the public contract should stay aligned with comparable CMS endpoints unless the team intentionally accepts a broader CMS divergence.
 
 Hierarchy repository failures should follow existing CMS patterns:
 
 - `FailureHierarchyNotFound` maps the same way it already does in `AuthorizationMetadataModule`: `404 Not Found`.
 - Other hierarchy or lookup integrity failures remain generic CMS `500` responses unless a broader CMS policy changes separately.
+
+For implementers and reviewers: "generic CMS `500`" is the required public outcome for metadata drift, not a required internal mechanism. The implementation may use any local result type, validation step, or exception handling pattern that fits CMS conventions, as long as unresolved required metadata cannot produce a successful partial response.
 
 ---
 
@@ -266,13 +254,7 @@ This section records implementation-boundary notes that remain relevant for plan
 
 1. **MSSQL datastore support** - The `dmscs.ResourceClaim` table and seed data currently exist only in the PostgreSQL deployment scripts. This spike scopes these endpoints to PostgreSQL only. MSSQL is unsupported for this feature area until equivalent repository and deployment support are added in later work. The implementation must not silently route these endpoints to PostgreSQL-only repository code when CMS is configured for MSSQL. This spike does not attempt broader datastore-composition cleanup.
 
-2. **Startup versus request-time validation** - These endpoints should follow the existing CMS pattern:
-
-   - configuration validation failures remain startup concerns only where CMS already validates configuration during startup
-   - database deploy and initial claims bootstrap failures remain startup concerns only when those existing startup paths are enabled
-   - hierarchy lookup failures, duplicate hierarchy rows, metadata drift, and related repository or projection failures remain request-time concerns for read endpoints
-
-   This spike does not introduce new startup or health-check validation for resource-claim endpoint data integrity beyond existing CMS startup behavior.
+2. **Startup versus request-time validation** - These endpoints should follow existing CMS behavior. This spike does not add new startup checks, health checks, or datastore-integrity validation beyond what CMS already performs. Hierarchy lookup failures, metadata drift, and projection failures remain request-time concerns for these read endpoints.
 
 3. **`GET /v2/resourceClaimActions` response shape** - **Resolved.** Verified against `management-api-2.3.0.yaml`: the `actions` array contains `{ name: string }` objects only. There is no `actionId` in this response shape. See Section 4 for the normative sample.
 
@@ -308,9 +290,9 @@ This design reuses existing configuration stores without introducing a parallel 
 - Preserve the hierarchy JSON as the structural source of truth.
 - Preserve the resource-claim table as the metadata lookup source.
 - Keep all four endpoints read-only.
-- Fail explicitly when required lookup data is missing.
+- Fail explicitly when required lookup data is missing; do not turn metadata drift into omitted nodes, empty child collections, or empty action/auth-strategy collections.
 - Treat PostgreSQL as the supported datastore path for this work; MSSQL support can be added later without changing the endpoint contract.
 - Use `dmscs.ResourceClaim` as the metadata source in DMS-1148 without adding endpoint-specific tenant behavior in this work.
-- Reuse the current CMS query pattern implemented through `FrontendPagingQuery`, endpoint-specific frontend query DTOs, `PagingQueryValidator<T>`, and repository query models derived from `PagingQuery` instead of introducing a feature-specific filtering or sorting abstraction here.
+- Reuse the current CMS query pattern instead of introducing a feature-specific filtering or sorting abstraction here.
 - Do not add write endpoints, schema redesigns, synthetic ids, or fallback ids.
-- Start from the companion story and the current `main` code paths. Key paths to examine: endpoint module pattern, repository result records, datastore registration, `IClaimsHierarchyRepository.GetClaimsHierarchy`, `IClaimSetRepository.GetActions`, `IClaimSetRepository.GetAuthorizationStrategies`.
+- Start from the companion story and the current `main` code paths for endpoint modules, repository result records, datastore registration, claims hierarchy access, action lookup, and authorization-strategy lookup.

--- a/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/spike-resource-claims-endpoints.md
@@ -125,7 +125,7 @@ Sample `resourceClaimActionAuthStrategies` response item (normative contract):
 
 CMS already has an implemented query-parameter pattern for paged read endpoints. The resource-claim endpoints should follow that current pattern using a frontend query DTO bound with `[AsParameters]`, a feature-specific `PagingQueryValidator<T>`, and a repository query model derived from `PagingQuery`.
 
-All four endpoints support these general query parameters:
+The three list endpoints (`GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies`) support these general query parameters:
 
 | Parameter | Type | Notes |
 |---|---|---|
@@ -133,6 +133,8 @@ All four endpoints support these general query parameters:
 | `offset` | int | Pagination offset |
 | `orderBy` | string | Field name to sort by |
 | `direction` | string | `asc`/`ascending` or `desc`/`descending` |
+
+`GET /v2/resourceClaims/{id}` accepts only its path parameter. Query parameters (`limit`, `offset`, `orderBy`, `direction`) do not apply to this route.
 
 Endpoint-specific filter parameters:
 
@@ -210,6 +212,8 @@ These endpoints should follow the standard CMS tenant model already used by repo
 No endpoint-specific tenant behavior is introduced for this feature area. The endpoint contract should not define a new "global plus tenant override" model unless CMS already supports it in the backing repository behavior.
 
 `dmscs.ResourceClaim` currently has a `TenantId` column, but it also retains a global unique constraint on `ClaimName`. That schema shape does not support tenant-specific duplicates of the same claim URI, so this spike does not define tenant override or duplicate-claim semantics for resource-claim metadata.
+
+`dmscs.ResourceClaim` rows are global configuration. The resource-claim metadata lookup does not filter by `TenantId`, regardless of whether multi-tenancy is enabled; it always queries rows where `TenantId IS NULL`. This is consistent with the global unique `ClaimName` constraint, which already prevents per-tenant duplicates, and with the fact that seeding is out of scope for this work (existing seed rows carry `TenantId IS NULL`).
 
 ---
 
@@ -291,7 +295,7 @@ The intended service implementation walks the claim hierarchy at runtime and joi
 
 - `GET /v2/resourceClaims`: the service walks the hierarchy, projects each root node to `ResourceClaimResponse`, and includes the full recursive subtree.
 - `GET /v2/resourceClaims/{id}`: the service resolves the selected node by id and returns that node with its full recursive subtree.
-- `GET /v2/resourceClaimActions`: the service resolves action names through `IClaimSetRepository.GetActions` and projects a flat list.
+- `GET /v2/resourceClaimActions`: the service derives action membership for each resource claim from the `DefaultAuthorization` entries in the hierarchy JSON — the same source used by `resourceClaimActionAuthStrategies`. `IClaimSetRepository.GetActions` is used only to resolve action names from action identifiers; it does not define which actions belong to a resource claim. The projection emits a flat list.
 - `GET /v2/resourceClaimActionAuthStrategies`: the service traverses the hierarchy, filters to claims with `DefaultAuthorization`, resolves action names and authorization strategy names through the existing claim-set repository APIs, and emits a flat response.
 
 This design reuses existing configuration stores without introducing a parallel persistence model or schema changes.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -1,0 +1,74 @@
+---
+jira: DMS-1148
+jira_url: https://edfi.atlassian.net/browse/DMS-1148
+---
+
+# Story: Serve Resource Claims Endpoints from CMS Claims Hierarchy
+
+## Description
+
+CMS needs Admin API-compatible read endpoints for resource claim metadata:
+
+- `GET /v2/resourceClaims`
+- `GET /v2/resourceClaims/{id}`
+- `GET /v2/resourceClaimActionAuthStrategies`
+
+Resource claim structure is stored in the CMS claims hierarchy JSON. The public response metadata comes from `dmscs.ResourceClaim`, keyed by the same full claim URI used in the hierarchy. Action and authorization-strategy details come from the existing claim-set repository.
+
+This story covers read-only projections over those existing stores. It does not add resource-claim write endpoints, synthetic ids, fallback ids, or a new claims persistence model.
+
+## Acceptance Criteria
+
+- `GET /v2/resourceClaims`:
+  - loads the single CMS claims hierarchy,
+  - projects every hierarchy node to a `ResourceClaimResponse`,
+  - joins each hierarchy node to `dmscs.ResourceClaim` by full claim URI,
+  - returns `id`, `name`, `parentId`, `parentName`, and `children`,
+  - uses `dmscs.ResourceClaim.ResourceName` for `name`, not the claim URI,
+  - uses `0` and `null` for root `parentId` and `parentName`,
+  - fails explicitly if any hierarchy node is missing resource-claim metadata.
+- `GET /v2/resourceClaims/{id}`:
+  - searches the valid projected hierarchy by `dmscs.ResourceClaim.Id`,
+  - returns the matching projected claim,
+  - returns `404 Not Found` only when the hierarchy projects successfully and the requested id is absent.
+- `GET /v2/resourceClaimActionAuthStrategies`:
+  - returns one flat item for each hierarchy claim with `DefaultAuthorization` actions,
+  - includes `resourceClaimId`, `resourceName`, `claimName`, and `authorizationStrategiesForActions`,
+  - resolves action names through `IClaimSetRepository.GetActions`,
+  - resolves authorization strategy names through `IClaimSetRepository.GetAuthorizationStrategies`,
+  - fails explicitly when action or authorization-strategy lookup data is missing or cannot be loaded.
+- Failure handling:
+  - missing claims hierarchy returns `404 Not Found`,
+  - multiple hierarchy rows, repository exceptions, duplicate claim metadata, missing metadata, missing parent metadata, missing action lookup, and missing authorization-strategy lookup are server failures,
+  - repository failures are not converted into empty dictionaries, empty arrays, or zero-valued ids,
+  - logs identify the failed claim URI, action name, or authorization strategy name when available.
+- Response model types:
+  - resource claim ids and parent ids use `long`,
+  - authorization strategy ids use `long`,
+  - action ids remain `int`,
+  - matching is exact and case-sensitive unless a different policy is explicitly documented in code and tests.
+- Datastore support:
+  - repository registration follows the selected CMS datastore,
+  - PostgreSQL support uses the existing `dmscs.ResourceClaim` schema and seed data,
+  - MSSQL support is either implemented with equivalent schema, seed data, and repository behavior, or the feature is deliberately gated with a clear startup/configuration failure,
+  - PostgreSQL-specific repository registration is not placed in common service wiring.
+- Tests cover:
+  - successful resource-claim hierarchy projection,
+  - successful lookup by id and not-found lookup by id,
+  - successful action/auth-strategy projection,
+  - missing hierarchy metadata,
+  - missing action lookup,
+  - authorization-strategy repository failure,
+  - missing authorization-strategy lookup,
+  - datastore-specific registration or gating behavior.
+
+## Tasks
+
+1. Add the resource-claim read model and service projection over `IClaimsHierarchyRepository` plus `IResourceClaimRepository`.
+2. Add a datastore-specific `IResourceClaimRepository` implementation and register it through datastore-specific wiring.
+3. Add the resource-claims endpoint module and map the three routes listed in this story.
+4. Map service result cases to explicit endpoint responses, preserving `404` only for missing hierarchy and absent id after a valid projection.
+5. Resolve action and authorization-strategy metadata through the existing claim-set repository APIs.
+6. Add focused unit and endpoint tests for the success and failure cases listed above.
+7. Update the spike or implementation note if the final datastore support differs from the intended PostgreSQL-plus-MSSQL behavior.
+8. Run the relevant backend and frontend tests and format changed C# files with `dotnet csharpier format`.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -119,6 +119,8 @@ This contract defines observable behavior, not an implementation shape. The impl
 - Tenant-aware lookups, such as `IClaimSetRepository.GetAuthorizationStrategies`, continue to use their current request tenant behavior.
 - The claims hierarchy remains the structural source used by these endpoints.
 - `dmscs.ResourceClaim` provides the resource-claim metadata for this projection.
+- `dmscs.ResourceClaim` metadata is global bootstrap metadata for this projection. Resource-claim metadata lookup must resolve the existing seeded rows where `TenantId IS NULL`; it must not require `TenantId = @TenantId` in multitenant requests.
+- This global `ResourceClaim` lookup rule does not apply to mutable tenant-owned CMS data. It reflects that `ResourceClaim` seed rows are global metadata and `ClaimName` is globally unique.
 - Resource-claim metadata lookup uses the exact full claim URI without casing normalization.
 - This story adds no endpoint-specific tenant behavior.
 
@@ -155,6 +157,7 @@ This contract defines observable behavior, not an implementation shape. The impl
 - Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
 - Query parameter filtering and pagination behavior, including case-insensitive `name`/`resourceName` filters, existing Config combined-filter behavior, and default `id` ordering when `orderBy` is omitted.
 - Tenant-scoped requests follow existing CMS dependency behavior.
+- Multitenant requests resolve `dmscs.ResourceClaim` metadata from the existing global seed rows (`TenantId IS NULL`) and do not require tenant-specific duplicate `ResourceClaim` rows.
 - PostgreSQL-only behavior for this story.
 
 ## Tasks

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -32,7 +32,7 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Uses `0` and `null` for root `parentId` and `parentName`.
 - Each root node includes its full recursive subtree via nested `children` arrays.
 - Fails explicitly if any hierarchy node is missing resource-claim metadata.
-- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
 - Supports endpoint-specific filters: `id` (long), `name` (string).
 
 ### `GET /v2/resourceClaims/{id}`
@@ -47,7 +47,7 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Resolves action names through `IClaimSetRepository.GetActions`.
 - Each item includes `resourceClaimId` (long), `resourceName`, `claimName`, and `actions`.
 - `actions` is an array of objects with only a `name` field (`{ name: string }`). There is no `actionId` in this shape.
-- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
 - Supports endpoint-specific filter: `resourceName` (string).
 
 ### `GET /v2/resourceClaimActionAuthStrategies`
@@ -56,19 +56,33 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Includes `resourceClaimId`, `resourceName`, `claimName`, and `authorizationStrategiesForActions`.
 - Resolves action names through `IClaimSetRepository.GetActions`.
 - Resolves authorization strategy names through `IClaimSetRepository.GetAuthorizationStrategies`.
-- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
 - Supports endpoint-specific filter: `resourceName` (string).
 
 ### Query parameter alignment
 
-DMS-1074 defines the shared CMS implementation pattern for Admin API-style filtering and sorting parameters. These endpoints should use that implementation pattern rather than introducing a feature-specific query abstraction.
+These endpoints should use the current CMS query implementation pattern rather than introducing a feature-specific query abstraction:
+
+- frontend query DTO bound with `[AsParameters]`
+- endpoint-specific frontend query model for endpoint filters
+- endpoint-specific `PagingQueryValidator<T>` allowlist for `orderBy`
+- repository query model derived from `PagingQuery`
+
+The shared paging behavior to preserve is:
+
+- `offset` optional, but if provided must be `>= 0`
+- `limit` optional, but if provided must be `> 0`
+- `direction` optional, but if provided must be one of `asc`, `ascending`, `desc`, `descending`
+- `orderBy` optional, but if provided must be in the endpoint allowlist
+- omitting both `limit` and `offset` does not impose an implicit row cap
+- omitting `direction` defaults to ascending behavior in current repository implementations unless explicitly documented otherwise
 
 ### Failure handling
 
 - `GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies` return `200 OK` with arrays on success.
 - Query filters that match no records return `200 OK` with an empty array.
 - `GET /v2/resourceClaims/{id}` returns `200 OK` with a JSON object when found and `404 Not Found` when absent.
-- Unsupported `orderBy` values return the same `400 Bad Request` validation response produced by the DMS-1074 query-pattern implementation.
+- Unsupported `orderBy` values return the same `400 Bad Request` validation response pattern used by current CMS paging-query validators.
 - Authorization failures remain `401` or `403`.
 - Unhandled server-side exceptions return the same generic CMS unknown-error response shape used by comparable endpoints.
 - The implementation must not invent new public endpoint failure types unless the team deliberately accepts a divergence from the spike document.
@@ -119,7 +133,7 @@ DMS-1074 defines the shared CMS implementation pattern for Admin API-style filte
 - Successful resource-claim-actions projection.
 - Successful action/auth-strategy projection.
 - Empty-result behavior for `resourceClaimActions` and `resourceClaimActionAuthStrategies` filters.
-- Validation failure for unsupported `orderBy`, using the DMS-1074 query-pattern validation response.
+- Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
 - Query parameter filtering and pagination behavior.
 - PostgreSQL-only behavior for this story.
 
@@ -130,7 +144,7 @@ DMS-1074 defines the shared CMS implementation pattern for Admin API-style filte
 3. Add the resource-claims endpoint module and map the four routes listed in this story.
 4. Map service result cases to explicit endpoint responses, preserving the required `200`, `400`, `404`, `401`/`403`, and generic `500` outcomes while using the same CMS error response patterns as comparable endpoints.
 5. Add the resource-claim-actions service projection and endpoint, resolving action names through the existing claim-set repository.
-6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for all four endpoints by reusing the shared DMS-1074 query implementation pattern.
+6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for all four endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`.
 7. Resolve authorization strategy metadata through the existing claim-set repository APIs for the auth-strategies endpoint.
 8. Register these endpoints with `MapSecuredGet` and document `ReadOnlyOrAdminScopePolicy` in the architecture brief and endpoint registration.
 9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -11,64 +11,112 @@ CMS needs Admin API-compatible read endpoints for resource claim metadata:
 
 - `GET /v2/resourceClaims`
 - `GET /v2/resourceClaims/{id}`
+- `GET /v2/resourceClaimActions`
 - `GET /v2/resourceClaimActionAuthStrategies`
 
 Resource claim structure is stored in the CMS claims hierarchy JSON. The public response metadata comes from `dmscs.ResourceClaim`, keyed by the same full claim URI used in the hierarchy. Action and authorization-strategy details come from the existing claim-set repository.
 
-This story covers read-only projections over those existing stores. It does not add resource-claim write endpoints, synthetic ids, fallback ids, or a new claims persistence model.
+This story covers read-only projections over those existing stores. It does not add resource-claim write endpoints, synthetic ids, fallback ids, or a new claims persistence model. Seeding or maintaining resource-claim metadata rows is also out of scope.
+
+See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-endpoints.md` for the full parity decisions, CMS divergences, failure contract, and open validation items. Response and failure contracts were verified against the ODS/Admin API source and published OpenAPI artifacts. The original tracking ticket for this feature area is [DMS-853](https://edfi.atlassian.net/browse/DMS-853).
 
 ## Acceptance Criteria
 
-- `GET /v2/resourceClaims`:
-  - loads the single CMS claims hierarchy,
-  - projects every hierarchy node to a `ResourceClaimResponse`,
-  - joins each hierarchy node to `dmscs.ResourceClaim` by full claim URI,
-  - returns `id`, `name`, `parentId`, `parentName`, and `children`,
-  - uses `dmscs.ResourceClaim.ResourceName` for `name`, not the claim URI,
-  - uses `0` and `null` for root `parentId` and `parentName`,
-  - fails explicitly if any hierarchy node is missing resource-claim metadata.
-- `GET /v2/resourceClaims/{id}`:
-  - searches the valid projected hierarchy by `dmscs.ResourceClaim.Id`,
-  - returns the matching projected claim,
-  - returns `404 Not Found` only when the hierarchy projects successfully and the requested id is absent.
-- `GET /v2/resourceClaimActionAuthStrategies`:
-  - returns one flat item for each hierarchy claim with `DefaultAuthorization` actions,
-  - includes `resourceClaimId`, `resourceName`, `claimName`, and `authorizationStrategiesForActions`,
-  - resolves action names through `IClaimSetRepository.GetActions`,
-  - resolves authorization strategy names through `IClaimSetRepository.GetAuthorizationStrategies`,
-  - fails explicitly when action or authorization-strategy lookup data is missing or cannot be loaded.
-- Failure handling:
-  - missing claims hierarchy returns `404 Not Found`,
-  - multiple hierarchy rows, repository exceptions, duplicate claim metadata, missing metadata, missing parent metadata, missing action lookup, and missing authorization-strategy lookup are server failures,
-  - repository failures are not converted into empty dictionaries, empty arrays, or zero-valued ids,
-  - logs identify the failed claim URI, action name, or authorization strategy name when available.
-- Response model types:
-  - resource claim ids and parent ids use `long`,
-  - authorization strategy ids use `long`,
-  - action ids remain `int`,
-  - matching is exact and case-sensitive unless a different policy is explicitly documented in code and tests.
-- Datastore support:
-  - repository registration follows the selected CMS datastore,
-  - PostgreSQL support uses the existing `dmscs.ResourceClaim` schema and seed data,
-  - MSSQL support is either implemented with equivalent schema, seed data, and repository behavior, or the feature is deliberately gated with a clear startup/configuration failure,
-  - PostgreSQL-specific repository registration is not placed in common service wiring.
-- Tests cover:
-  - successful resource-claim hierarchy projection,
-  - successful lookup by id and not-found lookup by id,
-  - successful action/auth-strategy projection,
-  - missing hierarchy metadata,
-  - missing action lookup,
-  - authorization-strategy repository failure,
-  - missing authorization-strategy lookup,
-  - datastore-specific registration or gating behavior.
+### `GET /v2/resourceClaims`
+
+- Loads the single CMS claims hierarchy.
+- Projects every hierarchy node to a `ResourceClaimResponse`.
+- Joins each hierarchy node to `dmscs.ResourceClaim` by full claim URI (exact, case-sensitive).
+- Returns `id`, `name`, `parentId`, `parentName`, and `children`.
+- Uses `dmscs.ResourceClaim.ResourceName` for `name`, not the claim URI.
+- Uses `0` and `null` for root `parentId` and `parentName`.
+- Each root node includes its full recursive subtree via nested `children` arrays.
+- Fails explicitly if any hierarchy node is missing resource-claim metadata.
+- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports endpoint-specific filters: `id` (long), `name` (string).
+
+### `GET /v2/resourceClaims/{id}`
+
+- Searches the valid projected hierarchy by `dmscs.ResourceClaim.Id`.
+- Returns the matching projected claim node including its full recursive subtree.
+- Returns `404 Not Found` when the requested id is absent.
+
+### `GET /v2/resourceClaimActions`
+
+- Returns a flat list of resource claim actions resolved from claim-set metadata.
+- Resolves action names through `IClaimSetRepository.GetActions`.
+- Each item includes `resourceClaimId` (long), `resourceName`, `claimName`, and `actions`.
+- `actions` is an array of objects with only a `name` field (`{ name: string }`). There is no `actionId` in this shape.
+- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports endpoint-specific filter: `resourceName` (string).
+
+### `GET /v2/resourceClaimActionAuthStrategies`
+
+- Returns one flat item for each hierarchy claim with `DefaultAuthorization` actions.
+- Includes `resourceClaimId`, `resourceName`, `claimName`, and `authorizationStrategiesForActions`.
+- Resolves action names through `IClaimSetRepository.GetActions`.
+- Resolves authorization strategy names through `IClaimSetRepository.GetAuthorizationStrategies`.
+- Supports the general query-parameter pattern defined by the DMS-1074 implementation, including `limit`, `offset`, `orderBy`, and `direction`.
+- Supports endpoint-specific filter: `resourceName` (string).
+
+### Query parameter alignment
+
+DMS-1074 defines the shared CMS implementation pattern for Admin API-style filtering and sorting parameters. These endpoints should use that implementation pattern rather than introducing a feature-specific query abstraction.
+
+### Failure handling
+
+- `GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies` return `200 OK` with arrays on success.
+- Query filters that match no records return `200 OK` with an empty array.
+- `GET /v2/resourceClaims/{id}` returns `200 OK` with a JSON object when found and `404 Not Found` when absent.
+- Unsupported `orderBy` values return the same `400 Bad Request` validation response produced by the DMS-1074 query-pattern implementation.
+- Authorization failures remain `401` or `403`.
+- Unhandled server-side exceptions return the same generic CMS unknown-error response shape used by comparable endpoints.
+- The implementation must not invent new public endpoint failure types unless the team deliberately accepts a divergence from the spike document.
+- `FailureHierarchyNotFound` maps to `404 Not Found`, consistent with existing CMS hierarchy-backed endpoint behavior.
+- Other hierarchy or lookup integrity failures remain generic CMS `500` responses unless broader CMS behavior changes separately.
+
+### Response model types
+
+- Resource claim ids and parent ids use `long`.
+- Authorization strategy ids use `long`.
+- Action ids remain `int`.
+- Matching is exact and case-sensitive unless a different policy is explicitly documented in code and tests.
+
+### Authorization
+
+- These endpoints use `MapSecuredGet`.
+- `MapSecuredGet` applies `ReadOnlyOrAdminScopePolicy` for these routes.
+
+### Datastore support
+
+- Repository registration follows the selected CMS datastore for supported implementations.
+- PostgreSQL support uses the existing `dmscs.ResourceClaim` schema and seed data.
+- This story targets PostgreSQL as the supported datastore path for these endpoints.
+- MSSQL support for these endpoints is out of scope and may be added later with equivalent repository behavior and deployment artifacts without changing the public endpoint contract.
+- This story does not include broader datastore-composition cleanup beyond what is required to support the PostgreSQL path.
+
+### Tests cover
+
+- Successful resource-claim hierarchy projection for the list endpoint.
+- Successful single-item projection with full recursive subtree.
+- Lookup by id - found and not found.
+- Successful resource-claim-actions projection.
+- Successful action/auth-strategy projection.
+- Empty-result behavior for `resourceClaimActions` and `resourceClaimActionAuthStrategies` filters.
+- Validation failure for unsupported `orderBy`, using the DMS-1074 query-pattern validation response.
+- Query parameter filtering and pagination behavior.
+- PostgreSQL-only behavior for this story.
 
 ## Tasks
 
 1. Add the resource-claim read model and service projection over `IClaimsHierarchyRepository` plus `IResourceClaimRepository`.
 2. Add a datastore-specific `IResourceClaimRepository` implementation and register it through datastore-specific wiring.
-3. Add the resource-claims endpoint module and map the three routes listed in this story.
-4. Map service result cases to explicit endpoint responses, preserving `404` only for missing hierarchy and absent id after a valid projection.
-5. Resolve action and authorization-strategy metadata through the existing claim-set repository APIs.
-6. Add focused unit and endpoint tests for the success and failure cases listed above.
-7. Update the spike or implementation note if the final datastore support differs from the intended PostgreSQL-plus-MSSQL behavior.
-8. Run the relevant backend and frontend tests and format changed C# files with `dotnet csharpier format`.
+3. Add the resource-claims endpoint module and map the four routes listed in this story.
+4. Map service result cases to explicit endpoint responses, preserving the required `200`, `400`, `404`, `401`/`403`, and generic `500` outcomes while using the same CMS error response patterns as comparable endpoints.
+5. Add the resource-claim-actions service projection and endpoint, resolving action names through the existing claim-set repository.
+6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for all four endpoints by reusing the shared DMS-1074 query implementation pattern.
+7. Resolve authorization strategy metadata through the existing claim-set repository APIs for the auth-strategies endpoint.
+8. Register these endpoints with `MapSecuredGet` and document `ReadOnlyOrAdminScopePolicy` in the architecture brief and endpoint registration.
+9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract.
+10. Add focused unit and endpoint tests for the success and failure cases listed above, including query parameter behavior and empty-filter-result behavior.
+11. Run the relevant backend and frontend tests and format changed C# files with `dotnet csharpier format`.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -112,12 +112,11 @@ Endpoint-specific `orderBy` allowlists:
 
 - These endpoints use the current CMS tenant behavior of each dependency rather than introducing feature-specific tenant semantics.
 - Request tenant scope is established by the existing tenant middleware.
-- Tenant-aware lookups, such as `IClaimSetRepository.GetAuthorizationStrategies`, continue to use the current request `TenantContext`.
-- `IClaimsHierarchyRepository` reads the single CMS claims hierarchy table. The current PostgreSQL schema does not carry a hierarchy `TenantId`.
-- `dmscs.ResourceClaim` rows are global CMS configuration. The current PostgreSQL schema has no `TenantId` column and retains a unique `ClaimName` constraint.
-- Resource-claim metadata lookup must not add a `TenantId` predicate, `TenantId` column, or tenant-specific duplicate-claim behavior as part of this story.
-- This story does not introduce endpoint-specific tenant overrides or a new global-plus-tenant resource-claim model.
-- This story does not define support for duplicate `ClaimName` values across tenants. The current schema retains a unique `ClaimName` constraint.
+- Tenant-aware lookups, such as `IClaimSetRepository.GetAuthorizationStrategies`, continue to use their current request tenant behavior.
+- The claims hierarchy remains the structural source used by these endpoints.
+- `dmscs.ResourceClaim` provides the resource-claim metadata for this projection.
+- Resource-claim metadata lookup is by full claim URI, exact and case-sensitive.
+- This story adds no endpoint-specific tenant behavior.
 
 ### Authorization
 
@@ -152,6 +151,7 @@ Endpoint-specific `orderBy` allowlists:
 - Explicit failure when a hierarchy node has no matching resource-claim metadata row (metadata drift).
 - Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
 - Query parameter filtering and pagination behavior.
+- Tenant-scoped requests follow existing CMS dependency behavior.
 - PostgreSQL-only behavior for this story.
 
 ## Tasks

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -34,6 +34,8 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Fails explicitly if any hierarchy node is missing resource-claim metadata.
 - Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
 - Supports endpoint-specific filters: `id` (long), `name` (string).
+- Without filters, returns root nodes as the top-level collection. With `id` or `name` filters, returns matching nodes from anywhere in the hierarchy as the top-level collection, with each matching node retaining its original `parentId`, `parentName`, and full recursive `children` subtree.
+- Applies `orderBy`, `direction`, `limit`, and `offset` to the top-level result collection after filtering. Paging and sorting do not remove or reorder descendant `children` within each returned subtree.
 
 ### `GET /v2/resourceClaims/{id}`
 
@@ -79,6 +81,14 @@ The shared paging behavior to preserve is:
 - omitting both `limit` and `offset` does not impose an implicit row cap
 - omitting `direction` defaults to ascending behavior in current repository implementations unless explicitly documented otherwise
 
+Endpoint-specific `orderBy` allowlists:
+
+| Endpoint | Allowed `orderBy` values |
+|---|---|
+| `GET /v2/resourceClaims` | `id`, `name`, `parentId`, `parentName` |
+| `GET /v2/resourceClaimActions` | `resourceClaimId`, `resourceName`, `claimName` |
+| `GET /v2/resourceClaimActionAuthStrategies` | `resourceClaimId`, `resourceName`, `claimName` |
+
 ### Failure handling
 
 - `GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies` return `200 OK` with arrays on success.
@@ -100,11 +110,12 @@ The shared paging behavior to preserve is:
 
 ### Tenant scope
 
-- These endpoints use the standard CMS tenant-resolution pattern already used by repositories such as `ClaimSetRepository`.
-- Repository behavior is driven by the current request `TenantContext`, established by the existing tenant middleware.
-- When multi-tenancy is enabled, tenant-aware lookups (such as `ClaimSet`) are scoped by `TenantId`.
-- When multi-tenancy is disabled, those lookups use rows where `TenantId IS NULL`.
-- `dmscs.ResourceClaim` rows are global configuration. The resource-claim metadata lookup always queries rows where `TenantId IS NULL`, regardless of whether multi-tenancy is enabled. This is consistent with the global unique `ClaimName` constraint and the fact that existing seed rows carry `TenantId IS NULL`.
+- These endpoints use the current CMS tenant behavior of each dependency rather than introducing feature-specific tenant semantics.
+- Request tenant scope is established by the existing tenant middleware.
+- Tenant-aware lookups, such as `IClaimSetRepository.GetAuthorizationStrategies`, continue to use the current request `TenantContext`.
+- `IClaimsHierarchyRepository` reads the single CMS claims hierarchy table. The current PostgreSQL schema does not carry a hierarchy `TenantId`.
+- `dmscs.ResourceClaim` rows are global CMS configuration. The current PostgreSQL schema has no `TenantId` column and retains a unique `ClaimName` constraint.
+- Resource-claim metadata lookup must not add a `TenantId` predicate, `TenantId` column, or tenant-specific duplicate-claim behavior as part of this story.
 - This story does not introduce endpoint-specific tenant overrides or a new global-plus-tenant resource-claim model.
 - This story does not define support for duplicate `ClaimName` values across tenants. The current schema retains a unique `ClaimName` constraint.
 
@@ -115,10 +126,11 @@ The shared paging behavior to preserve is:
 
 ### Datastore support
 
-- Repository registration follows the selected CMS datastore for supported implementations.
+- Repository registration follows the current CMS DI pattern while keeping unsupported datastore behavior explicit.
 - PostgreSQL support uses the existing `dmscs.ResourceClaim` schema and seed data.
 - This story targets PostgreSQL as the supported datastore path for these endpoints.
 - MSSQL support for these endpoints is out of scope and may be added later with equivalent repository behavior and deployment artifacts without changing the public endpoint contract.
+- The implementation must not silently route these endpoints to PostgreSQL-only repository code when CMS is configured for MSSQL.
 - This story does not include broader datastore-composition cleanup beyond what is required to support the PostgreSQL path.
 
 ### Validation timing
@@ -133,6 +145,7 @@ The shared paging behavior to preserve is:
 - Successful resource-claim hierarchy projection for the list endpoint.
 - Successful single-item projection with full recursive subtree.
 - Lookup by id - found and not found.
+- Resource-claim list filtering by root and child `id`/`name`, including the rule that matching child nodes are returned with their own full subtree.
 - Successful resource-claim-actions projection.
 - Successful action/auth-strategy projection.
 - Empty-result behavior for `resourceClaimActions` and `resourceClaimActionAuthStrategies` filters.
@@ -144,13 +157,13 @@ The shared paging behavior to preserve is:
 ## Tasks
 
 1. Add the resource-claim read model and service projection over `IClaimsHierarchyRepository` plus `IResourceClaimRepository`.
-2. Add a datastore-specific `IResourceClaimRepository` implementation and register it through datastore-specific wiring.
+2. Add `IResourceClaimRepository` in the backend repository abstractions, add the PostgreSQL implementation under the PostgreSQL repository project, and register it with the current CMS DI pattern without enabling it for unsupported MSSQL execution.
 3. Add the resource-claims endpoint module and map the four routes listed in this story.
 4. Map service result cases to explicit endpoint responses, preserving the required `200`, `400`, `404`, `401`/`403`, and generic `500` outcomes while using the same CMS error response patterns as comparable endpoints.
 5. Add the resource-claim-actions service projection and endpoint, resolving action names through the existing claim-set repository.
-6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for the three list endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`. `GET /v2/resourceClaims/{id}` accepts only its path parameter.
+6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for the three list endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`. Apply the hierarchy filtering and paging semantics defined in the acceptance criteria. `GET /v2/resourceClaims/{id}` accepts only its path parameter.
 7. Resolve authorization strategy metadata through the existing claim-set repository APIs for the auth-strategies endpoint.
 8. Register these endpoints with `MapSecuredGet` and document `ReadOnlyOrAdminScopePolicy` in the architecture brief and endpoint registration.
-9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract.
+9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract. Add an explicit guard so unsupported MSSQL configuration cannot use PostgreSQL-only resource-claim repositories.
 10. Add focused unit and endpoint tests for the success and failure cases listed above, including query parameter behavior and empty-filter-result behavior.
 11. Run the relevant backend and frontend tests and format changed C# files with `dotnet csharpier format`.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -18,7 +18,7 @@ Resource claim structure is stored in the CMS claims hierarchy JSON. The public 
 
 This story covers read-only projections over those existing stores. It does not add resource-claim write endpoints, synthetic ids, fallback ids, or a new claims persistence model. Seeding or maintaining resource-claim metadata rows is also out of scope.
 
-See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-endpoints.md` for the full parity decisions, CMS divergences, failure contract, and open validation items. Response and failure contracts were verified against the ODS/Admin API source and published OpenAPI artifacts. The original tracking ticket for this feature area is [DMS-853](https://edfi.atlassian.net/browse/DMS-853).
+See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-endpoints.md` for parity decisions, CMS divergences, failure contract, and validation boundaries. Response and failure contracts were verified against the ODS/Admin API source and published OpenAPI artifacts. The original tracking ticket for this feature area is [DMS-853](https://edfi.atlassian.net/browse/DMS-853).
 
 ## Acceptance Criteria
 
@@ -26,7 +26,7 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 
 - Loads the single CMS claims hierarchy.
 - Projects every hierarchy node to a `ResourceClaimResponse`.
-- Joins each hierarchy node to `dmscs.ResourceClaim` by full claim URI (exact, case-sensitive).
+- Joins each hierarchy node to `dmscs.ResourceClaim` by exact full claim URI, without casing normalization.
 - Returns `id`, `name`, `parentId`, `parentName`, and `children`.
 - Uses `dmscs.ResourceClaim.ResourceName` for `name`, not the claim URI.
 - Uses `0` and `null` for root `parentId` and `parentName`.
@@ -65,21 +65,9 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 
 ### Query parameter alignment
 
-The three list endpoints (`GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies`) use the current CMS query implementation pattern rather than introducing a feature-specific query abstraction. `GET /v2/resourceClaims/{id}` accepts only its path parameter and does not support these query parameters.
+The three list endpoints (`GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies`) reuse the current CMS query pattern for paging, sorting, validation, and endpoint-specific filters. `GET /v2/resourceClaims/{id}` accepts only its path parameter and does not support these query parameters.
 
-- frontend query DTO bound with `[AsParameters]`
-- endpoint-specific frontend query model for endpoint filters
-- endpoint-specific `PagingQueryValidator<T>` allowlist for `orderBy`
-- repository query model derived from `PagingQuery`
-
-The shared paging behavior to preserve is:
-
-- `offset` optional, but if provided must be `>= 0`
-- `limit` optional, but if provided must be `> 0`
-- `direction` optional, but if provided must be one of `asc`, `ascending`, `desc`, `descending`
-- `orderBy` optional, but if provided must be in the endpoint allowlist
-- omitting both `limit` and `offset` does not impose an implicit row cap
-- omitting `direction` defaults to ascending behavior in current repository implementations unless explicitly documented otherwise
+The shared paging behavior to preserve is the existing CMS behavior: optional `limit`/`offset`, validated `direction`, endpoint-specific `orderBy` allowlists, no implicit row cap when paging is omitted, and the current default sort direction behavior.
 
 Endpoint-specific `orderBy` allowlists:
 
@@ -89,24 +77,40 @@ Endpoint-specific `orderBy` allowlists:
 | `GET /v2/resourceClaimActions` | `resourceClaimId`, `resourceName`, `claimName` |
 | `GET /v2/resourceClaimActionAuthStrategies` | `resourceClaimId`, `resourceName`, `claimName` |
 
+Additional query rules:
+
+- `name` and `resourceName` filters are case-insensitive.
+- When multiple filters are supplied, including `id` and `name` together for `GET /v2/resourceClaims`, these endpoints follow the existing Config query-filter behavior.
+- When `orderBy` is omitted, default ordering is determined by the current query-parameter implementation, which defaults to `id`.
+
 ### Failure handling
 
 - `GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies` return `200 OK` with arrays on success.
 - Query filters that match no records return `200 OK` with an empty array.
 - `GET /v2/resourceClaims/{id}` returns `200 OK` with a JSON object when found and `404 Not Found` when absent.
-- Unsupported `orderBy` values return the same `400 Bad Request` validation response pattern used by current CMS paging-query validators.
+- Unsupported `orderBy` values return the existing CMS `400 Bad Request` validation response pattern.
 - Authorization failures remain `401` or `403`.
 - Unhandled server-side exceptions return the same generic CMS unknown-error response shape used by comparable endpoints.
 - The implementation must not invent new public endpoint failure types unless the team deliberately accepts a divergence from the spike document.
 - `FailureHierarchyNotFound` maps to `404 Not Found`, consistent with existing CMS hierarchy-backed endpoint behavior.
 - Other hierarchy or lookup integrity failures remain generic CMS `500` responses unless broader CMS behavior changes separately.
 
+### Data integrity contract
+
+The hierarchy projection must be complete with respect to the CMS claims hierarchy source. Every hierarchy node that participates in these endpoint responses must resolve to exactly one `dmscs.ResourceClaim` metadata row by the exact full claim URI.
+
+If any required hierarchy node cannot be resolved to resource-claim metadata, the endpoint must not return a successful partial response. The request must fail explicitly using the existing CMS generic server-error response pattern for lookup or projection integrity failures.
+
+Action and authorization-strategy lookup data is also complete-or-fail. If a `DefaultAuthorization` entry references an action or authorization strategy that cannot be resolved through the existing claim-set repository lookups, the endpoint must not return a successful partial response. It must fail using the existing CMS generic server-error response pattern for lookup or projection integrity failures.
+
+This contract defines observable behavior, not an implementation shape. The implementation may detect metadata drift before projection, during recursive projection, through a validation helper, or inside an existing service/repository boundary. Do not silently skip unresolved hierarchy nodes, omit unresolved child subtrees, or return empty action/auth-strategy results because metadata is missing.
+
 ### Response model types
 
 - Resource claim ids and parent ids use `long`.
 - Authorization strategy ids use `long`.
 - Action ids remain `int`.
-- Matching is exact and case-sensitive unless a different policy is explicitly documented in code and tests.
+- Matching uses the exact full claim URI without casing normalization unless a different policy is explicitly documented in code and tests.
 
 ### Tenant scope
 
@@ -115,7 +119,7 @@ Endpoint-specific `orderBy` allowlists:
 - Tenant-aware lookups, such as `IClaimSetRepository.GetAuthorizationStrategies`, continue to use their current request tenant behavior.
 - The claims hierarchy remains the structural source used by these endpoints.
 - `dmscs.ResourceClaim` provides the resource-claim metadata for this projection.
-- Resource-claim metadata lookup is by full claim URI, exact and case-sensitive.
+- Resource-claim metadata lookup uses the exact full claim URI without casing normalization.
 - This story adds no endpoint-specific tenant behavior.
 
 ### Authorization
@@ -130,13 +134,11 @@ Endpoint-specific `orderBy` allowlists:
 - This story targets PostgreSQL as the supported datastore path for these endpoints.
 - MSSQL support for these endpoints is out of scope and may be added later with equivalent repository behavior and deployment artifacts without changing the public endpoint contract.
 - The implementation must not silently route these endpoints to PostgreSQL-only repository code when CMS is configured for MSSQL.
-- This story does not include broader datastore-composition cleanup beyond what is required to support the PostgreSQL path.
+- Broader datastore-composition cleanup is out of scope.
 
 ### Validation timing
 
-- These endpoints follow the existing CMS startup/runtime pattern rather than introducing new health or startup validation.
-- Invalid application configuration remains a startup concern only where CMS already validates options and startup configuration.
-- Database deploy and initial claims bootstrap failures remain startup concerns only when the existing startup initialization paths are enabled.
+- These endpoints follow existing CMS startup/runtime behavior rather than introducing new health or startup validation.
 - Missing claims hierarchy, multiple hierarchy rows, resource-claim metadata drift, missing lookup rows, and projection failures remain request-time concerns for these read endpoints.
 
 ### Tests cover
@@ -148,22 +150,19 @@ Endpoint-specific `orderBy` allowlists:
 - Successful resource-claim-actions projection.
 - Successful action/auth-strategy projection.
 - Empty-result behavior for `resourceClaimActions` and `resourceClaimActionAuthStrategies` filters.
-- Explicit failure when a hierarchy node has no matching resource-claim metadata row (metadata drift).
+- Explicit failure when a hierarchy node has no matching resource-claim metadata row (metadata drift). This test must prove the endpoint does not return a successful partial tree, silently omit the unresolved node, or silently omit its descendant subtree.
+- Explicit failure when `DefaultAuthorization` references an unresolved action id or authorization strategy id. This test must prove the endpoint does not return `200 OK` with a partial `actions` or `authorizationStrategiesForActions` collection.
 - Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
-- Query parameter filtering and pagination behavior.
+- Query parameter filtering and pagination behavior, including case-insensitive `name`/`resourceName` filters, existing Config combined-filter behavior, and default `id` ordering when `orderBy` is omitted.
 - Tenant-scoped requests follow existing CMS dependency behavior.
 - PostgreSQL-only behavior for this story.
 
 ## Tasks
 
-1. Add the resource-claim read model and service projection over `IClaimsHierarchyRepository` plus `IResourceClaimRepository`.
-2. Add `IResourceClaimRepository` in the backend repository abstractions, add the PostgreSQL implementation under the PostgreSQL repository project, and register it with the current CMS DI pattern without enabling it for unsupported MSSQL execution.
-3. Add the resource-claims endpoint module and map the four routes listed in this story.
-4. Map service result cases to explicit endpoint responses, preserving the required `200`, `400`, `404`, `401`/`403`, and generic `500` outcomes while using the same CMS error response patterns as comparable endpoints.
-5. Add the resource-claim-actions service projection and endpoint, resolving action names through the existing claim-set repository.
-6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for the three list endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`. Apply the hierarchy filtering and paging semantics defined in the acceptance criteria. `GET /v2/resourceClaims/{id}` accepts only its path parameter.
-7. Resolve authorization strategy metadata through the existing claim-set repository APIs for the auth-strategies endpoint.
-8. Register these endpoints with `MapSecuredGet` and document `ReadOnlyOrAdminScopePolicy` in the architecture brief and endpoint registration.
-9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract. Add an explicit guard so unsupported MSSQL configuration cannot use PostgreSQL-only resource-claim repositories.
-10. Add focused unit and endpoint tests for the success and failure cases listed above, including query parameter behavior and empty-filter-result behavior.
-11. Run the relevant backend and frontend tests and format changed C# files with `dotnet csharpier format`.
+1. Add the resource-claim read models and service projections over the claims hierarchy, `dmscs.ResourceClaim`, and existing claim-set metadata lookups.
+2. Add the resource-claim repository abstraction, PostgreSQL implementation, and datastore registration while keeping unsupported MSSQL behavior explicit.
+3. Add the endpoint module and map the four read-only routes with `MapSecuredGet`.
+4. Map service results to the public outcomes in the acceptance criteria using existing CMS response patterns.
+5. Implement list filtering, sorting, and paging by reusing the current CMS query pattern and the hierarchy-specific semantics defined above.
+6. Keep the implementation scoped to PostgreSQL support; add an explicit guard so unsupported MSSQL configuration cannot use PostgreSQL-only resource-claim repositories.
+7. Add focused unit and endpoint tests for the success, failure, query, tenant, and PostgreSQL-only cases listed above.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -82,6 +82,15 @@ DMS-1074 defines the shared CMS implementation pattern for Admin API-style filte
 - Action ids remain `int`.
 - Matching is exact and case-sensitive unless a different policy is explicitly documented in code and tests.
 
+### Tenant scope
+
+- These endpoints use the standard CMS tenant-resolution pattern already used by repositories such as `ClaimSetRepository`.
+- Repository behavior is driven by the current request `TenantContext`, established by the existing tenant middleware.
+- When multi-tenancy is enabled, `dmscs.ResourceClaim` and other tenant-aware lookups for these endpoints are scoped by `TenantId`.
+- When multi-tenancy is disabled, those lookups use rows where `TenantId IS NULL`.
+- This story does not introduce endpoint-specific tenant overrides or a new global-plus-tenant resource-claim model.
+- This story does not define support for duplicate `ClaimName` values across tenants. The current schema retains a unique `ClaimName` constraint.
+
 ### Authorization
 
 - These endpoints use `MapSecuredGet`.
@@ -94,6 +103,13 @@ DMS-1074 defines the shared CMS implementation pattern for Admin API-style filte
 - This story targets PostgreSQL as the supported datastore path for these endpoints.
 - MSSQL support for these endpoints is out of scope and may be added later with equivalent repository behavior and deployment artifacts without changing the public endpoint contract.
 - This story does not include broader datastore-composition cleanup beyond what is required to support the PostgreSQL path.
+
+### Validation timing
+
+- These endpoints follow the existing CMS startup/runtime pattern rather than introducing new health or startup validation.
+- Invalid application configuration remains a startup concern only where CMS already validates options and startup configuration.
+- Database deploy and initial claims bootstrap failures remain startup concerns only when the existing startup initialization paths are enabled.
+- Missing claims hierarchy, multiple hierarchy rows, resource-claim metadata drift, missing lookup rows, and projection failures remain request-time concerns for these read endpoints.
 
 ### Tests cover
 

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -40,11 +40,13 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Searches the valid projected hierarchy by `dmscs.ResourceClaim.Id`.
 - Returns the matching projected claim node including its full recursive subtree.
 - Returns `404 Not Found` when the requested id is absent.
+- Accepts only its path parameter. Query parameters (`limit`, `offset`, `orderBy`, `direction`) do not apply to this route.
 
 ### `GET /v2/resourceClaimActions`
 
 - Returns a flat list of resource claim actions resolved from claim-set metadata.
-- Resolves action names through `IClaimSetRepository.GetActions`.
+- Action membership for each resource claim is derived from the `DefaultAuthorization` entries in the hierarchy JSON — the same source used by `resourceClaimActionAuthStrategies`.
+- Resolves action names through `IClaimSetRepository.GetActions`. `GetActions` provides name resolution only; it does not define which actions belong to a resource claim.
 - Each item includes `resourceClaimId` (long), `resourceName`, `claimName`, and `actions`.
 - `actions` is an array of objects with only a `name` field (`{ name: string }`). There is no `actionId` in this shape.
 - Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
@@ -61,7 +63,7 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 
 ### Query parameter alignment
 
-These endpoints should use the current CMS query implementation pattern rather than introducing a feature-specific query abstraction:
+The three list endpoints (`GET /v2/resourceClaims`, `GET /v2/resourceClaimActions`, and `GET /v2/resourceClaimActionAuthStrategies`) use the current CMS query implementation pattern rather than introducing a feature-specific query abstraction. `GET /v2/resourceClaims/{id}` accepts only its path parameter and does not support these query parameters.
 
 - frontend query DTO bound with `[AsParameters]`
 - endpoint-specific frontend query model for endpoint filters
@@ -100,8 +102,9 @@ The shared paging behavior to preserve is:
 
 - These endpoints use the standard CMS tenant-resolution pattern already used by repositories such as `ClaimSetRepository`.
 - Repository behavior is driven by the current request `TenantContext`, established by the existing tenant middleware.
-- When multi-tenancy is enabled, `dmscs.ResourceClaim` and other tenant-aware lookups for these endpoints are scoped by `TenantId`.
+- When multi-tenancy is enabled, tenant-aware lookups (such as `ClaimSet`) are scoped by `TenantId`.
 - When multi-tenancy is disabled, those lookups use rows where `TenantId IS NULL`.
+- `dmscs.ResourceClaim` rows are global configuration. The resource-claim metadata lookup always queries rows where `TenantId IS NULL`, regardless of whether multi-tenancy is enabled. This is consistent with the global unique `ClaimName` constraint and the fact that existing seed rows carry `TenantId IS NULL`.
 - This story does not introduce endpoint-specific tenant overrides or a new global-plus-tenant resource-claim model.
 - This story does not define support for duplicate `ClaimName` values across tenants. The current schema retains a unique `ClaimName` constraint.
 
@@ -133,6 +136,7 @@ The shared paging behavior to preserve is:
 - Successful resource-claim-actions projection.
 - Successful action/auth-strategy projection.
 - Empty-result behavior for `resourceClaimActions` and `resourceClaimActionAuthStrategies` filters.
+- Explicit failure when a hierarchy node has no matching resource-claim metadata row (metadata drift).
 - Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
 - Query parameter filtering and pagination behavior.
 - PostgreSQL-only behavior for this story.
@@ -144,7 +148,7 @@ The shared paging behavior to preserve is:
 3. Add the resource-claims endpoint module and map the four routes listed in this story.
 4. Map service result cases to explicit endpoint responses, preserving the required `200`, `400`, `404`, `401`/`403`, and generic `500` outcomes while using the same CMS error response patterns as comparable endpoints.
 5. Add the resource-claim-actions service projection and endpoint, resolving action names through the existing claim-set repository.
-6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for all four endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`.
+6. Implement general query parameters (`limit`, `offset`, `orderBy`, `direction`) and endpoint-specific filters for the three list endpoints by reusing the current CMS query implementation pattern based on frontend query DTOs, `PagingQueryValidator<T>`, and repository models derived from `PagingQuery`. `GET /v2/resourceClaims/{id}` accepts only its path parameter.
 7. Resolve authorization strategy metadata through the existing claim-set repository APIs for the auth-strategies endpoint.
 8. Register these endpoints with `MapSecuredGet` and document `ReadOnlyOrAdminScopePolicy` in the architecture brief and endpoint registration.
 9. Keep this story scoped to the PostgreSQL implementation path, and document that MSSQL support can be added later without changing the public endpoint contract.

--- a/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
+++ b/reference/spikes/DMS-1082/ticket-resource-claims-endpoints.md
@@ -34,7 +34,7 @@ See the architecture brief at `reference/spikes/DMS-1082/spike-resource-claims-e
 - Fails explicitly if any hierarchy node is missing resource-claim metadata.
 - Supports the current CMS paging-query pattern, including `limit`, `offset`, `orderBy`, and `direction`.
 - Supports endpoint-specific filters: `id` (long), `name` (string).
-- Without filters, returns root nodes as the top-level collection. With `id` or `name` filters, returns matching nodes from anywhere in the hierarchy as the top-level collection, with each matching node retaining its original `parentId`, `parentName`, and full recursive `children` subtree.
+- Without filters, returns root nodes as the top-level collection. With `id` or `name` filters, applies those filters to the top-level root-node collection only. Matching root nodes retain their original `parentId`, `parentName`, and full recursive `children` subtree.
 - Applies `orderBy`, `direction`, `limit`, and `offset` to the top-level result collection after filtering. Paging and sorting do not remove or reorder descendant `children` within each returned subtree.
 
 ### `GET /v2/resourceClaims/{id}`
@@ -73,15 +73,15 @@ Endpoint-specific `orderBy` allowlists:
 
 | Endpoint | Allowed `orderBy` values |
 |---|---|
-| `GET /v2/resourceClaims` | `id`, `name`, `parentId`, `parentName` |
-| `GET /v2/resourceClaimActions` | `resourceClaimId`, `resourceName`, `claimName` |
+| `GET /v2/resourceClaims` | `name`, `parentName`, `parentId`, `id` |
+| `GET /v2/resourceClaimActions` | `resourceClaimId`, `resourceName` |
 | `GET /v2/resourceClaimActionAuthStrategies` | `resourceClaimId`, `resourceName`, `claimName` |
 
 Additional query rules:
 
 - `name` and `resourceName` filters are case-insensitive.
 - When multiple filters are supplied, including `id` and `name` together for `GET /v2/resourceClaims`, these endpoints follow the existing Config query-filter behavior.
-- When `orderBy` is omitted, default ordering is determined by the current query-parameter implementation, which defaults to `id`.
+- When `orderBy` is omitted, default ordering is determined by the current query-parameter implementation: `name` for `resourceClaims`, `resourceClaimId` for `resourceClaimActions`, and `resourceClaimId` for `resourceClaimActionAuthStrategies`.
 
 ### Failure handling
 
@@ -155,7 +155,7 @@ This contract defines observable behavior, not an implementation shape. The impl
 - Explicit failure when a hierarchy node has no matching resource-claim metadata row (metadata drift). This test must prove the endpoint does not return a successful partial tree, silently omit the unresolved node, or silently omit its descendant subtree.
 - Explicit failure when `DefaultAuthorization` references an unresolved action id or authorization strategy id. This test must prove the endpoint does not return `200 OK` with a partial `actions` or `authorizationStrategiesForActions` collection.
 - Validation failure for unsupported `orderBy`, using the current CMS paging-query validation response pattern.
-- Query parameter filtering and pagination behavior, including case-insensitive `name`/`resourceName` filters, existing Config combined-filter behavior, and default `id` ordering when `orderBy` is omitted.
+- Query parameter filtering and pagination behavior, including case-insensitive `name`/`resourceName` filters, existing Config combined-filter behavior, and the endpoint-specific default sort field when `orderBy` is omitted.
 - Tenant-scoped requests follow existing CMS dependency behavior.
 - Multitenant requests resolve `dmscs.ResourceClaim` metadata from the existing global seed rows (`TenantId IS NULL`) and do not require tenant-specific duplicate `ResourceClaim` rows.
 - PostgreSQL-only behavior for this story.


### PR DESCRIPTION
This pull request documents the investigation and proposed implementation approach for adding Admin API-compatible resource claim read endpoints to CMS. It introduces two new reference documents: a detailed spike analysis and a user story with acceptance criteria and implementation tasks. These materials are intended to guide future development and ensure alignment between CMS's data model and the required API contracts.

Key updates include:

**Spike Analysis and Implementation Approach**  
- Added `spike-resource-claims-endpoints.md`, which explains the motivation, data model differences (hierarchical JSON vs. relational rows), and the projection-based approach for serving resource claim endpoints from CMS. It details technical tradeoffs, risks (such as data drift between sources), and guidance for explicit failure handling and testing.

**User Story and Acceptance Criteria**  
- Added `ticket-resource-claims-endpoints.md`, outlining the story for implementing the endpoints, with precise acceptance criteria for endpoint behavior, failure handling, response models, and datastore support. It also provides a checklist of development tasks and test requirements to ensure robust and maintainable implementation.Document the CMS approach for Admin API-compatible resource claims endpoints. Define how claims hierarchy, resource-claim metadata, actions, and authorization strategies combine into read-only projections. Capture endpoint behavior, failure modes, datastore considerations, and implementation tasks for follow-up work.