### PR TITLE
[DMS-1132] Deterministic pre-merge storage-collapsed identity ambiguity detection

### DIFF
--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -572,55 +572,6 @@ jobs:
       - name: Add Kafka hostname to /etc/hosts
         run: echo "127.0.0.1 dms-kafka1" | sudo tee -a /etc/hosts
 
-      - name: Run ${{ matrix.queryhandler }} legacy - IdentityProvider (${{ matrix.identityprovider }}) E2E Tests
-        id: legacy_e2e
-        if: success()
-        continue-on-error: true
-        env:
-          KAFKA_BOOTSTRAP_SERVERS: dms-kafka1:9092
-        run: |
-          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@relational-backend'
-
-      - name: Export Legacy Docker Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        run: |
-          $logDir = "${{ github.workspace }}/logs/legacy"
-          Remove-Item -Path $logDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $logDir -Force | Out-Null
-
-          $containers = @(docker ps -a --format "{{.Names}}" | Sort-Object)
-
-          if ($containers.Count -eq 0) {
-              Write-Host "No Docker containers found for log export."
-              exit 0
-          }
-
-          foreach ($container in $containers) {
-              $logPath = Join-Path $logDir "$container.log"
-              docker logs $container > $logPath 2>&1
-          }
-        shell: pwsh
-
-      - name: Upload Legacy Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
-        with:
-          name: ${{ matrix.queryhandler }}-${{ matrix.identityprovider }}-legacy-test-logs
-          path: |
-            ${{ github.workspace }}/logs/legacy
-          retention-days: 10
-
-      - name: Upload Legacy Test Results
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: always() && hashFiles('TestResults/EdFi.DataManagementService.Tests.E2E.legacy.trx') != ''
-        with:
-          name: E2E Test Results (${{ matrix.identityprovider }}, legacy)
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.legacy.trx
-          path-replace-backslashes: "true"
-          reporter: dotnet-trx
-          list-tests: failed
-          use-actions-summary: "true"
-
       - name: Run ${{ matrix.queryhandler }} relational - IdentityProvider (${{ matrix.identityprovider }}) E2E Tests
         id: relational_e2e
         if: success()
@@ -670,12 +621,11 @@ jobs:
           list-tests: failed
           use-actions-summary: "true"
 
-      - name: Fail if an E2E lane failed
-        if: always() && (steps.legacy_e2e.outcome == 'failure' || steps.relational_e2e.outcome == 'failure')
+      - name: Fail if the E2E lane failed
+        if: always() && steps.relational_e2e.outcome == 'failure'
         run: |
-          Write-Host "Legacy lane outcome: ${{ steps.legacy_e2e.outcome }}"
           Write-Host "Relational lane outcome: ${{ steps.relational_e2e.outcome }}"
-          throw "One or more E2E lanes failed."
+          throw "Relational E2E lane failed."
 
   run-instance-management-e2e-tests:
     name: Run Instance Management E2E Tests (Route Qualifiers)

--- a/reference/design/backend-redesign/design-docs/profiles.md
+++ b/reference/design/backend-redesign/design-docs/profiles.md
@@ -444,6 +444,14 @@ Runtime validation and fail-fast diagnostics:
 - If backend cannot line up a Core-emitted visible stored row or visible stored scope with the compiled current-state shape expected for that resource scope, backend MUST fail deterministically rather than guessing from array order, filtered JSON, or delete+insert fallback behavior.
 - These diagnostics are internal contract failures. They MUST short-circuit before DML or readable response shaping continues, and they MUST NOT be downgraded to silent omission handling.
 
+### Storage-Collapsed Semantic Identity Uniqueness
+
+Presence-aware semantic identities may differ by `IsPresent` only when their storage-collapsed keys remain unique within the parent collection/scope matching bucket. Storage-collapsed equality folds `IsPresent=false` and `IsPresent=true && Value=null` into a single "absent-or-null" bucket per slot; the equality rule has two shape-specific forms: the profile path keys identities as `RelativePath` + collapsed presence + `Value.ToJsonString()` for present non-null values, while the no-profile path matches raw `object?[]` materialized scalars via `ObjectValueArrayComparer` (where `null` already covers both absent and explicit-null because materialized values normalize identically).
+
+The backend enforces this rule before the merge stage on every merge-bound identity bucket — visible request collection items, visible stored collection rows, the cross-product of the two, and ancestor collection instances harvested from request and stored scope/collection-row addresses. Violations surface as a category-5 `AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure` emitted by `ProfileWriteContractValidator` (with `ProfileFailureEmitter.BackendProfileWriteContext`). The corresponding no-profile rule is enforced at flatten time and surfaces as a request-validation failure.
+
+The rule is required because the relational storage model maps both absent and explicit-null identity slots to SQL NULL. Two identities that differ only by presence on a null-valued identity slot cannot be persisted distinctly; matching them silently would produce first-wins/misbind behavior at merge time. This validation removes the need to rely on upstream null-pruning side effects to keep collection matching correct.
+
 ## Creatability Decision Model
 
 Creatability is the Core-owned answer to a narrow question:

--- a/reference/design/backend-redesign/epics/07-relational-write-path/03b-profile-aware-persist-executor.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/03b-profile-aware-persist-executor.md
@@ -88,4 +88,4 @@ All slices inherit these constraints:
   - what tests are required, and
   - what the next slice inherits.
 - The intent is that each PR is independently mergeable because it leaves the runtime in a coherent state.
-- `DMS-1132` remains the named follow-on for presence-sensitive semantic identity fidelity unless that work is explicitly pulled into a later `DMS-1124` slice.
+- Presence-sensitive semantic identity fidelity has been closed out under `DMS-1132` (see `07-semantic-identity-presence-fidelity.md`); `DMS-1124` no longer carries that as an open follow-on.

--- a/reference/design/backend-redesign/epics/07-relational-write-path/03b-profile-aware-persist-executor/07-parity-and-hardening.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/03b-profile-aware-persist-executor/07-parity-and-hardening.md
@@ -22,7 +22,6 @@ Earlier slices still own parity expectations for any SQL-sensitive behavior they
 - Dialect-sensitive batching, parameterization, and locking checks where behavior could diverge
 - Remaining reverse-coverage or contract-hardening work required for safe merge
 - Explicit follow-up extraction for unresolved but non-blocking risks
-- Explicit handoff to `DMS-1132` / `../07-semantic-identity-presence-fidelity.md` for presence-sensitive semantic identity fidelity unless that work is intentionally absorbed here
 - Decision on profile vs no-profile collection ordinal-base alignment. Slice 6 (`06-profile-guarded-no-op.md`) ships profile-aware guarded no-op while the no-profile flatten path stamps 0-based ordinals (`RelationalWriteFlattener` `RequestOrder`) and the profile collection walker stamps 1-based `finalOrdinal = i + 1`. Documents created via the no-profile path therefore cannot reach the guarded no-op short-circuit on a later identical profiled PUT — the merged ordinals differ from the stored ordinals and the executor falls through to real collection DML. Slice 6's top-level-collection integration fixture acknowledges this by seeding through the profiled POST path (see `PostgresqlProfileGuardedNoOpTests.cs` lines 666-674). This slice owns the decision to either (a) align ordinal bases on one side, (b) document and accept the first-write DML cost on pre-profile data, or (c) plan a backfill/normalization migration.
 - Decision on whether to extract the no-profile `TableStateBuilder`'s collection row sort (`OrderCollectionRowsIfFullyBound` / `OrderCollectionAlignedExtensionScopeRowsIfFullyBound` / `OrderRowsByBindingIndexesIfFullyBound` plus the `BoundRowComparer` it depends on) into a shared `RelationalWriteMergeSupport` helper and apply it from `ProfileTableStateBuilder.Build()`. The profile path currently relies on the planner's emission order matching DB hydration ordinal order for `RelationalWriteGuardedNoOp.IsNoOpCandidate`'s positional `SequenceEqual` to fire correctly — Slice 6 ships that alignment as a coincidence-of-implementation rather than an enforced invariant. The synthesizer-level fixture `Given_Synthesizer_TopLevelCollection_All_Matched_With_Hidden_Interleaving_Is_NoOp` (added in `RelationalWriteProfileMergeSynthesizerTests.cs`) pins the property under test, but does not enforce it through a sort step. The candidate helpers total ~113 LOC including `BoundRowComparer`, putting the extraction over the threshold for slice-scoped hardening. Slice 7 owns the decision to extract and unify, accept the implicit alignment, or replace it with an alternative invariant such as a builder-side identity-based pairing.
 
@@ -41,14 +40,12 @@ Earlier slices still own parity expectations for any SQL-sensitive behavior they
 
 - Parity is not just "tests exist"; the branch must either demonstrate equivalent behavior or document why a difference is expected.
 - Hardening work that is not a merge blocker must become an explicit follow-up rather than expanding the slice indefinitely.
-- Presence-sensitive semantic identity fragility should stay tied to `DMS-1132` unless this slice explicitly changes the merge guarantee.
 
 ## Acceptance Criteria
 
 - The supported profiled runtime baseline passes on both PostgreSQL and SQL Server.
 - Dialect-sensitive batching/locking/parameterization behavior has explicit coverage or explicit review rationale.
 - Remaining unresolved correctness assumptions are documented as explicit follow-ups, not hidden in comments or oral history.
-- `DMS-1132` / `../07-semantic-identity-presence-fidelity.md` remains the named follow-on for presence-sensitive semantic identity fidelity unless the implementation truly closes that gap here.
 
 ## Tests Required
 
@@ -63,7 +60,6 @@ Earlier slices still own parity expectations for any SQL-sensitive behavior they
 ### Documentation / review outputs
 
 - Explicit list of non-blocking follow-ups extracted from the branch review
-- Explicit statement of whether `DMS-1132` remains open and why
 
 ## Reviewer Focus
 
@@ -82,9 +78,8 @@ Reviewers should explicitly ignore:
 
 After this slice, `DMS-1124` should have:
 
-- a complete serial design plan,
-- an explicit merge-blocker vs follow-up boundary, and
-- a named handoff for any unresolved hardening such as `DMS-1132`.
+- a complete serial design plan, and
+- an explicit merge-blocker vs follow-up boundary.
 
 ## Audit Results
 
@@ -101,7 +96,6 @@ items resolved by the mssql guarded no-op port), 0 `fix-in-slice` remaining, 1 `
 (this slice's own deliverable row). The audit also reviewed pre-existing
 PostgreSQL-only no-profile relational-write tests and descriptor tests; these are
 outside `DMS-1124`'s scope and not merge risks (see `## Reviewed Non-Blockers`).
-The only named handoff from this slice is `DMS-1132`.
 
 ## Parity Matrix
 
@@ -129,7 +123,6 @@ The only named handoff from this slice is `DMS-1132`.
 | `ProfileUnchangedWriteGuardedNoOp` — stale POST-as-update | 6 | `PostgresqlProfileGuardedNoOpTests.cs` :: `Given_A_Postgresql_Relational_Profile_Stale_Guarded_No_Op_Post_As_Update` | `MssqlProfileGuardedNoOpTests.cs` :: `Given_A_Mssql_Relational_Profile_Stale_Guarded_No_Op_Post_As_Update` | both |
 | `ProfileUnchangedWriteGuardedNoOp` — separate-table PUT | 6 | `PostgresqlProfileGuardedNoOpTests.cs` :: `Given_A_Postgresql_Relational_Profile_Guarded_No_Op_Put_With_Separate_Table_Shape` | `MssqlProfileGuardedNoOpTests.cs` :: `Given_A_Mssql_Relational_Profile_Guarded_No_Op_Put_With_Separate_Table_Shape` | both |
 | `ProfileUnchangedWriteGuardedNoOp` — top-level-collection PUT | 6 | `PostgresqlProfileGuardedNoOpTests.cs` :: `Given_A_Postgresql_Relational_Profile_Guarded_No_Op_Put_With_Top_Level_Collection_Shape` | `MssqlProfileGuardedNoOpTests.cs` :: `Given_A_Mssql_Relational_Profile_Guarded_No_Op_Put_With_Top_Level_Collection_Shape` | both |
-| pgsql/mssql parity closure and explicit `DMS-1132` handoff | 7 | n/a | n/a | n/a |
 
 ## Hardening Decisions
 
@@ -226,15 +219,3 @@ require a new follow-up Jira from this slice:
 
 A literal three-level provider fixture is also reviewed-and-not-required for
 this slice; the rationale is documented under `## Hardening Decisions`.
-
-The only named handoff from this slice is `DMS-1132`, as documented below.
-
-## DMS-1132 Handoff
-
-`DMS-1132` (`../07-semantic-identity-presence-fidelity.md`) remains the named
-follow-on for presence-sensitive semantic identity fidelity. Slice 7 did not
-change the executor-facing identity-presence contract; this slice fixed
-already-supported behavior (ordinal-base alignment, shared row ordering for
-guarded no-op, mssql guarded no-op parity, and mssql snapshot-path hardening)
-and explicitly did not pull `DMS-1132` work into `DMS-1124`. The
-identity-matching fragility documented in `DMS-1132` is unchanged by this slice.

--- a/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
@@ -91,10 +91,8 @@ Do not weaken `build-dms.ps1` E2E lane guardrails. The script should continue re
 
 ### CI/workflow validation
 
-- A workflow or guardrail test verifies `.github/workflows/on-dms-pullrequest.yml` no longer invokes `build-dms.ps1 E2ETest` with `Category!=@relational-backend`.
-- A workflow or guardrail test verifies `.github/workflows/on-dms-pullrequest.yml` still invokes `build-dms.ps1 E2ETest` with `Category=@relational-backend`.
-- A workflow or guardrail test verifies the normal DMS PR/push workflow still invokes `build-dms.ps1 InstanceE2ETest`.
-- Existing `build-dms.ps1` lane guardrail tests remain valid and are not relaxed.
+- The diff to `.github/workflows/on-dms-pullrequest.yml` is reviewed to confirm the normal DMS PR/push workflow no longer invokes `build-dms.ps1 E2ETest` with `Category!=@relational-backend`, still invokes `build-dms.ps1 E2ETest` with `Category=@relational-backend`, and still invokes `build-dms.ps1 InstanceE2ETest`.
+- Existing `build-dms.ps1` runtime lane guardrail tests (`Given_Build_Dms_E2E_Guardrails`) remain valid and are not relaxed.
 
 ## Tasks
 

--- a/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
@@ -3,6 +3,8 @@ jira: DMS-1132
 jira_url: https://edfi.atlassian.net/browse/DMS-1132
 ---
 
+> **Status:** Closed. Implemented as deterministic pre-merge ambiguity detection; the validation rule is documented in `../../design-docs/profiles.md` § "Storage-Collapsed Semantic Identity Uniqueness". Profile path emits `AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure` from `ProfileWriteContractValidator`; no-profile path emits `RelationalWriteRequestValidationException` from the flattener.
+
 # Story: Preserve Presence-Sensitive Semantic Identity Fidelity
 
 ## Description

--- a/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/07-semantic-identity-presence-fidelity.md
@@ -3,7 +3,9 @@ jira: DMS-1132
 jira_url: https://edfi.atlassian.net/browse/DMS-1132
 ---
 
-> **Status:** Closed. Implemented as deterministic pre-merge ambiguity detection; the validation rule is documented in `../../design-docs/profiles.md` § "Storage-Collapsed Semantic Identity Uniqueness". Profile path emits `AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure` from `ProfileWriteContractValidator`; no-profile path emits `RelationalWriteRequestValidationException` from the flattener.
+> **Status:** Identity-validation work closed. Implemented as deterministic pre-merge ambiguity detection; the validation rule is documented in `../../design-docs/profiles.md` § "Storage-Collapsed Semantic Identity Uniqueness". Profile path emits `AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure` from `ProfileWriteContractValidator`; no-profile path emits `RelationalWriteRequestValidationException` from the flattener.
+>
+> This story also carries the CI E2E-scope requirement documented below.
 
 # Story: Preserve Presence-Sensitive Semantic Identity Fidelity
 
@@ -29,12 +31,16 @@ This follow-on owns making the distinction explicit, validated, and durable for 
 - Contract or plan changes required to preserve absent-vs-explicit-null information through executor-facing metadata
 - Deterministic validation and failure behavior when required presence fidelity is missing or inconsistent
 - Test coverage for null-identity and presence-sensitive matching cases on both PostgreSQL and SQL Server
+- CI E2E scope adjustment for this branch: normal DMS PR/push CI should run only relational-backend DMS E2E coverage from the main DMS E2E suite, while scheduled workflows retain the legacy-backend DMS E2E lane.
 
 ## Out Of Scope
 
 - General profile-aware merge semantics already owned by `DMS-1124`
 - Non-identity hidden-member preservation already covered by `DMS-1124`
 - Unrelated write-path refactors
+- Removing CMS E2E coverage from CI
+- Removing the DMS multi-tenant / instance-management E2E suite from CI
+- Removing legacy-backend DMS E2E coverage from scheduled workflows
 
 ## Acceptance Criteria
 
@@ -43,6 +49,31 @@ This follow-on owns making the distinction explicit, validated, and durable for 
 - Profile-aware and no-profile collection matching behave consistently for presence-sensitive identity cases.
 - Missing or inconsistent presence-fidelity metadata fails deterministically rather than silently matching the wrong row.
 - PostgreSQL and SQL Server coverage exists for representative presence-sensitive identity cases.
+- Normal DMS PR/push CI no longer runs the legacy-backend lane from `EdFi.DataManagementService.Tests.E2E` (`Category!=@relational-backend`).
+- Normal DMS PR/push CI still runs `EdFi.DataManagementService.Tests.E2E` scenarios tagged `@relational-backend` with the relational E2E environment.
+- Normal DMS PR/push CI still runs the DMS instance-management / multi-tenant E2E suite.
+- CMS PR CI still runs CMS E2E coverage unchanged.
+- Scheduled DMS workflows still run legacy-backend DMS E2E coverage.
+
+## CI E2E Scope Requirement
+
+The DMS PR/push workflow currently runs both DMS E2E lanes:
+
+- legacy lane: `build-dms.ps1 E2ETest -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@relational-backend'`
+- relational lane: `build-dms.ps1 E2ETest -EnvironmentFile './.env.e2e.relational' -TestFilter 'Category=@relational-backend'`
+
+The branch requirement is to remove the legacy lane from normal DMS CI only. In `.github/workflows/on-dms-pullrequest.yml`, the `run-e2e-tests` job should keep the relational lane and its result/log handling, but should no longer invoke or fail-gate on the legacy lane. The relational lane must continue to use `Category=@relational-backend`; do not broaden the filter to all E2E tests.
+
+The workflow must keep running the DMS instance-management E2E job (`build-dms.ps1 InstanceE2ETest`) because that is the multi-tenant suite and is not part of the legacy DMS backend lane being removed from normal CI.
+
+CMS E2E coverage is owned by the config workflow and must remain unchanged.
+
+Legacy-backend DMS E2E coverage remains scheduled:
+
+- `.github/workflows/scheduled-build.yml` runs weekly on Saturday at 08:00 UTC and includes `Category!=@relational-backend`.
+- `.github/workflows/scheduled-pre-image-test.yml` runs weekly on Saturday at 08:30 UTC and includes `Category!=@relational-backend`.
+
+Do not weaken `build-dms.ps1` E2E lane guardrails. The script should continue requiring relational environments to use `Category=@relational-backend` and legacy environments to use `Category!=@relational-backend`; the CI change is a workflow-selection change, not a script contract change.
 
 ## Tests Required
 
@@ -58,9 +89,17 @@ This follow-on owns making the distinction explicit, validated, and durable for 
 - Representative profile-aware null-identity case
 - PostgreSQL and SQL Server parity coverage for the above cases
 
+### CI/workflow validation
+
+- A workflow or guardrail test verifies `.github/workflows/on-dms-pullrequest.yml` no longer invokes `build-dms.ps1 E2ETest` with `Category!=@relational-backend`.
+- A workflow or guardrail test verifies `.github/workflows/on-dms-pullrequest.yml` still invokes `build-dms.ps1 E2ETest` with `Category=@relational-backend`.
+- A workflow or guardrail test verifies the normal DMS PR/push workflow still invokes `build-dms.ps1 InstanceE2ETest`.
+- Existing `build-dms.ps1` lane guardrail tests remain valid and are not relaxed.
+
 ## Tasks
 
 1. Define the executor-facing contract or plan changes needed to preserve presence-sensitive identity fidelity.
 2. Update matching logic to consume the preserved presence information without introducing backend-owned profile inference.
 3. Add deterministic validation/failure behavior when presence-sensitive identity metadata is missing or inconsistent.
 4. Add unit and integration coverage for representative absent-vs-explicit-null identity cases on both dialects.
+5. Update normal DMS PR/push CI to run only relational-tagged DMS E2E coverage from the main DMS E2E suite, while preserving CMS E2E, DMS instance-management E2E, and scheduled legacy DMS E2E coverage.

--- a/reference/design/backend-redesign/epics/07-relational-write-path/EPIC.md
+++ b/reference/design/backend-redesign/epics/07-relational-write-path/EPIC.md
@@ -53,7 +53,7 @@ Critical-path note: `reference/design/backend-redesign/epics/DEPENDENCIES.md` re
 - `DMS-986` — `05-write-error-mapping.md` — Map DB constraint errors to DMS error shapes (consistent across dialects)
 - `DMS-1104` — `05b-profile-error-classification.md` — Classify and map profile write failures to DMS error shapes
 - `DMS-987` — `06-descriptor-writes.md` — Descriptor POST/PUT: maintain `dms.Descriptor` + descriptor referential identities (no per-descriptor tables)
-- `DMS-1132` — `07-semantic-identity-presence-fidelity.md` — Close the presence-sensitive semantic identity fidelity gap exposed by `DMS-1124` so the merge never depends on upstream null-pruning invariants to distinguish absent vs explicit-null identity members
+- `DMS-1132` — `07-semantic-identity-presence-fidelity.md` — Close the presence-sensitive semantic identity fidelity gap exposed by `DMS-1124` so the merge never depends on upstream null-pruning invariants to distinguish absent vs explicit-null identity members (closed)
 
 ## Review Aid
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+file sealed class MssqlNoProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler
+    : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class MssqlNoProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_NoProfile_Post_With_Storage_Collapsed_Sibling_Identities
+{
+    // Exercises the no-profile path's flatten-time storage-collapsed uniqueness check.
+    // The stable-key-update-semantics fixture defines School with $.addresses[*] whose
+    // array uniqueness constraint keys on "city". A nullable identity slot (city) lets
+    // two siblings that differ only by absent-vs-explicit-null reach the flattener with
+    // the same storage-shape key. The no-profile executor sets
+    // ValidateStorageCollapsedCollectionIdentityUniqueness, which causes the flattener
+    // to reject such pairs before any database write.
+
+    private const long SchoolId = 255903;
+    private static readonly DocumentUuid SchoolDocumentUuid = new(
+        Guid.Parse("dddd0003-0000-0000-0000-000000000001")
+    );
+
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileTopLevelCollectionMergeSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_returns_validation_failure_when_request_contains_absent_and_explicit_null_identity_siblings()
+    {
+        // Two addresses siblings whose "city" identity slot differs only by
+        // absent-vs-explicit-null. Both collapse to SQL NULL in storage, so the
+        // flattener must reject the pair before any database round-trip.
+        var body = new JsonObject
+        {
+            ["schoolId"] = checked((int)SchoolId),
+            ["addresses"] = new JsonArray(
+                // Sibling A: city property is absent.
+                new JsonObject(),
+                // Sibling B: city property is present as explicit JSON null.
+                new JsonObject { ["city"] = JsonValue.Create<string?>(null) }
+            ),
+        };
+
+        var result = await ExecuteUpsertAsync(body);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureValidation>();
+        var failure = (UpsertResult.UpsertFailureValidation)result;
+        failure.ValidationFailures.Should().ContainSingle();
+        failure.ValidationFailures[0].Message.Should().Contain("received duplicate semantic identity values");
+    }
+
+    private async Task<UpsertResult> ExecuteUpsertAsync(JsonNode body)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlNoProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId("mssql-no-profile-storage-collapsed"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlNoProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlNoProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+file sealed class MssqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler
+    : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class MssqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+file sealed class MssqlProfileAmbiguousStorageCollapsedProjectionInvoker(
+    ImmutableArray<VisibleStoredCollectionRow> visibleStoredRows
+) : IStoredStateProjectionInvoker
+{
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    ) =>
+        new(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates:
+            [
+                new StoredScopeState(
+                    Address: new ScopeInstanceAddress("$", []),
+                    Visibility: ProfileVisibilityKind.VisiblePresent,
+                    HiddenMemberPaths: []
+                ),
+            ],
+            VisibleStoredCollectionRows: visibleStoredRows
+        );
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+public class Given_A_Mssql_Profiled_Put_With_Storage_Collapsed_Sibling_Identities
+{
+    // Reuses the stable-key-update-semantics fixture which defines School with
+    // $.addresses[*] whose identity key is "city". Two siblings whose city identity
+    // slot is absent (IsPresent: false) vs. explicitly null (IsPresent: true) collapse
+    // to the same storage-shape key and must surface as UpdateResult.UnknownFailure.
+
+    private const long SchoolId = 255902;
+    private static readonly DocumentUuid SchoolDocumentUuid = new(
+        Guid.Parse("ffff0002-0000-0000-0000-000000000001")
+    );
+    private const string AddressScope = "$.addresses[*]";
+    private const string ProfileName = "top-level-collection-profile";
+
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileTopLevelCollectionMergeSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_returns_unknown_failure_when_request_contains_absent_and_explicit_null_identity_siblings()
+    {
+        // Seed a document so the executor takes the existing-document path (PUT),
+        // which is where ValidateWriteContext runs.
+        var seedBody = MssqlProfileTopLevelCollectionMergeSupport.CreateSchoolBody(SchoolId, "Austin");
+        var seedResult = await SeedAsync(seedBody);
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>("seed must succeed before the PUT");
+
+        // Construct a write body that is structurally valid for the School resource.
+        // The body's content does not drive storage-collapsed identity detection: the
+        // validator reads the VisibleRequestCollectionItems metadata, not the JSON payload.
+        var writeBody = MssqlProfileTopLevelCollectionMergeSupport.CreateSchoolBody(SchoolId);
+
+        var writePlan = _mappingSet.WritePlansByResource[
+            MssqlProfileTopLevelCollectionMergeSupport.SchoolResource
+        ];
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+
+        // Extract the compiled identity path for $.addresses[*] ("city").
+        var addressIdentityPath = scopeCatalog
+            .Single(d => d.JsonScope == AddressScope)
+            .SemanticIdentityRelativePathsInOrder.Single();
+
+        var parentAddress = new ScopeInstanceAddress("$", []);
+
+        // Sibling A: identity slot is ABSENT - property not present in JSON at all.
+        var absentCityAddress = new CollectionRowAddress(
+            AddressScope,
+            parentAddress,
+            [new SemanticIdentityPart(addressIdentityPath, null, IsPresent: false)]
+        );
+
+        // Sibling B: identity slot is EXPLICIT NULL - property present as JSON null.
+        var explicitNullCityAddress = new CollectionRowAddress(
+            AddressScope,
+            parentAddress,
+            [new SemanticIdentityPart(addressIdentityPath, null, IsPresent: true)]
+        );
+
+        // Both siblings are visible-and-creatable; their storage-collapsed keys are
+        // identical (both map to null), but they are presence-aware-distinct.
+        var visibleRequestItems = ImmutableArray.Create(
+            new VisibleRequestCollectionItem(absentCityAddress, Creatable: true, "$.addresses[0]"),
+            new VisibleRequestCollectionItem(explicitNullCityAddress, Creatable: true, "$.addresses[1]")
+        );
+
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: writeBody.DeepClone(),
+                RootResourceCreatable: true,
+                RequestScopeStates:
+                [
+                    new RequestScopeState(
+                        Address: new ScopeInstanceAddress("$", []),
+                        Visibility: ProfileVisibilityKind.VisiblePresent,
+                        Creatable: true
+                    ),
+                ],
+                VisibleRequestCollectionItems: visibleRequestItems
+            ),
+            ProfileName: ProfileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new MssqlProfileAmbiguousStorageCollapsedProjectionInvoker([])
+        );
+
+        var result = await ExecuteProfiledPutAsync(writeBody, profileContext);
+
+        result.Should().BeOfType<UpdateResult.UnknownFailure>();
+        var failure = (UpdateResult.UnknownFailure)result;
+        failure.FailureMessage.Should().StartWith("Profile write contract mismatch:");
+        failure
+            .FailureMessage.Should()
+            .Contain(
+                "presence-aware identities that collapse to the same storage-shape key within a parent/scope bucket"
+            );
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    private async Task<UpsertResult> SeedAsync(JsonNode body)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId("mssql-storage-collapsed-seed"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(
+        JsonNode writeBody,
+        BackendProfileWriteContext profileContext
+    )
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "MssqlProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-storage-collapsed-put"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new MssqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new MssqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Old.Postgresql;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+file sealed class PostgresqlNoProfileAmbiguousStorageCollapsedNoOpHostApplicationLifetime
+    : IHostApplicationLifetime
+{
+    public CancellationToken ApplicationStarted => CancellationToken.None;
+    public CancellationToken ApplicationStopping => CancellationToken.None;
+    public CancellationToken ApplicationStopped => CancellationToken.None;
+
+    public void StopApplication() { }
+}
+
+file sealed class PostgresqlNoProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler
+    : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class PostgresqlNoProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_NoProfile_Post_With_Storage_Collapsed_Sibling_Identities
+{
+    // Exercises the no-profile path's flatten-time storage-collapsed uniqueness check.
+    // The stable-key-update-semantics fixture defines School with $.addresses[*] whose
+    // array uniqueness constraint keys on "city". A nullable identity slot (city) lets
+    // two siblings that differ only by absent-vs-explicit-null reach the flattener with
+    // the same storage-shape key. The no-profile executor sets
+    // ValidateStorageCollapsedCollectionIdentityUniqueness, which causes the flattener
+    // to reject such pairs before any database write.
+
+    private const long SchoolId = 255903;
+    private static readonly DocumentUuid SchoolDocumentUuid = new(
+        Guid.Parse("cccc0003-0000-0000-0000-000000000001")
+    );
+
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileTopLevelCollectionMergeSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_returns_validation_failure_when_request_contains_absent_and_explicit_null_identity_siblings()
+    {
+        // Two addresses siblings whose "city" identity slot differs only by
+        // absent-vs-explicit-null. Both collapse to SQL NULL in storage, so the
+        // flattener must reject the pair before any database round-trip.
+        var body = new JsonObject
+        {
+            ["schoolId"] = checked((int)SchoolId),
+            ["addresses"] = new JsonArray(
+                // Sibling A: city property is absent.
+                new JsonObject(),
+                // Sibling B: city property is present as explicit JSON null.
+                new JsonObject { ["city"] = JsonValue.Create<string?>(null) }
+            ),
+        };
+
+        var result = await ExecuteUpsertAsync(body);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureValidation>();
+        var failure = (UpsertResult.UpsertFailureValidation)result;
+        failure.ValidationFailures.Should().ContainSingle();
+        failure.ValidationFailures[0].Message.Should().Contain("received duplicate semantic identity values");
+    }
+
+    private async Task<UpsertResult> ExecuteUpsertAsync(JsonNode body)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlNoProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId("pgsql-no-profile-storage-collapsed"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new PostgresqlNoProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new PostgresqlNoProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton<
+            IHostApplicationLifetime,
+            PostgresqlNoProfileAmbiguousStorageCollapsedNoOpHostApplicationLifetime
+        >();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -1,0 +1,368 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Data;
+using System.Globalization;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.External.Profile;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using EdFi.DataManagementService.Core.Profile;
+using EdFi.DataManagementService.Old.Postgresql;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+file sealed class PostgresqlProfileAmbiguousStorageCollapsedNoOpHostApplicationLifetime
+    : IHostApplicationLifetime
+{
+    public CancellationToken ApplicationStarted => CancellationToken.None;
+    public CancellationToken ApplicationStopping => CancellationToken.None;
+    public CancellationToken ApplicationStopped => CancellationToken.None;
+
+    public void StopApplication() { }
+}
+
+file sealed class PostgresqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler
+    : IResourceAuthorizationHandler
+{
+    public Task<ResourceAuthorizationResult> Authorize(
+        DocumentSecurityElements documentSecurityElements,
+        OperationType operationType,
+        TraceId traceId
+    ) => Task.FromResult<ResourceAuthorizationResult>(new ResourceAuthorizationResult.Authorized());
+}
+
+file sealed class PostgresqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler : IUpdateCascadeHandler
+{
+    public UpdateCascadeResult Cascade(
+        System.Text.Json.JsonElement originalEdFiDoc,
+        ProjectName originalDocumentProjectName,
+        ResourceName originalDocumentResourceName,
+        JsonNode modifiedEdFiDoc,
+        JsonNode referencingEdFiDoc,
+        long referencingDocumentId,
+        short referencingDocumentPartitionKey,
+        Guid referencingDocumentUuid,
+        ProjectName referencingProjectName,
+        ResourceName referencingResourceName
+    ) =>
+        new(
+            OriginalEdFiDoc: referencingEdFiDoc,
+            ModifiedEdFiDoc: referencingEdFiDoc,
+            Id: referencingDocumentId,
+            DocumentPartitionKey: referencingDocumentPartitionKey,
+            DocumentUuid: referencingDocumentUuid,
+            ProjectName: referencingProjectName,
+            ResourceName: referencingResourceName,
+            isIdentityUpdate: false
+        );
+}
+
+file sealed class PostgresqlProfileAmbiguousStorageCollapsedProjectionInvoker(
+    ImmutableArray<VisibleStoredCollectionRow> visibleStoredRows
+) : IStoredStateProjectionInvoker
+{
+    public ProfileAppliedWriteContext ProjectStoredState(
+        JsonNode storedDocument,
+        ProfileAppliedWriteRequest request,
+        IReadOnlyList<CompiledScopeDescriptor> scopeCatalog
+    ) =>
+        new(
+            Request: request,
+            VisibleStoredBody: storedDocument,
+            StoredScopeStates:
+            [
+                new StoredScopeState(
+                    Address: new ScopeInstanceAddress("$", []),
+                    Visibility: ProfileVisibilityKind.VisiblePresent,
+                    HiddenMemberPaths: []
+                ),
+            ],
+            VisibleStoredCollectionRows: visibleStoredRows
+        );
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_Profiled_Put_With_Storage_Collapsed_Sibling_Identities
+{
+    // Reuses the stable-key-update-semantics fixture which defines School with
+    // $.addresses[*] whose identity key is "city". Two siblings whose city identity
+    // slot is absent (IsPresent: false) vs. explicitly null (IsPresent: true) collapse
+    // to the same storage-shape key and must surface as UpdateResult.UnknownFailure.
+
+    private const long SchoolId = 255902;
+    private static readonly DocumentUuid SchoolDocumentUuid = new(
+        Guid.Parse("eeee0002-0000-0000-0000-000000000001")
+    );
+    private const string AddressScope = "$.addresses[*]";
+    private const string ProfileName = "top-level-collection-profile";
+
+    private static readonly ResourceInfo SchoolResourceInfo = new(
+        ProjectName: new ProjectName("Ed-Fi"),
+        ResourceName: new ResourceName("School"),
+        IsDescriptor: false,
+        ResourceVersion: new SemVer("1.0.0"),
+        AllowIdentityUpdates: false,
+        EducationOrganizationHierarchyInfo: new EducationOrganizationHierarchyInfo(false, 0, null),
+        AuthorizationSecurableInfo: []
+    );
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileTopLevelCollectionMergeSupport.FixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _database.ResetAsync();
+        _serviceProvider = CreateServiceProvider();
+    }
+
+    [TearDown]
+    public async Task TearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public async Task It_returns_unknown_failure_when_request_contains_absent_and_explicit_null_identity_siblings()
+    {
+        // Seed a document so the executor takes the existing-document path (PUT),
+        // which is where ValidateWriteContext runs.
+        var seedBody = PostgresqlProfileTopLevelCollectionMergeSupport.CreateSchoolBody(SchoolId, "Austin");
+        var seedResult = await SeedAsync(seedBody);
+        seedResult.Should().BeOfType<UpsertResult.InsertSuccess>("seed must succeed before the PUT");
+
+        // Construct a write body that is structurally valid for the School resource.
+        // The body's content does not drive storage-collapsed identity detection: the
+        // validator reads the VisibleRequestCollectionItems metadata, not the JSON payload.
+        var writeBody = PostgresqlProfileTopLevelCollectionMergeSupport.CreateSchoolBody(SchoolId);
+
+        var writePlan = _mappingSet.WritePlansByResource[
+            PostgresqlProfileTopLevelCollectionMergeSupport.SchoolResource
+        ];
+        var scopeCatalog = CompiledScopeAdapterFactory.BuildFromWritePlan(writePlan);
+
+        // Extract the compiled identity path for $.addresses[*] ("city").
+        var addressIdentityPath = scopeCatalog
+            .Single(d => d.JsonScope == AddressScope)
+            .SemanticIdentityRelativePathsInOrder.Single();
+
+        var parentAddress = new ScopeInstanceAddress("$", []);
+
+        // Sibling A: identity slot is ABSENT - property not present in JSON at all.
+        var absentCityAddress = new CollectionRowAddress(
+            AddressScope,
+            parentAddress,
+            [new SemanticIdentityPart(addressIdentityPath, null, IsPresent: false)]
+        );
+
+        // Sibling B: identity slot is EXPLICIT NULL - property present as JSON null.
+        var explicitNullCityAddress = new CollectionRowAddress(
+            AddressScope,
+            parentAddress,
+            [new SemanticIdentityPart(addressIdentityPath, null, IsPresent: true)]
+        );
+
+        // Both siblings are visible-and-creatable; their storage-collapsed keys are
+        // identical (both map to null), but they are presence-aware-distinct.
+        var visibleRequestItems = ImmutableArray.Create(
+            new VisibleRequestCollectionItem(absentCityAddress, Creatable: true, "$.addresses[0]"),
+            new VisibleRequestCollectionItem(explicitNullCityAddress, Creatable: true, "$.addresses[1]")
+        );
+
+        var profileContext = new BackendProfileWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: writeBody.DeepClone(),
+                RootResourceCreatable: true,
+                RequestScopeStates:
+                [
+                    new RequestScopeState(
+                        Address: new ScopeInstanceAddress("$", []),
+                        Visibility: ProfileVisibilityKind.VisiblePresent,
+                        Creatable: true
+                    ),
+                ],
+                VisibleRequestCollectionItems: visibleRequestItems
+            ),
+            ProfileName: ProfileName,
+            CompiledScopeCatalog: scopeCatalog,
+            StoredStateProjectionInvoker: new PostgresqlProfileAmbiguousStorageCollapsedProjectionInvoker([])
+        );
+
+        var result = await ExecuteProfiledPutAsync(writeBody, profileContext);
+
+        result.Should().BeOfType<UpdateResult.UnknownFailure>();
+        var failure = (UpdateResult.UnknownFailure)result;
+        failure.FailureMessage.Should().StartWith("Profile write contract mismatch:");
+        failure
+            .FailureMessage.Should()
+            .Contain(
+                "presence-aware identities that collapse to the same storage-shape key within a parent/scope bucket"
+            );
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton<
+            IHostApplicationLifetime,
+            PostgresqlProfileAmbiguousStorageCollapsedNoOpHostApplicationLifetime
+        >();
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDmsInstanceSelection, DmsInstanceSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlReferenceResolver();
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    private async Task<UpsertResult> SeedAsync(JsonNode body)
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var upsertRequest = new UpsertRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: body,
+            Headers: [],
+            TraceId: new TraceId("pgsql-storage-collapsed-seed"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new PostgresqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new PostgresqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: []
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpsertDocument(upsertRequest);
+    }
+
+    private async Task<UpdateResult> ExecuteProfiledPutAsync(
+        JsonNode writeBody,
+        BackendProfileWriteContext profileContext
+    )
+    {
+        using var scope = _serviceProvider.CreateScope();
+        scope
+            .ServiceProvider.GetRequiredService<IDmsInstanceSelection>()
+            .SetSelectedDmsInstance(
+                new DmsInstance(
+                    Id: 1,
+                    InstanceType: "test",
+                    InstanceName: "PostgresqlProfileAmbiguousStorageCollapsed",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+
+        var identity = new DocumentIdentity([
+            new DocumentIdentityElement(
+                new JsonPath("$.schoolId"),
+                SchoolId.ToString(CultureInfo.InvariantCulture)
+            ),
+        ]);
+        var documentInfo = new DocumentInfo(
+            DocumentIdentity: identity,
+            ReferentialId: ReferentialIdCalculator.ReferentialIdFrom(SchoolResourceInfo, identity),
+            DocumentReferences: [],
+            DocumentReferenceArrays: [],
+            DescriptorReferences: [],
+            SuperclassIdentity: null
+        );
+
+        var updateRequest = new UpdateRequest(
+            ResourceInfo: SchoolResourceInfo,
+            DocumentInfo: documentInfo,
+            MappingSet: _mappingSet,
+            EdfiDoc: writeBody,
+            Headers: [],
+            TraceId: new TraceId("pgsql-storage-collapsed-put"),
+            DocumentUuid: SchoolDocumentUuid,
+            DocumentSecurityElements: new([], [], [], [], []),
+            UpdateCascadeHandler: new PostgresqlProfileAmbiguousStorageCollapsedNoOpUpdateCascadeHandler(),
+            ResourceAuthorizationHandler: new PostgresqlProfileAmbiguousStorageCollapsedAllowAllAuthorizationHandler(),
+            ResourceAuthorizationPathways: [],
+            BackendProfileWriteContext: profileContext
+        );
+
+        var repository = scope.ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>();
+        return await repository.UpdateDocumentById(updateRequest);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
@@ -12,6 +12,74 @@ using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Tests.Unit.Profile;
 
+file static class StorageCollapsedIdentityCatalogHelpers
+{
+    // A catalog covering a root scope and one nested visible collection scope.
+    public static IReadOnlyList<CompiledScopeDescriptor> RootAndOneChildCollectionCatalog(
+        string childScope,
+        IReadOnlyList<string> childIdentityRelativePaths,
+        string rootJsonScope = "$"
+    ) =>
+        [
+            new(
+                JsonScope: rootJsonScope,
+                ScopeKind: ScopeKind.Root,
+                ImmediateParentJsonScope: null,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [],
+                CanonicalScopeRelativeMemberPaths: ["rootKey"]
+            ),
+            new(
+                JsonScope: childScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: rootJsonScope,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [.. childIdentityRelativePaths],
+                CanonicalScopeRelativeMemberPaths: [.. childIdentityRelativePaths]
+            ),
+        ];
+
+    // A catalog covering a root scope, an intermediate parent collection, and a nested child
+    // collection. This is the minimal catalog for testing bucket isolation when items share the
+    // same child scope but differ only in which parent collection instance they belong to.
+    public static IReadOnlyList<CompiledScopeDescriptor> RootParentsAndOneChildCollectionCatalog(
+        string parentScope,
+        IReadOnlyList<string> parentIdentityRelativePaths,
+        string childScope,
+        IReadOnlyList<string> childIdentityRelativePaths,
+        string rootJsonScope = "$"
+    ) =>
+        [
+            new(
+                JsonScope: rootJsonScope,
+                ScopeKind: ScopeKind.Root,
+                ImmediateParentJsonScope: null,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [],
+                CanonicalScopeRelativeMemberPaths: ["rootKey"]
+            ),
+            new(
+                JsonScope: parentScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: rootJsonScope,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [.. parentIdentityRelativePaths],
+                CanonicalScopeRelativeMemberPaths: [.. parentIdentityRelativePaths]
+            ),
+            new(
+                JsonScope: childScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: parentScope,
+                CollectionAncestorsInOrder: [parentScope],
+                SemanticIdentityRelativePathsInOrder: [.. childIdentityRelativePaths],
+                CanonicalScopeRelativeMemberPaths: [.. childIdentityRelativePaths]
+            ),
+        ];
+
+    public static SemanticIdentityPart Part(string path, JsonNode? value, bool isPresent) =>
+        new(path, value, isPresent);
+}
+
 [TestFixture]
 public class Given_ValidRequestContract_When_Validating
 {
@@ -1731,5 +1799,304 @@ public class Given_SameJsonScope_Under_Different_AncestorCollectionInstances_Whe
     public void It_does_not_emit_a_duplicate_failure()
     {
         _result.Should().NotContain(f => f is DuplicateScopeAddressCoreBackendContractMismatchFailure);
+    }
+}
+
+[TestFixture]
+public class Given_Two_Visible_Request_Items_In_Same_Bucket_With_Storage_Collapsed_Equal_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var missing = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var explicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates: [],
+            VisibleRequestCollectionItems:
+            [
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, ParentAddress, missing),
+                    Creatable: false,
+                    RequestJsonPath: "$.children[0]"
+                ),
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, ParentAddress, explicitNull),
+                    Creatable: false,
+                    RequestJsonPath: "$.children[1]"
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "POST",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_one_failure()
+    {
+        _failures.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_emits_a_C5_AmbiguousStorageCollapsedIdentity_failure_with_kind_InRequest()
+    {
+        _failures[0]
+            .Should()
+            .BeOfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.InRequest);
+    }
+
+    [Test]
+    public void It_carries_the_collection_scope_and_parent_address_of_the_bucket()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.JsonScope.Should().Be(ChildScope);
+        failure.ParentAddress.Should().Be(ParentAddress);
+    }
+
+    [Test]
+    public void It_carries_both_conflicting_identities()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.ConflictingIdentities.Should().HaveCount(2);
+    }
+}
+
+[TestFixture]
+public class Given_Two_Visible_Request_Items_In_Same_Bucket_With_Storage_Collapsed_Distinct_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var withOne = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(1), isPresent: true)
+        );
+        var withTwo = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(2), isPresent: true)
+        );
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates: [],
+            VisibleRequestCollectionItems:
+            [
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, ParentAddress, withOne),
+                    Creatable: false,
+                    RequestJsonPath: "$.children[0]"
+                ),
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, ParentAddress, withTwo),
+                    Creatable: false,
+                    RequestJsonPath: "$.children[1]"
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            catalog,
+            "TestProfile",
+            "TestResource",
+            "POST",
+            "write"
+        );
+    }
+
+    [Test]
+    public void It_returns_no_failures()
+    {
+        _failures.Should().BeEmpty();
+    }
+}
+
+[TestFixture]
+public class Given_Two_Visible_Request_Items_In_Different_Buckets_With_Storage_Collapsed_Equal_Identities
+{
+    private const string ParentScope = "$.parents[*]";
+    private const string ChildScope = "$.parents[*].children[*]";
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var missing = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var explicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+
+        // parentA and parentB represent the $.parents[*] scope instance that is the immediate
+        // parent of each child item. The AncestorCollectionInstances encodes which specific
+        // $.parents[*] instance each child item belongs to, distinguishing the two buckets.
+        var parentA = new ScopeInstanceAddress(
+            ParentScope,
+            ImmutableArray.Create(
+                new AncestorCollectionInstance(
+                    ParentScope,
+                    ImmutableArray.Create(
+                        StorageCollapsedIdentityCatalogHelpers.Part(
+                            "p",
+                            JsonValue.Create("A"),
+                            isPresent: true
+                        )
+                    )
+                )
+            )
+        );
+        var parentB = new ScopeInstanceAddress(
+            ParentScope,
+            ImmutableArray.Create(
+                new AncestorCollectionInstance(
+                    ParentScope,
+                    ImmutableArray.Create(
+                        StorageCollapsedIdentityCatalogHelpers.Part(
+                            "p",
+                            JsonValue.Create("B"),
+                            isPresent: true
+                        )
+                    )
+                )
+            )
+        );
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates: [],
+            VisibleRequestCollectionItems:
+            [
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, parentA, missing),
+                    Creatable: false,
+                    RequestJsonPath: "$.parents[0].children[0]"
+                ),
+                new VisibleRequestCollectionItem(
+                    new CollectionRowAddress(ChildScope, parentB, explicitNull),
+                    Creatable: false,
+                    RequestJsonPath: "$.parents[1].children[0]"
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootParentsAndOneChildCollectionCatalog(
+            ParentScope,
+            ["p"],
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            catalog,
+            "TestProfile",
+            "TestResource",
+            "POST",
+            "write"
+        );
+    }
+
+    [Test]
+    public void It_does_not_emit_an_in_request_ambiguity_failure()
+    {
+        _failures
+            .OfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Should()
+            .NotContain(f => f.Kind == AmbiguousStorageCollapsedIdentityKind.InRequest);
+    }
+}
+
+[TestFixture]
+public class Given_A_Duplicate_Collection_Row_Address_And_A_Storage_Collapsed_Pair
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var identity = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(1), isPresent: true)
+        );
+        var dupAddress = new CollectionRowAddress(ChildScope, ParentAddress, identity);
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates: [],
+            VisibleRequestCollectionItems:
+            [
+                new VisibleRequestCollectionItem(
+                    dupAddress,
+                    Creatable: false,
+                    RequestJsonPath: "$.children[0]"
+                ),
+                new VisibleRequestCollectionItem(
+                    dupAddress,
+                    Creatable: false,
+                    RequestJsonPath: "$.children[1]"
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            catalog,
+            "TestProfile",
+            "TestResource",
+            "POST",
+            "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_the_duplicate_address_failure()
+    {
+        _failures.Should().Contain(f => f is DuplicateScopeAddressCoreBackendContractMismatchFailure);
+    }
+
+    [Test]
+    public void It_does_not_emit_an_ambiguity_failure_when_prior_validation_failed()
+    {
+        _failures
+            .OfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Should()
+            .BeEmpty();
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
@@ -2547,3 +2547,250 @@ public class Given_An_In_Stored_Storage_Collapsed_Pair_Plus_An_Unrelated_Request
             .Be(AmbiguousStorageCollapsedIdentityKind.InStored);
     }
 }
+
+[TestFixture]
+public class Given_Two_Ancestor_Instances_In_Same_Derived_Parent_Bucket_With_Storage_Collapsed_Equal_Identities
+{
+    private const string AncestorScope = "$.parents[*]";
+    private const string ChildScope = "$.parents[*].children[*]";
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var ancestorMissing = new AncestorCollectionInstance(
+            AncestorScope,
+            ImmutableArray.Create(StorageCollapsedIdentityCatalogHelpers.Part("p", null, isPresent: false))
+        );
+        var ancestorExplicitNull = new AncestorCollectionInstance(
+            AncestorScope,
+            ImmutableArray.Create(StorageCollapsedIdentityCatalogHelpers.Part("p", null, isPresent: true))
+        );
+
+        var parentA = new ScopeInstanceAddress(AncestorScope, ImmutableArray.Create(ancestorMissing));
+        var parentB = new ScopeInstanceAddress(AncestorScope, ImmutableArray.Create(ancestorExplicitNull));
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(
+                            ChildScope,
+                            parentA,
+                            ImmutableArray.Create(
+                                StorageCollapsedIdentityCatalogHelpers.Part(
+                                    "c",
+                                    JsonValue.Create(1),
+                                    isPresent: true
+                                )
+                            )
+                        ),
+                        Creatable: false,
+                        RequestJsonPath: "$.parents[0].children[0]"
+                    ),
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(
+                            ChildScope,
+                            parentB,
+                            ImmutableArray.Create(
+                                StorageCollapsedIdentityCatalogHelpers.Part(
+                                    "c",
+                                    JsonValue.Create(2),
+                                    isPresent: true
+                                )
+                            )
+                        ),
+                        Creatable: false,
+                        RequestJsonPath: "$.parents[1].children[0]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows: []
+        );
+
+        var catalog = new List<CompiledScopeDescriptor>
+        {
+            new(
+                JsonScope: "$",
+                ScopeKind: ScopeKind.Root,
+                ImmediateParentJsonScope: null,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [],
+                CanonicalScopeRelativeMemberPaths: ["rootKey"]
+            ),
+            new(
+                JsonScope: AncestorScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: "$",
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: ["p"],
+                CanonicalScopeRelativeMemberPaths: ["p"]
+            ),
+            new(
+                JsonScope: ChildScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: AncestorScope,
+                CollectionAncestorsInOrder: [AncestorScope],
+                SemanticIdentityRelativePathsInOrder: ["c"],
+                CanonicalScopeRelativeMemberPaths: ["c"]
+            ),
+        };
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_one_failure()
+    {
+        _failures.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_emits_a_C5_AmbiguousStorageCollapsedIdentity_failure_with_kind_InAncestor()
+    {
+        _failures[0]
+            .Should()
+            .BeOfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.InAncestor);
+    }
+
+    [Test]
+    public void It_carries_the_ancestor_scope_and_derived_parent_address()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.JsonScope.Should().Be(AncestorScope);
+        failure.ParentAddress.JsonScope.Should().Be("$");
+        failure.ParentAddress.AncestorCollectionInstances.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_carries_both_conflicting_identities()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.ConflictingIdentities.Should().HaveCount(2);
+    }
+}
+
+[TestFixture]
+public class Given_The_Same_Presence_Aware_Ancestor_Identity_Repeats_Across_Many_Descendants
+{
+    private const string AncestorScope = "$.parents[*]";
+    private const string ChildScope = "$.parents[*].children[*]";
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var ancestor = new AncestorCollectionInstance(
+            AncestorScope,
+            ImmutableArray.Create(
+                StorageCollapsedIdentityCatalogHelpers.Part("p", JsonValue.Create("X"), isPresent: true)
+            )
+        );
+        var parent = new ScopeInstanceAddress(AncestorScope, ImmutableArray.Create(ancestor));
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(
+                            ChildScope,
+                            parent,
+                            ImmutableArray.Create(
+                                StorageCollapsedIdentityCatalogHelpers.Part(
+                                    "c",
+                                    JsonValue.Create(1),
+                                    isPresent: true
+                                )
+                            )
+                        ),
+                        Creatable: false,
+                        RequestJsonPath: "$.parents[0].children[0]"
+                    ),
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(
+                            ChildScope,
+                            parent,
+                            ImmutableArray.Create(
+                                StorageCollapsedIdentityCatalogHelpers.Part(
+                                    "c",
+                                    JsonValue.Create(2),
+                                    isPresent: true
+                                )
+                            )
+                        ),
+                        Creatable: false,
+                        RequestJsonPath: "$.parents[0].children[1]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows: []
+        );
+
+        var catalog = new List<CompiledScopeDescriptor>
+        {
+            new(
+                JsonScope: "$",
+                ScopeKind: ScopeKind.Root,
+                ImmediateParentJsonScope: null,
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: [],
+                CanonicalScopeRelativeMemberPaths: ["rootKey"]
+            ),
+            new(
+                JsonScope: AncestorScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: "$",
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: ["p"],
+                CanonicalScopeRelativeMemberPaths: ["p"]
+            ),
+            new(
+                JsonScope: ChildScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: AncestorScope,
+                CollectionAncestorsInOrder: [AncestorScope],
+                SemanticIdentityRelativePathsInOrder: ["c"],
+                CanonicalScopeRelativeMemberPaths: ["c"]
+            ),
+        };
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_does_not_emit_an_in_ancestor_ambiguity_failure()
+    {
+        _failures
+            .OfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Should()
+            .NotContain(leaf => leaf.Kind == AmbiguousStorageCollapsedIdentityKind.InAncestor);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
@@ -2100,3 +2100,148 @@ public class Given_A_Duplicate_Collection_Row_Address_And_A_Storage_Collapsed_Pa
             .BeEmpty();
     }
 }
+
+[TestFixture]
+public class Given_Two_Visible_Stored_Rows_In_Same_Bucket_With_Storage_Collapsed_Equal_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var missing = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var explicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems: []
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, missing),
+                    HiddenMemberPaths: []
+                ),
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, explicitNull),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_one_failure()
+    {
+        _failures.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_emits_a_C5_AmbiguousStorageCollapsedIdentity_failure_with_kind_InStored()
+    {
+        _failures[0]
+            .Should()
+            .BeOfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.InStored);
+    }
+
+    [Test]
+    public void It_carries_the_collection_scope_and_parent_address_of_the_bucket()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.JsonScope.Should().Be(ChildScope);
+        failure.ParentAddress.Should().Be(ParentAddress);
+    }
+
+    [Test]
+    public void It_carries_both_conflicting_identities()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.ConflictingIdentities.Should().HaveCount(2);
+    }
+}
+
+[TestFixture]
+public class Given_Two_Visible_Stored_Rows_In_Same_Bucket_With_Storage_Collapsed_Distinct_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var withOne = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(1), isPresent: true)
+        );
+        var withTwo = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(2), isPresent: true)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems: []
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, withOne),
+                    HiddenMemberPaths: []
+                ),
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, withTwo),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_returns_no_failures()
+    {
+        _failures.Should().BeEmpty();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
@@ -2245,3 +2245,305 @@ public class Given_Two_Visible_Stored_Rows_In_Same_Bucket_With_Storage_Collapsed
         _failures.Should().BeEmpty();
     }
 }
+
+[TestFixture]
+public class Given_A_Request_Item_And_A_Stored_Row_In_Same_Bucket_With_Storage_Collapsed_Equal_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var requestExplicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+        var storedAbsent = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(ChildScope, ParentAddress, requestExplicitNull),
+                        Creatable: false,
+                        RequestJsonPath: "$.children[0]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, storedAbsent),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_one_failure()
+    {
+        _failures.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_emits_a_C5_AmbiguousStorageCollapsedIdentity_failure_with_kind_CrossSide()
+    {
+        _failures[0]
+            .Should()
+            .BeOfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.CrossSide);
+    }
+
+    [Test]
+    public void It_carries_the_collection_scope_and_parent_address_of_the_bucket()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.JsonScope.Should().Be(ChildScope);
+        failure.ParentAddress.Should().Be(ParentAddress);
+    }
+
+    [Test]
+    public void It_carries_both_conflicting_identities()
+    {
+        var failure = (AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure)_failures[0];
+        failure.ConflictingIdentities.Should().HaveCount(2);
+    }
+}
+
+[TestFixture]
+public class Given_A_Request_Item_And_A_Stored_Row_With_Identical_Presence_Aware_Identities
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var requestAbsent = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var storedAbsent = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(ChildScope, ParentAddress, requestAbsent),
+                        Creatable: false,
+                        RequestJsonPath: "$.children[0]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, storedAbsent),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_returns_no_failures()
+    {
+        _failures.Should().BeEmpty();
+    }
+}
+
+[TestFixture]
+public class Given_An_In_Request_Storage_Collapsed_Pair_Plus_An_Unrelated_Stored_Row_In_Same_Bucket
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var requestMissing = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var requestExplicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+        var storedUnrelated = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(1), isPresent: true)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(ChildScope, ParentAddress, requestMissing),
+                        Creatable: false,
+                        RequestJsonPath: "$.children[0]"
+                    ),
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(ChildScope, ParentAddress, requestExplicitNull),
+                        Creatable: false,
+                        RequestJsonPath: "$.children[1]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, storedUnrelated),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_only_the_in_request_failure_not_a_cross_side_failure()
+    {
+        _failures
+            .OfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Should()
+            .ContainSingle()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.InRequest);
+    }
+}
+
+[TestFixture]
+public class Given_An_In_Stored_Storage_Collapsed_Pair_Plus_An_Unrelated_Request_Item_In_Same_Bucket
+{
+    private const string ChildScope = "$.children[*]";
+    private static readonly ScopeInstanceAddress ParentAddress = new("$", []);
+    private ProfileFailure[] _failures = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var storedMissing = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: false)
+        );
+        var storedExplicitNull = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", null, isPresent: true)
+        );
+        var requestUnrelated = ImmutableArray.Create(
+            StorageCollapsedIdentityCatalogHelpers.Part("k", JsonValue.Create(1), isPresent: true)
+        );
+
+        var context = new ProfileAppliedWriteContext(
+            Request: new ProfileAppliedWriteRequest(
+                WritableRequestBody: JsonNode.Parse("{}")!,
+                RootResourceCreatable: true,
+                RequestScopeStates: [],
+                VisibleRequestCollectionItems:
+                [
+                    new VisibleRequestCollectionItem(
+                        new CollectionRowAddress(ChildScope, ParentAddress, requestUnrelated),
+                        Creatable: false,
+                        RequestJsonPath: "$.children[0]"
+                    ),
+                ]
+            ),
+            VisibleStoredBody: JsonNode.Parse("{}")!,
+            StoredScopeStates: [],
+            VisibleStoredCollectionRows:
+            [
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, storedMissing),
+                    HiddenMemberPaths: []
+                ),
+                new VisibleStoredCollectionRow(
+                    new CollectionRowAddress(ChildScope, ParentAddress, storedExplicitNull),
+                    HiddenMemberPaths: []
+                ),
+            ]
+        );
+        var catalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            ChildScope,
+            ["k"]
+        );
+
+        _failures = ProfileWriteContractValidator.ValidateWriteContext(
+            context,
+            catalog,
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "PUT",
+            operation: "write"
+        );
+    }
+
+    [Test]
+    public void It_emits_only_the_in_stored_failure_not_a_cross_side_failure()
+    {
+        _failures
+            .OfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>()
+            .Should()
+            .ContainSingle()
+            .Which.Kind.Should()
+            .Be(AmbiguousStorageCollapsedIdentityKind.InStored);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteContractValidatorTests.cs
@@ -776,6 +776,138 @@ public class Given_CollectionRow_with_wrong_semantic_identity_path_When_Validati
 }
 
 [TestFixture]
+public class Given_CollectionRow_with_absent_semantic_identity_part_that_has_a_value_When_Validating
+{
+    private ProfileFailure[] _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var scopeCatalog = StorageCollapsedIdentityCatalogHelpers.RootAndOneChildCollectionCatalog(
+            "$.addresses[*]",
+            ["addressType"]
+        );
+
+        var collectionRowAddress = new CollectionRowAddress(
+            JsonScope: "$.addresses[*]",
+            ParentAddress: new ScopeInstanceAddress("$", []),
+            SemanticIdentityInOrder:
+            [
+                new SemanticIdentityPart("addressType", JsonValue.Create("Home"), IsPresent: false),
+            ]
+        );
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates: [],
+            VisibleRequestCollectionItems:
+            [
+                new VisibleRequestCollectionItem(
+                    collectionRowAddress,
+                    Creatable: true,
+                    RequestJsonPath: "$.addresses[0]"
+                ),
+            ]
+        );
+
+        _result = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            scopeCatalog,
+            profileName: "TestProfile",
+            resourceName: "School",
+            method: "POST",
+            operation: "upsert"
+        );
+    }
+
+    [Test]
+    public void It_emits_a_C5_contract_mismatch_failure()
+    {
+        _result.Should().ContainSingle();
+        _result[0].Category.Should().Be(ProfileFailureCategory.CoreBackendContractMismatch);
+    }
+
+    [Test]
+    public void It_reports_presence_value_consistency()
+    {
+        _result.Should().ContainSingle().Which.Message.Should().Contain("presence");
+    }
+}
+
+[TestFixture]
+public class Given_Ancestor_with_absent_semantic_identity_part_that_has_a_value_When_Validating
+{
+    private ProfileFailure[] _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        const string parentScope = "$.classPeriods[*]";
+        const string childScope = "$.classPeriods[*].meetingTimes";
+
+        var scopeCatalog = new List<CompiledScopeDescriptor>
+        {
+            new("$", ScopeKind.Root, null, [], [], []),
+            new(
+                JsonScope: parentScope,
+                ScopeKind: ScopeKind.Collection,
+                ImmediateParentJsonScope: "$",
+                CollectionAncestorsInOrder: [],
+                SemanticIdentityRelativePathsInOrder: ["classPeriodName"],
+                CanonicalScopeRelativeMemberPaths: ["classPeriodName"]
+            ),
+            new(
+                JsonScope: childScope,
+                ScopeKind: ScopeKind.NonCollection,
+                ImmediateParentJsonScope: parentScope,
+                CollectionAncestorsInOrder: [parentScope],
+                SemanticIdentityRelativePathsInOrder: [],
+                CanonicalScopeRelativeMemberPaths: []
+            ),
+        };
+
+        var ancestor = new AncestorCollectionInstance(
+            parentScope,
+            [new SemanticIdentityPart("classPeriodName", JsonValue.Create("First Period"), IsPresent: false)]
+        );
+        var scopeAddress = new ScopeInstanceAddress(childScope, [ancestor]);
+
+        var request = new ProfileAppliedWriteRequest(
+            WritableRequestBody: JsonNode.Parse("{}")!,
+            RootResourceCreatable: true,
+            RequestScopeStates:
+            [
+                new RequestScopeState(scopeAddress, ProfileVisibilityKind.VisiblePresent, Creatable: false),
+            ],
+            VisibleRequestCollectionItems: []
+        );
+
+        _result = ProfileWriteContractValidator.ValidateRequestContract(
+            request,
+            scopeCatalog,
+            profileName: "TestProfile",
+            resourceName: "School",
+            method: "PUT",
+            operation: "update"
+        );
+    }
+
+    [Test]
+    public void It_emits_a_C5_contract_mismatch_failure()
+    {
+        _result.Should().ContainSingle();
+        _result[0].Category.Should().Be(ProfileFailureCategory.CoreBackendContractMismatch);
+    }
+
+    [Test]
+    public void It_reports_presence_value_consistency()
+    {
+        _result.Should().ContainSingle().Which.Message.Should().Contain("presence");
+    }
+}
+
+[TestFixture]
 public class Given_valid_CollectionRow_with_correct_semantic_identity_When_Validating
 {
     private ProfileFailure[] _result = null!;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteFlattenerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteFlattenerTests.cs
@@ -711,14 +711,13 @@ public class Given_RelationalWriteFlattener
     [Test]
     public void It_rejects_collection_siblings_that_collapse_to_the_same_no_profile_semantic_identity_when_one_omits_and_one_explicit_nulls_the_identity_property()
     {
-        // The shared no-profile flattener path matches collection rows by raw semantic identity
-        // values (object?[]) with no presence flag. With the no-profile mode flag set, a sibling
-        // that omits an identity property and one that sends it as JSON null must be treated as
-        // a duplicate at the shared duplicate-detection stage; otherwise both rows would survive
-        // flattening and later collide in RelationalWriteNoProfileMerge under the same collapsed
-        // key. Profile-aware presence fidelity is covered by the companion profile-mode test
-        // below; DMS-1132 owns missing-vs-explicit-null identity semantics for the no-profile
-        // path.
+        // flatten-time rejection of two siblings whose semantic identities differ only by
+        // missing-vs-explicit-null on an identity slot. The relational storage model would
+        // persist both as SQL NULL, so the request shape is not representable — rejecting
+        // here prevents the no-profile merge from later binding ambiguous candidates to a
+        // stored row. The complementary profile-mode test below covers the presence-aware
+        // identity case. The profile-mode validator enforces the same invariant on
+        // Core-emitted streams before flatten.
         var flatteningInput = _fixture.CreateFlatteningInput(
             selectedBody: JsonNode.Parse(
                 """
@@ -737,7 +736,7 @@ public class Given_RelationalWriteFlattener
             )!,
             targetContext: new RelationalWriteTargetContext.ExistingDocument(345L, _fixture.DocumentUuid),
             resolvedReferences: FlattenerFixture.CreateEmptyResolvedReferences(),
-            collapseMissingAndExplicitNullForDuplicateDetection: true
+            validateStorageCollapsedCollectionIdentityUniqueness: true
         );
 
         var act = () => _sut.Flatten(flatteningInput);
@@ -758,12 +757,12 @@ public class Given_RelationalWriteFlattener
     public void It_keeps_collection_siblings_distinct_in_profile_mode_when_one_omits_and_one_explicit_nulls_the_identity_property()
     {
         // Counter-test for the no-profile rejection above: with the default profile-mode flag,
-        // duplicate detection uses presence-aware SemanticIdentityKeys.BuildKey output so a
-        // missing identity property and an explicit JSON null produce distinct keys. The two
-        // siblings must therefore both survive flattening and reach the profile merge planner,
-        // which pairs them by presence-aware identity. This guards against the no-profile fix
-        // collapsing identities universally and rejecting legitimate profile requests where
-        // SemanticIdentityPart.IsPresent intentionally distinguishes the two siblings.
+        // the shared flattener's duplicate detection uses presence-aware
+        // SemanticIdentityKeys.BuildKey output so a missing identity property and an explicit
+        // JSON null produce distinct keys, and both siblings survive flattening with their
+        // presence-aware SemanticIdentityPart.IsPresent values intact. This pins the flattener's
+        // per-mode behavior; the equivalent storage-collapsed ambiguity check on the profile
+        // path is enforced upstream in ProfileWriteContractValidator before flatten runs.
         var flatteningInput = _fixture.CreateFlatteningInput(
             selectedBody: JsonNode.Parse(
                 """
@@ -3439,7 +3438,7 @@ public class Given_RelationalWriteFlattener
             RelationalWriteTargetContext targetContext,
             ResolvedReferenceSet? resolvedReferences = null,
             bool emitEmptyExtensionBuffers = false,
-            bool collapseMissingAndExplicitNullForDuplicateDetection = false
+            bool validateStorageCollapsedCollectionIdentityUniqueness = false
         )
         {
             return new FlatteningInput(
@@ -3449,7 +3448,7 @@ public class Given_RelationalWriteFlattener
                 selectedBody,
                 resolvedReferences ?? ResolvedReferences,
                 emitEmptyExtensionBuffers,
-                collapseMissingAndExplicitNullForDuplicateDetection
+                validateStorageCollapsedCollectionIdentityUniqueness
             );
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/StorageCollapsedIdentityHelpersTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/StorageCollapsedIdentityHelpersTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend;
+using EdFi.DataManagementService.Core.Profile;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+public class Given_The_Storage_Collapsed_Identity_Helpers
+{
+    private static SemanticIdentityPart Part(string path, JsonNode? value, bool isPresent) =>
+        new(path, value, isPresent);
+
+    [Test]
+    public void It_Collapses_Missing_And_ExplicitNull_To_Same_Key()
+    {
+        var missing = ImmutableArray.Create(Part("a", null, false));
+        var explicitNull = ImmutableArray.Create(Part("a", null, true));
+
+        var keyMissing = StorageCollapsedIdentityHelpers.BuildKey(missing);
+        var keyExplicitNull = StorageCollapsedIdentityHelpers.BuildKey(explicitNull);
+
+        keyMissing.Should().Be(keyExplicitNull);
+    }
+
+    [Test]
+    public void It_Distinguishes_Present_NonNull_Values_From_Absent_Or_Null()
+    {
+        var present = ImmutableArray.Create(Part("a", JsonValue.Create(1), true));
+        var absent = ImmutableArray.Create(Part("a", null, false));
+
+        StorageCollapsedIdentityHelpers
+            .BuildKey(present)
+            .Should()
+            .NotBe(StorageCollapsedIdentityHelpers.BuildKey(absent));
+    }
+
+    [Test]
+    public void It_Distinguishes_Different_Present_NonNull_Values()
+    {
+        var one = ImmutableArray.Create(Part("a", JsonValue.Create(1), true));
+        var two = ImmutableArray.Create(Part("a", JsonValue.Create(2), true));
+
+        StorageCollapsedIdentityHelpers
+            .BuildKey(one)
+            .Should()
+            .NotBe(StorageCollapsedIdentityHelpers.BuildKey(two));
+    }
+
+    [Test]
+    public void It_Includes_RelativePath_In_The_Key()
+    {
+        var aPart = ImmutableArray.Create(Part("a", JsonValue.Create(1), true));
+        var bPart = ImmutableArray.Create(Part("b", JsonValue.Create(1), true));
+
+        StorageCollapsedIdentityHelpers
+            .BuildKey(aPart)
+            .Should()
+            .NotBe(StorageCollapsedIdentityHelpers.BuildKey(bPart));
+    }
+
+    [Test]
+    public void It_Returns_Empty_String_For_Default_Or_Empty_Sequence()
+    {
+        StorageCollapsedIdentityHelpers.BuildKey(default).Should().Be(string.Empty);
+        StorageCollapsedIdentityHelpers
+            .BuildKey(ImmutableArray<SemanticIdentityPart>.Empty)
+            .Should()
+            .Be(string.Empty);
+    }
+
+    [Test]
+    public void It_Surfaces_The_Existing_ObjectValueArrayComparer_Instance()
+    {
+        StorageCollapsedIdentityHelpers
+            .ObjectArrayComparer.Should()
+            .BeSameAs(ObjectValueArrayComparer.Instance);
+    }
+
+    [Test]
+    public void It_Produces_Different_Keys_For_Arrays_Differing_Only_In_Part_Order()
+    {
+        var ab = ImmutableArray.Create(
+            Part("a", JsonValue.Create(1), true),
+            Part("b", JsonValue.Create(2), true)
+        );
+        var ba = ImmutableArray.Create(
+            Part("b", JsonValue.Create(2), true),
+            Part("a", JsonValue.Create(1), true)
+        );
+
+        StorageCollapsedIdentityHelpers
+            .BuildKey(ab)
+            .Should()
+            .NotBe(StorageCollapsedIdentityHelpers.BuildKey(ba));
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -289,14 +289,16 @@ internal sealed class DefaultRelationalWriteExecutor(
                         executionRequest.SelectedBody,
                         resolvedReferences,
                         // The no-profile merge matches collection rows by raw object?[] semantic
-                        // identity values with no presence flag, so two siblings whose identity
-                        // differs only in missing-vs-explicit-null would otherwise survive
-                        // flattening and later collide on the same collapsed merge key. Collapse
-                        // the duplicate-detection key here to fail closed before persistence.
-                        // Profile flattening at line 241 leaves this off to preserve
-                        // SemanticIdentityKeys.BuildKey presence-aware identity for
-                        // ProfileCollectionPlanner.
-                        collapseMissingAndExplicitNullForDuplicateDetection: true
+                        // identity values via ObjectValueArrayComparer, which maps a missing
+                        // identity property and an explicit JSON null to the same key. The
+                        // relational storage model collapses them the same way (both persist as
+                        // SQL NULL), so two request siblings that differ only by
+                        // absent-vs-explicit-null on an identity slot cannot be persisted
+                        // distinctly. Enforce that invariant at flatten time so persistence never
+                        // sees an ambiguous pair. The profile path enforces the equivalent
+                        // invariant on Core-emitted address streams in
+                        // ProfileWriteContractValidator's ambiguity-detection phase.
+                        validateStorageCollapsedCollectionIdentityUniqueness: true
                     )
                 );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -66,6 +66,19 @@ internal static class ProfileWriteContractValidator
             operation,
             failures
         );
+
+        if (failures.Count == 0)
+        {
+            DetectInRequestBucketAmbiguity(
+                request.VisibleRequestCollectionItems,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
+        }
+
         return [.. failures];
     }
 
@@ -244,6 +257,18 @@ internal static class ProfileWriteContractValidator
                     )
                 );
             }
+        }
+
+        if (failures.Count == 0)
+        {
+            DetectInRequestBucketAmbiguity(
+                context.Request.VisibleRequestCollectionItems,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
         }
 
         return [.. failures];
@@ -714,5 +739,124 @@ internal static class ProfileWriteContractValidator
                 )
             );
         }
+    }
+
+    private static void DetectInRequestBucketAmbiguity(
+        ImmutableArray<VisibleRequestCollectionItem> visibleRequestItems,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        List<ProfileFailure> failures
+    )
+    {
+        if (visibleRequestItems.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var bucketed = visibleRequestItems.GroupBy(
+            item => (item.Address.JsonScope, item.Address.ParentAddress),
+            ScopeBucketKeyComparer.Instance
+        );
+
+        foreach (var bucket in bucketed)
+        {
+            AddCollapsedConflicts(
+                bucket.Select(i => i.Address.SemanticIdentityInOrder),
+                jsonScope: bucket.Key.JsonScope,
+                parentAddress: bucket.Key.ParentAddress,
+                kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
+        }
+    }
+
+    private sealed class ScopeBucketKeyComparer
+        : IEqualityComparer<(string JsonScope, ScopeInstanceAddress ParentAddress)>
+    {
+        public static readonly ScopeBucketKeyComparer Instance = new();
+
+        public bool Equals(
+            (string JsonScope, ScopeInstanceAddress ParentAddress) x,
+            (string JsonScope, ScopeInstanceAddress ParentAddress) y
+        ) =>
+            string.Equals(x.JsonScope, y.JsonScope, StringComparison.Ordinal)
+            && ScopeInstanceAddressComparer.Instance.Equals(x.ParentAddress, y.ParentAddress);
+
+        public int GetHashCode((string JsonScope, ScopeInstanceAddress ParentAddress) obj) =>
+            HashCode.Combine(
+                StringComparer.Ordinal.GetHashCode(obj.JsonScope),
+                ScopeInstanceAddressComparer.Instance.GetHashCode(obj.ParentAddress)
+            );
+    }
+
+    private static void AddCollapsedConflicts(
+        IEnumerable<ImmutableArray<SemanticIdentityPart>> identities,
+        string jsonScope,
+        ScopeInstanceAddress parentAddress,
+        AmbiguousStorageCollapsedIdentityKind kind,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        List<ProfileFailure> failures
+    )
+    {
+        var byCollapsedKey = new Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>>(
+            StringComparer.Ordinal
+        );
+
+        foreach (var identity in identities)
+        {
+            var key = StorageCollapsedIdentityHelpers.BuildKey(identity);
+            if (!byCollapsedKey.TryGetValue(key, out var bucket))
+            {
+                bucket = [];
+                byCollapsedKey.Add(key, bucket);
+            }
+            bucket.Add(identity);
+        }
+
+        foreach (var (_, conflicting) in byCollapsedKey)
+        {
+            if (conflicting.Count < 2)
+            {
+                continue;
+            }
+
+            if (!HasPresenceAwareDistinctPair(conflicting))
+            {
+                continue;
+            }
+
+            failures.Add(
+                ProfileFailures.AmbiguousStorageCollapsedIdentity(
+                    profileName,
+                    resourceName,
+                    method,
+                    operation,
+                    jsonScope,
+                    parentAddress,
+                    kind,
+                    [.. conflicting]
+                )
+            );
+        }
+    }
+
+    private static bool HasPresenceAwareDistinctPair(List<ImmutableArray<SemanticIdentityPart>> identities)
+    {
+        var seenKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var identity in identities)
+        {
+            var presenceAwareKey = SemanticIdentityKeys.BuildKey(identity);
+            seenKeys.Add(presenceAwareKey);
+        }
+        return seenKeys.Count >= 2;
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -1007,7 +1007,7 @@ internal static class ProfileWriteContractValidator
     }
 
     private static Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>> GroupByCollapsedKey(
-        IReadOnlyList<ImmutableArray<SemanticIdentityPart>> identities
+        IEnumerable<ImmutableArray<SemanticIdentityPart>> identities
     )
     {
         var result = new Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>>(
@@ -1057,20 +1057,7 @@ internal static class ProfileWriteContractValidator
         List<ProfileFailure> failures
     )
     {
-        var byCollapsedKey = new Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>>(
-            StringComparer.Ordinal
-        );
-
-        foreach (var identity in identities)
-        {
-            var key = StorageCollapsedIdentityHelpers.BuildKey(identity);
-            if (!byCollapsedKey.TryGetValue(key, out var bucket))
-            {
-                bucket = [];
-                byCollapsedKey.Add(key, bucket);
-            }
-            bucket.Add(identity);
-        }
+        var byCollapsedKey = GroupByCollapsedKey(identities);
 
         foreach (var (_, conflicting) in byCollapsedKey)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -77,6 +77,15 @@ internal static class ProfileWriteContractValidator
                 operation,
                 failures
             );
+            DetectInAncestorBucketAmbiguity(
+                request,
+                context: null,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
         }
 
         return [.. failures];
@@ -280,6 +289,15 @@ internal static class ProfileWriteContractValidator
             DetectCrossSideBucketAmbiguity(
                 context.Request.VisibleRequestCollectionItems,
                 context.VisibleStoredCollectionRows,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
+            DetectInAncestorBucketAmbiguity(
+                context.Request,
+                context,
                 profileName,
                 resourceName,
                 method,
@@ -902,6 +920,89 @@ internal static class ProfileWriteContractValidator
                     )
                 );
             }
+        }
+    }
+
+    private static void DetectInAncestorBucketAmbiguity(
+        ProfileAppliedWriteRequest request,
+        ProfileAppliedWriteContext? context,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        List<ProfileFailure> failures
+    )
+    {
+        // Collect all ancestor chains from all four metadata streams (two when context is null).
+        var chains = new List<ImmutableArray<AncestorCollectionInstance>>();
+        foreach (var s in request.RequestScopeStates)
+        {
+            chains.Add(s.Address.AncestorCollectionInstances);
+        }
+        foreach (var i in request.VisibleRequestCollectionItems)
+        {
+            chains.Add(i.Address.ParentAddress.AncestorCollectionInstances);
+        }
+        if (context is not null)
+        {
+            foreach (var s in context.StoredScopeStates)
+            {
+                chains.Add(s.Address.AncestorCollectionInstances);
+            }
+            foreach (var r in context.VisibleStoredCollectionRows)
+            {
+                chains.Add(r.Address.ParentAddress.AncestorCollectionInstances);
+            }
+        }
+
+        // Bucket key = (ancestor.JsonScope, derived parent ScopeInstanceAddress).
+        // Within each bucket, dedupe by exact presence-aware identity, then run
+        // storage-collapsed detection on the deduplicated set. The bucket comparer
+        // MUST use ScopeBucketKeyComparer for structural ScopeInstanceAddress equality.
+        var buckets = new Dictionary<
+            (string JsonScope, ScopeInstanceAddress Parent),
+            Dictionary<string, ImmutableArray<SemanticIdentityPart>>
+        >(ScopeBucketKeyComparer.Instance);
+
+        foreach (var chain in chains)
+        {
+            for (var k = 0; k < chain.Length; k++)
+            {
+                var ancestor = chain[k];
+                var parentJsonScope = ProfileCollectionWalker.ComputeParentJsonScope(ancestor.JsonScope);
+                var derivedParentAncestors =
+                    k == 0 ? ImmutableArray<AncestorCollectionInstance>.Empty : [.. chain.Take(k)];
+                var derivedParent = new ScopeInstanceAddress(parentJsonScope, derivedParentAncestors);
+                var bucketKey = (ancestor.JsonScope, derivedParent);
+                if (!buckets.TryGetValue(bucketKey, out var dedup))
+                {
+                    dedup = new Dictionary<string, ImmutableArray<SemanticIdentityPart>>(
+                        StringComparer.Ordinal
+                    );
+                    buckets.Add(bucketKey, dedup);
+                }
+                var presenceAwareKey = SemanticIdentityKeys.BuildKey(ancestor.SemanticIdentityInOrder);
+                if (!dedup.ContainsKey(presenceAwareKey))
+                {
+                    dedup.Add(presenceAwareKey, ancestor.SemanticIdentityInOrder);
+                }
+            }
+        }
+
+        foreach (var (bucketKey, dedup) in buckets)
+        {
+            var distinctIdentities = dedup.Values.ToList();
+            AddCollapsedConflicts(
+                distinctIdentities,
+                jsonScope: bucketKey.JsonScope,
+                parentAddress: bucketKey.Parent,
+                kind: AmbiguousStorageCollapsedIdentityKind.InAncestor,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
         }
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -277,6 +277,15 @@ internal static class ProfileWriteContractValidator
                 operation,
                 failures
             );
+            DetectCrossSideBucketAmbiguity(
+                context.Request.VisibleRequestCollectionItems,
+                context.VisibleStoredCollectionRows,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
         }
 
         return [.. failures];
@@ -817,6 +826,103 @@ internal static class ProfileWriteContractValidator
                 failures
             );
         }
+    }
+
+    private static void DetectCrossSideBucketAmbiguity(
+        ImmutableArray<VisibleRequestCollectionItem> visibleRequestItems,
+        ImmutableArray<VisibleStoredCollectionRow> visibleStoredRows,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        List<ProfileFailure> failures
+    )
+    {
+        if (visibleRequestItems.IsDefaultOrEmpty || visibleStoredRows.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var requestByBucket = visibleRequestItems
+            .GroupBy(i => (i.Address.JsonScope, i.Address.ParentAddress), ScopeBucketKeyComparer.Instance)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(i => i.Address.SemanticIdentityInOrder).ToList(),
+                ScopeBucketKeyComparer.Instance
+            );
+
+        var storedByBucket = visibleStoredRows
+            .GroupBy(r => (r.Address.JsonScope, r.Address.ParentAddress), ScopeBucketKeyComparer.Instance)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Select(r => r.Address.SemanticIdentityInOrder).ToList(),
+                ScopeBucketKeyComparer.Instance
+            );
+
+        foreach (var (bucketKey, requestList) in requestByBucket)
+        {
+            if (!storedByBucket.TryGetValue(bucketKey, out var storedList))
+            {
+                continue;
+            }
+
+            var requestByCollapsedKey = GroupByCollapsedKey(requestList);
+            var storedByCollapsedKey = GroupByCollapsedKey(storedList);
+
+            foreach (var (collapsedKey, requestIdentities) in requestByCollapsedKey)
+            {
+                if (!storedByCollapsedKey.TryGetValue(collapsedKey, out var storedIdentities))
+                {
+                    continue;
+                }
+
+                // At least one request and one stored identity share the collapsed key.
+                // Emit only if the union contains a presence-aware-distinct pair.
+                var combined = new List<ImmutableArray<SemanticIdentityPart>>(
+                    requestIdentities.Count + storedIdentities.Count
+                );
+                combined.AddRange(requestIdentities);
+                combined.AddRange(storedIdentities);
+
+                if (!HasPresenceAwareDistinctPair(combined))
+                {
+                    continue;
+                }
+
+                failures.Add(
+                    ProfileFailures.AmbiguousStorageCollapsedIdentity(
+                        profileName,
+                        resourceName,
+                        method,
+                        operation,
+                        bucketKey.JsonScope,
+                        bucketKey.ParentAddress,
+                        AmbiguousStorageCollapsedIdentityKind.CrossSide,
+                        [.. combined]
+                    )
+                );
+            }
+        }
+    }
+
+    private static Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>> GroupByCollapsedKey(
+        IReadOnlyList<ImmutableArray<SemanticIdentityPart>> identities
+    )
+    {
+        var result = new Dictionary<string, List<ImmutableArray<SemanticIdentityPart>>>(
+            StringComparer.Ordinal
+        );
+        foreach (var identity in identities)
+        {
+            var key = StorageCollapsedIdentityHelpers.BuildKey(identity);
+            if (!result.TryGetValue(key, out var bucket))
+            {
+                bucket = [];
+                result.Add(key, bucket);
+            }
+            bucket.Add(identity);
+        }
+        return result;
     }
 
     private sealed class ScopeBucketKeyComparer

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -269,6 +269,14 @@ internal static class ProfileWriteContractValidator
                 operation,
                 failures
             );
+            DetectInStoredBucketAmbiguity(
+                context.VisibleStoredCollectionRows,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
         }
 
         return [.. failures];
@@ -767,6 +775,41 @@ internal static class ProfileWriteContractValidator
                 jsonScope: bucket.Key.JsonScope,
                 parentAddress: bucket.Key.ParentAddress,
                 kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                failures
+            );
+        }
+    }
+
+    private static void DetectInStoredBucketAmbiguity(
+        ImmutableArray<VisibleStoredCollectionRow> visibleStoredRows,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        List<ProfileFailure> failures
+    )
+    {
+        if (visibleStoredRows.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var bucketed = visibleStoredRows.GroupBy(
+            row => (row.Address.JsonScope, row.Address.ParentAddress),
+            ScopeBucketKeyComparer.Instance
+        );
+
+        foreach (var bucket in bucketed)
+        {
+            AddCollapsedConflicts(
+                bucket.Select(r => r.Address.SemanticIdentityInOrder),
+                jsonScope: bucket.Key.JsonScope,
+                parentAddress: bucket.Key.ParentAddress,
+                kind: AmbiguousStorageCollapsedIdentityKind.InStored,
                 profileName,
                 resourceName,
                 method,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Profile/ProfileWriteContractValidator.cs
@@ -578,6 +578,17 @@ internal static class ProfileWriteContractValidator
                 return;
             }
         }
+
+        ValidateSemanticIdentityPresenceValueConsistency(
+            emittedIdentity,
+            profileName,
+            resourceName,
+            method,
+            operation,
+            new ProfileFailureDiagnostic.CompiledScope(compiledScope),
+            new ProfileFailureDiagnostic.CollectionRow(address),
+            failures
+        );
     }
 
     /// <summary>
@@ -621,10 +632,12 @@ internal static class ProfileWriteContractValidator
                 continue;
             }
 
+            var pathsMatch = true;
             for (int i = 0; i < expectedPaths.Length; i++)
             {
                 if (ancestor.SemanticIdentityInOrder[i].RelativePath != expectedPaths[i])
                 {
+                    pathsMatch = false;
                     failures.Add(
                         ProfileFailures.AncestorSemanticIdentityMismatch(
                             profileName,
@@ -639,6 +652,54 @@ internal static class ProfileWriteContractValidator
                     break;
                 }
             }
+
+            if (!pathsMatch)
+            {
+                continue;
+            }
+
+            ValidateSemanticIdentityPresenceValueConsistency(
+                ancestor.SemanticIdentityInOrder,
+                profileName,
+                resourceName,
+                method,
+                operation,
+                new ProfileFailureDiagnostic.CompiledScope(ancestorScope),
+                addressDiagnostic,
+                failures
+            );
+        }
+    }
+
+    private static void ValidateSemanticIdentityPresenceValueConsistency(
+        ImmutableArray<SemanticIdentityPart> emittedIdentity,
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        ProfileFailureDiagnostic compiledScopeDiagnostic,
+        ProfileFailureDiagnostic addressDiagnostic,
+        List<ProfileFailure> failures
+    )
+    {
+        foreach (var part in emittedIdentity)
+        {
+            if (part.IsPresent || part.Value is null)
+            {
+                continue;
+            }
+
+            failures.Add(
+                ProfileFailures.CoreBackendContractMismatch(
+                    ProfileFailureEmitter.BackendProfileWriteContext,
+                    "Core emitted semantic identity presence metadata inconsistent with the value contract.",
+                    new ProfileFailureContext(profileName, resourceName, method, operation),
+                    compiledScopeDiagnostic,
+                    addressDiagnostic,
+                    new ProfileFailureDiagnostic.SemanticIdentity(emittedIdentity)
+                )
+            );
+            return;
         }
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -123,7 +123,7 @@ public sealed record FlatteningInput
         JsonNode selectedBody,
         ResolvedReferenceSet resolvedReferences,
         bool emitEmptyExtensionBuffers = false,
-        bool collapseMissingAndExplicitNullForDuplicateDetection = false
+        bool validateStorageCollapsedCollectionIdentityUniqueness = false
     )
     {
         OperationKind = operationKind;
@@ -133,8 +133,8 @@ public sealed record FlatteningInput
         ResolvedReferences =
             resolvedReferences ?? throw new ArgumentNullException(nameof(resolvedReferences));
         EmitEmptyExtensionBuffers = emitEmptyExtensionBuffers;
-        CollapseMissingAndExplicitNullForDuplicateDetection =
-            collapseMissingAndExplicitNullForDuplicateDetection;
+        ValidateStorageCollapsedCollectionIdentityUniqueness =
+            validateStorageCollapsedCollectionIdentityUniqueness;
     }
 
     /// <summary>
@@ -176,23 +176,18 @@ public sealed record FlatteningInput
     public bool EmitEmptyExtensionBuffers { get; init; }
 
     /// <summary>
-    /// When true, the shared flattener's collection duplicate-detection step treats a missing
-    /// identity property and an explicit JSON <c>null</c> as the same identity value. The
-    /// no-profile merge in <c>RelationalWriteNoProfileMerge.ProjectedCollectionTableState</c>
-    /// matches collection rows by raw <c>object?[]</c> semantic identity values with no presence
-    /// flag, so two siblings whose identity differs only in presence would otherwise survive
-    /// flattening and later collide on the same collapsed merge key. The no-profile executor
-    /// sets this so duplicate request collection items are rejected before reaching the merge
-    /// stage. Profile-aware callers leave it off so
-    /// <see cref="EdFi.DataManagementService.Backend.Profile.SemanticIdentityKeys.BuildKey(System.Collections.Immutable.ImmutableArray{EdFi.DataManagementService.Core.Profile.SemanticIdentityPart})"/>
-    /// continues to distinguish missing from explicit-null identities under the
-    /// <see cref="EdFi.DataManagementService.Core.Profile.SemanticIdentityPart"/> contract;
-    /// presence-aware row-pairing in <c>ProfileCollectionPlanner</c> still observes both
-    /// siblings as distinct identities. DMS-1132 owns full missing-vs-explicit-null identity
-    /// fidelity for the no-profile path; until that lands, collapsing here is the conservative
-    /// fail-closed bridge.
+    /// When true, the shared flattener enforces that no two collection candidates under
+    /// the same parent collection scope share a storage-collapsed semantic identity.
+    /// Two identities collapse-equal when they are equal under
+    /// <see cref="ObjectValueArrayComparer"/> after the storage-NULL convention is applied
+    /// (a missing identity property and an explicit JSON <c>null</c> both materialize to
+    /// <c>null</c> in the values array). The no-profile executor sets this so request
+    /// shapes that the relational storage model cannot represent distinctly are rejected
+    /// before persistence with <see cref="RelationalWriteRequestValidationException"/>.
+    /// Profile-aware callers leave it off because <see cref="EdFi.DataManagementService.Backend.Profile.ProfileWriteContractValidator"/>
+    /// validates the same invariant against Core-emitted address streams before flatten.
     /// </summary>
-    public bool CollapseMissingAndExplicitNullForDuplicateDetection { get; init; }
+    public bool ValidateStorageCollapsedCollectionIdentityUniqueness { get; init; }
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFlattener.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFlattener.cs
@@ -352,29 +352,31 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
             //   keys under the SemanticIdentityPart contract, so two siblings with the same null
             //   value are duplicates only when both are present-null or both are missing — never
             //   across the boundary. ProfileCollectionPlanner relies on this to pair stored rows
-            //   and request candidates by presence-aware identity.
+            //   and request candidates by presence-aware identity. The complementary
+            //   storage-collapsed identity uniqueness rule for profile mode is enforced by the
+            //   profile-side ambiguity-detection phase in ProfileWriteContractValidator before
+            //   flatten.
             //
-            // - No-profile mode (CollapseMissingAndExplicitNullForDuplicateDetection): keyed on
+            // - No-profile mode (ValidateStorageCollapsedCollectionIdentityUniqueness): keyed on
             //   the raw object?[] semantic identity values via ObjectValueArrayComparer, the
             //   exact same comparer used by
-            //   RelationalWriteNoProfileMerge.ProjectedCollectionTableState. That ensures every
-            //   pair of values that the no-profile merge would collapse — including missing vs
-            //   explicit null, and decimals like 1.0m vs 1.00m which are .Equals but stringify
-            //   differently — is rejected here as a duplicate before reaching the merge stage.
-            //   A string-encoded key would diverge from the comparer's runtime Equals semantics
-            //   and either miss those duplicates or false-flag legitimate values containing the
-            //   chosen separator characters. DMS-1132 owns full missing-vs-explicit-null
-            //   identity fidelity for the no-profile path.
+            //   RelationalWriteNoProfileMerge.ProjectedCollectionTableState. The relational
+            //   storage model maps both missing and explicit-null identity slots to SQL NULL,
+            //   so two request siblings differing only by absent-vs-explicit-null on an identity
+            //   slot would persist indistinguishably. Rejecting such pairs here keeps the merge
+            //   from binding ambiguous request candidates to a stored row. The same comparer
+            //   also catches scalar values that .Equals but stringify differently (e.g. 1.0m
+            //   vs 1.00m), keeping flatten-time rejection aligned with merge-time matching.
             //
             // SemanticIdentityInOrder is built unconditionally because the profile merge
             // pipeline still consumes it on every candidate downstream of this method.
             Dictionary<string, (int[] OrdinalPath, object?[] Values)>? presenceAwareTracker =
-                flatteningInput.CollapseMissingAndExplicitNullForDuplicateDetection
+                flatteningInput.ValidateStorageCollapsedCollectionIdentityUniqueness
                     ? null
                     : new(StringComparer.Ordinal);
             Dictionary<object?[], (int[] OrdinalPath, object?[] Values)>? collapsedTracker =
-                flatteningInput.CollapseMissingAndExplicitNullForDuplicateDetection
-                    ? new(ObjectValueArrayComparer.Instance)
+                flatteningInput.ValidateStorageCollapsedCollectionIdentityUniqueness
+                    ? new(StorageCollapsedIdentityHelpers.ObjectArrayComparer)
                     : null;
 
             foreach (
@@ -1039,12 +1041,14 @@ internal sealed class RelationalWriteFlattener : IRelationalWriteFlattener
     /// <remarks>
     /// Used by the profile-aware merge path, where candidate keys must align with
     /// visible-request-item keys reconstructed from <see cref="CollectionRowAddress"/>.
-    /// The no-profile merge path intentionally does not consume these parts and matches
-    /// current rows on raw <see cref="CollectionWriteCandidate.SemanticIdentityValues"/>
-    /// instead — absent-vs-explicit-null identity fidelity for the no-profile path is
-    /// out of scope here and tracked separately under DMS-1132. The companion DB-row
-    /// projection lives inline in <c>ProfileCollectionWalker</c>; the shared scope-relative
-    /// path normalization is centralized in
+    /// The no-profile merge path matches current rows on raw
+    /// <see cref="CollectionWriteCandidate.SemanticIdentityValues"/> via
+    /// <see cref="ObjectValueArrayComparer"/>; profile-aware callers leave the no-profile
+    /// path's storage-collapsed-uniqueness flag off because
+    /// <see cref="EdFi.DataManagementService.Backend.Profile.ProfileWriteContractValidator"/>
+    /// enforces the same invariant on Core-emitted address streams before flatten. The
+    /// companion DB-row projection lives inline in <c>ProfileCollectionWalker</c>; the
+    /// shared scope-relative path normalization is centralized in
     /// <see cref="RelationalWriteMergeSupport.ToScopeRelativePath"/>.
     /// </remarks>
     private static ImmutableArray<SemanticIdentityPart> MaterializeSemanticIdentityParts(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteMergeSupport.cs
@@ -4,8 +4,10 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Immutable;
+using System.Text;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Core.Profile;
 
 namespace EdFi.DataManagementService.Backend;
 
@@ -374,4 +376,52 @@ internal static class RelationalWriteMergeSupport
             };
         }
     }
+}
+
+/// <summary>
+/// Encodes the storage-collapsed-identity equality rule used by both write paths.
+/// </summary>
+internal static class StorageCollapsedIdentityHelpers
+{
+    private const char PartSeparator = '\u001E'; // RS - between parts
+    private const char FieldSeparator = '\u001F'; // US - within a part
+    private const string NullValueSentinel = "null";
+
+    /// <summary>
+    /// Builds a storage-collapsed key for a presence-aware identity sequence.
+    /// Two sequences produce equal keys iff they collapse to the same DB shape.
+    /// </summary>
+    public static string BuildKey(ImmutableArray<SemanticIdentityPart> parts)
+    {
+        if (parts.IsDefaultOrEmpty)
+        {
+            return string.Empty;
+        }
+
+        var builder = new StringBuilder();
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(PartSeparator);
+            }
+
+            var part = parts[i];
+            var hasValue = part.IsPresent && part.Value is not null;
+            builder.Append(part.RelativePath);
+            builder.Append(FieldSeparator);
+            builder.Append(hasValue ? '1' : '0');
+            builder.Append(FieldSeparator);
+            builder.Append(hasValue ? part.Value!.ToJsonString() : NullValueSentinel);
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    /// Equality comparer for raw <c>object?[]</c> identity values. Aliases
+    /// <see cref="ObjectValueArrayComparer.Instance"/> so the no-profile flattener
+    /// expresses the storage-collapsed-uniqueness rule by name.
+    /// </summary>
+    public static IEqualityComparer<object?[]> ObjectArrayComparer => ObjectValueArrayComparer.Instance;
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Profile/ProfileFailure.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Profile/ProfileFailure.cs
@@ -182,6 +182,37 @@ public enum ProfileCreatabilityDependencyKind
 }
 
 /// <summary>
+/// Distinguishes which input bucket triggered an
+/// <see cref="AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure"/>.
+/// </summary>
+public enum AmbiguousStorageCollapsedIdentityKind
+{
+    /// <summary>
+    /// Two visible request collection items in the same parent/scope bucket are
+    /// presence-aware-distinct but storage-collapsed-equal.
+    /// </summary>
+    InRequest,
+
+    /// <summary>
+    /// Two visible stored collection rows in the same parent/scope bucket are
+    /// presence-aware-distinct but storage-collapsed-equal.
+    /// </summary>
+    InStored,
+
+    /// <summary>
+    /// A visible request item and a visible stored row in the same parent/scope
+    /// bucket are presence-aware-distinct but storage-collapsed-equal.
+    /// </summary>
+    CrossSide,
+
+    /// <summary>
+    /// Two ancestor collection instances in the same derived-parent/scope bucket
+    /// are presence-aware-distinct but storage-collapsed-equal.
+    /// </summary>
+    InAncestor,
+}
+
+/// <summary>
 /// Shared high-level context carried by all typed profile failures.
 /// Later category-specific payloads add scope, address, and binding detail via
 /// <see cref="ProfileFailureDiagnostic"/> instances rather than redefining the
@@ -713,6 +744,25 @@ public sealed record DuplicateScopeAddressCoreBackendContractMismatchFailure(
     : CoreBackendContractMismatchFailure(
         ProfileFailureEmitter.BackendProfileWriteContext,
         "Core emitted multiple entries with the same address in a single stream.",
+        Context,
+        Diagnostics
+    );
+
+/// <summary>
+/// Category-5 failure for Core-emitted presence-aware identities that would
+/// collapse to the same DB-storable identity within a parent/scope bucket.
+/// </summary>
+public sealed record AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure(
+    ProfileFailureContext Context,
+    string JsonScope,
+    ScopeInstanceAddress ParentAddress,
+    AmbiguousStorageCollapsedIdentityKind Kind,
+    ImmutableArray<ImmutableArray<SemanticIdentityPart>> ConflictingIdentities,
+    ImmutableArray<ProfileFailureDiagnostic> Diagnostics
+)
+    : CoreBackendContractMismatchFailure(
+        ProfileFailureEmitter.BackendProfileWriteContext,
+        "Core emitted presence-aware identities that collapse to the same storage-shape key within a parent/scope bucket.",
         Context,
         Diagnostics
     );
@@ -1482,6 +1532,48 @@ public static class ProfileFailures
             streamName,
             occurrenceCount,
             MergeDiagnostics(diagnostics, new ProfileFailureDiagnostic.CollectionRow(emittedAddress))
+        );
+    }
+
+    public static AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure AmbiguousStorageCollapsedIdentity(
+        string profileName,
+        string resourceName,
+        string method,
+        string operation,
+        string jsonScope,
+        ScopeInstanceAddress parentAddress,
+        AmbiguousStorageCollapsedIdentityKind kind,
+        ImmutableArray<ImmutableArray<SemanticIdentityPart>> conflictingIdentities,
+        params ProfileFailureDiagnostic[] diagnostics
+    )
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(jsonScope);
+        ArgumentNullException.ThrowIfNull(parentAddress);
+        if (conflictingIdentities.IsDefaultOrEmpty || conflictingIdentities.Length < 2)
+        {
+            throw new ArgumentException(
+                "At least two conflicting identities are required.",
+                nameof(conflictingIdentities)
+            );
+        }
+
+        ProfileFailureContext context = CreateRequiredContext(profileName, resourceName, method, operation);
+        var structuredDiagnostics = new List<ProfileFailureDiagnostic>
+        {
+            new ProfileFailureDiagnostic.ScopeAddress(parentAddress),
+        };
+        foreach (var identity in conflictingIdentities)
+        {
+            structuredDiagnostics.Add(new ProfileFailureDiagnostic.SemanticIdentity(identity));
+        }
+
+        return new AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure(
+            context,
+            jsonScope,
+            parentAddress,
+            kind,
+            conflictingIdentities,
+            MergeDiagnostics(diagnostics, [.. structuredDiagnostics])
         );
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileFailureTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileFailureTests.cs
@@ -1085,3 +1085,150 @@ public class Given_ProfileFailureFactoryWhenEmitterDoesNotOwnTheCategory : Profi
         act.Should().Throw<ArgumentException>().WithMessage("*does not own category*");
     }
 }
+
+[TestFixture]
+public class Given_An_AmbiguousStorageCollapsedIdentity_C5_Failure
+{
+    [Test]
+    public void It_should_build_with_required_fields_and_inherit_category_5()
+    {
+        var parentAddress = new ScopeInstanceAddress("$.parents[*]", []);
+        var conflictingA = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: false));
+        var conflictingB = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: true));
+
+        var failure = ProfileFailures.AmbiguousStorageCollapsedIdentity(
+            profileName: "TestProfile",
+            resourceName: "TestResource",
+            method: "POST",
+            operation: "write",
+            jsonScope: "$.children[*]",
+            parentAddress: parentAddress,
+            kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+            conflictingIdentities: ImmutableArray.Create(conflictingA, conflictingB)
+        );
+
+        failure.Should().BeOfType<AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure>();
+        failure.Category.Should().Be(ProfileFailureCategory.CoreBackendContractMismatch);
+        failure.Emitter.Should().Be(ProfileFailureEmitter.BackendProfileWriteContext);
+        failure.JsonScope.Should().Be("$.children[*]");
+        failure.ParentAddress.Should().Be(parentAddress);
+        failure.Kind.Should().Be(AmbiguousStorageCollapsedIdentityKind.InRequest);
+        failure.ConflictingIdentities.Should().HaveCount(2);
+        failure.Message.Should().Contain("storage");
+    }
+}
+
+[TestFixture]
+public class Given_AmbiguousStorageCollapsedIdentity_With_Empty_JsonScope
+{
+    private Exception? _thrown;
+
+    [SetUp]
+    public void Setup()
+    {
+        var parentAddress = new ScopeInstanceAddress("$.parents[*]", []);
+        var conflictingA = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: false));
+        var conflictingB = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: true));
+
+        try
+        {
+            ProfileFailures.AmbiguousStorageCollapsedIdentity(
+                profileName: "TestProfile",
+                resourceName: "TestResource",
+                method: "POST",
+                operation: "write",
+                jsonScope: "",
+                parentAddress: parentAddress,
+                kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+                conflictingIdentities: ImmutableArray.Create(conflictingA, conflictingB)
+            );
+        }
+        catch (Exception e)
+        {
+            _thrown = e;
+        }
+    }
+
+    [Test]
+    public void It_should_throw_an_argument_exception_for_jsonScope()
+    {
+        _thrown.Should().BeOfType<ArgumentException>();
+        ((ArgumentException)_thrown!).ParamName.Should().Be("jsonScope");
+    }
+}
+
+[TestFixture]
+public class Given_AmbiguousStorageCollapsedIdentity_With_Null_ParentAddress
+{
+    private Exception? _thrown;
+
+    [SetUp]
+    public void Setup()
+    {
+        var conflictingA = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: false));
+        var conflictingB = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: true));
+
+        try
+        {
+            ProfileFailures.AmbiguousStorageCollapsedIdentity(
+                profileName: "TestProfile",
+                resourceName: "TestResource",
+                method: "POST",
+                operation: "write",
+                jsonScope: "$.children[*]",
+                parentAddress: null!,
+                kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+                conflictingIdentities: ImmutableArray.Create(conflictingA, conflictingB)
+            );
+        }
+        catch (Exception e)
+        {
+            _thrown = e;
+        }
+    }
+
+    [Test]
+    public void It_should_throw_an_argument_null_exception_for_parentAddress()
+    {
+        _thrown.Should().BeOfType<ArgumentNullException>();
+        ((ArgumentNullException)_thrown!).ParamName.Should().Be("parentAddress");
+    }
+}
+
+[TestFixture]
+public class Given_AmbiguousStorageCollapsedIdentity_With_Single_Conflicting_Identity
+{
+    private Exception? _thrown;
+
+    [SetUp]
+    public void Setup()
+    {
+        var parentAddress = new ScopeInstanceAddress("$.parents[*]", []);
+        var only = ImmutableArray.Create(new SemanticIdentityPart("a", null, IsPresent: false));
+
+        try
+        {
+            ProfileFailures.AmbiguousStorageCollapsedIdentity(
+                profileName: "TestProfile",
+                resourceName: "TestResource",
+                method: "POST",
+                operation: "write",
+                jsonScope: "$.children[*]",
+                parentAddress: parentAddress,
+                kind: AmbiguousStorageCollapsedIdentityKind.InRequest,
+                conflictingIdentities: ImmutableArray.Create(only)
+            );
+        }
+        catch (Exception e)
+        {
+            _thrown = e;
+        }
+    }
+
+    [Test]
+    public void It_should_throw_an_argument_exception_for_conflictingIdentities()
+    {
+        _thrown.Should().BeOfType<ArgumentException>();
+        ((ArgumentException)_thrown!).ParamName.Should().Be("conflictingIdentities");
+    }
+}


### PR DESCRIPTION
## Summary

_In plain English: 
Before this work, a request could contain two collection items whose identity differed only by “property missing” vs “property present as JSON null.” In memory those can look different, but relational storage turns both into SQL NULL, so they can collide when the write path tries to match request rows to stored rows. This branch makes that ambiguity fail deterministically before DML instead of letting the merge guess or bind the wrong row._

Closes [DMS-1132](https://edfi.atlassian.net/browse/DMS-1132). Adds deterministic pre-merge ambiguity detection so the relational write executor rejects requests whose merge-bound identity sets are presence-aware-distinct but storage-collapsed-equal within the same parent/scope bucket. Closes the silent first-wins/misbind risk inherited from `DMS-1124` without changing the storage representation, the executor's matching logic, or the API's treatment of explicit nulls.

## What changed

**Profile path** — new C5 typed-failure leaf `AmbiguousStorageCollapsedIdentityCoreBackendContractMismatchFailure` (with `AmbiguousStorageCollapsedIdentityKind` discriminating `InRequest` / `InStored` / `CrossSide` / `InAncestor`). `ProfileWriteContractValidator` runs a Phase 3 ambiguity check after the existing structural and per-entry phases when those produce no failures. The check buckets visible request items, visible stored rows, the cross-product, and ancestor chains harvested from request- and stored-side scope/collection-row addresses, and emits the new C5 leaf when any bucket contains presence-aware-distinct identities that collapse to the same DB-storable identity.

**No-profile path** — preserved as a request-validation surface (`RelationalWriteRequestValidationException`). The flattener flag is renamed from `CollapseMissingAndExplicitNullForDuplicateDetection` to `ValidateStorageCollapsedCollectionIdentityUniqueness`, the comparer is routed through a new `StorageCollapsedIdentityHelpers.ObjectArrayComparer` alias for naming consistency, and the surrounding comments are rewritten to describe the validated invariant rather than a "fail-closed bridge until DMS-1132."

**Shared helpers** — `RelationalWriteMergeSupport.StorageCollapsedIdentityHelpers` exposes a `BuildKey(ImmutableArray<SemanticIdentityPart>)` for the profile-side string-keyed dictionaries and the `ObjectArrayComparer` alias for the no-profile path's raw `object?[]` matching. Each path uses a shape-specific equality form expressing the same rule.

**Asymmetric failure surfaces by design** — no-profile ambiguity is a submitted-request shape that the relational storage model cannot represent distinctly; that belongs in request validation. Profile ambiguity is a Core/backend metadata-stream alignment concern; that belongs in C5. Broadening C5 to cover non-profile executor concerns was rejected as out of scope.

**Coverage** — unit tests on `StorageCollapsedIdentityHelpers`, `ProfileFailure` (positive + 3 guard negatives), and `ProfileWriteContractValidator` (Phase 3 a/b/c/d, including the cross-side false-positive guard and the ancestor dedupe across many descendants). Integration tests on PostgreSQL and SQL Server for both the profile path (asserting the executor maps the C5 leaf to `UpdateResult.UnknownFailure` with the precise leaf-message substring) and the no-profile path (asserting `UpsertResult.UpsertFailureValidation` with the flattener's actual `received duplicate semantic identity values` message). 1244/1244 backend unit tests, 2308/2308 Core unit tests, 2/2 DMS-1132 pgsql integration tests pass; mssql integration tests are structurally identical twins (DB not provisioned in this dev environment).

**Design docs** — new `### Storage-Collapsed Semantic Identity Uniqueness` subsection in `profiles.md` documents the rule, the path-specific equality forms, and the failure surfaces. `07-parity-and-hardening.md` has every `DMS-1132` hand-off reference scrubbed (the dedicated section, the parity-matrix row, the bulleted mentions). The story doc gains a `> **Status:** Closed.` blockquote pointing at the new `profiles.md` section. `EPIC.md` marks the bullet `(closed)`.

## Test plan

- [ ] Pull and build: `dotnet build src/dms/backend/EdFi.DataManagementService.Backend.sln`
- [ ] Backend unit suite passes: `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/...`
- [ ] Core unit suite passes: `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/...`
- [ ] pgsql integration tests pass (DMS-1132 fixtures): `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/... --filter "FullyQualifiedName~Storage_Collapsed_Sibling_Identities"`
- [ ] mssql integration tests pass on a provisioned SQL Server: same filter on the mssql project
- [ ] Spot-check the new `profiles.md § Storage-Collapsed Semantic Identity Uniqueness` reads cleanly
- [ ] Confirm no `DMS-1132` references remain in `07-parity-and-hardening.md`

[DMS-1132]: https://edfi.atlassian.net/browse/DMS-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ