### PR TITLE
[DMS-1144] Profile namespace boundary and server-generated fields

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileFilteringMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProfileFilteringMiddlewareTests.cs
@@ -469,6 +469,115 @@ public class ProfileFilteringMiddlewareTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_Profile_Hides_Link_On_Reference : ProfileFilteringMiddlewareTests
+    {
+        private RequestInfo _requestInfo = null!;
+        private bool _nextCalled;
+
+        private static ProfileContext CreateProfileContextWithSchoolReferenceObjectRule()
+        {
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+
+            var resourceProfile = new ResourceProfile(
+                ResourceName: "Student",
+                LogicalSchema: null,
+                ReadContentType: contentType,
+                WriteContentType: null
+            );
+
+            return new ProfileContext(
+                ProfileName: "TestProfile",
+                ContentType: ProfileContentType.Read,
+                ResourceProfile: resourceProfile,
+                WasExplicitlySpecified: true
+            );
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _requestInfo = CreateRequestInfo();
+            _requestInfo.ProfileContext = CreateProfileContextWithSchoolReferenceObjectRule();
+
+            // Hand-populated link stands in for runtime link emission (DMS-1145).
+            var sourceBody = new JsonObject
+            {
+                ["id"] = "12345",
+                ["studentUniqueId"] = "STU001",
+                ["schoolReference"] = new JsonObject
+                {
+                    ["schoolId"] = 200,
+                    ["nameOfInstitution"] = "Test School",
+                    ["link"] = new JsonObject { ["rel"] = "School", ["href"] = "/ed-fi/schools/200" },
+                },
+            };
+
+            _requestInfo.FrontendResponse = new FrontendResponse(
+                StatusCode: 200,
+                Body: sourceBody,
+                Headers: []
+            );
+
+            _nextCalled = false;
+            var middleware = CreateMiddleware();
+
+            await middleware.Execute(
+                _requestInfo,
+                () =>
+                {
+                    _nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+        }
+
+        [Test]
+        public void It_calls_next()
+        {
+            _nextCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void It_preserves_link_on_filtered_reference()
+        {
+            var reference = _requestInfo.FrontendResponse.Body!["schoolReference"] as JsonObject;
+            reference.Should().NotBeNull();
+
+            var link = reference!["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("School");
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/schools/200");
+        }
+
+        [Test]
+        public void It_filters_unlisted_reference_members()
+        {
+            // schoolReference IncludeOnly = ["schoolId"] — nameOfInstitution is not listed
+            // and is not server-generated, so it must be filtered out. schoolId stays.
+            var reference = (_requestInfo.FrontendResponse.Body!["schoolReference"] as JsonObject)!;
+            reference["schoolId"]!.GetValue<int>().Should().Be(200);
+            reference["nameOfInstitution"].Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_Profile_Context_With_Null_ReadContentType : ProfileFilteringMiddlewareTests
     {
         private RequestInfo _requestInfo = null!;

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/OpenApi/ProfileOpenApiSpecificationFilterTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/OpenApi/ProfileOpenApiSpecificationFilterTests.cs
@@ -879,4 +879,24 @@ public class ProfileOpenApiSpecificationFilterTests
             readableSchema!.ContainsKey("link").Should().BeTrue("readable schemas MUST include link");
         }
     }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Shared_Server_Generated_Fields_Constant
+    {
+        [Test]
+        public void It_contains_exactly_the_four_canonical_names()
+        {
+            EdFi.DataManagementService.Core.Profile.ServerGeneratedFields.Names.Should()
+                .BeEquivalentTo("id", "link", "_etag", "_lastModifiedDate");
+        }
+
+        [Test]
+        public void It_is_case_sensitive()
+        {
+            EdFi.DataManagementService.Core.Profile.ServerGeneratedFields.Contains("id").Should().BeTrue();
+            EdFi.DataManagementService.Core.Profile.ServerGeneratedFields.Contains("Id").Should().BeFalse();
+            EdFi.DataManagementService.Core.Profile.ServerGeneratedFields.Contains("ID").Should().BeFalse();
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1183,6 +1183,211 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
+        public void Validate_should_return_error_for_server_generated_field_in_IncludeOnly_properties()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            // Schema has firstName so "ordinary members would validate" baseline holds.
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [new PropertyRule("link")],
+                [],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.IsValid.Should().BeFalse();
+            result.HasErrors.Should().BeTrue();
+            result.Failures.Should().HaveCount(1);
+            result.Failures[0].Severity.Should().Be(ValidationSeverity.Error);
+            result.Failures[0].MemberName.Should().Be("link");
+            result.Failures[0].Message.Should().Contain("server-generated field");
+            result.Failures[0].Message.Should().Contain("not profile-addressable");
+        }
+
+        [TestCase("id")]
+        [TestCase("link")]
+        [TestCase("_etag")]
+        [TestCase("_lastModifiedDate")]
+        public void Validate_should_return_error_for_each_server_generated_field_in_IncludeOnly_properties(
+            string serverGeneratedFieldName
+        )
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [new PropertyRule(serverGeneratedFieldName)],
+                [],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == serverGeneratedFieldName
+                    && f.Message.Contains("server-generated field")
+                    && f.Message.Contains("not profile-addressable")
+                );
+        }
+
+        [TestCase("id")]
+        [TestCase("link")]
+        [TestCase("_etag")]
+        [TestCase("_lastModifiedDate")]
+        public void Validate_should_return_error_for_each_server_generated_field_in_ExcludeOnly_properties(
+            string serverGeneratedFieldName
+        )
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                [new PropertyRule(serverGeneratedFieldName)],
+                [],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.IsValid.Should().BeFalse();
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == serverGeneratedFieldName
+                    && f.Message.Contains("server-generated field")
+                    && f.Message.Contains("not profile-addressable")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_server_generated_field_as_object_rule_name()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [new ObjectRule("link", MemberSelection.IncludeAll, null, null, null, null, null)],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_server_generated_field_as_collection_rule_name()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [new CollectionRule("link", MemberSelection.IncludeAll, null, null, null, null, null, null)],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_server_generated_field_as_extension_rule_name()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [],
+                [new ExtensionRule("link", MemberSelection.IncludeAll, null, null, null, null)]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
         public void Validate_should_succeed_for_profile_with_all_member_selection_modes()
         {
             // Arrange

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1803,5 +1803,69 @@ public class ProfileDataValidatorTests
                     && f.Message.Contains("server-generated field")
                 );
         }
+
+        [Test]
+        public void Validate_link_in_IncludeOnly_produces_server_generated_error_not_does_not_exist_error()
+        {
+            // Arrange — schema intentionally omits "link"; if the server-gen check did
+            // not run first, the validator would emit "Property 'link' does not exist".
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [new PropertyRule("link")],
+                [],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — exactly one failure, the server-gen message
+            result.Failures.Should().HaveCount(1);
+            result.Failures[0].Message.Should().Contain("server-generated field");
+            result.Failures[0].Message.Should().NotContain("does not exist");
+        }
+
+        [Test]
+        public void Validate_should_succeed_for_profile_addressing_only_ordinary_schema_members()
+        {
+            // Arrange — profile references schoolReference.schoolId only.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.IsValid.Should().BeTrue();
+            result.HasErrors.Should().BeFalse();
+            result.Failures.Should().BeEmpty();
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -2125,5 +2125,357 @@ public class ProfileDataValidatorTests
                     && f.Message.Contains("server-generated field")
                 );
         }
+
+        [TestCase("id")]
+        [TestCase("link")]
+        [TestCase("_etag")]
+        [TestCase("_lastModifiedDate")]
+        public void Validate_IncludeAll_content_type_should_return_error_for_property_rule_named_server_gen(
+            string serverGeneratedFieldName
+        )
+        {
+            // Arrange — top-level IncludeAll with a Property naming a server-generated
+            // field. The dispatched IncludeAll path does not look at Properties, so the
+            // server-gen rejection has to come from the recursive name pre-pass.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [new PropertyRule(serverGeneratedFieldName)],
+                [],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == serverGeneratedFieldName
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_object_rule_should_return_error_for_child_property_named_link()
+        {
+            // Arrange — IncludeAll object containing an explicit Property("link").
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("link")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_object_rule_should_return_error_for_child_nested_object_named_link()
+        {
+            // Arrange — IncludeAll object containing an explicit nested Object("link").
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects:
+                [
+                    new ObjectRule("link", MemberSelection.IncludeAll, null, null, null, null, null),
+                ],
+                Collections: null,
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_object_rule_should_return_error_for_child_collection_named_link()
+        {
+            // Arrange — IncludeAll object containing an explicit Collection("link").
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections:
+                [
+                    new CollectionRule(
+                        "link",
+                        MemberSelection.IncludeAll,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                ],
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_object_rule_should_return_error_for_child_extension_named_link()
+        {
+            // Arrange — IncludeAll object containing an explicit Extension("link").
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions: [new ExtensionRule("link", MemberSelection.IncludeAll, null, null, null, null)]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_collection_rule_should_return_error_for_child_property_named_link()
+        {
+            // Arrange — IncludeAll collection containing an explicit Property("link") on its items.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "addresses", "streetAddress");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("link")],
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [addressesRule],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "addresses[].link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_extension_rule_should_return_error_for_child_property_named_link()
+        {
+            // Arrange — IncludeAll extension containing an explicit Property("link").
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var sampleExtensionRule = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("link")],
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [],
+                [sampleExtensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "_ext.sample.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_extension_inside_object_should_report_full_enclosing_path_for_link_property()
+        {
+            // Arrange — Object("schoolReference") -> Extension("sample") -> Property("link").
+            // Failure path must preserve the enclosing object prefix and surface as
+            // "schoolReference._ext.sample.link", not "_ext.sample.link".
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions:
+                [
+                    new ExtensionRule(
+                        Name: "sample",
+                        MemberSelection: MemberSelection.IncludeOnly,
+                        LogicalSchema: null,
+                        Properties: [new PropertyRule("link")],
+                        Objects: null,
+                        Collections: null
+                    ),
+                ]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — server-gen failure carries the full path.
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference._ext.sample.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -2477,5 +2477,155 @@ public class ProfileDataValidatorTests
                     && f.Message.Contains("server-generated field")
                 );
         }
+
+        [TestCase("id")]
+        [TestCase("link")]
+        [TestCase("_etag")]
+        [TestCase("_lastModifiedDate")]
+        public void Validate_should_return_error_for_item_filter_property_named_server_gen(
+            string serverGeneratedFieldName
+        )
+        {
+            // Arrange — root collection rule whose ItemFilter selects a
+            // server-generated field. The parser accepts any propertyName, so
+            // the namespace contract has to be enforced by the validator.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "addresses", "streetAddress");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: new CollectionItemFilter(
+                    serverGeneratedFieldName,
+                    FilterMode.IncludeOnly,
+                    ["uri://ed-fi.org/AddressTypeDescriptor#Home"]
+                )
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [addressesRule],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == $"addresses[].{serverGeneratedFieldName}"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_item_filter_property_on_nested_collection()
+        {
+            // Arrange — Object("schoolReference") -> Collection("addresses")
+            // with an ItemFilter.PropertyName of "link". Failure path must
+            // preserve the enclosing object prefix. The schema declares
+            // schoolReference.{ schoolId, addresses[].streetAddress } so the
+            // only failure surfaced is the server-generated one.
+            var validator = new ProfileDataValidator(_logger);
+            var addressesSchema = new JsonObject
+            {
+                ["type"] = "array",
+                ["items"] = new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["streetAddress"] = new JsonObject { ["type"] = "string" },
+                    },
+                },
+            };
+            var schoolReferenceSchema = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["schoolId"] = new JsonObject { ["type"] = "string" },
+                    ["addresses"] = addressesSchema,
+                },
+            };
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject { ["schoolReference"] = schoolReferenceSchema },
+            };
+            _apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("Student")
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+            var studentNode =
+                _apiSchemaDocuments
+                    .GetCoreProjectSchema()
+                    .FindResourceSchemaNodeByResourceName(new("Student")) as JsonObject;
+            studentNode!["jsonSchemaForInsert"] = jsonSchemaForInsert;
+            studentNode["identityJsonPaths"] = new JsonArray { "$.schoolReference.schoolId" };
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: new CollectionItemFilter(
+                    "link",
+                    FilterMode.IncludeOnly,
+                    ["uri://ed-fi.org/AddressTypeDescriptor#Home"]
+                )
+            );
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: [addressesRule],
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — exactly one failure: the server-generated item filter.
+            result.HasErrors.Should().BeTrue();
+            result.Failures.Should().HaveCount(1);
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.addresses[].link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1867,5 +1867,263 @@ public class ProfileDataValidatorTests
             result.HasErrors.Should().BeFalse();
             result.Failures.Should().BeEmpty();
         }
+
+        [Test]
+        public void Validate_IncludeAll_content_type_should_return_error_for_object_rule_named_link()
+        {
+            // Arrange — parent content type is IncludeAll; server-gen names are
+            // not profile-addressable regardless of parent member selection.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [new ObjectRule("link", MemberSelection.IncludeAll, null, null, null, null, null)],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_content_type_should_return_error_for_collection_rule_named_link()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [new CollectionRule("link", MemberSelection.IncludeAll, null, null, null, null, null, null)],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_IncludeAll_content_type_should_return_error_for_extension_rule_named_link()
+        {
+            // Arrange
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [],
+                [new ExtensionRule("link", MemberSelection.IncludeAll, null, null, null, null)]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_object_rule_extensions()
+        {
+            // Arrange — ObjectRule.Extensions is populated by the parser and
+            // consumed by both projectors; the validator must traverse it too.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions:
+                [
+                    new ExtensionRule(
+                        Name: "link",
+                        MemberSelection: MemberSelection.IncludeAll,
+                        LogicalSchema: null,
+                        Properties: null,
+                        Objects: null,
+                        Collections: null
+                    ),
+                ]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_collection_rule_nested_collections()
+        {
+            // Arrange — CollectionRule.NestedCollections is populated by the
+            // parser and consumed by both projectors; the validator must
+            // traverse it too.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "addresses", "streetAddress");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("streetAddress")],
+                NestedObjects: null,
+                NestedCollections:
+                [
+                    new CollectionRule(
+                        Name: "link",
+                        MemberSelection: MemberSelection.IncludeAll,
+                        LogicalSchema: null,
+                        Properties: null,
+                        NestedObjects: null,
+                        NestedCollections: null,
+                        Extensions: null,
+                        ItemFilter: null
+                    ),
+                ],
+                Extensions: null,
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [addressesRule],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "addresses[].link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_collection_rule_extensions()
+        {
+            // Arrange — CollectionRule.Extensions is populated by the parser
+            // and consumed by both projectors; the validator must traverse it.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "addresses", "streetAddress");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("streetAddress")],
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions:
+                [
+                    new ExtensionRule(
+                        Name: "link",
+                        MemberSelection: MemberSelection.IncludeAll,
+                        LogicalSchema: null,
+                        Properties: null,
+                        Objects: null,
+                        Collections: null
+                    ),
+                ],
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [addressesRule],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "addresses[].link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -22,6 +22,135 @@ public class ProfileDataValidatorTests
         private IEffectiveApiSchemaProvider _effectiveApiSchemaProvider = null!;
         private ApiSchemaDocuments _apiSchemaDocuments = null!;
 
+        private static ApiSchemaDocuments CreateSchemaWithReferenceObject(
+            string resourceName,
+            string referenceName,
+            params string[] referencePropertyNames
+        )
+        {
+            var refProperties = new JsonObject();
+            foreach (var name in referencePropertyNames)
+            {
+                refProperties[name] = new JsonObject { ["type"] = "string" };
+            }
+
+            var referenceObject = new JsonObject { ["type"] = "object", ["properties"] = refProperties };
+
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject { [referenceName] = referenceObject },
+            };
+
+            var apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource(resourceName)
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            var resourceNode = apiSchemaDocuments
+                .GetCoreProjectSchema()
+                .FindResourceSchemaNodeByResourceName(new(resourceName));
+
+            if (resourceNode is JsonObject resourceObj)
+            {
+                resourceObj["jsonSchemaForInsert"] = jsonSchemaForInsert;
+                resourceObj["identityJsonPaths"] = new JsonArray
+                {
+                    $"$.{referenceName}.{referencePropertyNames[0]}",
+                };
+            }
+
+            return apiSchemaDocuments;
+        }
+
+        private static ApiSchemaDocuments CreateSchemaWithCollection(
+            string resourceName,
+            string collectionName,
+            params string[] itemPropertyNames
+        )
+        {
+            var itemProperties = new JsonObject();
+            foreach (var name in itemPropertyNames)
+            {
+                itemProperties[name] = new JsonObject { ["type"] = "string" };
+            }
+
+            var itemSchema = new JsonObject { ["type"] = "object", ["properties"] = itemProperties };
+
+            var collectionSchema = new JsonObject { ["type"] = "array", ["items"] = itemSchema };
+
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject { [collectionName] = collectionSchema },
+            };
+
+            var apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource(resourceName)
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            var resourceNode = apiSchemaDocuments
+                .GetCoreProjectSchema()
+                .FindResourceSchemaNodeByResourceName(new(resourceName));
+
+            if (resourceNode is JsonObject resourceObj)
+            {
+                resourceObj["jsonSchemaForInsert"] = jsonSchemaForInsert;
+            }
+
+            return apiSchemaDocuments;
+        }
+
+        private static ApiSchemaDocuments CreateSchemaWithExtension(
+            string resourceName,
+            string extensionName,
+            params string[] extensionPropertyNames
+        )
+        {
+            var extProperties = new JsonObject();
+            foreach (var name in extensionPropertyNames)
+            {
+                extProperties[name] = new JsonObject { ["type"] = "string" };
+            }
+
+            var extensionSchema = new JsonObject { ["type"] = "object", ["properties"] = extProperties };
+
+            var extSchema = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject { [extensionName] = extensionSchema },
+            };
+
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject { ["_ext"] = extSchema },
+            };
+
+            var apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource(resourceName)
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            var resourceNode = apiSchemaDocuments
+                .GetCoreProjectSchema()
+                .FindResourceSchemaNodeByResourceName(new(resourceName));
+
+            if (resourceNode is JsonObject resourceObj)
+            {
+                resourceObj["jsonSchemaForInsert"] = jsonSchemaForInsert;
+            }
+
+            return apiSchemaDocuments;
+        }
+
         private static ApiSchemaDocuments CreateSchemaWithProperties(
             string resourceName,
             params string[] propertyNames
@@ -1448,6 +1577,231 @@ public class ProfileDataValidatorTests
             result.IsValid.Should().BeTrue();
             result.HasErrors.Should().BeFalse();
             result.Failures.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_nested_object_rule_properties()
+        {
+            // Arrange — schema must contain schoolReference.schoolId so the failure
+            // is the server-gen rule, not "object does not exist".
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId"), new PropertyRule("link")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_nested_collection_rule_properties()
+        {
+            // Arrange — schema has addresses[].streetAddress
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "addresses", "streetAddress");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("link")],
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [addressesRule],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "addresses[].link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_link_in_extension_rule_properties()
+        {
+            // Arrange — schema has _ext.sample.sampleField
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("link")],
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "_ext.sample.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_nested_object_named_link()
+        {
+            // Arrange — schema has schoolReference.schoolId; profile defines a nested object named "link"
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var nestedRule = new ObjectRule(
+                Name: "link",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: [nestedRule],
+                Collections: null,
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
+        }
+
+        [Test]
+        public void Validate_should_return_error_for_nested_collection_named_link()
+        {
+            // Arrange — schema has schoolReference.schoolId; profile defines a nested collection named "link"
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var nestedCollectionNamedLink = new CollectionRule(
+                Name: "link",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: null
+            );
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: [nestedCollectionNamedLink],
+                Extensions: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [schoolReferenceRule],
+                [],
+                []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference.link"
+                    && f.Message.Contains("server-generated field")
+                );
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileResponseFilterTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileResponseFilterTests.cs
@@ -780,4 +780,160 @@ public class ProfileResponseFilterTests
             _result!["nonIdentityField"].Should().BeNull();
         }
     }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Link_On_Reference_Under_IncludeOnly : ProfileResponseFilterTests
+    {
+        private JsonObject _source = null!;
+        private JsonNode? _result;
+
+        [SetUp]
+        public void Setup()
+        {
+            _source = new JsonObject
+            {
+                ["id"] = "12345",
+                ["schoolId"] = 100,
+                ["schoolReference"] = new JsonObject
+                {
+                    ["schoolId"] = 200,
+                    ["link"] = new JsonObject { ["rel"] = "School", ["href"] = "/ed-fi/schools/200" },
+                },
+            };
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, objects: [schoolReferenceRule]);
+            var identityPropertyNames = Filter.ExtractIdentityPropertyNames([new JsonPath("$.schoolId")]);
+
+            _result = Filter.FilterDocument(_source, contentType, identityPropertyNames);
+        }
+
+        [Test]
+        public void It_preserves_link_subtree_on_filtered_reference()
+        {
+            var reference = (_result!["schoolReference"] as JsonObject)!;
+            var link = reference["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("School");
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/schools/200");
+        }
+
+        [Test]
+        public void It_preserves_link_via_deep_clone_not_alias()
+        {
+            var resultLink = (((_result!["schoolReference"] as JsonObject)!)["link"] as JsonObject)!;
+            var sourceLink = ((_source["schoolReference"] as JsonObject)!["link"] as JsonObject)!;
+
+            resultLink["href"] = "/mutated";
+
+            sourceLink["href"]!.GetValue<string>().Should().Be("/ed-fi/schools/200");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Root_Server_Generated_Fields_Under_IncludeOnly : ProfileResponseFilterTests
+    {
+        private JsonNode? _result;
+
+        [SetUp]
+        public void Setup()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "12345",
+                ["schoolId"] = 100,
+                ["_etag"] = "\"42\"",
+                ["_lastModifiedDate"] = "2026-05-11T00:00:00Z",
+                ["link"] = new JsonObject { ["rel"] = "Student", ["href"] = "/ed-fi/students/12345" },
+                ["nameOfInstitution"] = "Test School",
+            };
+
+            var contentType = CreateContentType(
+                MemberSelection.IncludeOnly,
+                properties: [new PropertyRule("nameOfInstitution")]
+            );
+            var identityPropertyNames = Filter.ExtractIdentityPropertyNames([new JsonPath("$.schoolId")]);
+
+            _result = Filter.FilterDocument(source, contentType, identityPropertyNames);
+        }
+
+        [Test]
+        public void It_preserves_etag()
+        {
+            _result!["_etag"]!.GetValue<string>().Should().Be("\"42\"");
+        }
+
+        [Test]
+        public void It_preserves_last_modified_date()
+        {
+            _result!["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-05-11T00:00:00Z");
+        }
+
+        [Test]
+        public void It_preserves_root_link()
+        {
+            var link = _result!["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("Student");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Illegal_ObjectRule_Named_Link : ProfileResponseFilterTests
+    {
+        private JsonNode? _result;
+
+        [SetUp]
+        public void Setup()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "12345",
+                ["schoolId"] = 100,
+                ["link"] = new JsonObject { ["rel"] = "Student", ["href"] = "/ed-fi/students/12345" },
+            };
+
+            var illegalLinkRule = new ObjectRule(
+                Name: "link",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("rel")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, objects: [illegalLinkRule]);
+            var identityPropertyNames = Filter.ExtractIdentityPropertyNames([new JsonPath("$.schoolId")]);
+
+            _result = Filter.FilterDocument(source, contentType, identityPropertyNames);
+        }
+
+        [Test]
+        public void It_preserves_link_rel_via_short_circuit_bypassing_rule_dispatch()
+        {
+            var link = _result!["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("Student");
+        }
+
+        [Test]
+        public void It_preserves_link_href_despite_IncludeOnly_listing_only_rel()
+        {
+            var link = (_result!["link"] as JsonObject)!;
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/students/12345");
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ReadableProfileProjectorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ReadableProfileProjectorTests.cs
@@ -2019,6 +2019,165 @@ public class ReadableProfileProjectorTests
     }
 
     // =======================================================================
+    //  Enclosure-survival: server-generated fields do not, on their own,
+    //  keep an enclosing nested object / collection item / extension object
+    //  alive when every profile-addressable member has been filtered out.
+    //  See design-docs/profiles.md §"Profile Namespace": server-generated
+    //  fields pass through "whenever their enclosing object survives
+    //  projection" — the projector does not decide whether to emit them.
+    // =======================================================================
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Nested_Object_With_Only_Link_After_Filtering : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["nameOfInstitution"] = "Outer School",
+                ["schoolReference"] = new JsonObject
+                {
+                    ["nameOfInstitution"] = "Filtered Out",
+                    ["link"] = new JsonObject { ["rel"] = "School", ["href"] = "/ed-fi/schools/200" },
+                },
+            };
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.ExcludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("nameOfInstitution")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, objects: [schoolReferenceRule]);
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_omits_the_enclosing_reference()
+        {
+            _result["schoolReference"].Should().BeNull();
+        }
+
+        [Test]
+        public void It_still_emits_unrelated_root_content()
+        {
+            _result["nameOfInstitution"]?.GetValue<string>().Should().Be("Outer School");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Collection_Item_With_Only_Link_After_Filtering : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["addresses"] = new JsonArray
+                {
+                    new JsonObject
+                    {
+                        ["addressTypeDescriptor"] = "uri://ed-fi.org/AddressTypeDescriptor#Home",
+                        ["city"] = "Austin",
+                        ["link"] = new JsonObject { ["rel"] = "Address", ["href"] = "/ed-fi/addresses/1" },
+                    },
+                    new JsonObject
+                    {
+                        ["addressTypeDescriptor"] = "uri://ed-fi.org/AddressTypeDescriptor#Mailing",
+                        ["city"] = "Boston",
+                        ["link"] = new JsonObject { ["rel"] = "Address", ["href"] = "/ed-fi/addresses/2" },
+                    },
+                },
+            };
+
+            var addressesRule = new CollectionRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.ExcludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("addressTypeDescriptor"), new PropertyRule("city")],
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: null,
+                ItemFilter: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, collections: [addressesRule]);
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_omits_the_collection_entirely()
+        {
+            _result["addresses"].Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Extension_Object_With_Only_Link_After_Filtering : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["_ext"] = new JsonObject
+                {
+                    ["SampleExt"] = new JsonObject
+                    {
+                        ["customField"] = "filtered-out",
+                        ["link"] = new JsonObject { ["rel"] = "SampleExt", ["href"] = "/ed-fi/sample-ext/1" },
+                    },
+                },
+            };
+
+            var sampleExtRule = new ExtensionRule(
+                Name: "SampleExt",
+                MemberSelection: MemberSelection.ExcludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("customField")],
+                Objects: null,
+                Collections: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, extensions: [sampleExtRule]);
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_omits_the_link_only_extension_object()
+        {
+            var ext = _result["_ext"] as JsonObject;
+            if (ext is not null)
+            {
+                ext["SampleExt"].Should().BeNull();
+            }
+        }
+    }
+
+    // =======================================================================
     //  Null property values in source documents
     // =======================================================================
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ReadableProfileProjectorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ReadableProfileProjectorTests.cs
@@ -1830,6 +1830,195 @@ public class ReadableProfileProjectorTests
     }
 
     // =======================================================================
+    //  Server-generated fields short-circuit per namespace contract
+    // =======================================================================
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Link_On_Reference_Under_IncludeOnly : ReadableProfileProjectorTests
+    {
+        private JsonObject _source = null!;
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["schoolReference"] = new JsonObject
+                {
+                    ["schoolId"] = 200,
+                    ["link"] = new JsonObject { ["rel"] = "School", ["href"] = "/ed-fi/schools/200" },
+                },
+            };
+
+            var schoolReferenceRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("schoolId")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, objects: [schoolReferenceRule]);
+
+            _result = _projector.Project(_source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_preserves_link_subtree_on_filtered_reference()
+        {
+            var reference = (_result["schoolReference"] as JsonObject)!;
+            var link = reference["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("School");
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/schools/200");
+        }
+
+        [Test]
+        public void It_preserves_link_via_deep_clone_not_alias()
+        {
+            var resultLink = (((_result["schoolReference"] as JsonObject)!)["link"] as JsonObject)!;
+            var sourceLink = ((_source["schoolReference"] as JsonObject)!["link"] as JsonObject)!;
+
+            resultLink["href"] = "/mutated";
+
+            sourceLink["href"]!.GetValue<string>().Should().Be("/ed-fi/schools/200");
+        }
+    }
+
+    // Root-scope `_etag` / `_lastModifiedDate` are preserved by the metadata block
+    // at the top of ProjectRoot, not by TryPreserveServerGenerated. Kept as
+    // regression coverage for the metadata-preservation contract.
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Root_Etag_And_LastModifiedDate_Under_IncludeOnly : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["_etag"] = "\"42\"",
+                ["_lastModifiedDate"] = "2026-05-11T00:00:00Z",
+                ["nameOfInstitution"] = "Test School",
+            };
+
+            var contentType = CreateContentType(
+                MemberSelection.IncludeOnly,
+                properties: [new PropertyRule("nameOfInstitution")]
+            );
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_preserves_etag()
+        {
+            _result["_etag"]!.GetValue<string>().Should().Be("\"42\"");
+        }
+
+        [Test]
+        public void It_preserves_last_modified_date()
+        {
+            _result["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-05-11T00:00:00Z");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Root_Link_Under_IncludeOnly : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["link"] = new JsonObject { ["rel"] = "Student", ["href"] = "/ed-fi/students/abc-123" },
+                ["nameOfInstitution"] = "Test School",
+            };
+
+            var contentType = CreateContentType(
+                MemberSelection.IncludeOnly,
+                properties: [new PropertyRule("nameOfInstitution")]
+            );
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_preserves_root_link()
+        {
+            var link = _result["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("Student");
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/students/abc-123");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Illegal_ObjectRule_Named_Link : ReadableProfileProjectorTests
+    {
+        private JsonNode _result = null!;
+
+        // Defensive: the validator would normally reject this profile. The projector
+        // must still bypass rule dispatch for server-generated names and preserve
+        // the link subtree intact.
+        [SetUp]
+        public void SetUp()
+        {
+            var source = new JsonObject
+            {
+                ["id"] = "abc-123",
+                ["schoolId"] = 100,
+                ["link"] = new JsonObject { ["rel"] = "Student", ["href"] = "/ed-fi/students/abc-123" },
+            };
+
+            var illegalLinkRule = new ObjectRule(
+                Name: "link",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("rel")],
+                NestedObjects: null,
+                Collections: null,
+                Extensions: null
+            );
+
+            var contentType = CreateContentType(MemberSelection.IncludeAll, objects: [illegalLinkRule]);
+
+            _result = _projector.Project(source, contentType, IdentityNames("schoolId"));
+        }
+
+        [Test]
+        public void It_preserves_link_rel_via_short_circuit_bypassing_rule_dispatch()
+        {
+            var link = _result["link"] as JsonObject;
+            link.Should().NotBeNull();
+            link!["rel"]!.GetValue<string>().Should().Be("Student");
+        }
+
+        [Test]
+        public void It_preserves_link_href_despite_IncludeOnly_listing_only_rel()
+        {
+            var link = (_result["link"] as JsonObject)!;
+            link["href"]!.GetValue<string>().Should().Be("/ed-fi/students/abc-123");
+        }
+    }
+
+    // =======================================================================
     //  Null property values in source documents
     // =======================================================================
 

--- a/src/dms/core/EdFi.DataManagementService.Core/OpenApi/ProfileOpenApiSpecificationFilter.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/OpenApi/ProfileOpenApiSpecificationFilter.cs
@@ -17,18 +17,6 @@ namespace EdFi.DataManagementService.Core.OpenApi;
 public class ProfileOpenApiSpecificationFilter(ILogger logger)
 {
     /// <summary>
-    /// Server-generated metadata fields that are always included in readable schemas
-    /// and always excluded from writable schemas.
-    /// </summary>
-    private static readonly HashSet<string> _serverGeneratedFields =
-    [
-        "id",
-        "link",
-        "_etag",
-        "_lastModifiedDate",
-    ];
-
-    /// <summary>
     /// Property name suffixes that identify natural key and reference fields.
     /// These are always included in both readable and writable schemas.
     /// </summary>
@@ -1000,7 +988,7 @@ public class ProfileOpenApiSpecificationFilter(ILogger logger)
         foreach ((string propertyName, JsonNode? _) in properties)
         {
             // Writable schemas: Always exclude server-generated fields
-            if (_serverGeneratedFields.Contains(propertyName))
+            if (ServerGeneratedFields.Contains(propertyName))
             {
                 propertiesToRemove.Add(propertyName);
                 continue;
@@ -1092,7 +1080,7 @@ public class ProfileOpenApiSpecificationFilter(ILogger logger)
     /// </summary>
     private static bool IsReadableRequiredProperty(string propertyName)
     {
-        return _serverGeneratedFields.Contains(propertyName)
+        return ServerGeneratedFields.Contains(propertyName)
             || Array.Exists(
                 _identityFieldSuffixes,
                 suffix => propertyName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)
@@ -1106,7 +1094,7 @@ public class ProfileOpenApiSpecificationFilter(ILogger logger)
     private static bool IsWritableIdentityProperty(string propertyName)
     {
         // Natural identity fields (UniqueId) and references are kept in writable
-        // Server-generated fields are excluded elsewhere via _serverGeneratedFields
+        // Server-generated fields are excluded elsewhere via ServerGeneratedFields
         return Array.Exists(
             _identityFieldSuffixes,
             suffix => propertyName.EndsWith(suffix, StringComparison.OrdinalIgnoreCase)

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -657,6 +657,12 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         failures.AddRange(
             properties.SelectMany(property =>
             {
+                var serverGenFailure = CheckServerGeneratedField(property.Name, "Property", context);
+                if (serverGenFailure is not null)
+                {
+                    return new List<ValidationFailure> { serverGenFailure };
+                }
+
                 var memberPath = $"$.{context.PathPrefix}{property.Name}";
                 var propertyFailures = new List<ValidationFailure>();
 
@@ -703,6 +709,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var nestedObj in nestedObjects)
         {
+            var serverGenFailure = CheckServerGeneratedField(nestedObj.Name, "Nested object", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
             if (!schemaProperties.ContainsKey(nestedObj.Name))
             {
                 failures.Add(
@@ -749,6 +762,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var collection in collections)
         {
+            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Nested collection", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
             if (!schemaProperties.ContainsKey(collection.Name))
             {
                 failures.Add(

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -264,6 +264,33 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return failures;
     }
 
+    /// <summary>
+    /// Server-generated field names are outside the profile DSL namespace and cannot
+    /// be referenced by IncludeOnly or ExcludeOnly. Returns a <see cref="ValidationFailure"/>
+    /// with <see cref="ValidationSeverity.Error"/> if the member name is server-generated,
+    /// otherwise null. Severity is always Error, independent of <paramref name="context"/>.
+    /// </summary>
+    private static ValidationFailure? CheckServerGeneratedField(
+        string memberName,
+        string memberKindLabel,
+        ValidationContext context
+    )
+    {
+        if (!ServerGeneratedFields.Contains(memberName))
+        {
+            return null;
+        }
+
+        return new ValidationFailure(
+            ValidationSeverity.Error,
+            context.ProfileName,
+            context.ResourceName,
+            $"{context.PathPrefix}{memberName}",
+            $"{memberKindLabel} '{memberName}' in {context.ContentTypeName} content type "
+                + "is a server-generated field and is not profile-addressable."
+        );
+    }
+
     private static List<ValidationFailure> ValidateContentTypeMembers(
         ContentTypeDefinition contentType,
         JsonObject schemaProperties,
@@ -319,6 +346,12 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         failures.AddRange(
             contentType.Properties.SelectMany(property =>
             {
+                var serverGenFailure = CheckServerGeneratedField(property.Name, "Property", context);
+                if (serverGenFailure is not null)
+                {
+                    return new List<ValidationFailure> { serverGenFailure };
+                }
+
                 var memberPath = $"$.{context.PathPrefix}{property.Name}";
                 var propertyFailures = new List<ValidationFailure>();
 
@@ -354,6 +387,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // Validate objects
         foreach (var obj in contentType.Objects)
         {
+            var serverGenFailure = CheckServerGeneratedField(obj.Name, "Object", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
             if (!schemaProperties.ContainsKey(obj.Name))
             {
                 failures.Add(
@@ -384,6 +424,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // Validate collections
         foreach (var collection in contentType.Collections)
         {
+            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Collection", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
             if (!schemaProperties.ContainsKey(collection.Name))
             {
                 failures.Add(
@@ -430,6 +477,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     )
     {
         var failures = new List<ValidationFailure>();
+
+        var serverGenFailure = CheckServerGeneratedField(extension.Name, "Extension", context);
+        if (serverGenFailure is not null)
+        {
+            failures.Add(serverGenFailure);
+            return failures;
+        }
 
         if (!schemaProperties.ContainsKey("_ext"))
         {

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -371,6 +371,15 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
 
         var childContext = context.WithPathPrefix($"{context.PathPrefix}{collectionRule.Name}[].");
+        if (collectionRule.ItemFilter is not null)
+        {
+            AddIfServerGenerated(
+                collectionRule.ItemFilter.PropertyName,
+                "Collection item filter property",
+                childContext,
+                failures
+            );
+        }
         foreach (var property in collectionRule.Properties ?? [])
         {
             AddIfServerGenerated(property.Name, "Property", childContext, failures);

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -539,13 +539,24 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        // Validate nested objects with member selection
-        foreach (
-            var obj in contentType.Objects.Where(o =>
-                o.MemberSelection != MemberSelection.IncludeAll && schemaProperties.ContainsKey(o.Name)
-            )
-        )
+        // Server-generated names are not profile-addressable regardless of the
+        // parent content type's member selection. Check each top-level rule name
+        // before applying the IncludeAll/schema-key filter that would otherwise
+        // skip the rule silently.
+        foreach (var obj in contentType.Objects)
         {
+            var serverGenFailure = CheckServerGeneratedField(obj.Name, "Object", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
+            if (obj.MemberSelection == MemberSelection.IncludeAll || !schemaProperties.ContainsKey(obj.Name))
+            {
+                continue;
+            }
+
             if (
                 schemaProperties[obj.Name] is JsonObject objSchema
                 && objSchema["properties"] is JsonObject objProperties
@@ -561,13 +572,23 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             }
         }
 
-        // Validate nested collections with member selection
-        foreach (
-            var collection in contentType.Collections.Where(c =>
-                c.MemberSelection != MemberSelection.IncludeAll && schemaProperties.ContainsKey(c.Name)
-            )
-        )
+        foreach (var collection in contentType.Collections)
         {
+            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Collection", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
+            if (
+                collection.MemberSelection == MemberSelection.IncludeAll
+                || !schemaProperties.ContainsKey(collection.Name)
+            )
+            {
+                continue;
+            }
+
             if (
                 schemaProperties[collection.Name] is JsonObject collectionObj
                 && collectionObj["items"] is JsonObject itemsNode
@@ -586,13 +607,20 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             }
         }
 
-        // Validate extensions with member selection
-        foreach (
-            var extension in contentType.Extensions.Where(e =>
-                e.MemberSelection != MemberSelection.IncludeAll
-            )
-        )
+        foreach (var extension in contentType.Extensions)
         {
+            var serverGenFailure = CheckServerGeneratedField(extension.Name, "Extension", context);
+            if (serverGenFailure is not null)
+            {
+                failures.Add(serverGenFailure);
+                continue;
+            }
+
+            if (extension.MemberSelection == MemberSelection.IncludeAll)
+            {
+                continue;
+            }
+
             failures.AddRange(ValidateExtensionRule(extension, schemaProperties, context));
         }
 
@@ -640,6 +668,17 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                     containerName
                 )
             );
+        }
+
+        // Validate extensions declared inside the object. Mirrors
+        // ValidateExtensionRuleMembers' completeness so server-generated names
+        // and existence errors apply on every branch the parser populates.
+        if (objectRule.Extensions is not null)
+        {
+            foreach (var extension in objectRule.Extensions)
+            {
+                failures.AddRange(ValidateExtensionRule(extension, schemaProperties, context));
+            }
         }
 
         return failures;
@@ -843,6 +882,28 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                     containerName
                 )
             );
+        }
+
+        // Validate nested collections in collection items
+        if (collectionRule.NestedCollections is not null)
+        {
+            failures.AddRange(
+                ValidateNestedCollectionRules(
+                    collectionRule.NestedCollections,
+                    itemSchemaProperties,
+                    context,
+                    containerName
+                )
+            );
+        }
+
+        // Validate extensions declared inside collection items
+        if (collectionRule.Extensions is not null)
+        {
+            foreach (var extension in collectionRule.Extensions)
+            {
+                failures.AddRange(ValidateExtensionRule(extension, itemSchemaProperties, context));
+            }
         }
 
         return failures;

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -266,7 +266,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
     /// <summary>
     /// Server-generated field names are outside the profile DSL namespace and cannot
-    /// be referenced by IncludeOnly or ExcludeOnly. Returns a <see cref="ValidationFailure"/>
+    /// be referenced by any MemberSelection mode. Returns a <see cref="ValidationFailure"/>
     /// with <see cref="ValidationSeverity.Error"/> if the member name is server-generated,
     /// otherwise null. Severity is always Error, independent of <paramref name="context"/>.
     /// </summary>
@@ -291,6 +291,146 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         );
     }
 
+    /// <summary>
+    /// Recursive walk over every explicit rule name in a content type, emitting a
+    /// server-generated-field failure for any rule whose name is server-generated.
+    /// Runs ahead of schema/member-selection validation so the rejection contract
+    /// applies regardless of <see cref="MemberSelection"/>, and so siblings deeper
+    /// in the tree are not silently skipped by an IncludeAll ancestor. When a rule
+    /// name is server-generated the walk does not descend into its children: the
+    /// outer name is already invalid, so reporting failures from its bogus subtree
+    /// would be noise. Only server-gen failures are produced here — schema existence
+    /// and identity-path checks remain on their original code paths.
+    /// </summary>
+    private static List<ValidationFailure> CollectServerGeneratedNameFailures(
+        ContentTypeDefinition contentType,
+        ValidationContext context
+    )
+    {
+        var failures = new List<ValidationFailure>();
+
+        foreach (var property in contentType.Properties)
+        {
+            AddIfServerGenerated(property.Name, "Property", context, failures);
+        }
+        foreach (var obj in contentType.Objects)
+        {
+            WalkObjectRuleNames(obj, context, failures);
+        }
+        foreach (var collection in contentType.Collections)
+        {
+            WalkCollectionRuleNames(collection, context, failures);
+        }
+        foreach (var extension in contentType.Extensions)
+        {
+            WalkExtensionRuleNames(extension, context, failures);
+        }
+
+        return failures;
+    }
+
+    private static void WalkObjectRuleNames(
+        ObjectRule objectRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (AddIfServerGenerated(objectRule.Name, "Object", context, failures))
+        {
+            return;
+        }
+
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
+        foreach (var property in objectRule.Properties ?? [])
+        {
+            AddIfServerGenerated(property.Name, "Property", childContext, failures);
+        }
+        foreach (var nested in objectRule.NestedObjects ?? [])
+        {
+            WalkObjectRuleNames(nested, childContext, failures);
+        }
+        foreach (var nestedCollection in objectRule.Collections ?? [])
+        {
+            WalkCollectionRuleNames(nestedCollection, childContext, failures);
+        }
+        foreach (var nestedExtension in objectRule.Extensions ?? [])
+        {
+            WalkExtensionRuleNames(nestedExtension, childContext, failures);
+        }
+    }
+
+    private static void WalkCollectionRuleNames(
+        CollectionRule collectionRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (AddIfServerGenerated(collectionRule.Name, "Collection", context, failures))
+        {
+            return;
+        }
+
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}{collectionRule.Name}[].");
+        foreach (var property in collectionRule.Properties ?? [])
+        {
+            AddIfServerGenerated(property.Name, "Property", childContext, failures);
+        }
+        foreach (var nested in collectionRule.NestedObjects ?? [])
+        {
+            WalkObjectRuleNames(nested, childContext, failures);
+        }
+        foreach (var nestedCollection in collectionRule.NestedCollections ?? [])
+        {
+            WalkCollectionRuleNames(nestedCollection, childContext, failures);
+        }
+        foreach (var nestedExtension in collectionRule.Extensions ?? [])
+        {
+            WalkExtensionRuleNames(nestedExtension, childContext, failures);
+        }
+    }
+
+    private static void WalkExtensionRuleNames(
+        ExtensionRule extensionRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (AddIfServerGenerated(extensionRule.Name, "Extension", context, failures))
+        {
+            return;
+        }
+
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}_ext.{extensionRule.Name}.");
+        foreach (var property in extensionRule.Properties ?? [])
+        {
+            AddIfServerGenerated(property.Name, "Property", childContext, failures);
+        }
+        foreach (var nested in extensionRule.Objects ?? [])
+        {
+            WalkObjectRuleNames(nested, childContext, failures);
+        }
+        foreach (var nestedCollection in extensionRule.Collections ?? [])
+        {
+            WalkCollectionRuleNames(nestedCollection, childContext, failures);
+        }
+    }
+
+    private static bool AddIfServerGenerated(
+        string memberName,
+        string memberKindLabel,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        var failure = CheckServerGeneratedField(memberName, memberKindLabel, context);
+        if (failure is null)
+        {
+            return false;
+        }
+        failures.Add(failure);
+        return true;
+    }
+
     private static List<ValidationFailure> ValidateContentTypeMembers(
         ContentTypeDefinition contentType,
         JsonObject schemaProperties,
@@ -310,25 +450,34 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             resourceSchema
         );
 
-        return contentType.MemberSelection switch
-        {
-            MemberSelection.IncludeOnly => ValidateMembers(
-                contentType,
-                schemaProperties,
-                baseContext.ForMemberSelection(MemberSelection.IncludeOnly)
-            ),
-            MemberSelection.ExcludeOnly => ValidateMembers(
-                contentType,
-                schemaProperties,
-                baseContext.ForMemberSelection(MemberSelection.ExcludeOnly)
-            ),
-            MemberSelection.IncludeAll => ValidateNestedMemberSelection(
-                contentType,
-                schemaProperties,
-                baseContext
-            ),
-            _ => [],
-        };
+        // Reject server-generated rule names everywhere before any schema or
+        // member-selection pruning. Schema validation below skips server-gen
+        // names so the pre-pass is the single source of those failures.
+        var failures = CollectServerGeneratedNameFailures(contentType, baseContext);
+
+        failures.AddRange(
+            contentType.MemberSelection switch
+            {
+                MemberSelection.IncludeOnly => ValidateMembers(
+                    contentType,
+                    schemaProperties,
+                    baseContext.ForMemberSelection(MemberSelection.IncludeOnly)
+                ),
+                MemberSelection.ExcludeOnly => ValidateMembers(
+                    contentType,
+                    schemaProperties,
+                    baseContext.ForMemberSelection(MemberSelection.ExcludeOnly)
+                ),
+                MemberSelection.IncludeAll => ValidateNestedMemberSelection(
+                    contentType,
+                    schemaProperties,
+                    baseContext
+                ),
+                _ => [],
+            }
+        );
+
+        return failures;
     }
 
     /// <summary>
@@ -342,14 +491,15 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        // Validate properties
+        // Validate properties. Server-generated names are emitted by the
+        // pre-pass; skip them here so they do not double-fail or surface a
+        // misleading "does not exist" message.
         failures.AddRange(
             contentType.Properties.SelectMany(property =>
             {
-                var serverGenFailure = CheckServerGeneratedField(property.Name, "Property", context);
-                if (serverGenFailure is not null)
+                if (ServerGeneratedFields.Contains(property.Name))
                 {
-                    return new List<ValidationFailure> { serverGenFailure };
+                    return Enumerable.Empty<ValidationFailure>();
                 }
 
                 var memberPath = $"$.{context.PathPrefix}{property.Name}";
@@ -387,10 +537,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // Validate objects
         foreach (var obj in contentType.Objects)
         {
-            var serverGenFailure = CheckServerGeneratedField(obj.Name, "Object", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(obj.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -424,10 +572,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // Validate collections
         foreach (var collection in contentType.Collections)
         {
-            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Collection", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(collection.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -478,10 +624,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        var serverGenFailure = CheckServerGeneratedField(extension.Name, "Extension", context);
-        if (serverGenFailure is not null)
+        if (ServerGeneratedFields.Contains(extension.Name))
         {
-            failures.Add(serverGenFailure);
             return failures;
         }
 
@@ -518,12 +662,15 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             return failures;
         }
 
+        // Preserve the enclosing context prefix so error paths under a nested
+        // extension (e.g. an Extensions rule inside an Object or Collection)
+        // report as "schoolReference._ext.sample.x" rather than "_ext.sample.x".
         failures.AddRange(
             ValidateExtensionRuleMembers(
                 extension,
                 extensionProperties,
                 context
-                    .WithPathPrefix($"_ext.{extension.Name}.")
+                    .WithPathPrefix($"{context.PathPrefix}_ext.{extension.Name}.")
                     .ForMemberSelection(extension.MemberSelection)
             )
         );
@@ -539,16 +686,16 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        // Server-generated names are not profile-addressable regardless of the
-        // parent content type's member selection. Check each top-level rule name
-        // before applying the IncludeAll/schema-key filter that would otherwise
-        // skip the rule silently.
+        // Server-generated rule names are emitted by the pre-pass in
+        // ValidateContentTypeMembers, so skip them here. Schema and member
+        // selection checks below intentionally do not look at
+        // contentType.Properties: under IncludeAll the projector ignores
+        // explicit child Property rules, so emitting "does not exist" warnings
+        // for them would be a behavior change unrelated to the namespace rule.
         foreach (var obj in contentType.Objects)
         {
-            var serverGenFailure = CheckServerGeneratedField(obj.Name, "Object", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(obj.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -574,10 +721,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var collection in contentType.Collections)
         {
-            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Collection", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(collection.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -609,10 +754,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var extension in contentType.Extensions)
         {
-            var serverGenFailure = CheckServerGeneratedField(extension.Name, "Extension", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(extension.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -696,10 +839,9 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         failures.AddRange(
             properties.SelectMany(property =>
             {
-                var serverGenFailure = CheckServerGeneratedField(property.Name, "Property", context);
-                if (serverGenFailure is not null)
+                if (ServerGeneratedFields.Contains(property.Name))
                 {
-                    return new List<ValidationFailure> { serverGenFailure };
+                    return Enumerable.Empty<ValidationFailure>();
                 }
 
                 var memberPath = $"$.{context.PathPrefix}{property.Name}";
@@ -748,10 +890,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var nestedObj in nestedObjects)
         {
-            var serverGenFailure = CheckServerGeneratedField(nestedObj.Name, "Nested object", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(nestedObj.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 
@@ -801,10 +941,8 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         foreach (var collection in collections)
         {
-            var serverGenFailure = CheckServerGeneratedField(collection.Name, "Nested collection", context);
-            if (serverGenFailure is not null)
+            if (ServerGeneratedFields.Contains(collection.Name))
             {
-                failures.Add(serverGenFailure);
                 continue;
             }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileResponseFilter.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileResponseFilter.cs
@@ -19,6 +19,22 @@ internal class ProfileResponseFilter : IProfileResponseFilter
     private const string IdFieldName = "id";
     private const string ExtensionFieldName = "_ext";
 
+    /// <summary>
+    /// Server-generated field names short-circuit filtering: they pass through
+    /// as deep-cloned subtrees, ahead of any rule dispatch. This is defensive
+    /// against a loosened validator and enforces the profile-namespace boundary.
+    /// </summary>
+    private static bool TryPreserveServerGenerated(JsonObject result, string name, JsonNode? value)
+    {
+        if (!ServerGeneratedFields.Contains(name))
+        {
+            return false;
+        }
+
+        result[name] = value?.DeepClone();
+        return true;
+    }
+
     /// <inheritdoc />
     public JsonNode FilterDocument(
         JsonNode document,
@@ -60,6 +76,11 @@ internal class ProfileResponseFilter : IProfileResponseFilter
             if (propertyName == IdFieldName || identityPropertyNames.Contains(propertyName))
             {
                 result[propertyName] = propertyValue?.DeepClone();
+                continue;
+            }
+
+            if (TryPreserveServerGenerated(result, propertyName, propertyValue))
+            {
                 continue;
             }
 
@@ -132,6 +153,11 @@ internal class ProfileResponseFilter : IProfileResponseFilter
         {
             string propertyName = property.Key;
             JsonNode? propertyValue = property.Value;
+
+            if (TryPreserveServerGenerated(result, propertyName, propertyValue))
+            {
+                continue;
+            }
 
             // Handle extensions within nested object
             if (propertyName == ExtensionFieldName && propertyValue is JsonObject extObject)
@@ -220,6 +246,11 @@ internal class ProfileResponseFilter : IProfileResponseFilter
             {
                 string propertyName = property.Key;
                 JsonNode? propertyValue = property.Value;
+
+                if (TryPreserveServerGenerated(filteredItem, propertyName, propertyValue))
+                {
+                    continue;
+                }
 
                 // Handle extensions within collection item
                 if (propertyName == ExtensionFieldName && propertyValue is JsonObject extObject)
@@ -384,6 +415,11 @@ internal class ProfileResponseFilter : IProfileResponseFilter
         {
             string propertyName = property.Key;
             JsonNode? propertyValue = property.Value;
+
+            if (TryPreserveServerGenerated(result, propertyName, propertyValue))
+            {
+                continue;
+            }
 
             // Handle nested objects with explicit rules
             if (extensionRule.ObjectRulesByName.TryGetValue(propertyName, out ObjectRule? objectRule))

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ReadableProfileProjector.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ReadableProfileProjector.cs
@@ -161,13 +161,14 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
     private static JsonObject ProjectNestedObject(JsonObject source, ObjectRule objectRule)
     {
         var result = new JsonObject();
+        List<KeyValuePair<string, JsonNode?>>? deferredServerGenerated = null;
 
         foreach (var property in source)
         {
             string name = property.Key;
             JsonNode? value = property.Value;
 
-            if (TryPreserveServerGenerated(result, name, value))
+            if (TryStageServerGenerated(ref deferredServerGenerated, name, value))
             {
                 continue;
             }
@@ -222,6 +223,7 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
             }
         }
 
+        AttachDeferredServerGeneratedIfSurvived(result, deferredServerGenerated);
         return result;
     }
 
@@ -266,13 +268,14 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
     private static JsonObject ProjectCollectionItem(JsonObject source, CollectionRule collectionRule)
     {
         var result = new JsonObject();
+        List<KeyValuePair<string, JsonNode?>>? deferredServerGenerated = null;
 
         foreach (var property in source)
         {
             string name = property.Key;
             JsonNode? value = property.Value;
 
-            if (TryPreserveServerGenerated(result, name, value))
+            if (TryStageServerGenerated(ref deferredServerGenerated, name, value))
             {
                 continue;
             }
@@ -332,6 +335,7 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
             }
         }
 
+        AttachDeferredServerGeneratedIfSurvived(result, deferredServerGenerated);
         return result;
     }
 
@@ -389,13 +393,14 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
     private static JsonObject ProjectExtensionObject(JsonObject source, ExtensionRule extensionRule)
     {
         var result = new JsonObject();
+        List<KeyValuePair<string, JsonNode?>>? deferredServerGenerated = null;
 
         foreach (var property in source)
         {
             string name = property.Key;
             JsonNode? value = property.Value;
 
-            if (TryPreserveServerGenerated(result, name, value))
+            if (TryStageServerGenerated(ref deferredServerGenerated, name, value))
             {
                 continue;
             }
@@ -435,6 +440,7 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
             }
         }
 
+        AttachDeferredServerGeneratedIfSurvived(result, deferredServerGenerated);
         return result;
     }
 
@@ -487,9 +493,12 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
     }
 
     /// <summary>
-    /// Server-generated field names short-circuit projection: they pass through
-    /// as deep-cloned subtrees, ahead of any rule dispatch. This is defensive
-    /// against a loosened validator and enforces the profile-namespace boundary.
+    /// Root-only short-circuit: server-generated field names pass through as
+    /// deep-cloned subtrees, ahead of any rule dispatch. The document root always
+    /// survives projection, so attaching server-generated members directly is
+    /// correct. Nested objects, collection items, and extension objects use the
+    /// staged variant below, because their enclosing scope must survive on
+    /// profile-addressable content before server-generated members ride along.
     /// </summary>
     private static bool TryPreserveServerGenerated(JsonObject result, string name, JsonNode? value)
     {
@@ -500,5 +509,47 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
 
         result[name] = value?.DeepClone();
         return true;
+    }
+
+    /// <summary>
+    /// Stages a server-generated field for deferred attachment. Used by every
+    /// projection scope below the root: <see cref="ProjectNestedObject"/>,
+    /// <see cref="ProjectCollectionItem"/>, and <see cref="ProjectExtensionObject"/>.
+    /// The design contract is that server-generated fields pass through
+    /// "whenever their enclosing object survives projection" — that is, when at
+    /// least one profile-addressable member of the enclosing object survives.
+    /// Capturing first and merging at the end (only when other content survived)
+    /// prevents a `link`-only enclosing object from being emitted.
+    /// </summary>
+    private static bool TryStageServerGenerated(
+        ref List<KeyValuePair<string, JsonNode?>>? staged,
+        string name,
+        JsonNode? value
+    )
+    {
+        if (!ServerGeneratedFields.Contains(name))
+        {
+            return false;
+        }
+
+        staged ??= [];
+        staged.Add(new KeyValuePair<string, JsonNode?>(name, value?.DeepClone()));
+        return true;
+    }
+
+    private static void AttachDeferredServerGeneratedIfSurvived(
+        JsonObject result,
+        List<KeyValuePair<string, JsonNode?>>? staged
+    )
+    {
+        if (staged is null || result.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (name, value) in staged)
+        {
+            result[name] = value;
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ReadableProfileProjector.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ReadableProfileProjector.cs
@@ -94,6 +94,13 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
                 continue;
             }
 
+            // Server-generated short-circuit at root only fires for "link"; the other
+            // three server-generated names are handled by the metadata block above.
+            if (TryPreserveServerGenerated(result, name, value))
+            {
+                continue;
+            }
+
             // Extensions
             if (name == ExtensionFieldName && value is JsonObject extObject)
             {
@@ -159,6 +166,11 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
         {
             string name = property.Key;
             JsonNode? value = property.Value;
+
+            if (TryPreserveServerGenerated(result, name, value))
+            {
+                continue;
+            }
 
             // Extensions within nested object
             if (name == ExtensionFieldName && value is JsonObject extObject)
@@ -259,6 +271,11 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
         {
             string name = property.Key;
             JsonNode? value = property.Value;
+
+            if (TryPreserveServerGenerated(result, name, value))
+            {
+                continue;
+            }
 
             // Extensions within collection item
             if (name == ExtensionFieldName && value is JsonObject extObject)
@@ -378,6 +395,11 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
             string name = property.Key;
             JsonNode? value = property.Value;
 
+            if (TryPreserveServerGenerated(result, name, value))
+            {
+                continue;
+            }
+
             // Nested objects with explicit rules
             if (extensionRule.ObjectRulesByName.TryGetValue(name, out ObjectRule? objectRule))
             {
@@ -462,5 +484,21 @@ internal sealed class ReadableProfileProjector : IReadableProfileProjector
             MemberSelection.ExcludeOnly => !propertyNameSet.Contains(name),
             _ => true,
         };
+    }
+
+    /// <summary>
+    /// Server-generated field names short-circuit projection: they pass through
+    /// as deep-cloned subtrees, ahead of any rule dispatch. This is defensive
+    /// against a loosened validator and enforces the profile-namespace boundary.
+    /// </summary>
+    private static bool TryPreserveServerGenerated(JsonObject result, string name, JsonNode? value)
+    {
+        if (!ServerGeneratedFields.Contains(name))
+        {
+            return false;
+        }
+
+        result[name] = value?.DeepClone();
+        return true;
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ServerGeneratedFields.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ServerGeneratedFields.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Frozen;
+
+namespace EdFi.DataManagementService.Core.Profile;
+
+/// <summary>
+/// Canonical, case-sensitive set of server-generated field names that are not
+/// addressable by the profile DSL. Single source of truth consumed by
+/// <see cref="ProfileDataValidator"/>, <see cref="ReadableProfileProjector"/>,
+/// <see cref="ProfileResponseFilter"/>, and the OpenAPI schema filter.
+/// </summary>
+internal static class ServerGeneratedFields
+{
+    public static FrozenSet<string> Names { get; } =
+        FrozenSet.Create(StringComparer.Ordinal, "id", "link", "_etag", "_lastModifiedDate");
+
+    public static bool Contains(string name) => Names.Contains(name);
+}


### PR DESCRIPTION
## Summary

- Enforces the profile-DSL namespace boundary established in `design-docs/profiles.md`: server-generated fields (`id`, `link`, `_etag`, `_lastModifiedDate`) are not profile-addressable.
- New `Profile/ServerGeneratedFields.cs` (FrozenSet, ordinal/case-sensitive) is the single source of truth, consumed by `ProfileOpenApiSpecificationFilter` (refactor only — byte-equivalent), `ProfileDataValidator` (Error-severity rejection rule at every IncludeOnly/ExcludeOnly site, before existence checks), `ReadableProfileProjector`, and `ProfileResponseFilter` (iteration-top `TryPreserveServerGenerated` short-circuit at all four scopes — defensive against a loose validator and ensures `link` survives `IncludeOnly` filtering on references).
- Adds 30 unit tests across validator + both projectors + an integration test through `ProfileFilteringMiddleware` that proves `link` survives on a filtered reference under real middleware. Hand-populated `link` stands in for runtime emission until DMS-1145 lands.

## Test plan

- [x] `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit` — 2352/2352 pass
- [x] `ProfileOpenApiSpecificationFilterTests` regression suite remains green (OpenAPI output unchanged)
- [x] `ProfileDataValidatorTests` covers all 4 server-gen names in IncludeOnly/ExcludeOnly Properties + Objects/Collections/Extensions rule names at root + nested objects/collections/extensions + ordering invariant (server-gen error before "does not exist") + negative control
- [x] `ReadableProfileProjectorTests` covers link on filtered reference, defensive deep-clone, root server-gen preservation, and defensive rule-dispatch bypass (illegal ObjectRule named "link")
- [x] `ProfileResponseFilterTests` mirrors the projector coverage against the legacy filter
- [x] `ProfileFilteringMiddlewareTests` integration: real middleware + real `ProfileResponseFilter`, hand-populated `link` on `schoolReference`, IncludeOnly = [schoolId], asserts both link survival and that an unlisted non-server-generated key is filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)