### PR TITLE
[DMS-1022] API-level integration harness for the DMS HTTP pipeline

### DIFF
--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -305,6 +305,72 @@ jobs:
           list-tests: failed
           use-actions-summary: "true"
 
+  run-dms-api-postgresql-integration-tests:
+    name: Run DMS API PostgreSQL Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+    services:
+      postgres:
+        image: postgres:16.3-alpine
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+    env:
+      ConnectionStrings__DatabaseConnection: "Host=localhost;Port=5432;Username=postgres;Database=edfi_dms_backend_integration;Pooling=true;Minimum Pool Size=10;Maximum Pool Size=50;Application Name=EdFi.DataManagementService;NoResetOnClose=true;"
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Nuget packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore DMS API PostgreSQL Integration Tests
+        run: |
+          dotnet restore ./src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj --verbosity:normal
+
+      - name: Run DMS API PostgreSQL Integration Tests
+        if: success()
+        run: |
+          dotnet test ./src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj `
+            -c ${{ env.CONFIGURATION }} `
+            --no-restore `
+            -v normal `
+            --filter "Category=ApiIntegration&Category=PostgresqlIntegration" `
+            --logger "trx;LogFileName=EdFi.DataManagementService.Tests.Integration.Postgresql.trx" `
+            --logger "console" `
+            --nologo
+
+      - name: Upload DMS API PostgreSQL Integration Test Results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: (success() || failure())
+        with:
+          name: DMS API PostgreSQL Integration Tests
+          path: "**/*.trx"
+          path-replace-backslashes: "true"
+          reporter: dotnet-trx
+          list-tests: failed
+          use-actions-summary: "true"
+
   run-old-postgresql-integration-tests:
     name: Run Old PostgreSQL Integration Tests
     runs-on: ubuntu-latest
@@ -1047,6 +1113,7 @@ jobs:
         run-instance-management-e2e-tests,
         run-backend-mssql-integration-tests,
         run-backend-postgresql-integration-tests,
+        run-dms-api-postgresql-integration-tests,
         run-old-postgresql-integration-tests,
         run-cli-integration-tests,
         validate-resources-spec,

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -242,6 +242,97 @@ jobs:
         if: always()
         run: docker rm -f dms-ci-mssql
 
+  run-dms-api-mssql-integration-tests:
+    name: Run DMS API MSSQL Integration Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Cache Nuget packages
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Start MSSQL Container
+        run: |
+          $mssqlPassword = "Aa1!$([Guid]::NewGuid().ToString('N'))"
+
+          "MSSQL_SA_PASSWORD=$mssqlPassword" >> $env:GITHUB_ENV
+          "ConnectionStrings__MssqlAdmin=Server=localhost,1433;User Id=sa;Password=$mssqlPassword;TrustServerCertificate=true;" >> $env:GITHUB_ENV
+
+          docker run --detach --name dms-ci-api-mssql `
+            --env ACCEPT_EULA=Y `
+            --env MSSQL_SA_PASSWORD=$mssqlPassword `
+            --env MSSQL_PID=Developer `
+            --publish 1433:1433 `
+            mcr.microsoft.com/mssql/server:2022-latest | Out-Null
+
+      - name: Wait for MSSQL
+        run: |
+          $maxAttempts = 30
+
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            docker exec dms-ci-api-mssql /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$env:MSSQL_SA_PASSWORD" -Q "SELECT 1" -C -b
+
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+
+            Start-Sleep -Seconds 5
+          }
+
+          docker logs dms-ci-api-mssql
+          throw "SQL Server did not become ready within the timeout period."
+
+      - name: Restore DMS API MSSQL Integration Tests
+        run: |
+          dotnet restore ./src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj --verbosity:normal
+
+      - name: Run DMS API MSSQL Integration Tests
+        if: success()
+        run: |
+          dotnet test ./src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj `
+            -c ${{ env.CONFIGURATION }} `
+            --no-restore `
+            -v normal `
+            --filter "Category=ApiIntegration&Category=MssqlIntegration" `
+            --logger "trx;LogFileName=EdFi.DataManagementService.Tests.Integration.Mssql.trx" `
+            --logger "console" `
+            --nologo
+
+      - name: Upload DMS API MSSQL Integration Test Results
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
+        if: (success() || failure())
+        with:
+          name: DMS API MSSQL Integration Tests
+          path: "**/*.trx"
+          path-replace-backslashes: "true"
+          reporter: dotnet-trx
+          list-tests: failed
+          use-actions-summary: "true"
+
+      - name: Export MSSQL Logs
+        if: failure()
+        run: docker logs dms-ci-api-mssql
+
+      - name: Teardown MSSQL Container
+        if: always()
+        run: docker rm -f dms-ci-api-mssql
+
   run-backend-postgresql-integration-tests:
     name: Run Backend PostgreSQL Integration Tests
     runs-on: ubuntu-latest
@@ -1114,6 +1205,7 @@ jobs:
         run-backend-mssql-integration-tests,
         run-backend-postgresql-integration-tests,
         run-dms-api-postgresql-integration-tests,
+        run-dms-api-mssql-integration-tests,
         run-old-postgresql-integration-tests,
         run-cli-integration-tests,
         validate-resources-spec,

--- a/docs/RUNNING-LOCALLY.md
+++ b/docs/RUNNING-LOCALLY.md
@@ -55,6 +55,49 @@ Visual Studio. The file name is
 > `appsettings.json` file on EdFi.DataManagementService.Api.Tests.Integration
 > folder.
 
+## API-level integration tests
+
+The `EdFi.DataManagementService.Tests.Integration` project boots the real DMS
+HTTP pipeline against a provisioned PostgreSQL and/or SQL Server database,
+with auth/CMS/profile-catalog/application-context faked. See
+[`src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md`](../src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md)
+for the fixture map, runtime-compatibility materialization details, and the
+recipe for adding a scenario.
+
+### Prerequisites
+
+Start PostgreSQL via the repo docker compose, then set the admin
+connection string:
+
+```powershell
+cd eng/docker-compose
+pwsh ./start-postgresql.ps1
+$env:ConnectionStrings__DatabaseConnection = "host=localhost;port=5435;username=postgres;password=abcdefgh1!;database=edfi_dms_backend_integration;pooling=true;minimum pool size=10;maximum pool size=50;Application Name=EdFi.DataManagementService;NoResetOnClose=true;"
+```
+
+Start SQL Server in a container, then set the admin connection string:
+
+```powershell
+docker run -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD='<password>' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+$env:ConnectionStrings__MssqlAdmin = "Server=localhost,1433;User Id=sa;Password=<password>;TrustServerCertificate=true"
+```
+
+### Run
+
+```powershell
+# All dialects
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration
+
+# PostgreSQL only
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration --filter "Category=PostgresqlIntegration"
+
+# SQL Server only
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration --filter "Category=MssqlIntegration"
+```
+
+Tests whose dialect is unconfigured cleanly `Assert.Ignore`, so partial
+local setups still produce a useful test run.
+
 ## Running Unit Tests and Generate Code Coverage Report
 
 > [!CAUTION]

--- a/reference/design/backend-redesign/epics/13-test-migration/01-backend-integration-tests.md
+++ b/reference/design/backend-redesign/epics/13-test-migration/01-backend-integration-tests.md
@@ -65,3 +65,7 @@ Scope boundaries for implementation and review:
    - execute HTTP requests with and without profile media types and assert responses/persisted state.
 3. Add a test category for integration tests and wire into CI as appropriate.
 4. Add fixtures/assertions covering the shared profile scenario matrix from `02-parity-and-fixtures.md`, including no-profile omitted-scope and `_ext` coverage, semantic-identity-based visible-row matching rather than request ordinal, hidden-data preservation across base and `_ext` scopes plus key-unified/presence/FK/descriptor bindings, visible-vs-hidden non-collection behavior, update-allowed/create-denied pairings including the three-level chain, and unchanged-write guarded no-op behavior.
+
+## Implementation
+
+The harness implementation lives at `src/dms/tests/EdFi.DataManagementService.Tests.Integration/`. See its README for run commands, fixture map, and the runtime-compatibility materialization details.

--- a/reference/design/backend-redesign/epics/13-test-migration/01-backend-integration-tests.md
+++ b/reference/design/backend-redesign/epics/13-test-migration/01-backend-integration-tests.md
@@ -25,6 +25,20 @@ This story runs the shared profile scenario matrix defined in `reference/design/
 
 Fixture names and helper APIs in this story should use the shared scenario names from the matrix verbatim.
 
+## Implementation Clarification
+
+This story owns creating an API-level integration harness. The harness should run the DMS HTTP pipeline against real provisioned PostgreSQL and SQL Server relational databases, while using controlled test doubles for nonessential external concerns such as auth/config-service dependencies where appropriate. This is not intended to be a full docker-stack E2E suite.
+
+The backend/unit/database integration layers remain the exhaustive coverage point for unusual apiSchema/profile shapes and deep merge edge cases. The API-level harness should cover representative no-profile and profiled scenarios through HTTP, using the shared scenario names where applicable, and assert both response JSON/error semantics and enough persisted relational state to prove the public pipeline is correctly wired to the relational backend.
+
+Scope boundaries for implementation and review:
+
+- The primary deliverable is the reusable API-level integration harness plus representative coverage through that harness on both PostgreSQL and SQL Server.
+- Do not require every shared profile matrix variant to be exercised through HTTP. The shared matrix must remain covered across the test strategy, with exhaustive edge-case coverage allowed to stay in backend/unit/database integration tests.
+- Do not require this story to port every existing PostgreSQL-only backend relational-write integration test to SQL Server. Add only the SQL Server coverage needed for the representative API-level scenarios owned by this story.
+- Do not expand this story into a full E2E suite or require real CMS/auth service wiring when controlled test doubles can prove the DMS HTTP-to-relational-backend boundary.
+- Reviewers should evaluate whether the public DMS pipeline is proven for representative no-profile success, profiled success, profiled failure/error semantics, CRUD/query behavior, and persisted relational state, rather than expecting exhaustive HTTP coverage for every rare schema/profile shape.
+
 ## Acceptance Criteria
 
 - Integration tests validate:

--- a/src/dms/EdFi.DataManagementService.sln
+++ b/src/dms/EdFi.DataManagementService.sln
@@ -82,6 +82,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Tests.Unit", "tests\EdFi.DataManagementService.Tests.Unit\EdFi.DataManagementService.Tests.Unit.csproj", "{E72AE3F0-E664-4339-BD96-984AF109B34A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Backend.Tests.Integration.Common", "backend\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj", "{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -476,6 +478,18 @@ Global
 		{E72AE3F0-E664-4339-BD96-984AF109B34A}.Release|x64.Build.0 = Release|Any CPU
 		{E72AE3F0-E664-4339-BD96-984AF109B34A}.Release|x86.ActiveCfg = Release|Any CPU
 		{E72AE3F0-E664-4339-BD96-984AF109B34A}.Release|x86.Build.0 = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|x64.Build.0 = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Debug|x86.Build.0 = Debug|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x64.ActiveCfg = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x64.Build.0 = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x86.ActiveCfg = Release|Any CPU
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -513,6 +527,7 @@ Global
 		{1D27E6BA-7885-4B07-A7FB-04D0E94D4E04} = {2B193382-DF21-4223-888A-CE5CD3B52C25}
 		{36A6B176-FF97-468B-8C91-34B2981ACC63} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 		{E72AE3F0-E664-4339-BD96-984AF109B34A} = {22F7EF40-C77C-4AF0-8C1E-500EA6B85496}
+		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAB3D5DE-BC6C-44FD-831C-9C7BE3935343}

--- a/src/dms/EdFi.DataManagementService.sln
+++ b/src/dms/EdFi.DataManagementService.sln
@@ -84,6 +84,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Backend.Tests.Integration.Common", "backend\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj", "{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EdFi.DataManagementService.Tests.Integration", "tests\EdFi.DataManagementService.Tests.Integration\EdFi.DataManagementService.Tests.Integration.csproj", "{23B5C669-8FBA-49E4-BB29-9A9FAC705264}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -490,6 +492,18 @@ Global
 		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x64.Build.0 = Release|Any CPU
 		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x86.ActiveCfg = Release|Any CPU
 		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE}.Release|x86.Build.0 = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|x64.Build.0 = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Debug|x86.Build.0 = Debug|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|x64.ActiveCfg = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|x64.Build.0 = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|x86.ActiveCfg = Release|Any CPU
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -528,6 +542,7 @@ Global
 		{36A6B176-FF97-468B-8C91-34B2981ACC63} = {75AE8F7B-B980-48AE-8518-073830FA6471}
 		{E72AE3F0-E664-4339-BD96-984AF109B34A} = {22F7EF40-C77C-4AF0-8C1E-500EA6B85496}
 		{E99049FC-E18E-4DE6-9197-AE2851AEBCAE} = {75AE8F7B-B980-48AE-8518-073830FA6471}
+		{23B5C669-8FBA-49E4-BB29-9A9FAC705264} = {22F7EF40-C77C-4AF0-8C1E-500EA6B85496}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CAB3D5DE-BC6C-44FD-831C-9C7BE3935343}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/DatabaseSetupFixture.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/DatabaseSetupFixture.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/EdFi.DataManagementService.Backend.Mssql.Tests.Integration.csproj
@@ -25,6 +25,7 @@
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Mssql\EdFi.DataManagementService.Backend.Mssql.csproj" />
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Plans\EdFi.DataManagementService.Backend.Plans.csproj" />
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
+        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj" />
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core\EdFi.DataManagementService.Core.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/HydrationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/HydrationExecutorTests.cs
@@ -7,6 +7,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionDescriptorProjectionTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCompatibilityGateTestsBase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCompatibilityGateTestsBase.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDatabaseFingerprintReaderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDatabaseFingerprintReaderTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionPipelineTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionPipelineTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorProjectionTests.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadGetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadGetTests.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadTestSupport.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Model;
 using Microsoft.Data.SqlClient;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadTestSupportTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadTestSupportTests.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlEffectiveSchemaHashMismatchTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlEffectiveSchemaHashMismatchTests.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlFingerprintTestDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlFingerprintTestDatabase.cs
@@ -6,6 +6,7 @@
 using System.Text.RegularExpressions;
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using Microsoft.Data.SqlClient;
 
 namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlAuthoritativeSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlAuthoritativeSmokeTests.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using Be.Vlaanderen.Basisregisters.Generators.Guid;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlBaselineDatabaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlBaselineDatabaseTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlFocusedSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlFocusedSmokeTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlHarnessTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlHarnessTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlTestDatabaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlGeneratedDdlTestDatabaseTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlIfMatchCascadeReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlIfMatchCascadeReferentialIdentityTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlJournalingTriggerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlJournalingTriggerTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPreflightHashMismatchNegativeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPreflightHashMismatchNegativeTests.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileCollectionAlignedExtensionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileCollectionAlignedExtensionMergeTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileExecutorRoutingTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileGuardedNoOpTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileGuardedNoOpTests.cs
@@ -21,6 +21,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileNestedCollectionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileNestedCollectionMergeTests.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeFixtureTests.cs
@@ -16,6 +16,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileRootTableOnlyMergeTests.cs
@@ -25,6 +25,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileSeparateTableMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileSeparateTableMergeFixtureTests.cs
@@ -11,6 +11,7 @@
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Profile;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileSeparateTableMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileSeparateTableMergeTests.cs
@@ -16,6 +16,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileTopLevelCollectionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileTopLevelCollectionMergeTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileTopLevelCollectionReferenceBackedMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileTopLevelCollectionReferenceBackedMergeTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTestDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTestDatabase.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using Microsoft.Data.SqlClient;
 
 namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTestDatabaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTestDatabaseTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferenceResolverTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlReferentialIdentityTests.cs
@@ -5,6 +5,7 @@
 
 using System.Globalization;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Microsoft.Data.SqlClient;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteByIdTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteByIdTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeDs52SurveySmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeDs52SurveySmokeTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentArtProgramAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentArtProgramAssociationSmokeTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
@@ -12,6 +12,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Mssql;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration.csproj
@@ -25,6 +25,7 @@
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Plans\EdFi.DataManagementService.Backend.Plans.csproj" />
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Postgresql\EdFi.DataManagementService.Backend.Postgresql.csproj" />
         <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
+        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj" />
         <ProjectReference Include="..\..\core\EdFi.DataManagementService.Core\EdFi.DataManagementService.Core.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCompatibilityGateTestsBase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCompatibilityGateTestsBase.cs
@@ -6,6 +6,7 @@
 using System.Text;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadGetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadGetTests.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Postgresql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Postgresql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadTestSupport.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Model;
 using Npgsql;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadTestSupportTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadTestSupportTests.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
 using Npgsql;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlEffectiveSchemaHashMismatchTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlEffectiveSchemaHashMismatchTests.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlAuthoritativeSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlAuthoritativeSmokeTests.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using Be.Vlaanderen.Basisregisters.Generators.Guid;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NpgsqlTypes;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlBaselineDatabaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlBaselineDatabaseTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlFocusedSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlFocusedSmokeTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NpgsqlTypes;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlHarnessTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlHarnessTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlTestDatabaseTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlGeneratedDdlTestDatabaseTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlIfMatchCascadeReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlIfMatchCascadeReferentialIdentityTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Postgresql;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlJournalingTriggerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlJournalingTriggerTests.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNoProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPreflightHashMismatchNegativeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPreflightHashMismatchNegativeTests.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Backend.Ddl;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using NUnit.Framework;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileAmbiguousStorageCollapsedIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileAmbiguousStorageCollapsedIdentityTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileCollectionAlignedExtensionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileCollectionAlignedExtensionMergeTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileExecutorRoutingTests.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileGuardedNoOpTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileGuardedNoOpTests.cs
@@ -20,6 +20,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
@@ -6,6 +6,7 @@
 using System.Data;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileNestedCollectionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileNestedCollectionMergeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeFixtureTests.cs
@@ -51,6 +51,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileRootTableOnlyMergeTests.cs
@@ -23,6 +23,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileSeparateTableMergeFixtureTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileSeparateTableMergeFixtureTests.cs
@@ -14,6 +14,7 @@
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Profile;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileSeparateTableMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileSeparateTableMergeTests.cs
@@ -38,6 +38,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileTopLevelCollectionMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileTopLevelCollectionMergeTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileTopLevelCollectionReferenceBackedMergeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileTopLevelCollectionReferenceBackedMergeTests.cs
@@ -11,6 +11,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.External.Profile;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlReferentialIdentityTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlReferentialIdentityTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Globalization;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using FluentAssertions;
 using Npgsql;
 using NUnit.Framework;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteByIdTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteByIdTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
@@ -13,6 +13,7 @@ using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Postgresql;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeDs52ContactSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeDs52ContactSmokeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeDs52SchoolSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeDs52SchoolSmokeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSmokeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSchoolAssociationSmokeTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSectionAssociationSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleStudentSectionAssociationSmokeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSurveyQuestionSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteAuthoritativeSampleSurveyQuestionSmokeTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteCollectionReorderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteCollectionReorderTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteCreateBaselineTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteCreateBaselineTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteGuardedNoOpTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteGuardedNoOpTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteMultiBatchCollectionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteMultiBatchCollectionTests.cs
@@ -13,6 +13,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWritePostAsUpdateSmokeTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWritePostAsUpdateSmokeTests.cs
@@ -13,6 +13,7 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteRollbackSafetyTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteRollbackSafetyTests.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteUpdateSemanticsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalWriteUpdateSemanticsTests.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/BaselineDatabaseConfiguration.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/BaselineDatabaseConfiguration.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Configuration;
+
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
+
+/// <summary>
+/// Resolves the relational-test admin connection string for callers that lease
+/// per-test isolated databases from a generated-DDL baseline. Resolution order:
+/// the ConnectionStrings__DatabaseConnection environment variable wins, then the
+/// DatabaseConnection entry of appsettings.json / appsettings.Test.json in the
+/// consumer's working directory, otherwise throws.
+/// </summary>
+public static class BaselineDatabaseConfiguration
+{
+    private const string EnvironmentVariableName = "ConnectionStrings__DatabaseConnection";
+    private const string ConfigurationConnectionStringName = "DatabaseConnection";
+
+    private static IConfiguration? _configuration;
+
+    public static string DatabaseConnectionString =>
+        Environment.GetEnvironmentVariable(EnvironmentVariableName)
+        ?? Config().GetConnectionString(ConfigurationConnectionStringName)
+        ?? throw new InvalidOperationException(
+            $"Connection string '{ConfigurationConnectionStringName}' is not configured. "
+                + $"Set the {EnvironmentVariableName} environment variable, or add a "
+                + "DatabaseConnection entry to appsettings.json / appsettings.Test.json."
+        );
+
+    private static IConfiguration Config()
+    {
+        if (_configuration is not null)
+        {
+            return _configuration;
+        }
+
+        var builder = new ConfigurationBuilder();
+        if (File.Exists("appsettings.json"))
+        {
+            builder.AddJsonFile("appsettings.json");
+        }
+        if (File.Exists("appsettings.Test.json"))
+        {
+            builder.AddJsonFile("appsettings.Test.json");
+        }
+        _configuration = builder.Build();
+        return _configuration;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/BaselineDatabaseConfiguration.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/BaselineDatabaseConfiguration.cs
@@ -18,6 +18,8 @@ public static class BaselineDatabaseConfiguration
 {
     private const string EnvironmentVariableName = "ConnectionStrings__DatabaseConnection";
     private const string ConfigurationConnectionStringName = "DatabaseConnection";
+    private const string MssqlAdminEnvironmentVariableName = "ConnectionStrings__MssqlAdmin";
+    private const string MssqlAdminConfigurationConnectionStringName = "MssqlAdmin";
 
     private static IConfiguration? _configuration;
 
@@ -29,6 +31,15 @@ public static class BaselineDatabaseConfiguration
                 + $"Set the {EnvironmentVariableName} environment variable, or add a "
                 + "DatabaseConnection entry to appsettings.json / appsettings.Test.json."
         );
+
+    /// <summary>
+    /// Optional admin connection string for SQL Server. Returns null when neither the
+    /// ConnectionStrings__MssqlAdmin environment variable nor the MssqlAdmin entry of
+    /// appsettings.json / appsettings.Test.json is set.
+    /// </summary>
+    public static string? MssqlAdminConnectionString =>
+        Environment.GetEnvironmentVariable(MssqlAdminEnvironmentVariableName)
+        ?? Config().GetConnectionString(MssqlAdminConfigurationConnectionStringName);
 
     private static IConfiguration Config()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj
@@ -12,8 +12,4 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
         <PackageReference Include="Npgsql" />
     </ItemGroup>
-    <ItemGroup>
-        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />
-        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
-    </ItemGroup>
 </Project>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Npgsql" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />
+        <ProjectReference Include="..\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlDatabaseResetSql.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlDatabaseResetSql.cs
@@ -3,9 +3,9 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
-internal static class MssqlDatabaseResetSql
+public static class MssqlDatabaseResetSql
 {
     public static string Build(params (string Schema, string Table)[] excludedTables)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlGeneratedDdlBaselineDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlGeneratedDdlBaselineDatabase.cs
@@ -8,9 +8,9 @@ using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Data.SqlClient;
 
-namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
-internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
+public sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
 {
     private const int DefaultCommandTimeoutSeconds = 300;
     private static readonly object _sync = new();
@@ -330,7 +330,7 @@ internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
             ORDER BY [file_id];
             """;
 
-        await using SqlConnection connection = new(Configuration.MssqlAdminConnectionString!);
+        await using SqlConnection connection = new(BaselineDatabaseConfiguration.MssqlAdminConnectionString!);
         await connection.OpenAsync();
         await using SqlCommand command = connection.CreateCommand();
         command.CommandText = sql;
@@ -356,7 +356,7 @@ internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
             );
     }
 
-    internal static string BuildSnapshotPath(
+    public static string BuildSnapshotPath(
         string physicalName,
         string databaseName,
         int fileId,
@@ -384,7 +384,7 @@ internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
 
     private static async Task ExecuteAdminNonQueryAsync(string sql, int commandTimeoutSeconds)
     {
-        await using SqlConnection connection = new(Configuration.MssqlAdminConnectionString!);
+        await using SqlConnection connection = new(BaselineDatabaseConfiguration.MssqlAdminConnectionString!);
         await connection.OpenAsync();
         await using SqlCommand command = connection.CreateCommand();
         command.CommandText = sql;
@@ -482,7 +482,7 @@ internal sealed class MssqlGeneratedDdlBaselineDatabase : IAsyncDisposable
     private sealed record MssqlSnapshotSourceFile(string LogicalName, string SnapshotPath);
 }
 
-internal sealed class MssqlGeneratedDdlBaselineLease : IAsyncDisposable
+public sealed class MssqlGeneratedDdlBaselineLease : IAsyncDisposable
 {
     private readonly Func<ValueTask> _releaseLeaseAsync;
     private bool _disposed;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlGeneratedDdlTestDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlGeneratedDdlTestDatabase.cs
@@ -7,9 +7,9 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Data.SqlClient;
 
-namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
-internal sealed record MssqlForeignKeyMetadata(
+public sealed record MssqlForeignKeyMetadata(
     string ConstraintName,
     string[] Columns,
     string ReferencedSchema,
@@ -19,7 +19,7 @@ internal sealed record MssqlForeignKeyMetadata(
     string UpdateAction
 );
 
-internal sealed partial class MssqlGeneratedDdlTestDatabase : IAsyncDisposable
+public sealed partial class MssqlGeneratedDdlTestDatabase : IAsyncDisposable
 {
     private const int DefaultCommandTimeoutSeconds = 300;
     private static readonly (string Schema, string Table)[] _generatedDdlBaselineTables =

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlTestDatabaseHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/MssqlTestDatabaseHelper.cs
@@ -5,11 +5,11 @@
 
 using Microsoft.Data.SqlClient;
 
-namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
 public static class MssqlTestDatabaseHelper
 {
-    public static bool IsConfigured() => Configuration.MssqlAdminConnectionString is not null;
+    public static bool IsConfigured() => BaselineDatabaseConfiguration.MssqlAdminConnectionString is not null;
 
     public static string GenerateUniqueDatabaseName()
     {
@@ -18,7 +18,7 @@ public static class MssqlTestDatabaseHelper
 
     public static string BuildConnectionString(string databaseName)
     {
-        SqlConnectionStringBuilder builder = new(Configuration.MssqlAdminConnectionString!)
+        SqlConnectionStringBuilder builder = new(BaselineDatabaseConfiguration.MssqlAdminConnectionString!)
         {
             InitialCatalog = databaseName,
         };
@@ -28,7 +28,7 @@ public static class MssqlTestDatabaseHelper
 
     public static void CreateDatabase(string databaseName)
     {
-        using SqlConnection connection = new(Configuration.MssqlAdminConnectionString!);
+        using SqlConnection connection = new(BaselineDatabaseConfiguration.MssqlAdminConnectionString!);
         connection.Open();
 
         using SqlCommand command = connection.CreateCommand();
@@ -41,7 +41,7 @@ public static class MssqlTestDatabaseHelper
     {
         SqlConnection.ClearAllPools();
 
-        using SqlConnection connection = new(Configuration.MssqlAdminConnectionString!);
+        using SqlConnection connection = new(BaselineDatabaseConfiguration.MssqlAdminConnectionString!);
         connection.Open();
 
         using SqlCommand command = connection.CreateCommand();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/PostgresqlGeneratedDdlBaselineDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/PostgresqlGeneratedDdlBaselineDatabase.cs
@@ -6,9 +6,9 @@
 using System.Security.Cryptography;
 using System.Text;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
-internal sealed class PostgresqlGeneratedDdlBaselineDatabase : IAsyncDisposable
+public sealed class PostgresqlGeneratedDdlBaselineDatabase : IAsyncDisposable
 {
     private static readonly object _sync = new();
     private static readonly Dictionary<string, SharedBaselineEntry> _sharedBaselines = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/PostgresqlGeneratedDdlTestDatabase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Integration.Common/PostgresqlGeneratedDdlTestDatabase.cs
@@ -6,9 +6,9 @@
 using System.Globalization;
 using Npgsql;
 
-namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+namespace EdFi.DataManagementService.Backend.Tests.Integration.Common;
 
-internal sealed record PostgresqlForeignKeyMetadata(
+public sealed record PostgresqlForeignKeyMetadata(
     string ConstraintName,
     string[] Columns,
     string ReferencedSchema,
@@ -18,7 +18,7 @@ internal sealed record PostgresqlForeignKeyMetadata(
     string UpdateAction
 );
 
-internal sealed class PostgresqlGeneratedDdlTestDatabase : IAsyncDisposable
+public sealed class PostgresqlGeneratedDdlTestDatabase : IAsyncDisposable
 {
     private const int DefaultCommandTimeoutSeconds = 300;
     private static readonly string[] _generatedDdlBaselineTables =
@@ -463,7 +463,9 @@ internal sealed class PostgresqlGeneratedDdlTestDatabase : IAsyncDisposable
 
     private static string BuildAdminConnectionString()
     {
-        var builder = new NpgsqlConnectionStringBuilder(Configuration.DatabaseConnectionString)
+        var builder = new NpgsqlConnectionStringBuilder(
+            BaselineDatabaseConfiguration.DatabaseConnectionString
+        )
         {
             Database = "postgres",
         };
@@ -473,7 +475,9 @@ internal sealed class PostgresqlGeneratedDdlTestDatabase : IAsyncDisposable
 
     private static string BuildConnectionString(string databaseName)
     {
-        var builder = new NpgsqlConnectionStringBuilder(Configuration.DatabaseConnectionString)
+        var builder = new NpgsqlConnectionStringBuilder(
+            BaselineDatabaseConfiguration.DatabaseConnectionString
+        )
         {
             Database = databaseName,
         };

--- a/src/dms/core/EdFi.DataManagementService.Core/EdFi.DataManagementService.Core.csproj
+++ b/src/dms/core/EdFi.DataManagementService.Core/EdFi.DataManagementService.Core.csproj
@@ -47,6 +47,7 @@
         <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Mssql.Tests.Integration" />
         <InternalsVisibleTo Include="EdFi.DataManagementService.Old.Postgresql.Tests.Integration" />
         <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Tests.Common" />
+        <InternalsVisibleTo Include="EdFi.DataManagementService.Tests.Integration" />
         <!-- For FakeItEasy unit test proxies-->
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Properties/AssemblyInfo.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Properties/AssemblyInfo.cs
@@ -6,3 +6,4 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit")]
+[assembly: InternalsVisibleTo("EdFi.DataManagementService.Tests.Integration")]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationHarness.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using System.Net.Http.Headers;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+namespace EdFi.DataManagementService.Tests.Integration;
+
+/// <summary>
+/// Per-test surface exposed to scenario static methods. Owns the HttpClient
+/// (pre-configured with the smoke bearer token), a DbConnection for post-HTTP
+/// assertions on the leased database, and the FixtureContext describing what
+/// has been provisioned.
+/// </summary>
+public sealed class ApiIntegrationHarness : IAsyncDisposable
+{
+    public ApiIntegrationHarness(HttpClient httpClient, DbConnection dbConnection, FixtureContext fixture)
+    {
+        HttpClient = httpClient;
+        DbConnection = dbConnection;
+        Fixture = fixture;
+
+        HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            ExternalDoublesConstants.SmokeToken
+        );
+    }
+
+    public HttpClient HttpClient { get; }
+    public DbConnection DbConnection { get; }
+    public FixtureContext Fixture { get; }
+
+    public async ValueTask DisposeAsync()
+    {
+        HttpClient.Dispose();
+        await DbConnection.DisposeAsync();
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+
+namespace EdFi.DataManagementService.Tests.Integration;
+
+/// <summary>
+/// Abstract per-test lifecycle for API integration tests. Boots an in-process DMS
+/// host via <see cref="WebApplicationFactory{TEntryPoint}"/> wired to the active
+/// fixture's ApiSchema directory and a per-test leased database. The dialect-specific
+/// hooks (<see cref="LeaseDatabaseAsync"/>, <see cref="OpenAssertionConnectionAsync"/>,
+/// <see cref="ReleaseDatabaseAsync"/>) and the <see cref="Datastore"/> identifier are
+/// supplied by per-dialect derived bases.
+/// </summary>
+[Category("ApiIntegration")]
+public abstract class ApiIntegrationTestBase
+{
+    private WebApplicationFactory<Program>? _factory;
+    private string? _leasedConnectionString;
+    private DbConnection? _assertionConnection;
+    private FixtureContext? _fixtureContext;
+    private string? _startupStatusFilePath;
+
+    protected ApiIntegrationHarness Harness { get; private set; } = null!;
+
+    /// <summary>The fixture this test class is bound to.</summary>
+    protected abstract FixtureKey Fixture { get; }
+
+    /// <summary>
+    /// Datastore identifier consumed by <c>AppSettings:Datastore</c>; supplied by
+    /// the per-dialect base class (for example, <c>"postgresql"</c> or <c>"mssql"</c>).
+    /// </summary>
+    protected abstract string Datastore { get; }
+
+    /// <summary>
+    /// Provisions a fresh per-test database from the dialect's baseline and returns its
+    /// connection string. Implementations must guarantee the returned database is owned
+    /// by this test and will be dropped in <see cref="ReleaseDatabaseAsync"/>.
+    /// </summary>
+    protected abstract Task<string> LeaseDatabaseAsync(FixtureContext fixture);
+
+    /// <summary>Opens a <see cref="DbConnection"/> against the leased database for post-HTTP assertions.</summary>
+    protected abstract Task<DbConnection> OpenAssertionConnectionAsync(string leasedConnectionString);
+
+    /// <summary>Releases (drops) the leased database identified by <paramref name="leasedConnectionString"/>.</summary>
+    protected abstract Task ReleaseDatabaseAsync(string leasedConnectionString);
+
+    [SetUp]
+    public async Task ApiIntegrationSetUp()
+    {
+        _fixtureContext = FixtureContextLoader.Load(Fixture);
+        _leasedConnectionString = await LeaseDatabaseAsync(_fixtureContext);
+        _startupStatusFilePath = Path.Combine(Path.GetTempPath(), $"api-int-startup-{Guid.NewGuid():N}.json");
+
+        var fixtureContext = _fixtureContext;
+        var leasedConnectionString = _leasedConnectionString;
+        var startupStatusFilePath = _startupStatusFilePath;
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (_, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?>
+                        {
+                            ["AppSettings:UseRelationalBackend"] = "true",
+                            ["AppSettings:UseApiSchemaPath"] = "true",
+                            ["AppSettings:ApiSchemaPath"] = fixtureContext.ApiSchemaDirectory,
+                            ["AppSettings:StartupStatusFilePath"] = startupStatusFilePath,
+                            ["AppSettings:Datastore"] = Datastore,
+                            ["AppSettings:QueryHandler"] = "postgresql",
+                            ["AppSettings:DeployDatabaseOnStartup"] = "false",
+                            ["AppSettings:BypassAuthorization"] = "true",
+                            ["ConfigurationServiceSettings:BaseUrl"] = "http://localhost/test-cms",
+                            ["ConfigurationServiceSettings:ClientId"] = "test-cms-client",
+                            ["ConfigurationServiceSettings:ClientSecret"] = "test-cms-secret",
+                            ["ConfigurationServiceSettings:Scope"] = "edfi_admin_api/full_access",
+                        }
+                    );
+                }
+            );
+            builder.ConfigureServices(services =>
+            {
+                ExternalDoublesRegistration.RegisterAll(services, fixtureContext, leasedConnectionString);
+            });
+        });
+
+        _assertionConnection = await OpenAssertionConnectionAsync(_leasedConnectionString);
+        var httpClient = _factory.CreateClient();
+        Harness = new ApiIntegrationHarness(httpClient, _assertionConnection, _fixtureContext);
+    }
+
+    [TearDown]
+    public async Task ApiIntegrationTearDown()
+    {
+        if (Harness is not null)
+        {
+            await Harness.DisposeAsync();
+            Harness = null!;
+        }
+
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+            _factory = null;
+        }
+        _assertionConnection = null;
+
+        if (_leasedConnectionString is not null)
+        {
+            await ReleaseDatabaseAsync(_leasedConnectionString);
+            _leasedConnectionString = null;
+        }
+
+        _fixtureContext = null;
+
+        if (_startupStatusFilePath is not null && File.Exists(_startupStatusFilePath))
+        {
+            try
+            {
+                File.Delete(_startupStatusFilePath);
+            }
+            catch
+            {
+                // Best-effort cleanup; never mask test failures.
+            }
+            _startupStatusFilePath = null;
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -8,7 +8,6 @@ using EdFi.DataManagementService.Tests.Integration.Doubles;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.Configuration;
 
 namespace EdFi.DataManagementService.Tests.Integration;
 
@@ -67,28 +66,24 @@ public abstract class ApiIntegrationTestBase
         _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.UseEnvironment("Test");
-            builder.ConfigureAppConfiguration(
-                (_, configuration) =>
-                {
-                    configuration.AddInMemoryCollection(
-                        new Dictionary<string, string?>
-                        {
-                            ["AppSettings:UseRelationalBackend"] = "true",
-                            ["AppSettings:UseApiSchemaPath"] = "true",
-                            ["AppSettings:ApiSchemaPath"] = fixtureContext.ApiSchemaDirectory,
-                            ["AppSettings:StartupStatusFilePath"] = startupStatusFilePath,
-                            ["AppSettings:Datastore"] = Datastore,
-                            ["AppSettings:QueryHandler"] = "postgresql",
-                            ["AppSettings:DeployDatabaseOnStartup"] = "false",
-                            ["AppSettings:BypassAuthorization"] = "true",
-                            ["ConfigurationServiceSettings:BaseUrl"] = "http://localhost/test-cms",
-                            ["ConfigurationServiceSettings:ClientId"] = "test-cms-client",
-                            ["ConfigurationServiceSettings:ClientSecret"] = "test-cms-secret",
-                            ["ConfigurationServiceSettings:Scope"] = "edfi_admin_api/full_access",
-                        }
-                    );
-                }
-            );
+
+            // UseSetting writes into the host's IConfiguration before AddServices() runs,
+            // so options bound during service registration (e.g. AppSettings:UseRelationalBackend,
+            // AppSettings:Datastore) observe the harness-owned values without relying on
+            // process environment variables or file-based appsettings.
+            builder.UseSetting("AppSettings:UseRelationalBackend", "true");
+            builder.UseSetting("AppSettings:UseApiSchemaPath", "true");
+            builder.UseSetting("AppSettings:ApiSchemaPath", fixtureContext.ApiSchemaDirectory);
+            builder.UseSetting("AppSettings:StartupStatusFilePath", startupStatusFilePath);
+            builder.UseSetting("AppSettings:Datastore", Datastore);
+            builder.UseSetting("AppSettings:QueryHandler", "postgresql");
+            builder.UseSetting("AppSettings:DeployDatabaseOnStartup", "false");
+            builder.UseSetting("AppSettings:BypassAuthorization", "true");
+            builder.UseSetting("ConfigurationServiceSettings:BaseUrl", "http://localhost/test-cms");
+            builder.UseSetting("ConfigurationServiceSettings:ClientId", "test-cms-client");
+            builder.UseSetting("ConfigurationServiceSettings:ClientSecret", "test-cms-secret");
+            builder.UseSetting("ConfigurationServiceSettings:Scope", "edfi_admin_api/full_access");
+
             builder.ConfigureServices(services =>
             {
                 ExternalDoublesRegistration.RegisterAll(services, fixtureContext, leasedConnectionString);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -103,13 +103,20 @@ public abstract class ApiIntegrationTestBase
             await Harness.DisposeAsync();
             Harness = null!;
         }
+        else if (_assertionConnection is not null)
+        {
+            // Host startup failed before the harness was constructed; the assertion
+            // connection is otherwise unreferenced. Dispose it directly so that the
+            // leased database can be dropped without an open session blocking it.
+            await _assertionConnection.DisposeAsync();
+        }
+        _assertionConnection = null;
 
         if (_factory is not null)
         {
             await _factory.DisposeAsync();
             _factory = null;
         }
-        _assertionConnection = null;
 
         if (_leasedConnectionString is not null)
         {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/AllowAllClaimSetProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/AllowAllClaimSetProvider.cs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Security.Model;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Returns a single claim set granting Create/Read/Update/Delete on every resource
+/// listed in the supplied <see cref="FixtureContext"/>, all under the
+/// <c>NoFurtherAuthorizationRequired</c> strategy. Resource claim URIs are built
+/// from the lowercased project and resource names so they line up with how the
+/// resource-action authorization middleware composes claims at request time.
+/// </summary>
+internal sealed class AllowAllClaimSetProvider(FixtureContext fixture) : IClaimSetProvider
+{
+    private static readonly string[] _actions = ["Create", "Read", "Update", "Delete"];
+
+    public Task<IList<ClaimSet>> GetAllClaimSets(string? tenant = null)
+    {
+        var resourceClaims = fixture
+            .Resources.SelectMany(r =>
+                _actions.Select(a => new ResourceClaim(
+                    Name: $"{Conventions.EdFiOdsResourceClaimBaseUri}/{r.ProjectName.ToLowerInvariant()}/{r.ResourceName.ToLowerInvariant()}",
+                    Action: a,
+                    AuthorizationStrategies:
+                    [
+                        new AuthorizationStrategy(
+                            AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired
+                        ),
+                    ]
+                ))
+            )
+            .ToList();
+
+        return Task.FromResult<IList<ClaimSet>>([
+            new ClaimSet(Name: ExternalDoublesConstants.SmokeClaimSetName, ResourceClaims: resourceClaims),
+        ]);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesConstants.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesConstants.cs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Stable identifiers and well-known names shared by the external-doubles wired up for
+/// API integration tests. Values are intentionally fixed so request/response payloads and
+/// log lines remain deterministic across runs.
+/// </summary>
+internal static class ExternalDoublesConstants
+{
+    public const string SmokeToken = "smoke-token";
+    public const string SmokeClientId = "smoke-client";
+    public const string SmokeClaimSetName = "SIS-Vendor";
+    public static readonly Guid StableClientUuid = Guid.Parse("11111111-1111-4111-8111-111111111111");
+    public const long StableApplicationId = 1;
+    public const long StableApplicationContextId = 1;
+    public const long StableDmsInstanceId = 1;
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Profile;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Replaces every DI binding the API integration harness needs to fake (auth/CMS/
+/// application-context/profile-catalog/DMS-instance) and leaves the rest of the
+/// DMS HTTP pipeline real. Called from the test base's WebApplicationFactory
+/// ConfigureServices override.
+/// </summary>
+internal static class ExternalDoublesRegistration
+{
+    public static void RegisterAll(
+        IServiceCollection services,
+        FixtureContext fixture,
+        string leasedConnectionString
+    )
+    {
+        services.RemoveAll<IJwtValidationService>();
+        services.RemoveAll<IClaimSetProvider>();
+        services.RemoveAll<IApplicationContextProvider>();
+        services.RemoveAll<IDmsInstanceProvider>();
+        services.RemoveAll<IProfileCmsProvider>();
+
+        services.AddSingleton<IJwtValidationService>(
+            FakeJwtValidationService.Allowing(
+                ExternalDoublesConstants.SmokeToken,
+                ExternalDoublesConstants.SmokeClientId
+            )
+        );
+        services.AddSingleton<IClaimSetProvider>(new AllowAllClaimSetProvider(fixture));
+        services.AddSingleton<IApplicationContextProvider>(FakeApplicationContextProvider.Stable());
+        services.AddSingleton<IDmsInstanceProvider>(
+            FakeDmsInstanceProvider.WithSingleInstance(
+                id: ExternalDoublesConstants.StableDmsInstanceId,
+                connectionString: leasedConnectionString
+            )
+        );
+        services.AddSingleton<IProfileCmsProvider>(FakeProfileCmsProvider.FromFixture(fixture));
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -31,6 +32,7 @@ internal static class ExternalDoublesRegistration
         services.RemoveAll<IApplicationContextProvider>();
         services.RemoveAll<IDmsInstanceProvider>();
         services.RemoveAll<IProfileCmsProvider>();
+        services.RemoveAll<IStartupProcessExit>();
 
         services.AddSingleton<IJwtValidationService>(
             FakeJwtValidationService.Allowing(
@@ -47,5 +49,6 @@ internal static class ExternalDoublesRegistration
             )
         );
         services.AddSingleton<IProfileCmsProvider>(FakeProfileCmsProvider.FromFixture(fixture));
+        services.AddSingleton<IStartupProcessExit, NonExitingStartupProcessExit>();
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeApplicationContextProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeApplicationContextProvider.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using FakeItEasy;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Builds an <see cref="IApplicationContextProvider"/> stub that returns the same
+/// stable <see cref="ApplicationContext"/> for every lookup, including forced reloads.
+/// The context references the single stable DMS instance id used by the rest of the
+/// external-doubles stack.
+/// </summary>
+internal static class FakeApplicationContextProvider
+{
+    public static IApplicationContextProvider Stable()
+    {
+        var fake = A.Fake<IApplicationContextProvider>();
+        var context = new ApplicationContext(
+            ExternalDoublesConstants.StableApplicationContextId,
+            ExternalDoublesConstants.StableApplicationId,
+            ExternalDoublesConstants.SmokeClientId,
+            ExternalDoublesConstants.StableClientUuid,
+            [ExternalDoublesConstants.StableDmsInstanceId]
+        );
+
+        A.CallTo(() => fake.GetApplicationByClientIdAsync(A<string>._))
+            .Returns(Task.FromResult<ApplicationContext?>(context));
+        A.CallTo(() => fake.ReloadApplicationByClientIdAsync(A<string>._))
+            .Returns(Task.FromResult<ApplicationContext?>(context));
+
+        return fake;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeDmsInstanceProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeDmsInstanceProvider.cs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Builds an <see cref="IDmsInstanceProvider"/> stub that exposes a single in-memory
+/// DMS instance pointing at a test-leased database connection string. The instance has
+/// no route-qualifier context, so it is returned for any tenant the caller asks about.
+/// </summary>
+internal static class FakeDmsInstanceProvider
+{
+    public static IDmsInstanceProvider WithSingleInstance(long id, string connectionString) =>
+        new SingleInstanceProvider(id, connectionString);
+
+    private sealed class SingleInstanceProvider : IDmsInstanceProvider
+    {
+        private const string DefaultTenantKey = "";
+        private readonly DmsInstance _instance;
+        private readonly IReadOnlyList<DmsInstance> _instances;
+
+        public SingleInstanceProvider(long id, string connectionString)
+        {
+            _instance = new DmsInstance(
+                Id: id,
+                InstanceType: "default",
+                InstanceName: "integration-test",
+                ConnectionString: connectionString,
+                RouteContext: new Dictionary<RouteQualifierName, RouteQualifierValue>()
+            );
+            _instances = [_instance];
+        }
+
+        public Task<IList<DmsInstance>> LoadDmsInstances(string? tenant = null) =>
+            Task.FromResult<IList<DmsInstance>>([_instance]);
+
+        public Task RefreshInstancesIfExpiredAsync(string? tenant = null) => Task.CompletedTask;
+
+        public IReadOnlyList<DmsInstance> GetAll(string? tenant = null) => _instances;
+
+        public DmsInstance? GetById(long id, string? tenant = null) => id == _instance.Id ? _instance : null;
+
+        public bool IsLoaded(string? tenant = null) => true;
+
+        public Task<IList<string>> LoadTenants() => Task.FromResult<IList<string>>([DefaultTenantKey]);
+
+        public bool TenantExists(string tenant) => true;
+
+        public IReadOnlyList<string> GetLoadedTenantKeys() => [DefaultTenantKey];
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeJwtValidationService.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeJwtValidationService.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Security.Claims;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Security;
+using FakeItEasy;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Builds a JWT validation service stub that unconditionally returns the same principal
+/// and <see cref="ClientAuthorizations"/> for every token. The returned authorization
+/// references the smoke claim set name and the single stable DMS instance id.
+/// </summary>
+internal static class FakeJwtValidationService
+{
+    public static IJwtValidationService Allowing(string tokenId, string clientId)
+    {
+        var fake = A.Fake<IJwtValidationService>();
+        var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim("client_id", clientId)], "test"));
+        var authorizations = new ClientAuthorizations(
+            tokenId,
+            clientId,
+            ExternalDoublesConstants.SmokeClaimSetName,
+            [],
+            [],
+            [new DmsInstanceId(ExternalDoublesConstants.StableDmsInstanceId)]
+        );
+
+        A.CallTo(() => fake.ValidateAndExtractClientAuthorizationsAsync(A<string>._, A<CancellationToken>._))
+            .Returns(Task.FromResult(((ClaimsPrincipal?)principal, (ClientAuthorizations?)authorizations)));
+
+        return fake;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeProfileCmsProvider.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeProfileCmsProvider.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Profile;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Loads the profile catalog for the active <see cref="FixtureContext"/> from XML files
+/// on disk and serves it as if it had come from the Configuration Management Service.
+/// Profile XML is parsed eagerly through <see cref="ProfileDefinitionParser"/> so that
+/// malformed fixture files surface as a clear load-time failure rather than a confusing
+/// downstream parse error. Application-to-profile assignments are intentionally empty;
+/// scenarios that need an assigned profile wire it in separately.
+/// </summary>
+internal sealed class FakeProfileCmsProvider : IProfileCmsProvider
+{
+    private readonly Lazy<IReadOnlyList<CmsProfileResponse>> _catalog;
+
+    public FakeProfileCmsProvider(FixtureContext fixture)
+    {
+        _catalog = new Lazy<IReadOnlyList<CmsProfileResponse>>(() =>
+            LoadCatalog(fixture.ProfileXmlDirectory)
+        );
+    }
+
+    public static FakeProfileCmsProvider FromFixture(FixtureContext fixture) => new(fixture);
+
+    public Task<ApplicationProfileInfo?> GetApplicationProfileInfoAsync(
+        long applicationId,
+        string? tenantId
+    ) => Task.FromResult<ApplicationProfileInfo?>(null);
+
+    public Task<CmsProfileResponse?> GetProfileAsync(long profileId, string? tenantId)
+    {
+        CmsProfileResponse? match = _catalog.Value.FirstOrDefault(p => p.Id == profileId);
+        return Task.FromResult(match);
+    }
+
+    public Task<IReadOnlyList<CmsProfileResponse>> GetProfilesAsync(string? tenantId) =>
+        Task.FromResult(_catalog.Value);
+
+    private static IReadOnlyList<CmsProfileResponse> LoadCatalog(string profileXmlDirectory)
+    {
+        if (!Directory.Exists(profileXmlDirectory))
+        {
+            return [];
+        }
+
+        string[] files = Directory.GetFiles(profileXmlDirectory, "*.xml");
+        Array.Sort(files, StringComparer.Ordinal);
+
+        var profiles = new List<CmsProfileResponse>(files.Length);
+        long nextId = 1;
+        foreach (string path in files)
+        {
+            string xml = File.ReadAllText(path);
+            ProfileDefinitionParseResult parsed = ProfileDefinitionParser.Parse(xml);
+            if (!parsed.IsSuccess || parsed.Definition is null)
+            {
+                throw new InvalidOperationException(
+                    $"Profile fixture '{path}' failed to parse: {parsed.ErrorMessage}"
+                );
+            }
+
+            profiles.Add(new CmsProfileResponse(nextId, parsed.Definition.ProfileName, xml));
+            nextId++;
+        }
+
+        return profiles;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/NonExitingStartupProcessExit.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/NonExitingStartupProcessExit.cs
@@ -8,14 +8,11 @@ using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
 namespace EdFi.DataManagementService.Tests.Integration.Doubles;
 
 /// <summary>
-/// Replaces <see cref="EnvironmentStartupProcessExit"/> so that fatal startup failures
-/// during a test surface as a rethrown exception caught by NUnit's setup pipeline
+/// Replaces <see cref="EnvironmentStartupProcessExit"/> so that fatal startup
+/// failures surface as a rethrown exception caught by NUnit's setup pipeline
 /// instead of terminating the test host with <see cref="Environment.Exit(int)"/>.
-/// The captured <see cref="LastExitCode"/> is exposed for diagnostic assertions.
 /// </summary>
 internal sealed class NonExitingStartupProcessExit : IStartupProcessExit
 {
-    public int? LastExitCode { get; private set; }
-
-    public void Exit(int exitCode) => LastExitCode = exitCode;
+    public void Exit(int exitCode) { }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/NonExitingStartupProcessExit.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/NonExitingStartupProcessExit.cs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Replaces <see cref="EnvironmentStartupProcessExit"/> so that fatal startup failures
+/// during a test surface as a rethrown exception caught by NUnit's setup pipeline
+/// instead of terminating the test host with <see cref="Environment.Exit(int)"/>.
+/// The captured <see cref="LastExitCode"/> is exposed for diagnostic assertions.
+/// </summary>
+internal sealed class NonExitingStartupProcessExit : IStartupProcessExit
+{
+    public int? LastExitCode { get; private set; }
+
+    public void Exit(int exitCode) => LastExitCode = exitCode;
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="FakeItEasy" />
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.Data.SqlClient" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="NUnit3TestAdapter" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\frontend\EdFi.DataManagementService.Frontend.AspNetCore\EdFi.DataManagementService.Frontend.AspNetCore.csproj" />
+        <ProjectReference Include="..\..\backend\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
+        <ProjectReference Include="..\..\backend\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="appsettings.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
@@ -31,6 +31,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\frontend\EdFi.DataManagementService.Frontend.AspNetCore\EdFi.DataManagementService.Frontend.AspNetCore.csproj" />
         <ProjectReference Include="..\..\backend\EdFi.DataManagementService.Backend.Tests.Common\EdFi.DataManagementService.Backend.Tests.Common.csproj" />
+        <ProjectReference Include="..\..\backend\EdFi.DataManagementService.Backend.Ddl\EdFi.DataManagementService.Backend.Ddl.csproj" />
         <ProjectReference Include="..\..\backend\EdFi.DataManagementService.Backend.Tests.Integration.Common\EdFi.DataManagementService.Backend.Tests.Integration.Common.csproj" />
     </ItemGroup>
     <ItemGroup>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/EdFi.DataManagementService.Tests.Integration.csproj
@@ -41,5 +41,8 @@
         <None Update="appsettings.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
+        <None Include="appsettings.Test.json" Condition="Exists('appsettings.Test.json')">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 </Project>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContext.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContext.cs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Resolved test-time context for a fixture: where its ApiSchema lives on disk,
+/// where its test-owned profile XML catalog lives, and the qualified resource names
+/// the fake claim-set provider must grant CRUD on.
+/// </summary>
+public sealed record FixtureContext(
+    FixtureKey Key,
+    string ApiSchemaDirectory,
+    string ProfileXmlDirectory,
+    IReadOnlyList<QualifiedResourceName> Resources
+);
+
+/// <summary>
+/// A project-qualified resource name used to build resource-claim URIs for the fake
+/// claim-set provider. Project and resource names are matched against ApiSchema
+/// values case-insensitively when forming the claim URI.
+/// </summary>
+public readonly record struct QualifiedResourceName(string ProjectName, string ResourceName);
+
+/// <summary>
+/// Identifies a known integration-test fixture. Each value maps to an on-disk
+/// ApiSchema directory and the resource set the fake claim-set provider exposes.
+/// </summary>
+public enum FixtureKey
+{
+    SmallReferentialIdentity,
+    FocusedStableKeyUpdateSemantics,
+    ProfileRootOnlyMerge,
+    ProfileSeparateTableMerge,
+    ProfileNestedAndRootExtensionChildren,
+    ProfileCollectionAlignedExtension,
+    ProfileCollectionAlignedExtensionHiddenDescendant,
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContext.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContext.cs
@@ -30,7 +30,6 @@ public readonly record struct QualifiedResourceName(string ProjectName, string R
 /// </summary>
 public enum FixtureKey
 {
-    SmallReferentialIdentity,
     FocusedStableKeyUpdateSemantics,
     ProfileRootOnlyMerge,
     ProfileSeparateTableMerge,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Text.Json;
+using EdFi.DataManagementService.Backend.Tests.Common;
+
+namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Resolves a <see cref="FixtureKey"/> to a fully populated <see cref="FixtureContext"/>.
+/// The fixture's source ApiSchema files (named according to each fixture's manifest)
+/// are materialized into a process-cached temp directory whose file names match the
+/// <c>ApiSchema*.json</c> pattern the DMS host scans for when
+/// <c>AppSettings:UseApiSchemaPath</c> is enabled.
+/// </summary>
+internal static class FixtureContextLoader
+{
+    private static readonly ConcurrentDictionary<FixtureKey, Lazy<FixtureContext>> _cache = new();
+
+    public static FixtureContext Load(FixtureKey key) =>
+        _cache
+            .GetOrAdd(
+                key,
+                k => new Lazy<FixtureContext>(
+                    () => BuildContext(k),
+                    LazyThreadSafetyMode.ExecutionAndPublication
+                )
+            )
+            .Value;
+
+    private static FixtureContext BuildContext(FixtureKey key)
+    {
+        string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
+
+        IReadOnlyList<string> apiSchemaFiles = ReadApiSchemaFileList(fixtureDirectory);
+        IReadOnlyList<string> resolvedSourcePaths = ResolveSourcePaths(fixtureDirectory, apiSchemaFiles);
+
+        string apiSchemaDirectory = MaterializeApiSchemaDirectory(key, resolvedSourcePaths);
+
+        IReadOnlyList<QualifiedResourceName> resources = ResourceEnumerator.FromApiSchemaFiles(
+            resolvedSourcePaths
+        );
+
+        string profileXmlDirectory = FixturePathResolver.ResolveRepositoryRelativePath(
+            AppContext.BaseDirectory,
+            $"src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/{key}"
+        );
+
+        return new FixtureContext(key, apiSchemaDirectory, profileXmlDirectory, resources);
+    }
+
+    private static IReadOnlyList<string> ReadApiSchemaFileList(string fixtureDirectory)
+    {
+        string manifestPath = Path.Combine(fixtureDirectory, "fixture.json");
+        if (!File.Exists(manifestPath))
+        {
+            throw new FileNotFoundException($"Fixture manifest not found at '{manifestPath}'.", manifestPath);
+        }
+
+        using FileStream stream = File.OpenRead(manifestPath);
+        using JsonDocument document = JsonDocument.Parse(stream);
+
+        if (
+            !document.RootElement.TryGetProperty("apiSchemaFiles", out JsonElement filesElement)
+            || filesElement.ValueKind != JsonValueKind.Array
+            || filesElement.GetArrayLength() == 0
+        )
+        {
+            throw new InvalidOperationException(
+                $"Fixture manifest '{manifestPath}' must declare at least one apiSchemaFiles entry."
+            );
+        }
+
+        var files = new List<string>(filesElement.GetArrayLength());
+        foreach (JsonElement entry in filesElement.EnumerateArray())
+        {
+            string? relativePath = entry.GetString();
+            if (string.IsNullOrWhiteSpace(relativePath))
+            {
+                throw new InvalidOperationException(
+                    $"Fixture manifest '{manifestPath}' contains an empty apiSchemaFiles entry."
+                );
+            }
+            files.Add(relativePath);
+        }
+
+        return files;
+    }
+
+    private static IReadOnlyList<string> ResolveSourcePaths(
+        string fixtureDirectory,
+        IReadOnlyList<string> apiSchemaFiles
+    )
+    {
+        var resolved = new List<string>(apiSchemaFiles.Count);
+        foreach (string entry in apiSchemaFiles)
+        {
+            resolved.Add(FixturePathResolver.ResolveFixtureInputPath(fixtureDirectory, entry));
+        }
+        return resolved;
+    }
+
+    /// <summary>
+    /// Copies the fixture's ApiSchema source files into a per-fixture temp directory using
+    /// file names that match the host's <c>ApiSchema*.json</c> scan pattern. The directory
+    /// is cached for the lifetime of the test process.
+    /// </summary>
+    private static string MaterializeApiSchemaDirectory(FixtureKey key, IReadOnlyList<string> sourcePaths)
+    {
+        string materializedDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "dms-api-integration-fixtures",
+            key.ToString()
+        );
+
+        if (Directory.Exists(materializedDirectory))
+        {
+            Directory.Delete(materializedDirectory, recursive: true);
+        }
+        Directory.CreateDirectory(materializedDirectory);
+
+        var seenTargetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string sourcePath in sourcePaths)
+        {
+            string targetName = BuildScannableFileName(Path.GetFileName(sourcePath), seenTargetNames);
+            string targetPath = Path.Combine(materializedDirectory, targetName);
+            File.Copy(sourcePath, targetPath, overwrite: true);
+        }
+
+        return materializedDirectory;
+    }
+
+    /// <summary>
+    /// Produces a file name that matches the host's <c>ApiSchema*.json</c> scan pattern,
+    /// preserving the source name when it already conforms and otherwise prefixing it
+    /// with <c>ApiSchema-</c>. Collisions are disambiguated with a numeric suffix.
+    /// </summary>
+    private static string BuildScannableFileName(string sourceFileName, HashSet<string> seen)
+    {
+        string candidate = sourceFileName.StartsWith("ApiSchema", StringComparison.OrdinalIgnoreCase)
+            ? sourceFileName
+            : $"ApiSchema-{Path.GetFileNameWithoutExtension(sourceFileName)}{Path.GetExtension(sourceFileName)}";
+
+        if (seen.Add(candidate))
+        {
+            return candidate;
+        }
+
+        string stem = Path.GetFileNameWithoutExtension(candidate);
+        string extension = Path.GetExtension(candidate);
+        int suffix = 2;
+        while (true)
+        {
+            string disambiguated = $"{stem}-{suffix}{extension}";
+            if (seen.Add(disambiguated))
+            {
+                return disambiguated;
+            }
+            suffix++;
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
@@ -43,8 +43,9 @@ internal static class FixtureContextLoader
     {
         string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
 
-        IReadOnlyList<string> apiSchemaFiles = ReadApiSchemaFileList(fixtureDirectory);
-        IReadOnlyList<string> sourceDialects = ReadDialectsList(fixtureDirectory);
+        (IReadOnlyList<string> apiSchemaFiles, IReadOnlyList<string> sourceDialects) = ReadFixtureManifest(
+            fixtureDirectory
+        );
         IReadOnlyList<string> resolvedSourcePaths = ResolveSourcePaths(fixtureDirectory, apiSchemaFiles);
 
         (string materializedDirectory, IReadOnlyList<string> materializedFilePaths) =
@@ -62,7 +63,9 @@ internal static class FixtureContextLoader
         return new FixtureContext(key, materializedDirectory, profileXmlDirectory, resources);
     }
 
-    private static IReadOnlyList<string> ReadApiSchemaFileList(string fixtureDirectory)
+    private static (IReadOnlyList<string> ApiSchemaFiles, IReadOnlyList<string> Dialects) ReadFixtureManifest(
+        string fixtureDirectory
+    )
     {
         string manifestPath = Path.Combine(fixtureDirectory, "fixture.json");
         if (!File.Exists(manifestPath))
@@ -97,33 +100,24 @@ internal static class FixtureContextLoader
             files.Add(relativePath);
         }
 
-        return files;
-    }
-
-    private static IReadOnlyList<string> ReadDialectsList(string fixtureDirectory)
-    {
-        string manifestPath = Path.Combine(fixtureDirectory, "fixture.json");
-        using FileStream stream = File.OpenRead(manifestPath);
-        using JsonDocument document = JsonDocument.Parse(stream);
-
+        var dialects = new List<string>();
         if (
-            !document.RootElement.TryGetProperty("dialects", out JsonElement dialectsElement)
-            || dialectsElement.ValueKind != JsonValueKind.Array
+            document.RootElement.TryGetProperty("dialects", out JsonElement dialectsElement)
+            && dialectsElement.ValueKind == JsonValueKind.Array
         )
         {
-            return [];
-        }
-
-        var dialects = new List<string>(dialectsElement.GetArrayLength());
-        foreach (JsonElement entry in dialectsElement.EnumerateArray())
-        {
-            string? dialect = entry.GetString();
-            if (!string.IsNullOrWhiteSpace(dialect))
+            dialects.Capacity = dialectsElement.GetArrayLength();
+            foreach (JsonElement entry in dialectsElement.EnumerateArray())
             {
-                dialects.Add(dialect);
+                string? dialect = entry.GetString();
+                if (!string.IsNullOrWhiteSpace(dialect))
+                {
+                    dialects.Add(dialect);
+                }
             }
         }
-        return dialects;
+
+        return (files, dialects);
     }
 
     private static IReadOnlyList<string> ResolveSourcePaths(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureContextLoader.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Concurrent;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.Tests.Common;
 
 namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
@@ -14,11 +15,18 @@ namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
 /// The fixture's source ApiSchema files (named according to each fixture's manifest)
 /// are materialized into a process-cached temp directory whose file names match the
 /// <c>ApiSchema*.json</c> pattern the DMS host scans for when
-/// <c>AppSettings:UseApiSchemaPath</c> is enabled.
+/// <c>AppSettings:UseApiSchemaPath</c> is enabled. The materialized files are
+/// augmented with neutral defaults for fields the DMS HTTP middleware expects on
+/// every <c>ResourceSchema</c>/<c>projectSchema</c> but which the DDL-only fixtures
+/// omit. Both the DMS host and the per-dialect baseline cache consume this same
+/// materialized directory so the effective schema seen by the host matches the
+/// schema the DDL pipeline runs against.
 /// </summary>
 internal static class FixtureContextLoader
 {
     private static readonly ConcurrentDictionary<FixtureKey, Lazy<FixtureContext>> _cache = new();
+
+    private static readonly JsonSerializerOptions _writeOptions = new() { WriteIndented = true };
 
     public static FixtureContext Load(FixtureKey key) =>
         _cache
@@ -36,12 +44,14 @@ internal static class FixtureContextLoader
         string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
 
         IReadOnlyList<string> apiSchemaFiles = ReadApiSchemaFileList(fixtureDirectory);
+        IReadOnlyList<string> sourceDialects = ReadDialectsList(fixtureDirectory);
         IReadOnlyList<string> resolvedSourcePaths = ResolveSourcePaths(fixtureDirectory, apiSchemaFiles);
 
-        string apiSchemaDirectory = MaterializeApiSchemaDirectory(key, resolvedSourcePaths);
+        (string materializedDirectory, IReadOnlyList<string> materializedFilePaths) =
+            MaterializeApiSchemaDirectory(key, resolvedSourcePaths, sourceDialects);
 
         IReadOnlyList<QualifiedResourceName> resources = ResourceEnumerator.FromApiSchemaFiles(
-            resolvedSourcePaths
+            materializedFilePaths
         );
 
         string profileXmlDirectory = FixturePathResolver.ResolveRepositoryRelativePath(
@@ -49,7 +59,7 @@ internal static class FixtureContextLoader
             $"src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/{key}"
         );
 
-        return new FixtureContext(key, apiSchemaDirectory, profileXmlDirectory, resources);
+        return new FixtureContext(key, materializedDirectory, profileXmlDirectory, resources);
     }
 
     private static IReadOnlyList<string> ReadApiSchemaFileList(string fixtureDirectory)
@@ -90,6 +100,32 @@ internal static class FixtureContextLoader
         return files;
     }
 
+    private static IReadOnlyList<string> ReadDialectsList(string fixtureDirectory)
+    {
+        string manifestPath = Path.Combine(fixtureDirectory, "fixture.json");
+        using FileStream stream = File.OpenRead(manifestPath);
+        using JsonDocument document = JsonDocument.Parse(stream);
+
+        if (
+            !document.RootElement.TryGetProperty("dialects", out JsonElement dialectsElement)
+            || dialectsElement.ValueKind != JsonValueKind.Array
+        )
+        {
+            return [];
+        }
+
+        var dialects = new List<string>(dialectsElement.GetArrayLength());
+        foreach (JsonElement entry in dialectsElement.EnumerateArray())
+        {
+            string? dialect = entry.GetString();
+            if (!string.IsNullOrWhiteSpace(dialect))
+            {
+                dialects.Add(dialect);
+            }
+        }
+        return dialects;
+    }
+
     private static IReadOnlyList<string> ResolveSourcePaths(
         string fixtureDirectory,
         IReadOnlyList<string> apiSchemaFiles
@@ -104,11 +140,21 @@ internal static class FixtureContextLoader
     }
 
     /// <summary>
-    /// Copies the fixture's ApiSchema source files into a per-fixture temp directory using
-    /// file names that match the host's <c>ApiSchema*.json</c> scan pattern. The directory
-    /// is cached for the lifetime of the test process.
+    /// Reads each source ApiSchema file, augments it with neutral defaults for
+    /// runtime-required fields the DDL-only fixtures omit, and writes the
+    /// augmented document under <c>%TEMP%/dms-api-integration-fixtures/&lt;key&gt;/inputs</c>.
+    /// A generated <c>fixture.json</c> manifest sits alongside the inputs so the
+    /// per-dialect baseline cache can discover the augmented files using the same
+    /// <c>EffectiveSchemaFixtureLoader</c> contract as the on-disk DDL fixtures.
     /// </summary>
-    private static string MaterializeApiSchemaDirectory(FixtureKey key, IReadOnlyList<string> sourcePaths)
+    private static (
+        string MaterializedDirectory,
+        IReadOnlyList<string> MaterializedFilePaths
+    ) MaterializeApiSchemaDirectory(
+        FixtureKey key,
+        IReadOnlyList<string> sourcePaths,
+        IReadOnlyList<string> dialects
+    )
     {
         string materializedDirectory = Path.Combine(
             Path.GetTempPath(),
@@ -122,15 +168,127 @@ internal static class FixtureContextLoader
         }
         Directory.CreateDirectory(materializedDirectory);
 
+        string inputsDirectory = Path.Combine(materializedDirectory, "inputs");
+        Directory.CreateDirectory(inputsDirectory);
+
         var seenTargetNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var manifestEntries = new List<string>(sourcePaths.Count);
+        var materializedFilePaths = new List<string>(sourcePaths.Count);
+
         foreach (string sourcePath in sourcePaths)
         {
             string targetName = BuildScannableFileName(Path.GetFileName(sourcePath), seenTargetNames);
-            string targetPath = Path.Combine(materializedDirectory, targetName);
-            File.Copy(sourcePath, targetPath, overwrite: true);
+            string targetPath = Path.Combine(inputsDirectory, targetName);
+
+            string sourceJson = File.ReadAllText(sourcePath);
+            JsonNode root =
+                JsonNode.Parse(sourceJson)
+                ?? throw new InvalidOperationException(
+                    $"ApiSchema file '{sourcePath}' parsed to a null JSON document."
+                );
+
+            if (root is JsonObject rootObject)
+            {
+                AugmentForRuntime(rootObject);
+            }
+
+            File.WriteAllText(targetPath, root.ToJsonString(_writeOptions));
+            manifestEntries.Add(targetName);
+            materializedFilePaths.Add(targetPath);
         }
 
-        return materializedDirectory;
+        WriteManifest(materializedDirectory, manifestEntries, dialects);
+
+        return (materializedDirectory, materializedFilePaths);
+    }
+
+    /// <summary>
+    /// Inserts neutral defaults onto the root ApiSchema document for fields the
+    /// DMS runtime expects but the DDL-only fixtures omit. Pre-existing values
+    /// are preserved as-is so fixtures that deliberately declare these fields are
+    /// not silently overwritten.
+    /// </summary>
+    private static void AugmentForRuntime(JsonObject root)
+    {
+        if (root["projectSchema"] is not JsonObject projectSchema)
+        {
+            return;
+        }
+
+        AugmentProjectSchemaDefaults(projectSchema);
+
+        if (projectSchema["resourceSchemas"] is JsonObject resourceSchemas)
+        {
+            foreach (KeyValuePair<string, JsonNode?> entry in resourceSchemas)
+            {
+                if (entry.Value is JsonObject resourceSchema)
+                {
+                    AugmentResourceSchemaDefaults(resourceSchema);
+                }
+            }
+        }
+    }
+
+    private static void AugmentProjectSchemaDefaults(JsonObject projectSchema)
+    {
+        AddIfMissing(projectSchema, "resourceNameMapping", () => new JsonObject());
+        AddIfMissing(projectSchema, "caseInsensitiveEndpointNameMapping", () => new JsonObject());
+        AddIfMissing(projectSchema, "educationOrganizationHierarchy", () => new JsonObject());
+        AddIfMissing(projectSchema, "educationOrganizationTypes", () => new JsonArray());
+        AddIfMissing(projectSchema, "domains", () => new JsonArray());
+        AddIfMissing(projectSchema, "description", () => JsonValue.Create(string.Empty));
+    }
+
+    private static void AugmentResourceSchemaDefaults(JsonObject resourceSchema)
+    {
+        AddIfMissing(resourceSchema, "booleanJsonPaths", () => new JsonArray());
+        AddIfMissing(resourceSchema, "numericJsonPaths", () => new JsonArray());
+        AddIfMissing(resourceSchema, "dateJsonPaths", () => new JsonArray());
+        AddIfMissing(resourceSchema, "dateTimeJsonPaths", () => new JsonArray());
+        AddIfMissing(resourceSchema, "authorizationPathways", () => new JsonArray());
+        AddIfMissing(resourceSchema, "decimalPropertyValidationInfos", () => new JsonArray());
+        AddIfMissing(resourceSchema, "queryFieldMapping", () => new JsonObject());
+        AddIfMissing(
+            resourceSchema,
+            "securableElements",
+            () =>
+                new JsonObject
+                {
+                    ["Namespace"] = new JsonArray(),
+                    ["EducationOrganization"] = new JsonArray(),
+                    ["Student"] = new JsonArray(),
+                    ["Contact"] = new JsonArray(),
+                    ["Staff"] = new JsonArray(),
+                }
+        );
+    }
+
+    private static void AddIfMissing(JsonObject target, string propertyName, Func<JsonNode> defaultFactory)
+    {
+        if (!target.ContainsKey(propertyName))
+        {
+            target[propertyName] = defaultFactory();
+        }
+    }
+
+    private static void WriteManifest(
+        string materializedDirectory,
+        IReadOnlyList<string> apiSchemaFileNames,
+        IReadOnlyList<string> dialects
+    )
+    {
+        var manifest = new JsonObject
+        {
+            ["apiSchemaFiles"] = new JsonArray([
+                .. apiSchemaFileNames.Select(name => (JsonNode)JsonValue.Create(name)),
+            ]),
+            ["dialects"] = new JsonArray([.. dialects.Select(d => (JsonNode)JsonValue.Create(d))]),
+        };
+
+        File.WriteAllText(
+            Path.Combine(materializedDirectory, "fixture.json"),
+            manifest.ToJsonString(_writeOptions)
+        );
     }
 
     /// <summary>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureRepositoryPaths.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureRepositoryPaths.cs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Tests.Common;
+
+namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Resolves the on-disk repository directory that owns each fixture's source
+/// ApiSchema files and its <c>fixture.json</c> manifest. The per-dialect baseline
+/// caches use this directory to feed the same DDL-generation pipeline the
+/// existing backend integration tests rely on
+/// (<see cref="EffectiveSchemaFixtureLoader"/> +
+/// <see cref="EdFi.DataManagementService.Backend.Ddl.DdlPipelineHelpers"/>).
+/// </summary>
+internal static class FixtureRepositoryPaths
+{
+    private static readonly IReadOnlyDictionary<FixtureKey, string> _repoRelativePaths = new Dictionary<
+        FixtureKey,
+        string
+    >
+    {
+        [FixtureKey.SmallReferentialIdentity] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity",
+        [FixtureKey.FocusedStableKeyUpdateSemantics] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-update-semantics",
+        [FixtureKey.ProfileRootOnlyMerge] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge",
+        [FixtureKey.ProfileSeparateTableMerge] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-separate-table-merge",
+        [FixtureKey.ProfileNestedAndRootExtensionChildren] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children",
+        [FixtureKey.ProfileCollectionAlignedExtension] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension",
+        [FixtureKey.ProfileCollectionAlignedExtensionHiddenDescendant] =
+            "src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant",
+    };
+
+    /// <summary>
+    /// Resolves the absolute repository-relative directory for a fixture key.
+    /// </summary>
+    public static string ResolveFixtureDirectory(FixtureKey key)
+    {
+        if (!_repoRelativePaths.TryGetValue(key, out string? relativePath))
+        {
+            throw new InvalidOperationException($"No repository path mapping for FixtureKey '{key}'.");
+        }
+
+        return FixturePathResolver.ResolveRepositoryRelativePath(AppContext.BaseDirectory, relativePath);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureRepositoryPaths.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/FixtureRepositoryPaths.cs
@@ -22,8 +22,6 @@ internal static class FixtureRepositoryPaths
         string
     >
     {
-        [FixtureKey.SmallReferentialIdentity] =
-            "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity",
         [FixtureKey.FocusedStableKeyUpdateSemantics] =
             "src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-update-semantics",
         [FixtureKey.ProfileRootOnlyMerge] =

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/ProfileRootOnlyMerge/profilerootonlymergeitem-readonly.xml
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/ProfileRootOnlyMerge/profilerootonlymergeitem-readonly.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Read-only companion profile used to exercise the "method not allowed with
+    profile" branch: the profile is valid and resolves, but its resource has
+    no WriteContentType, so a write that names this profile's writable content
+    type must be rejected with 405.
+-->
+<Profile name="ProfileRootOnlyMergeItem-ReadOnly">
+    <Resource name="ProfileRootOnlyMergeItem">
+        <ReadContentType memberSelection="IncludeOnly">
+            <Property name="profileRootOnlyMergeItemId" />
+            <Property name="displayName" />
+        </ReadContentType>
+    </Resource>
+</Profile>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/ProfileRootOnlyMerge/profilerootonlymergeitem-visible.xml
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/Profiles/ProfileRootOnlyMerge/profilerootonlymergeitem-visible.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Profile XML for ProfileRootOnlyMergeProfileScenario. Root content type is
+    IncludeAll so the strict request shaper does not reject server-supplied
+    metadata (notably the `id` field that ValidateMatchingDocumentUuids
+    requires on PUT bodies). The nested profileScope object is IncludeOnly so
+    clearableText remains visible while preservedText is hidden from both the
+    readable projection and the writable shape — scenarios use that to prove
+    the relational "hidden" column survives a profiled write that never names
+    it.
+-->
+<Profile name="ProfileRootOnlyMergeItem-Visible">
+    <Resource name="ProfileRootOnlyMergeItem">
+        <ReadContentType memberSelection="IncludeAll">
+            <Object name="profileScope" memberSelection="IncludeOnly">
+                <Property name="clearableText" />
+            </Object>
+        </ReadContentType>
+        <WriteContentType memberSelection="IncludeAll">
+            <Object name="profileScope" memberSelection="IncludeOnly">
+                <Property name="clearableText" />
+            </Object>
+        </WriteContentType>
+    </Resource>
+</Profile>

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/ResourceEnumerator.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Fixtures/ResourceEnumerator.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+
+namespace EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+/// <summary>
+/// Walks each ApiSchema file's <c>projectSchema.resourceSchemas</c> and returns
+/// distinct <c>(projectName, resourceName)</c> pairs. Consumed by the fake
+/// claim-set provider so it can grant CRUD on every resource the fixture exposes.
+/// </summary>
+internal static class ResourceEnumerator
+{
+    public static IReadOnlyList<QualifiedResourceName> FromApiSchemaFiles(
+        IReadOnlyList<string> apiSchemaFilePaths
+    )
+    {
+        var seen = new HashSet<QualifiedResourceName>();
+        var resources = new List<QualifiedResourceName>();
+
+        foreach (string filePath in apiSchemaFilePaths)
+        {
+            string json = File.ReadAllText(filePath);
+            JsonNode root =
+                JsonNode.Parse(json)
+                ?? throw new InvalidOperationException(
+                    $"ApiSchema file '{filePath}' parsed to a null JSON document."
+                );
+
+            JsonObject projectSchema =
+                root["projectSchema"]?.AsObject()
+                ?? throw new InvalidOperationException(
+                    $"ApiSchema file '{filePath}' is missing 'projectSchema'."
+                );
+
+            string projectName =
+                projectSchema["projectName"]?.GetValue<string>()
+                ?? throw new InvalidOperationException(
+                    $"ApiSchema file '{filePath}' is missing 'projectSchema.projectName'."
+                );
+
+            JsonObject? resourceSchemas = projectSchema["resourceSchemas"]?.AsObject();
+            if (resourceSchemas is null)
+            {
+                continue;
+            }
+
+            foreach (KeyValuePair<string, JsonNode?> entry in resourceSchemas)
+            {
+                JsonObject? resourceSchema = entry.Value?.AsObject();
+                if (resourceSchema is null)
+                {
+                    continue;
+                }
+
+                string? resourceName = resourceSchema["resourceName"]?.GetValue<string>();
+                if (string.IsNullOrWhiteSpace(resourceName))
+                {
+                    continue;
+                }
+
+                var qualified = new QualifiedResourceName(projectName, resourceName);
+                if (seen.Add(qualified))
+                {
+                    resources.Add(qualified);
+                }
+            }
+        }
+
+        return resources;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/HarnessAssemblyTeardown.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/HarnessAssemblyTeardown.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+
+namespace EdFi.DataManagementService.Tests.Integration;
+
+/// <summary>
+/// Assembly-level NUnit setup fixture that disposes every cached per-fixture
+/// baseline database after all tests in this assembly finish. The baselines are
+/// retained in process-static dictionaries during the run so they can be reused
+/// across tests; without this teardown the underlying template databases,
+/// snapshots, and idle slot pools would persist past the test host. CI
+/// containers mask this, but local repeated runs accumulate resources.
+/// </summary>
+[SetUpFixture]
+public sealed class HarnessAssemblyTeardown
+{
+    [OneTimeTearDown]
+    public async Task DisposeBaselinesAsync()
+    {
+        await PostgresqlBaselineCache.DisposeAllAsync();
+        await MssqlBaselineCache.DisposeAllAsync();
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/HttpResponseEtagExtensions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/HttpResponseEtagExtensions.cs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Tests.Integration;
+
+internal static class HttpResponseEtagExtensions
+{
+    /// <summary>
+    /// Reads the raw ETag header. <see cref="System.Net.Http.Headers.HttpResponseHeaders.ETag"/>
+    /// requires the strict RFC 7232 quoted form, but DMS emits an opaque
+    /// unquoted value (the API metadata fingerprint), so the strongly typed
+    /// property returns null. Routing through <c>TryGetValues</c> preserves
+    /// whatever DMS actually sent.
+    /// </summary>
+    public static bool TryReadRawEtag(this HttpResponseMessage response, out string etag)
+    {
+        if (response.Headers.TryGetValues("ETag", out IEnumerable<string>? values))
+        {
+            string? first = values.FirstOrDefault();
+            if (!string.IsNullOrEmpty(first))
+            {
+                etag = first;
+                return true;
+            }
+        }
+        etag = string.Empty;
+        return false;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlApiIntegrationTestBase.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.DataManagementService.Tests.Integration.Mssql;
+
+/// <summary>
+/// SQL Server-flavored concrete <see cref="ApiIntegrationTestBase"/>. Acquires a
+/// snapshot-restored per-test database lease from the cached
+/// <see cref="MssqlGeneratedDdlBaselineDatabase"/> for the bound fixture and hands
+/// its connection string to the harness.
+/// </summary>
+[Category("MssqlIntegration")]
+public abstract class MssqlApiIntegrationTestBase : ApiIntegrationTestBase
+{
+    private MssqlGeneratedDdlBaselineLease? _lease;
+
+    protected override string Datastore => "mssql";
+
+    [OneTimeSetUp]
+    public void GuardConnectionStringPresent()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "MssqlAdmin is not configured (set ConnectionStrings__MssqlAdmin or add it to appsettings.Test.json); skipping SQL Server API integration tests."
+            );
+        }
+    }
+
+    protected override async Task<string> LeaseDatabaseAsync(FixtureContext fixture)
+    {
+        MssqlGeneratedDdlBaselineDatabase baseline = await MssqlBaselineCache.CreateOrGetAsync(fixture);
+        _lease = await baseline.AcquireRestoredDatabaseAsync();
+        return _lease.Database.ConnectionString;
+    }
+
+    protected override async Task<DbConnection> OpenAssertionConnectionAsync(string leasedConnectionString)
+    {
+        SqlConnection connection = new(leasedConnectionString);
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    protected override async Task ReleaseDatabaseAsync(string leasedConnectionString)
+    {
+        if (_lease is not null)
+        {
+            await _lease.DisposeAsync();
+            _lease = null;
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
@@ -31,6 +31,8 @@ internal static class MssqlBaselineCache
     /// Returns the cached baseline database for the supplied fixture, building it on
     /// first access. The fixture signature handed to the baseline is the
     /// <see cref="FixtureKey"/> value so distinct fixtures get distinct snapshots.
+    /// The DDL is generated from the same materialized ApiSchema directory the DMS
+    /// host scans for so the effective schema hash matches at request time.
     /// </summary>
     public static async Task<MssqlGeneratedDdlBaselineDatabase> CreateOrGetAsync(FixtureContext fixture)
     {
@@ -38,7 +40,7 @@ internal static class MssqlBaselineCache
 
         Lazy<Task<MssqlGeneratedDdlBaselineDatabase>> lazy = _cache.GetOrAdd(
             fixture.Key,
-            key => new(() => BuildBaselineAsync(key), LazyThreadSafetyMode.ExecutionAndPublication)
+            _ => new(() => BuildBaselineAsync(fixture), LazyThreadSafetyMode.ExecutionAndPublication)
         );
 
         try
@@ -52,11 +54,10 @@ internal static class MssqlBaselineCache
         }
     }
 
-    private static async Task<MssqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(FixtureKey key)
+    private static async Task<MssqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(FixtureContext fixture)
     {
-        string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
         EffectiveSchemaSet effectiveSchemaSet = EffectiveSchemaFixtureLoader.LoadFromFixtureDirectory(
-            fixtureDirectory
+            fixture.ApiSchemaDirectory
         );
         (_, string generatedDdl) = DdlPipelineHelpers.BuildDdlForDialect(
             effectiveSchemaSet,
@@ -64,6 +65,6 @@ internal static class MssqlBaselineCache
             strict: true
         );
 
-        return await MssqlGeneratedDdlBaselineDatabase.CreateAsync(key.ToString(), generatedDdl);
+        return await MssqlGeneratedDdlBaselineDatabase.CreateAsync(fixture.Key.ToString(), generatedDdl);
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
@@ -67,4 +67,36 @@ internal static class MssqlBaselineCache
 
         return await MssqlGeneratedDdlBaselineDatabase.CreateAsync(fixture.Key.ToString(), generatedDdl);
     }
+
+    /// <summary>
+    /// Disposes every cached baseline database and removes it from the cache.
+    /// Drives the underlying template-database cleanup. Safe to call from an
+    /// assembly-level teardown; subsequent <see cref="CreateOrGetAsync"/> calls
+    /// will repopulate the cache.
+    /// </summary>
+    public static async Task DisposeAllAsync()
+    {
+        foreach (
+            KeyValuePair<FixtureKey, Lazy<Task<MssqlGeneratedDdlBaselineDatabase>>> entry in _cache.ToArray()
+        )
+        {
+            if (!_cache.TryRemove(entry))
+            {
+                continue;
+            }
+            if (!entry.Value.IsValueCreated)
+            {
+                continue;
+            }
+            try
+            {
+                MssqlGeneratedDdlBaselineDatabase baseline = await entry.Value.Value;
+                await baseline.DisposeAsync();
+            }
+            catch
+            {
+                // Best-effort teardown; do not mask test failures.
+            }
+        }
+    }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Mssql/MssqlBaselineCache.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Concurrent;
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+namespace EdFi.DataManagementService.Tests.Integration.Mssql;
+
+/// <summary>
+/// Wraps <see cref="MssqlGeneratedDdlBaselineDatabase"/> per fixture so the same
+/// snapshot-backed baseline is reused across tests within a process. Per-fixture
+/// provisioning (loading the effective schema set, running the production DDL
+/// pipeline, and applying the resulting DDL) happens once; per-test leases are
+/// then acquired by callers via
+/// <see cref="MssqlGeneratedDdlBaselineDatabase.AcquireRestoredDatabaseAsync(int?)"/>.
+/// </summary>
+internal static class MssqlBaselineCache
+{
+    private static readonly ConcurrentDictionary<
+        FixtureKey,
+        Lazy<Task<MssqlGeneratedDdlBaselineDatabase>>
+    > _cache = new();
+
+    /// <summary>
+    /// Returns the cached baseline database for the supplied fixture, building it on
+    /// first access. The fixture signature handed to the baseline is the
+    /// <see cref="FixtureKey"/> value so distinct fixtures get distinct snapshots.
+    /// </summary>
+    public static async Task<MssqlGeneratedDdlBaselineDatabase> CreateOrGetAsync(FixtureContext fixture)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        Lazy<Task<MssqlGeneratedDdlBaselineDatabase>> lazy = _cache.GetOrAdd(
+            fixture.Key,
+            key => new(() => BuildBaselineAsync(key), LazyThreadSafetyMode.ExecutionAndPublication)
+        );
+
+        try
+        {
+            return await lazy.Value;
+        }
+        catch
+        {
+            _cache.TryRemove(new(fixture.Key, lazy));
+            throw;
+        }
+    }
+
+    private static async Task<MssqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(FixtureKey key)
+    {
+        string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
+        EffectiveSchemaSet effectiveSchemaSet = EffectiveSchemaFixtureLoader.LoadFromFixtureDirectory(
+            fixtureDirectory
+        );
+        (_, string generatedDdl) = DdlPipelineHelpers.BuildDdlForDialect(
+            effectiveSchemaSet,
+            SqlDialect.Mssql,
+            strict: true
+        );
+
+        return await MssqlGeneratedDdlBaselineDatabase.CreateAsync(key.ToString(), generatedDdl);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlApiIntegrationTestBase.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using Npgsql;
+
+namespace EdFi.DataManagementService.Tests.Integration.Postgresql;
+
+/// <summary>
+/// PostgreSQL-flavored concrete <see cref="ApiIntegrationTestBase"/>. Leases an
+/// isolated per-test database from the cached
+/// <see cref="PostgresqlGeneratedDdlBaselineDatabase"/> for the bound fixture and
+/// hands its connection string to the harness.
+/// </summary>
+[Category("PostgresqlIntegration")]
+public abstract class PostgresqlApiIntegrationTestBase : ApiIntegrationTestBase
+{
+    private PostgresqlGeneratedDdlTestDatabase? _leasedDb;
+
+    protected override string Datastore => "postgresql";
+
+    [OneTimeSetUp]
+    public void GuardConnectionStringPresent()
+    {
+        try
+        {
+            _ = BaselineDatabaseConfiguration.DatabaseConnectionString;
+        }
+        catch (InvalidOperationException)
+        {
+            Assert.Ignore(
+                "DatabaseConnection is not configured (set ConnectionStrings__DatabaseConnection or add it to appsettings.Test.json); skipping PostgreSQL API integration tests."
+            );
+        }
+    }
+
+    protected override async Task<string> LeaseDatabaseAsync(FixtureContext fixture)
+    {
+        PostgresqlGeneratedDdlBaselineDatabase baseline = await PostgresqlBaselineCache.CreateOrGetAsync(
+            fixture
+        );
+        _leasedDb = await baseline.CreateIsolatedDatabaseAsync();
+        return _leasedDb.ConnectionString;
+    }
+
+    protected override async Task<DbConnection> OpenAssertionConnectionAsync(string leasedConnectionString)
+    {
+        NpgsqlConnection connection = new(leasedConnectionString);
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    protected override async Task ReleaseDatabaseAsync(string leasedConnectionString)
+    {
+        if (_leasedDb is not null)
+        {
+            await _leasedDb.DisposeAsync();
+            _leasedDb = null;
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Concurrent;
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+
+namespace EdFi.DataManagementService.Tests.Integration.Postgresql;
+
+/// <summary>
+/// Wraps <see cref="PostgresqlGeneratedDdlBaselineDatabase"/> per fixture so the
+/// same baseline database is reused across tests within a process. Per-fixture
+/// provisioning (loading the effective schema set, running the production DDL
+/// pipeline, and applying the resulting DDL to a template database) happens
+/// once; per-test isolated databases are then cloned from that template by
+/// callers via <see cref="PostgresqlGeneratedDdlBaselineDatabase.CreateIsolatedDatabaseAsync(int)"/>.
+/// </summary>
+internal static class PostgresqlBaselineCache
+{
+    private static readonly ConcurrentDictionary<
+        FixtureKey,
+        Lazy<Task<PostgresqlGeneratedDdlBaselineDatabase>>
+    > _cache = new();
+
+    /// <summary>
+    /// Returns the cached baseline database for the supplied fixture, building it on
+    /// first access. The fixture signature handed to the baseline is the
+    /// <see cref="FixtureKey"/> value so distinct fixtures get distinct templates.
+    /// </summary>
+    public static async Task<PostgresqlGeneratedDdlBaselineDatabase> CreateOrGetAsync(FixtureContext fixture)
+    {
+        ArgumentNullException.ThrowIfNull(fixture);
+
+        Lazy<Task<PostgresqlGeneratedDdlBaselineDatabase>> lazy = _cache.GetOrAdd(
+            fixture.Key,
+            key => new(() => BuildBaselineAsync(key), LazyThreadSafetyMode.ExecutionAndPublication)
+        );
+
+        try
+        {
+            return await lazy.Value;
+        }
+        catch
+        {
+            _cache.TryRemove(new(fixture.Key, lazy));
+            throw;
+        }
+    }
+
+    private static async Task<PostgresqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(FixtureKey key)
+    {
+        string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
+        EffectiveSchemaSet effectiveSchemaSet = EffectiveSchemaFixtureLoader.LoadFromFixtureDirectory(
+            fixtureDirectory
+        );
+        (_, string generatedDdl) = DdlPipelineHelpers.BuildDdlForDialect(
+            effectiveSchemaSet,
+            SqlDialect.Pgsql,
+            strict: true
+        );
+
+        return await PostgresqlGeneratedDdlBaselineDatabase.CreateAsync(key.ToString(), generatedDdl);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
@@ -31,6 +31,8 @@ internal static class PostgresqlBaselineCache
     /// Returns the cached baseline database for the supplied fixture, building it on
     /// first access. The fixture signature handed to the baseline is the
     /// <see cref="FixtureKey"/> value so distinct fixtures get distinct templates.
+    /// The DDL is generated from the same materialized ApiSchema directory the DMS
+    /// host scans for so the effective schema hash matches at request time.
     /// </summary>
     public static async Task<PostgresqlGeneratedDdlBaselineDatabase> CreateOrGetAsync(FixtureContext fixture)
     {
@@ -38,7 +40,7 @@ internal static class PostgresqlBaselineCache
 
         Lazy<Task<PostgresqlGeneratedDdlBaselineDatabase>> lazy = _cache.GetOrAdd(
             fixture.Key,
-            key => new(() => BuildBaselineAsync(key), LazyThreadSafetyMode.ExecutionAndPublication)
+            _ => new(() => BuildBaselineAsync(fixture), LazyThreadSafetyMode.ExecutionAndPublication)
         );
 
         try
@@ -52,11 +54,12 @@ internal static class PostgresqlBaselineCache
         }
     }
 
-    private static async Task<PostgresqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(FixtureKey key)
+    private static async Task<PostgresqlGeneratedDdlBaselineDatabase> BuildBaselineAsync(
+        FixtureContext fixture
+    )
     {
-        string fixtureDirectory = FixtureRepositoryPaths.ResolveFixtureDirectory(key);
         EffectiveSchemaSet effectiveSchemaSet = EffectiveSchemaFixtureLoader.LoadFromFixtureDirectory(
-            fixtureDirectory
+            fixture.ApiSchemaDirectory
         );
         (_, string generatedDdl) = DdlPipelineHelpers.BuildDdlForDialect(
             effectiveSchemaSet,
@@ -64,6 +67,6 @@ internal static class PostgresqlBaselineCache
             strict: true
         );
 
-        return await PostgresqlGeneratedDdlBaselineDatabase.CreateAsync(key.ToString(), generatedDdl);
+        return await PostgresqlGeneratedDdlBaselineDatabase.CreateAsync(fixture.Key.ToString(), generatedDdl);
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Postgresql/PostgresqlBaselineCache.cs
@@ -69,4 +69,39 @@ internal static class PostgresqlBaselineCache
 
         return await PostgresqlGeneratedDdlBaselineDatabase.CreateAsync(fixture.Key.ToString(), generatedDdl);
     }
+
+    /// <summary>
+    /// Disposes every cached baseline database and removes it from the cache.
+    /// Drives the underlying template-database cleanup. Safe to call from an
+    /// assembly-level teardown; subsequent <see cref="CreateOrGetAsync"/> calls
+    /// will repopulate the cache.
+    /// </summary>
+    public static async Task DisposeAllAsync()
+    {
+        foreach (
+            KeyValuePair<
+                FixtureKey,
+                Lazy<Task<PostgresqlGeneratedDdlBaselineDatabase>>
+            > entry in _cache.ToArray()
+        )
+        {
+            if (!_cache.TryRemove(entry))
+            {
+                continue;
+            }
+            if (!entry.Value.IsValueCreated)
+            {
+                continue;
+            }
+            try
+            {
+                PostgresqlGeneratedDdlBaselineDatabase baseline = await entry.Value.Value;
+                await baseline.DisposeAsync();
+            }
+            catch
+            {
+                // Best-effort teardown; do not mask test failures.
+            }
+        }
+    }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
@@ -138,10 +138,14 @@ Profile XML for each fixture lives at
 that uses a profile in any of its scenarios gets its own directory. The
 fake CMS profile catalog walks that directory at harness startup.
 
-The current smoke scenario binds to `ProfileRootOnlyMerge` in no-profile
-mode, so `Fixtures/Profiles/ProfileRootOnlyMerge/` contains only a
-`.gitkeep` placeholder. Profile XML will be added there when profiled
-scenarios land.
+`Fixtures/Profiles/ProfileRootOnlyMerge/` holds the first profile XML
+files used by the suite (`profilerootonlymergeitem-visible.xml` and
+`profilerootonlymergeitem-readonly.xml`). They back the profiled HTTP
+scenarios in `Scenarios/ProfileRootOnlyMergeProfileScenario.cs`, which
+cover profiled create/read, hidden-field preservation through a
+profiled PUT, and the read-only-profile-used-for-write 405 path. The
+unprofiled CRUD scenarios bound to the same fixture continue to run
+in no-profile mode regardless of what profile XML is present.
 
 Use lowercase `.xml` extensions. Linux CI is case-sensitive about file
 extensions, and the catalog walker matches the lowercase pattern.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
@@ -1,0 +1,184 @@
+# EdFi.DataManagementService.Tests.Integration
+
+API-level integration tests that exercise the real DMS HTTP pipeline against
+real provisioned PostgreSQL and SQL Server databases.
+
+## What this is
+
+These tests boot the production DMS host via
+`WebApplicationFactory<Program>` and drive it through HTTP against an isolated
+per-test database leased from a per-fixture cached baseline. The pieces that
+exist purely to talk to external systems are faked in `Doubles/`: JWT
+validation, the CMS claim-set provider, the application context, the DMS
+instance directory. Everything else is the real production code path -
+ApiSchema loading, profile XML parsing, write/read middleware, the relational
+backend, and the DDL/journaling pipeline that provisions each baseline.
+
+## What this is not
+
+- Not a docker-stack E2E. See `EdFi.DataManagementService.Tests.E2E` for tests
+  that run against a fully composed stack (DMS, CMS, identity provider,
+  Kafka).
+- Not an exhaustive matrix. Deep edge cases for backend DDL generation,
+  relational write merging, and apiSchema shape coverage live in
+  `EdFi.DataManagementService.Backend.Postgresql.Tests.Integration` and
+  `EdFi.DataManagementService.Backend.Mssql.Tests.Integration`.
+- Not an authorization end-to-end. JWT and claim-set lookups are faked, so
+  these tests prove the public DMS pipeline is correctly wired to the
+  relational backend - not that production auth integrates correctly.
+
+## Prerequisites
+
+Tests skip cleanly via `Assert.Ignore` when their dialect's connection string
+is unconfigured, so it is fine to run with only one dialect available.
+
+### PostgreSQL
+
+Start PostgreSQL via the repo docker compose:
+
+```powershell
+cd eng/docker-compose
+pwsh ./start-postgresql.ps1
+```
+
+Then set the admin connection string:
+
+```powershell
+$env:ConnectionStrings__DatabaseConnection = "host=localhost;port=5435;username=postgres;password=abcdefgh1!;database=edfi_dms_backend_integration;pooling=true;minimum pool size=10;maximum pool size=50;Application Name=EdFi.DataManagementService;NoResetOnClose=true;"
+```
+
+### SQL Server
+
+Start SQL Server in a container:
+
+```powershell
+docker run -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD='<password>' -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest
+```
+
+Then set the admin connection string:
+
+```powershell
+$env:ConnectionStrings__MssqlAdmin = "Server=localhost,1433;User Id=sa;Password=<password>;TrustServerCertificate=true"
+```
+
+### appsettings.Test.json alternative
+
+Either connection string can also be supplied via an `appsettings.Test.json`
+file in the project directory, under the standard `ConnectionStrings` section.
+
+## Running
+
+All dialects:
+
+```powershell
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration
+```
+
+PostgreSQL only:
+
+```powershell
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration --filter "Category=PostgresqlIntegration"
+```
+
+SQL Server only:
+
+```powershell
+dotnet test src/dms/tests/EdFi.DataManagementService.Tests.Integration --filter "Category=MssqlIntegration"
+```
+
+Via the repo build script (runs all `*.Tests.Integration` projects):
+
+```powershell
+./build-dms.ps1 IntegrationTest -Configuration Debug
+```
+
+## Fixture map
+
+Every test binds to a `FixtureKey`, which resolves to a source repo directory
+holding the fixture's ApiSchema and `fixture.json` manifest. The harness
+consumes that directory both to provision the DDL baseline and to drive the
+DMS host's ApiSchema loader, so the host and the DDL pipeline see the same
+effective schema.
+
+| FixtureKey | Source repo path | Purpose |
+| --- | --- | --- |
+| `FocusedStableKeyUpdateSemantics` | `src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-update-semantics/` | Stable-key update semantics for a single resource shape. |
+| `ProfileRootOnlyMerge` | `src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/` | Profile-aware merges that stay on the root resource table. |
+| `ProfileSeparateTableMerge` | `src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-separate-table-merge/` | Profile-aware merges that span a separate child table. |
+| `ProfileNestedAndRootExtensionChildren` | `src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/` | Nested children plus root-level extension children under a profile. |
+| `ProfileCollectionAlignedExtension` | `src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/` | Extension scope aligned to a profile-visible collection. |
+| `ProfileCollectionAlignedExtensionHiddenDescendant` | `src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/` | Same shape with a hidden descendant; loaded only by scenarios that need it. |
+
+`SmallReferentialIdentity` is intentionally excluded from this harness. It is
+a synthetic backend/non-strict fixture authored without post-key-unification
+columns, and the production DMS runtime mapping compiler is strict and
+rejects it. It remains valid for the non-strict
+`Backend.{Postgresql,Mssql}.Tests.Integration` projects.
+
+## Runtime-compatibility materialization
+
+Before the DMS host and the DDL baseline pipeline are given the source
+fixture, the harness performs a one-pass augmentation step that adds neutral
+defaults - empty arrays, empty objects, empty strings - for fields the DMS
+HTTP middleware requires but the DDL-tier fixtures do not declare. The
+materialized fixture is written once to a temp directory and is the single
+source both the host and the DDL pipeline read, so effective-schema hashes
+match.
+
+Materialization only fills in empty/neutral values. Scenarios that need
+non-empty query metadata, authorization securable definitions, or other
+non-default values must supply that content explicitly in the source fixture
+or in a scenario-owned overlay - they will not be invented by the harness.
+
+## Profile XML
+
+Profile XML for each fixture lives at
+`Fixtures/Profiles/<FixtureKey>/*.xml` within this project. Each fixture
+that uses a profile in any of its scenarios gets its own directory. The
+fake CMS profile catalog walks that directory at harness startup.
+
+The current smoke scenario binds to `ProfileRootOnlyMerge` in no-profile
+mode, so `Fixtures/Profiles/ProfileRootOnlyMerge/` contains only a
+`.gitkeep` placeholder. Profile XML will be added there when profiled
+scenarios land.
+
+Use lowercase `.xml` extensions. Linux CI is case-sensitive about file
+extensions, and the catalog walker matches the lowercase pattern.
+
+## Invariants
+
+- Every test starts from a schema-only database plus whatever explicit seed
+  the scenario inserts. There is no inter-test state.
+- The DMS host (and its in-memory ApiSchema cache) is disposed before the
+  leased database is released back to the baseline.
+- The host and the DDL pipeline read the same materialized ApiSchema; their
+  effective-schema hashes match.
+- Failures in DMS host startup surface as test exceptions rather than
+  silently terminating the NUnit process, because
+  `Doubles/NonExitingStartupProcessExit.cs` replaces the production
+  `IStartupProcessExit`.
+
+## Adding a new scenario
+
+1. **Pick a `FixtureKey`.** Reuse one of the existing fixtures whose shape
+   matches what you need to assert. Add a new key (and a new repository path
+   entry in `FixtureRepositoryPaths`) only when no existing fixture
+   exercises the shape.
+2. **Add profile XML** under `Fixtures/Profiles/<FixtureKey>/` if the
+   scenario is profile-constrained. Skip this for no-profile scenarios.
+3. **Write the scenario** as a `static` method on a class in `Scenarios/`,
+   taking the `ApiIntegrationHarness` as its single argument. Use
+   `harness.HttpClient` for HTTP and `harness.DbConnection` for persisted-
+   state assertions.
+4. **Add per-dialect wrappers** in `Tests/Postgresql/` and `Tests/Mssql/`.
+   Each wrapper extends the matching dialect base, overrides `Fixture` to
+   bind to the chosen `FixtureKey`, and exposes one `[Test]` method per
+   scenario entry point.
+
+## Debugging
+
+When a runtime failure produces little useful output in the test console,
+read the Serilog rolling file at
+`bin/Debug/net10.0/logs/YYYYMMDD.log`. The DMS host writes full exception
+detail there, including ApiSchema-loading and startup-validation failures
+that the test console may swallow.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/README.md
@@ -109,11 +109,12 @@ effective schema.
 | `ProfileCollectionAlignedExtension` | `src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/` | Extension scope aligned to a profile-visible collection. |
 | `ProfileCollectionAlignedExtensionHiddenDescendant` | `src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/` | Same shape with a hidden descendant; loaded only by scenarios that need it. |
 
-`SmallReferentialIdentity` is intentionally excluded from this harness. It is
-a synthetic backend/non-strict fixture authored without post-key-unification
-columns, and the production DMS runtime mapping compiler is strict and
-rejects it. It remains valid for the non-strict
-`Backend.{Postgresql,Mssql}.Tests.Integration` projects.
+The harness's `FixtureKey` enum lists only fixtures whose effective schema the
+strict production DMS runtime mapping compiler accepts. The backend-only
+`small/referential-identity` fixture (used by
+`Backend.{Postgresql,Mssql}.Tests.Integration` in non-strict mode) is omitted
+here because the runtime compiler is hardcoded strict and rejects fixtures
+authored without post-key-unification columns.
 
 ## Runtime-compatibility materialization
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Basic CRUD smoke: POST a Student then GET-by-id from the Location header,
+/// asserting the request fields round-trip through the real DMS HTTP pipeline
+/// against the leased database. Hard-coded for the ProfileRootOnlyMerge fixture's
+/// Student shape: project endpoint <c>ed-fi</c>, resource <c>students</c>, required
+/// identity <c>studentUniqueId</c>, required non-identity <c>firstName</c>.
+/// </summary>
+internal static class CrudRoundTripScenario
+{
+    private const string StudentsEndpoint = "/data/ed-fi/students";
+    private const string StudentUniqueId = "smoke-001";
+    private const string FirstName = "Ada";
+
+    public static async Task It_creates_and_reads_a_student(ApiIntegrationHarness harness)
+    {
+        var payload = new JsonObject { ["studentUniqueId"] = StudentUniqueId, ["firstName"] = FirstName };
+
+        using var createContent = new StringContent(
+            payload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage createResponse = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            createContent
+        );
+        string createBody = await createResponse.Content.ReadAsStringAsync();
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
+        createResponse.Headers.Location.Should().NotBeNull();
+
+        string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
+            ? createResponse.Headers.Location!.AbsolutePath
+            : createResponse.Headers.Location!.OriginalString;
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(locationPath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+
+        JsonNode? returnedNode = JsonNode.Parse(getBody);
+        returnedNode.Should().NotBeNull("GET response must be a JSON document");
+        JsonObject returned = returnedNode!.AsObject();
+        returned["studentUniqueId"]!.GetValue<string>().Should().Be(StudentUniqueId);
+        returned["firstName"]!.GetValue<string>().Should().Be(FirstName);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
@@ -43,7 +43,7 @@ internal static class CrudRoundTripScenario
 
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
         createResponse.Headers.Location.Should().NotBeNull();
-        TryReadRawEtag(createResponse, out _).Should().BeTrue("a POST create must emit an ETag header");
+        createResponse.TryReadRawEtag(out _).Should().BeTrue("a POST create must emit an ETag header");
 
         string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
             ? createResponse.Headers.Location!.AbsolutePath
@@ -89,7 +89,8 @@ internal static class CrudRoundTripScenario
         string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
             ? createResponse.Headers.Location!.AbsolutePath
             : createResponse.Headers.Location!.OriginalString;
-        TryReadRawEtag(createResponse, out string initialEtag)
+        createResponse
+            .TryReadRawEtag(out string initialEtag)
             .Should()
             .BeTrue("the initial POST must emit an ETag so PUT can If-Match against it");
         string resourceId = locationPath.Split('/')[^1];
@@ -113,7 +114,7 @@ internal static class CrudRoundTripScenario
         using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
         string putBody = await putResponse.Content.ReadAsStringAsync();
         putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, putBody);
-        TryReadRawEtag(putResponse, out string putEtag).Should().BeTrue("PUT must return the new ETag");
+        putResponse.TryReadRawEtag(out string putEtag).Should().BeTrue("PUT must return the new ETag");
         putEtag.Should().NotBe(initialEtag, "PUT must advance the ETag");
 
         using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(locationPath);
@@ -179,22 +180,27 @@ internal static class CrudRoundTripScenario
         );
         string firstPageBody = await firstPage.Content.ReadAsStringAsync();
         firstPage.StatusCode.Should().Be(HttpStatusCode.OK, firstPageBody);
-        JsonNode
-            .Parse(firstPageBody)!
-            .AsArray()
-            .Count.Should()
-            .Be(2, "limit=2 returns the first two seeded students");
+        JsonArray firstPageArray = JsonNode.Parse(firstPageBody)!.AsArray();
+        firstPageArray.Count.Should().Be(2, "limit=2 returns the first two seeded students");
 
         using HttpResponseMessage secondPage = await harness.HttpClient.GetAsync(
             $"{StudentsEndpoint}?offset=2&limit=2"
         );
         string secondPageBody = await secondPage.Content.ReadAsStringAsync();
         secondPage.StatusCode.Should().Be(HttpStatusCode.OK, secondPageBody);
-        JsonNode
-            .Parse(secondPageBody)!
-            .AsArray()
-            .Count.Should()
-            .Be(1, "offset=2 leaves only one of three seeded students");
+        JsonArray secondPageArray = JsonNode.Parse(secondPageBody)!.AsArray();
+        secondPageArray.Count.Should().Be(1, "offset=2 leaves only one of three seeded students");
+
+        string[] returnedIds = firstPageArray
+            .Concat(secondPageArray)
+            .Select(node => node!["studentUniqueId"]!.GetValue<string>())
+            .ToArray();
+        returnedIds
+            .Should()
+            .BeEquivalentTo(
+                ids,
+                "the union of the two pages must cover every seeded student without overlap"
+            );
     }
 
     public static async Task It_rejects_create_with_missing_reference(ApiIntegrationHarness harness)
@@ -271,28 +277,6 @@ internal static class CrudRoundTripScenario
 
         int persistedStudentCount = await CountStudentRowsAsync(harness, StudentUniqueId);
         persistedStudentCount.Should().Be(1, "the referenced Student must remain after the rejected DELETE");
-    }
-
-    /// <summary>
-    /// Reads the raw ETag header. <see cref="System.Net.Http.Headers.HttpResponseHeaders.ETag"/>
-    /// requires the strict RFC 7232 quoted form, but DMS emits an opaque
-    /// unquoted value (the API metadata fingerprint), so the strongly typed
-    /// property returns null. Round-tripping through <c>TryGetValues</c>
-    /// preserves whatever DMS actually sent.
-    /// </summary>
-    private static bool TryReadRawEtag(HttpResponseMessage response, out string etag)
-    {
-        if (response.Headers.TryGetValues("ETag", out IEnumerable<string>? values))
-        {
-            string? first = values.FirstOrDefault();
-            if (!string.IsNullOrEmpty(first))
-            {
-                etag = first;
-                return true;
-            }
-        }
-        etag = string.Empty;
-        return false;
     }
 
     private static async Task<int> CountStudentRowsAsync(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data.Common;
 using System.Net;
 using System.Text;
 using System.Text.Json.Nodes;
@@ -22,6 +23,8 @@ internal static class CrudRoundTripScenario
     private const string StudentsEndpoint = "/data/ed-fi/students";
     private const string StudentUniqueId = "smoke-001";
     private const string FirstName = "Ada";
+    private const string MergeItemsEndpoint = "/data/ed-fi/profileRootOnlyMergeItems";
+    private const string MissingStudentUniqueId = "smoke-missing-student-001";
 
     public static async Task It_creates_and_reads_a_student(ApiIntegrationHarness harness)
     {
@@ -40,6 +43,7 @@ internal static class CrudRoundTripScenario
 
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
         createResponse.Headers.Location.Should().NotBeNull();
+        createResponse.Headers.ETag.Should().NotBeNull("a POST create must return an ETag header");
 
         string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
             ? createResponse.Headers.Location!.AbsolutePath
@@ -55,5 +59,236 @@ internal static class CrudRoundTripScenario
         JsonObject returned = returnedNode!.AsObject();
         returned["studentUniqueId"]!.GetValue<string>().Should().Be(StudentUniqueId);
         returned["firstName"]!.GetValue<string>().Should().Be(FirstName);
+
+        int persistedRowCount = await CountStudentRowsAsync(harness, StudentUniqueId);
+        persistedRowCount.Should().Be(1, "the POSTed Student must be persisted in the relational backend");
+    }
+
+    public static async Task It_updates_a_student_via_put(ApiIntegrationHarness harness)
+    {
+        const string putFirstName = "Ada-renamed";
+
+        var initialPayload = new JsonObject
+        {
+            ["studentUniqueId"] = StudentUniqueId,
+            ["firstName"] = FirstName,
+        };
+        using var createContent = new StringContent(
+            initialPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage createResponse = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            createContent
+        );
+        createResponse
+            .StatusCode.Should()
+            .Be(HttpStatusCode.Created, await createResponse.Content.ReadAsStringAsync());
+
+        string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
+            ? createResponse.Headers.Location!.AbsolutePath
+            : createResponse.Headers.Location!.OriginalString;
+        string initialEtag = createResponse.Headers.ETag!.Tag;
+        string resourceId = locationPath.Split('/')[^1];
+
+        var putPayload = new JsonObject
+        {
+            ["id"] = resourceId,
+            ["studentUniqueId"] = StudentUniqueId,
+            ["firstName"] = putFirstName,
+        };
+        using var putContent = new StringContent(
+            putPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, locationPath) { Content = putContent };
+        // If-Match is a request header, not a content header; setting it on
+        // StringContent.Headers would silently no-op.
+        putRequest.Headers.TryAddWithoutValidation("If-Match", initialEtag);
+
+        using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
+        string putBody = await putResponse.Content.ReadAsStringAsync();
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, putBody);
+        putResponse.Headers.ETag.Should().NotBeNull("PUT must return the new ETag");
+        putResponse.Headers.ETag!.Tag.Should().NotBe(initialEtag, "PUT must advance the ETag");
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(locationPath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+        JsonObject returned = JsonNode.Parse(getBody)!.AsObject();
+        returned["firstName"]!.GetValue<string>().Should().Be(putFirstName);
+    }
+
+    public static async Task It_deletes_a_student(ApiIntegrationHarness harness)
+    {
+        var payload = new JsonObject { ["studentUniqueId"] = StudentUniqueId, ["firstName"] = FirstName };
+        using var createContent = new StringContent(
+            payload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage createResponse = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            createContent
+        );
+        createResponse
+            .StatusCode.Should()
+            .Be(HttpStatusCode.Created, await createResponse.Content.ReadAsStringAsync());
+
+        string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
+            ? createResponse.Headers.Location!.AbsolutePath
+            : createResponse.Headers.Location!.OriginalString;
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(locationPath);
+        string deleteBody = await deleteResponse.Content.ReadAsStringAsync();
+        deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, deleteBody);
+
+        using HttpResponseMessage getAfterDelete = await harness.HttpClient.GetAsync(locationPath);
+        getAfterDelete.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+        int persistedRowCount = await CountStudentRowsAsync(harness, StudentUniqueId);
+        persistedRowCount.Should().Be(0, "DELETE must remove the row from the relational backend");
+    }
+
+    public static async Task It_pages_students_via_query(ApiIntegrationHarness harness)
+    {
+        // Seed three students. ValidateQueryMiddleware rejects orderBy when the
+        // resource has an empty queryFieldMapping (this fixture does), so the
+        // scenario asserts only the limit/offset window sizes rather than a
+        // specific element order.
+        string[] ids = ["smoke-page-001", "smoke-page-002", "smoke-page-003"];
+        foreach (string id in ids)
+        {
+            var payload = new JsonObject { ["studentUniqueId"] = id, ["firstName"] = $"Name-{id}" };
+            using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+            using HttpResponseMessage response = await harness.HttpClient.PostAsync(
+                StudentsEndpoint,
+                content
+            );
+            response
+                .StatusCode.Should()
+                .Be(HttpStatusCode.Created, await response.Content.ReadAsStringAsync());
+        }
+
+        using HttpResponseMessage firstPage = await harness.HttpClient.GetAsync(
+            $"{StudentsEndpoint}?offset=0&limit=2"
+        );
+        string firstPageBody = await firstPage.Content.ReadAsStringAsync();
+        firstPage.StatusCode.Should().Be(HttpStatusCode.OK, firstPageBody);
+        JsonNode
+            .Parse(firstPageBody)!
+            .AsArray()
+            .Count.Should()
+            .Be(2, "limit=2 returns the first two seeded students");
+
+        using HttpResponseMessage secondPage = await harness.HttpClient.GetAsync(
+            $"{StudentsEndpoint}?offset=2&limit=2"
+        );
+        string secondPageBody = await secondPage.Content.ReadAsStringAsync();
+        secondPage.StatusCode.Should().Be(HttpStatusCode.OK, secondPageBody);
+        JsonNode
+            .Parse(secondPageBody)!
+            .AsArray()
+            .Count.Should()
+            .Be(1, "offset=2 leaves only one of three seeded students");
+    }
+
+    public static async Task It_rejects_create_with_missing_reference(ApiIntegrationHarness harness)
+    {
+        var payload = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = 1,
+            ["studentReference"] = new JsonObject { ["studentUniqueId"] = MissingStudentUniqueId },
+        };
+        using var content = new StringContent(payload.ToJsonString(), Encoding.UTF8, "application/json");
+        using HttpResponseMessage response = await harness.HttpClient.PostAsync(MergeItemsEndpoint, content);
+        string body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().BeOneOf([HttpStatusCode.Conflict, HttpStatusCode.BadRequest], body);
+        body.Should()
+            .Contain("studentReference", "the error body should identify the unresolved reference field");
+    }
+
+    public static async Task It_rejects_delete_when_referenced(ApiIntegrationHarness harness)
+    {
+        var studentPayload = new JsonObject
+        {
+            ["studentUniqueId"] = StudentUniqueId,
+            ["firstName"] = FirstName,
+        };
+        using var studentContent = new StringContent(
+            studentPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage studentCreate = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            studentContent
+        );
+        studentCreate
+            .StatusCode.Should()
+            .Be(HttpStatusCode.Created, await studentCreate.Content.ReadAsStringAsync());
+        string studentLocationPath = studentCreate.Headers.Location!.IsAbsoluteUri
+            ? studentCreate.Headers.Location!.AbsolutePath
+            : studentCreate.Headers.Location!.OriginalString;
+
+        var itemPayload = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = 2,
+            ["studentReference"] = new JsonObject { ["studentUniqueId"] = StudentUniqueId },
+        };
+        using var itemContent = new StringContent(
+            itemPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage itemCreate = await harness.HttpClient.PostAsync(
+            MergeItemsEndpoint,
+            itemContent
+        );
+        itemCreate
+            .StatusCode.Should()
+            .Be(HttpStatusCode.Created, await itemCreate.Content.ReadAsStringAsync());
+
+        using HttpResponseMessage deleteResponse = await harness.HttpClient.DeleteAsync(studentLocationPath);
+        string deleteBody = await deleteResponse.Content.ReadAsStringAsync();
+        deleteResponse
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.Conflict,
+                "deleting a Student referenced by a profileRootOnlyMergeItem must be rejected"
+            );
+        deleteBody
+            .Should()
+            .Contain(
+                "ProfileRootOnlyMergeItem",
+                "the conflict body should identify the dependent resource by its PascalCase resource name"
+            );
+
+        int persistedStudentCount = await CountStudentRowsAsync(harness, StudentUniqueId);
+        persistedStudentCount.Should().Be(1, "the referenced Student must remain after the rejected DELETE");
+    }
+
+    private static async Task<int> CountStudentRowsAsync(
+        ApiIntegrationHarness harness,
+        string studentUniqueId
+    )
+    {
+        // Double-quoted identifiers work on PostgreSQL natively and on SQL Server
+        // with the default QUOTED_IDENTIFIER ON setting (Microsoft.Data.SqlClient
+        // sets this by default), so a single statement covers both dialects.
+        await using DbCommand command = harness.DbConnection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*) FROM "edfi"."Student" WHERE "StudentUniqueId" = @studentUniqueId
+            """;
+        DbParameter parameter = command.CreateParameter();
+        parameter.ParameterName = "@studentUniqueId";
+        parameter.Value = studentUniqueId;
+        command.Parameters.Add(parameter);
+
+        object? result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
@@ -124,6 +124,92 @@ internal static class CrudRoundTripScenario
         returned["firstName"]!.GetValue<string>().Should().Be(putFirstName);
     }
 
+    public static async Task It_upserts_a_student_via_post(ApiIntegrationHarness harness)
+    {
+        const string upsertUniqueId = "smoke-upsert-001";
+        const string firstNameInitial = "Ada";
+        const string firstNameUpdated = "Grace";
+
+        var insertPayload = new JsonObject
+        {
+            ["studentUniqueId"] = upsertUniqueId,
+            ["firstName"] = firstNameInitial,
+        };
+        using var insertContent = new StringContent(
+            insertPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage insertResponse = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            insertContent
+        );
+        string insertBody = await insertResponse.Content.ReadAsStringAsync();
+        insertResponse.StatusCode.Should().Be(HttpStatusCode.Created, insertBody);
+        insertResponse.Headers.Location.Should().NotBeNull("the initial POST must return a Location header");
+        insertResponse
+            .TryReadRawEtag(out string insertEtag)
+            .Should()
+            .BeTrue("the initial POST must emit an ETag header");
+
+        string insertLocationPath = insertResponse.Headers.Location!.IsAbsoluteUri
+            ? insertResponse.Headers.Location!.AbsolutePath
+            : insertResponse.Headers.Location!.OriginalString;
+
+        var upsertPayload = new JsonObject
+        {
+            ["studentUniqueId"] = upsertUniqueId,
+            ["firstName"] = firstNameUpdated,
+        };
+        using var upsertContent = new StringContent(
+            upsertPayload.ToJsonString(),
+            Encoding.UTF8,
+            "application/json"
+        );
+        using HttpResponseMessage upsertResponse = await harness.HttpClient.PostAsync(
+            StudentsEndpoint,
+            upsertContent
+        );
+        string upsertBody = await upsertResponse.Content.ReadAsStringAsync();
+        upsertResponse
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.OK,
+                $"POST on an existing natural key must upsert through the update path, not insert a duplicate or fail as conflict. Body: {upsertBody}"
+            );
+        upsertResponse
+            .Headers.Location.Should()
+            .NotBeNull(
+                "the upsert-update POST must return a Location header pointing at the existing document"
+            );
+        string upsertLocationPath = upsertResponse.Headers.Location!.IsAbsoluteUri
+            ? upsertResponse.Headers.Location!.AbsolutePath
+            : upsertResponse.Headers.Location!.OriginalString;
+        upsertLocationPath
+            .Should()
+            .Be(
+                insertLocationPath,
+                "POST upsert must keep the original resource id rather than mint a new one"
+            );
+        upsertResponse
+            .TryReadRawEtag(out string upsertEtag)
+            .Should()
+            .BeTrue("POST upsert-update must emit the new ETag");
+        upsertEtag.Should().NotBe(insertEtag, "POST upsert-update must advance the ETag");
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(insertLocationPath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+        JsonObject returned = JsonNode.Parse(getBody)!.AsObject();
+        returned["studentUniqueId"]!.GetValue<string>().Should().Be(upsertUniqueId);
+        returned["firstName"]!.GetValue<string>().Should().Be(firstNameUpdated);
+
+        int persistedRowCount = await CountStudentRowsAsync(harness, upsertUniqueId);
+        persistedRowCount
+            .Should()
+            .Be(1, "POST upsert-update must not create a duplicate relational row for the same natural key");
+    }
+
     public static async Task It_deletes_a_student(ApiIntegrationHarness harness)
     {
         var payload = new JsonObject { ["studentUniqueId"] = StudentUniqueId, ["firstName"] = FirstName };
@@ -214,7 +300,16 @@ internal static class CrudRoundTripScenario
         using HttpResponseMessage response = await harness.HttpClient.PostAsync(MergeItemsEndpoint, content);
         string body = await response.Content.ReadAsStringAsync();
 
-        response.StatusCode.Should().BeOneOf([HttpStatusCode.Conflict, HttpStatusCode.BadRequest], body);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict, body);
+        JsonObject problem = JsonNode.Parse(body)!.AsObject();
+        problem["type"]!
+            .GetValue<string>()
+            .Should()
+            .Be(
+                "urn:ed-fi:api:data-conflict:unresolved-reference",
+                "unresolved references must map to the data-conflict problem type, not generic bad-request"
+            );
+        problem["status"]!.GetValue<int>().Should().Be(409);
         body.Should()
             .Contain("studentReference", "the error body should identify the unresolved reference field");
     }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/CrudRoundTripScenario.cs
@@ -43,7 +43,7 @@ internal static class CrudRoundTripScenario
 
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
         createResponse.Headers.Location.Should().NotBeNull();
-        createResponse.Headers.ETag.Should().NotBeNull("a POST create must return an ETag header");
+        TryReadRawEtag(createResponse, out _).Should().BeTrue("a POST create must emit an ETag header");
 
         string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
             ? createResponse.Headers.Location!.AbsolutePath
@@ -89,7 +89,9 @@ internal static class CrudRoundTripScenario
         string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
             ? createResponse.Headers.Location!.AbsolutePath
             : createResponse.Headers.Location!.OriginalString;
-        string initialEtag = createResponse.Headers.ETag!.Tag;
+        TryReadRawEtag(createResponse, out string initialEtag)
+            .Should()
+            .BeTrue("the initial POST must emit an ETag so PUT can If-Match against it");
         string resourceId = locationPath.Split('/')[^1];
 
         var putPayload = new JsonObject
@@ -111,8 +113,8 @@ internal static class CrudRoundTripScenario
         using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
         string putBody = await putResponse.Content.ReadAsStringAsync();
         putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, putBody);
-        putResponse.Headers.ETag.Should().NotBeNull("PUT must return the new ETag");
-        putResponse.Headers.ETag!.Tag.Should().NotBe(initialEtag, "PUT must advance the ETag");
+        TryReadRawEtag(putResponse, out string putEtag).Should().BeTrue("PUT must return the new ETag");
+        putEtag.Should().NotBe(initialEtag, "PUT must advance the ETag");
 
         using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(locationPath);
         string getBody = await getResponse.Content.ReadAsStringAsync();
@@ -269,6 +271,28 @@ internal static class CrudRoundTripScenario
 
         int persistedStudentCount = await CountStudentRowsAsync(harness, StudentUniqueId);
         persistedStudentCount.Should().Be(1, "the referenced Student must remain after the rejected DELETE");
+    }
+
+    /// <summary>
+    /// Reads the raw ETag header. <see cref="System.Net.Http.Headers.HttpResponseHeaders.ETag"/>
+    /// requires the strict RFC 7232 quoted form, but DMS emits an opaque
+    /// unquoted value (the API metadata fingerprint), so the strongly typed
+    /// property returns null. Round-tripping through <c>TryGetValues</c>
+    /// preserves whatever DMS actually sent.
+    /// </summary>
+    private static bool TryReadRawEtag(HttpResponseMessage response, out string etag)
+    {
+        if (response.Headers.TryGetValues("ETag", out IEnumerable<string>? values))
+        {
+            string? first = values.FirstOrDefault();
+            if (!string.IsNullOrEmpty(first))
+            {
+                etag = first;
+                return true;
+            }
+        }
+        etag = string.Empty;
+        return false;
     }
 
     private static async Task<int> CountStudentRowsAsync(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ProfileRootOnlyMergeProfileScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ProfileRootOnlyMergeProfileScenario.cs
@@ -54,7 +54,8 @@ internal static class ProfileRootOnlyMergeProfileScenario
 
         createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
         createResponse.Headers.Location.Should().NotBeNull();
-        TryReadRawEtag(createResponse, out _)
+        createResponse
+            .TryReadRawEtag(out _)
             .Should()
             .BeTrue("a profiled POST must emit an ETag header alongside Location");
 
@@ -128,7 +129,8 @@ internal static class ProfileRootOnlyMergeProfileScenario
         string locationPath = seedResponse.Headers.Location!.IsAbsoluteUri
             ? seedResponse.Headers.Location!.AbsolutePath
             : seedResponse.Headers.Location!.OriginalString;
-        TryReadRawEtag(seedResponse, out string seedEtag)
+        seedResponse
+            .TryReadRawEtag(out string seedEtag)
             .Should()
             .BeTrue("the unprofiled seed POST must emit an ETag so the profiled PUT can If-Match against it");
         string resourceId = locationPath.Split('/')[^1];
@@ -226,12 +228,10 @@ internal static class ProfileRootOnlyMergeProfileScenario
         string profileContentType
     )
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, MergeItemsEndpoint);
-        // Setting Content-Type via MediaTypeHeaderValue (rather than a StringContent
-        // constructor parameter) avoids HttpClient defaulting to "; charset=utf-8",
-        // which the profile header regex rejects.
-        request.Content = new StringContent(payload.ToJsonString(), Encoding.UTF8);
-        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(profileContentType);
+        var request = new HttpRequestMessage(HttpMethod.Post, MergeItemsEndpoint)
+        {
+            Content = new StringContent(payload.ToJsonString(), Encoding.UTF8, profileContentType),
+        };
         return await harness.HttpClient.SendAsync(request);
     }
 
@@ -245,24 +245,6 @@ internal static class ProfileRootOnlyMergeProfileScenario
         request.Headers.Accept.Clear();
         request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(profileContentType));
         return await harness.HttpClient.SendAsync(request);
-    }
-
-    private static bool TryReadRawEtag(HttpResponseMessage response, out string etag)
-    {
-        // DMS emits an opaque, unquoted ETag value that HttpResponseHeaders.ETag
-        // rejects as malformed (it requires RFC 7232 quoting), so route through
-        // TryGetValues to preserve the raw header.
-        if (response.Headers.TryGetValues("ETag", out IEnumerable<string>? values))
-        {
-            string? first = values.FirstOrDefault();
-            if (!string.IsNullOrEmpty(first))
-            {
-                etag = first;
-                return true;
-            }
-        }
-        etag = string.Empty;
-        return false;
     }
 
     private static async Task<(

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ProfileRootOnlyMergeProfileScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/ProfileRootOnlyMergeProfileScenario.cs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json.Nodes;
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Profiled HTTP coverage bound to the <c>ProfileRootOnlyMerge</c> fixture and its
+/// <c>ProfileRootOnlyMergeItem-Visible</c> / <c>ProfileRootOnlyMergeItem-ReadOnly</c>
+/// profile XML files. Drives the full DMS HTTP pipeline through real profile content
+/// types so the read/write profile machinery, hidden-field preservation on PUT, and
+/// profile-aware HTTP error semantics are exercised end-to-end against both
+/// PostgreSQL and SQL Server backends.
+/// </summary>
+internal static class ProfileRootOnlyMergeProfileScenario
+{
+    private const string MergeItemsEndpoint = "/data/ed-fi/profileRootOnlyMergeItems";
+    private const string StandardJsonContentType = "application/json";
+
+    private const string VisibleWritableContentType =
+        "application/vnd.ed-fi.profilerootonlymergeitem.profilerootonlymergeitem-visible.writable+json";
+    private const string VisibleReadableContentType =
+        "application/vnd.ed-fi.profilerootonlymergeitem.profilerootonlymergeitem-visible.readable+json";
+    private const string ReadOnlyWritableContentType =
+        "application/vnd.ed-fi.profilerootonlymergeitem.profilerootonlymergeitem-readonly.writable+json";
+
+    public static async Task It_creates_and_reads_via_visible_profile(ApiIntegrationHarness harness)
+    {
+        const int itemId = 4001;
+        const string displayName = "visible-create";
+        const string clearableText = "visible-clearable";
+
+        var payload = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = itemId,
+            ["displayName"] = displayName,
+            ["profileScope"] = new JsonObject { ["clearableText"] = clearableText },
+        };
+
+        using HttpResponseMessage createResponse = await PostProfiledAsync(
+            harness,
+            payload,
+            VisibleWritableContentType
+        );
+        string createBody = await createResponse.Content.ReadAsStringAsync();
+
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created, createBody);
+        createResponse.Headers.Location.Should().NotBeNull();
+        TryReadRawEtag(createResponse, out _)
+            .Should()
+            .BeTrue("a profiled POST must emit an ETag header alongside Location");
+
+        string locationPath = createResponse.Headers.Location!.IsAbsoluteUri
+            ? createResponse.Headers.Location!.AbsolutePath
+            : createResponse.Headers.Location!.OriginalString;
+
+        using HttpResponseMessage getResponse = await GetProfiledAsync(
+            harness,
+            locationPath,
+            VisibleReadableContentType
+        );
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+
+        JsonObject returned = JsonNode.Parse(getBody)!.AsObject();
+        returned["profileRootOnlyMergeItemId"]!.GetValue<int>().Should().Be(itemId);
+        returned["displayName"]!.GetValue<string>().Should().Be(displayName);
+
+        JsonNode? returnedProfileScope = returned["profileScope"];
+        returnedProfileScope.Should().NotBeNull("clearableText is visible to this profile");
+        JsonObject profileScopeObject = returnedProfileScope!.AsObject();
+        profileScopeObject["clearableText"]!.GetValue<string>().Should().Be(clearableText);
+        profileScopeObject
+            .ContainsKey("preservedText")
+            .Should()
+            .BeFalse("preservedText is hidden by ProfileRootOnlyMergeItem-Visible and must not be returned");
+
+        (string? persistedDisplayName, string? persistedClearable, string? persistedPreserved) =
+            await ReadMergeItemColumnsAsync(harness, itemId);
+        persistedDisplayName.Should().Be(displayName, "the create must persist visible scalar columns");
+        persistedClearable.Should().Be(clearableText, "the create must persist the visible scoped column");
+        persistedPreserved
+            .Should()
+            .BeNull("the create never named preservedText so the hidden column stays empty");
+    }
+
+    public static async Task It_preserves_hidden_field_on_profiled_put(ApiIntegrationHarness harness)
+    {
+        const int itemId = 4002;
+        const string seededDisplayName = "seeded-display";
+        const string seededClearable = "seeded-clearable";
+        const string seededPreserved = "seeded-preserved";
+        const string putDisplayName = "profiled-display";
+        const string putClearable = "profiled-clearable";
+
+        var seedPayload = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = itemId,
+            ["displayName"] = seededDisplayName,
+            ["profileScope"] = new JsonObject
+            {
+                ["clearableText"] = seededClearable,
+                ["preservedText"] = seededPreserved,
+            },
+        };
+
+        using var seedContent = new StringContent(
+            seedPayload.ToJsonString(),
+            Encoding.UTF8,
+            StandardJsonContentType
+        );
+        using HttpResponseMessage seedResponse = await harness.HttpClient.PostAsync(
+            MergeItemsEndpoint,
+            seedContent
+        );
+        seedResponse
+            .StatusCode.Should()
+            .Be(HttpStatusCode.Created, await seedResponse.Content.ReadAsStringAsync());
+        string locationPath = seedResponse.Headers.Location!.IsAbsoluteUri
+            ? seedResponse.Headers.Location!.AbsolutePath
+            : seedResponse.Headers.Location!.OriginalString;
+        TryReadRawEtag(seedResponse, out string seedEtag)
+            .Should()
+            .BeTrue("the unprofiled seed POST must emit an ETag so the profiled PUT can If-Match against it");
+        string resourceId = locationPath.Split('/')[^1];
+
+        var putPayload = new JsonObject
+        {
+            ["id"] = resourceId,
+            ["profileRootOnlyMergeItemId"] = itemId,
+            ["displayName"] = putDisplayName,
+            ["profileScope"] = new JsonObject { ["clearableText"] = putClearable },
+        };
+        using var putContent = new StringContent(
+            putPayload.ToJsonString(),
+            Encoding.UTF8,
+            VisibleWritableContentType
+        );
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, locationPath) { Content = putContent };
+        putRequest.Headers.TryAddWithoutValidation("If-Match", seedEtag);
+
+        using HttpResponseMessage putResponse = await harness.HttpClient.SendAsync(putRequest);
+        string putBody = await putResponse.Content.ReadAsStringAsync();
+        putResponse.StatusCode.Should().Be(HttpStatusCode.NoContent, putBody);
+
+        using HttpResponseMessage getResponse = await harness.HttpClient.GetAsync(locationPath);
+        string getBody = await getResponse.Content.ReadAsStringAsync();
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK, getBody);
+        JsonObject returned = JsonNode.Parse(getBody)!.AsObject();
+        returned["displayName"]!.GetValue<string>().Should().Be(putDisplayName);
+
+        JsonObject returnedProfileScope = returned["profileScope"]!.AsObject();
+        returnedProfileScope["clearableText"]!.GetValue<string>().Should().Be(putClearable);
+        returnedProfileScope["preservedText"]!
+            .GetValue<string>()
+            .Should()
+            .Be(
+                seededPreserved,
+                "an unprofiled GET must still return the hidden preservedText since the profiled PUT must not erase it"
+            );
+
+        (string? persistedDisplayName, string? persistedClearable, string? persistedPreserved) =
+            await ReadMergeItemColumnsAsync(harness, itemId);
+        persistedDisplayName.Should().Be(putDisplayName, "PUT must overwrite the visible scalar column");
+        persistedClearable.Should().Be(putClearable, "PUT must overwrite the visible scoped column");
+        persistedPreserved
+            .Should()
+            .Be(
+                seededPreserved,
+                "the hidden relational column must keep its seeded value through a profiled PUT that never named it"
+            );
+    }
+
+    public static async Task It_rejects_write_against_read_only_profile(ApiIntegrationHarness harness)
+    {
+        var payload = new JsonObject
+        {
+            ["profileRootOnlyMergeItemId"] = 4003,
+            ["displayName"] = "read-only-write-rejected",
+        };
+
+        using HttpResponseMessage response = await PostProfiledAsync(
+            harness,
+            payload,
+            ReadOnlyWritableContentType
+        );
+        string body = await response.Content.ReadAsStringAsync();
+
+        response
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.MethodNotAllowed,
+                "POST under a profile that exposes only a ReadContentType must return 405"
+            );
+        body.Should()
+            .Contain(
+                // The header parser captures the profile name from the Content-Type
+                // header verbatim (lowercase), and the resolver echoes it back in
+                // the error body, so the assertion matches the parsed casing rather
+                // than the original "ProfileRootOnlyMergeItem-ReadOnly" XML name.
+                "profilerootonlymergeitem-readonly",
+                "the error body must name the profile that rejected the write"
+            );
+        body.Should()
+            .Contain(
+                "ProfileRootOnlyMergeItem",
+                "the error body must name the resource that was not writable under the profile"
+            );
+
+        int persistedRowCount = await CountMergeItemRowsAsync(harness, 4003);
+        persistedRowCount.Should().Be(0, "the rejected profiled POST must not create a row");
+    }
+
+    private static async Task<HttpResponseMessage> PostProfiledAsync(
+        ApiIntegrationHarness harness,
+        JsonObject payload,
+        string profileContentType
+    )
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, MergeItemsEndpoint);
+        // Setting Content-Type via MediaTypeHeaderValue (rather than a StringContent
+        // constructor parameter) avoids HttpClient defaulting to "; charset=utf-8",
+        // which the profile header regex rejects.
+        request.Content = new StringContent(payload.ToJsonString(), Encoding.UTF8);
+        request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(profileContentType);
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> GetProfiledAsync(
+        ApiIntegrationHarness harness,
+        string locationPath,
+        string profileContentType
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, locationPath);
+        request.Headers.Accept.Clear();
+        request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(profileContentType));
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static bool TryReadRawEtag(HttpResponseMessage response, out string etag)
+    {
+        // DMS emits an opaque, unquoted ETag value that HttpResponseHeaders.ETag
+        // rejects as malformed (it requires RFC 7232 quoting), so route through
+        // TryGetValues to preserve the raw header.
+        if (response.Headers.TryGetValues("ETag", out IEnumerable<string>? values))
+        {
+            string? first = values.FirstOrDefault();
+            if (!string.IsNullOrEmpty(first))
+            {
+                etag = first;
+                return true;
+            }
+        }
+        etag = string.Empty;
+        return false;
+    }
+
+    private static async Task<(
+        string? DisplayName,
+        string? ClearableText,
+        string? PreservedText
+    )> ReadMergeItemColumnsAsync(ApiIntegrationHarness harness, int profileRootOnlyMergeItemId)
+    {
+        // Double-quoted identifiers are accepted by both PostgreSQL (native) and SQL
+        // Server (default QUOTED_IDENTIFIER ON), so a single statement covers both.
+        await using DbCommand command = harness.DbConnection.CreateCommand();
+        command.CommandText = """
+            SELECT "DisplayName", "ProfileScopeClearableText", "ProfileScopePreservedText"
+            FROM "edfi"."ProfileRootOnlyMergeItem"
+            WHERE "ProfileRootOnlyMergeItemId" = @profileRootOnlyMergeItemId
+            """;
+        DbParameter parameter = command.CreateParameter();
+        parameter.ParameterName = "@profileRootOnlyMergeItemId";
+        parameter.Value = profileRootOnlyMergeItemId;
+        command.Parameters.Add(parameter);
+
+        await using DbDataReader reader = await command.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+        {
+            return (null, null, null);
+        }
+
+        string? displayName = await reader.IsDBNullAsync(0) ? null : reader.GetString(0);
+        string? clearable = await reader.IsDBNullAsync(1) ? null : reader.GetString(1);
+        string? preserved = await reader.IsDBNullAsync(2) ? null : reader.GetString(2);
+        return (displayName, clearable, preserved);
+    }
+
+    private static async Task<int> CountMergeItemRowsAsync(
+        ApiIntegrationHarness harness,
+        int profileRootOnlyMergeItemId
+    )
+    {
+        await using DbCommand command = harness.DbConnection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*) FROM "edfi"."ProfileRootOnlyMergeItem"
+            WHERE "ProfileRootOnlyMergeItemId" = @profileRootOnlyMergeItemId
+            """;
+        DbParameter parameter = command.CreateParameter();
+        parameter.ParameterName = "@profileRootOnlyMergeItemId";
+        parameter.Value = profileRootOnlyMergeItemId;
+        command.Parameters.Add(parameter);
+
+        object? result = await command.ExecuteScalarAsync();
+        return Convert.ToInt32(result, System.Globalization.CultureInfo.InvariantCulture);
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
@@ -16,4 +16,21 @@ public sealed class Given_Mssql_CrudRoundTrip : MssqlApiIntegrationTestBase
     [Test]
     public Task It_creates_and_reads_a_student() =>
         CrudRoundTripScenario.It_creates_and_reads_a_student(Harness);
+
+    [Test]
+    public Task It_updates_a_student_via_put() => CrudRoundTripScenario.It_updates_a_student_via_put(Harness);
+
+    [Test]
+    public Task It_deletes_a_student() => CrudRoundTripScenario.It_deletes_a_student(Harness);
+
+    [Test]
+    public Task It_pages_students_via_query() => CrudRoundTripScenario.It_pages_students_via_query(Harness);
+
+    [Test]
+    public Task It_rejects_create_with_missing_reference() =>
+        CrudRoundTripScenario.It_rejects_create_with_missing_reference(Harness);
+
+    [Test]
+    public Task It_rejects_delete_when_referenced() =>
+        CrudRoundTripScenario.It_rejects_delete_when_referenced(Harness);
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
@@ -21,6 +21,10 @@ public sealed class Given_Mssql_CrudRoundTrip : MssqlApiIntegrationTestBase
     public Task It_updates_a_student_via_put() => CrudRoundTripScenario.It_updates_a_student_via_put(Harness);
 
     [Test]
+    public Task It_upserts_a_student_via_post() =>
+        CrudRoundTripScenario.It_upserts_a_student_via_post(Harness);
+
+    [Test]
     public Task It_deletes_a_student() => CrudRoundTripScenario.It_deletes_a_student(Harness);
 
     [Test]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_CrudRoundTrip.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+public sealed class Given_Mssql_CrudRoundTrip : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    [Test]
+    public Task It_creates_and_reads_a_student() =>
+        CrudRoundTripScenario.It_creates_and_reads_a_student(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ProfileRootOnlyMerge_ProfiledHttp.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_ProfileRootOnlyMerge_ProfiledHttp.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+public sealed class Given_Mssql_ProfileRootOnlyMerge_ProfiledHttp : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    [Test]
+    public Task It_creates_and_reads_via_visible_profile() =>
+        ProfileRootOnlyMergeProfileScenario.It_creates_and_reads_via_visible_profile(Harness);
+
+    [Test]
+    public Task It_preserves_hidden_field_on_profiled_put() =>
+        ProfileRootOnlyMergeProfileScenario.It_preserves_hidden_field_on_profiled_put(Harness);
+
+    [Test]
+    public Task It_rejects_write_against_read_only_profile() =>
+        ProfileRootOnlyMergeProfileScenario.It_rejects_write_against_read_only_profile(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
@@ -21,6 +21,10 @@ public sealed class Given_Postgresql_CrudRoundTrip : PostgresqlApiIntegrationTes
     public Task It_updates_a_student_via_put() => CrudRoundTripScenario.It_updates_a_student_via_put(Harness);
 
     [Test]
+    public Task It_upserts_a_student_via_post() =>
+        CrudRoundTripScenario.It_upserts_a_student_via_post(Harness);
+
+    [Test]
     public Task It_deletes_a_student() => CrudRoundTripScenario.It_deletes_a_student(Harness);
 
     [Test]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+public sealed class Given_Postgresql_CrudRoundTrip : PostgresqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    [Test]
+    public Task It_creates_and_reads_a_student() =>
+        CrudRoundTripScenario.It_creates_and_reads_a_student(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_CrudRoundTrip.cs
@@ -16,4 +16,21 @@ public sealed class Given_Postgresql_CrudRoundTrip : PostgresqlApiIntegrationTes
     [Test]
     public Task It_creates_and_reads_a_student() =>
         CrudRoundTripScenario.It_creates_and_reads_a_student(Harness);
+
+    [Test]
+    public Task It_updates_a_student_via_put() => CrudRoundTripScenario.It_updates_a_student_via_put(Harness);
+
+    [Test]
+    public Task It_deletes_a_student() => CrudRoundTripScenario.It_deletes_a_student(Harness);
+
+    [Test]
+    public Task It_pages_students_via_query() => CrudRoundTripScenario.It_pages_students_via_query(Harness);
+
+    [Test]
+    public Task It_rejects_create_with_missing_reference() =>
+        CrudRoundTripScenario.It_rejects_create_with_missing_reference(Harness);
+
+    [Test]
+    public Task It_rejects_delete_when_referenced() =>
+        CrudRoundTripScenario.It_rejects_delete_when_referenced(Harness);
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ProfileRootOnlyMerge_ProfiledHttp.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Postgresql/Given_Postgresql_ProfileRootOnlyMerge_ProfiledHttp.cs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Postgresql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Postgresql;
+
+public sealed class Given_Postgresql_ProfileRootOnlyMerge_ProfiledHttp : PostgresqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.ProfileRootOnlyMerge;
+
+    [Test]
+    public Task It_creates_and_reads_via_visible_profile() =>
+        ProfileRootOnlyMergeProfileScenario.It_creates_and_reads_via_visible_profile(Harness);
+
+    [Test]
+    public Task It_preserves_hidden_field_on_profiled_put() =>
+        ProfileRootOnlyMergeProfileScenario.It_preserves_hidden_field_on_profiled_put(Harness);
+
+    [Test]
+    public Task It_rejects_write_against_read_only_profile() =>
+        ProfileRootOnlyMergeProfileScenario.It_rejects_write_against_read_only_profile(Harness);
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/appsettings.json
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Builds an API-level integration harness that drives the real DMS HTTP pipeline (`WebApplicationFactory<Program>`) against per-test provisioned PostgreSQL and SQL Server databases, with auth / CMS / profile-catalog / application-context faked. Adds CI lanes for both dialects.

## What's in the branch

- **Harness foundation**: new `EdFi.DataManagementService.Tests.Integration` project — fixture loader with runtime-compatible ApiSchema materialization, per-dialect `ApiIntegrationTestBase`, external doubles (`FakeJwtValidationService`, `AllowAllClaimSetProvider`, `FakeApplicationContextProvider`, `FakeDmsInstanceProvider`, `FakeProfileCmsProvider`).
- **Shared extraction**: pulled the per-dialect baseline-DB helpers (`Postgresql/MssqlGeneratedDdlBaselineDatabase`, `…TestDatabase`, `BaselineDatabaseConfiguration`) out of the two backend integration projects into a new `Backend.Tests.Integration.Common` project so the harness can consume them without `InternalsVisibleTo`.
- **Group A no-profile scenarios** on the `ProfileRootOnlyMerge` fixture: POST+GET with persisted-row assertion, PUT-update with ETag advance, DELETE with row-gone assertion, query+paging, reference-validation failure, delete-conflict rejection.
- **Profiled HTTP scenarios** on the same fixture: a `ProfileRootOnlyMergeItem-Visible` profile (root `IncludeAll` so the `ValidateMatchingDocumentUuids` id field survives the strict request shaper, nested `profileScope` `IncludeOnly` to hide `preservedText`) and a `ProfileRootOnlyMergeItem-ReadOnly` profile drive `ProfileRootOnlyMergeProfileScenario` — profiled create/read with the hidden-field assertion on GET, hidden-field preservation through a profiled PUT (asserted against both the unprofiled GET response and the `ProfileScopePreservedText` relational column), and the read-only profile used for the 405 write-rejection branch.
- **Per-dialect test wrappers** under `Tests/Postgresql/` and `Tests/Mssql/` that thread each scenario through both backends.
- **Lifecycle**: assembly-level `[SetUpFixture]` (`HarnessAssemblyTeardown`) disposes cached baseline databases at run end so local repeated runs do not leak template DBs / snapshots / slot pools; teardown also disposes the assertion connection cleanly when DMS startup fails before the harness is constructed.
- **CI**: two new PR jobs — `run-dms-api-postgresql-integration-tests` and `run-dms-api-mssql-integration-tests` — each runs its dialect's filter against a service container; neither needs DMS/CMS docker, Keycloak, Kafka, or OpenSearch.
- **Docs**: project README, `docs/RUNNING-LOCALLY.md` section, cross-reference from `reference/design/backend-redesign/epics/13-test-migration/01-backend-integration-tests.md`.

## Notable behaviors documented in code

- DMS emits `ETag` as a raw opaque value (the API metadata fingerprint), not in RFC 7232 quoted form, so `HttpResponseHeaders.ETag` returns null. Scenarios read via `Headers.TryGetValues("ETag", ...)` (helper `TryReadRawEtag`).
- `If-Match` is a request header, not a content header; scenarios use `HttpRequestMessage` + `SendAsync` rather than `PutAsync(uri, content)`.
- Persisted-state assertions use `"edfi"."Student"` / `"StudentUniqueId"` — double-quoted PascalCase works on PostgreSQL natively and on SQL Server with `QUOTED_IDENTIFIER ON` (default for `Microsoft.Data.SqlClient`).

## Test plan

- [ ] Solution builds cleanly (`dotnet build src/dms/EdFi.DataManagementService.sln -c Debug`)
- [ ] PostgreSQL suite passes locally — 9/9 (`Category=PostgresqlIntegration`)
- [ ] SQL Server suite passes — verify in CI (no local MSSQL container available at branch close)
- [ ] CSharpier formatting clean for changed files (enforced by Husky pre-commit hook)
- [ ] Sibling `Backend.{Postgresql,Mssql}.Tests.Integration` projects still pass — verify in CI; the shared extraction changes their internal usings but does not change observable behavior
