### PR TITLE
[DMS-912] Enable smoke test suites against local DMS stack

### DIFF
--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Verify SDK Generation
         run: |
           Write-Host "Checking SDK generation results..."
-          $sdkPath = "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll"
+          $sdkPath = "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll"
           Write-Host "Expected SDK path: $sdkPath"
 
           if (Test-Path $sdkPath) {
@@ -158,12 +158,12 @@ jobs:
 
       - name: Run NonDestructive DMS SDK Tests
         run: |
-          ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll"
+          ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll"
         working-directory: eng/smoke_test/
 
       - name: Run Destructive DMS SDK Tests
         run: |
-          ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll"
+          ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll"
         working-directory: eng/smoke_test/
 
       - name: Run NonDestructive ODS SDK Tests

--- a/.gitignore
+++ b/.gitignore
@@ -446,7 +446,7 @@ CLAUDE.local.md
 
 # SDK generation artifacts
 /eng/sdkGen/csharp/*
-openApi-codegen-cli.jar
+openApi-codegen-cli-*.jar
 /.github/copilot-instructions.md
 
 # Claude temporary files leaking into the project root in 2.1.5

--- a/build-sdk.ps1
+++ b/build-sdk.ps1
@@ -90,71 +90,164 @@ function DownloadCodeGen {
     }
 }
 
-function GenerateSdk {
-    param (
-        [string]
-        $ApiPackage,
+function Rename-DescriptorOperationId {
+    param([string]$old)
+    if ($old -match 'ById$') {
+        return ($old -replace 'ById$', 'DescriptorById')
+    } elseif ($old -match 's$') {
+        return ($old -replace 's$', 'Descriptors')
+    } else {
+        return "${old}Descriptor"
+    }
+}
 
-        [string]
-        $ModelPackage,
-
-        [string]
-        $Endpoint,
-
-        [string]
-        $ExtraOperationIdMappings = ""
+function Merge-DmsSpecs {
+    # Merges resources-spec and descriptors-spec into a single OpenAPI document so the generator
+    # runs once and emits a complete HostConfiguration.cs / IApi.cs. The two-pass flow used to
+    # let the descriptors pass clobber the resources-pass HostConfiguration, leaving resource
+    # APIs unregistered in DI and the smoke test tool throwing NREs on every resource call.
+    param(
+        [string]$ResourcesEndpoint,
+        [string]$DescriptorsEndpoint
     )
 
-    # Download and parse OpenAPI spec
-    $spec = Invoke-WebRequest -Uri $Endpoint | ConvertFrom-Json
+    $resources = (Invoke-WebRequest -Uri $ResourcesEndpoint).Content | ConvertFrom-Json -Depth 100 -AsHashtable
+    $descriptors = (Invoke-WebRequest -Uri $DescriptorsEndpoint).Content | ConvertFrom-Json -Depth 100 -AsHashtable
 
-    # Find all operationIds that contain an underscore
-    $operationIds = $spec.paths.PSObject.Properties.Value | ForEach-Object {
-        $_.PSObject.Properties.Value | Where-Object { $_.operationId -and $_.operationId -like "*_*" } | ForEach-Object { $_.operationId }
+    # Rename descriptor operationIds that collide with resource ones (e.g. getGradingPeriods
+    # appears in both specs; without renaming we'd get duplicate C# method names in Apis.All).
+    $resourceIds = @{}
+    foreach ($pathOps in $resources.paths.Values) {
+        foreach ($op in $pathOps.Values) {
+            if ($op -is [System.Collections.IDictionary] -and $op.ContainsKey('operationId')) {
+                $resourceIds[$op.operationId] = $true
+            }
+        }
+    }
+    foreach ($pathOps in $descriptors.paths.Values) {
+        foreach ($op in $pathOps.Values) {
+            if ($op -is [System.Collections.IDictionary] -and $op.ContainsKey('operationId') -and $resourceIds.ContainsKey($op.operationId)) {
+                $op.operationId = Rename-DescriptorOperationId $op.operationId
+            }
+        }
     }
 
-    # Normalize operationId to camelCase without underscores (for the left side of mapping)
+    # Union descriptor paths/schemas/tags into resources. Parameters/responses/securitySchemes
+    # are identical across both specs (verified by inspection) so the resources copy is kept.
+    foreach ($pathName in $descriptors.paths.Keys) {
+        if (-not $resources.paths.ContainsKey($pathName)) {
+            $resources.paths[$pathName] = $descriptors.paths[$pathName]
+        }
+    }
+    foreach ($schemaName in $descriptors.components.schemas.Keys) {
+        if (-not $resources.components.schemas.ContainsKey($schemaName)) {
+            $resources.components.schemas[$schemaName] = $descriptors.components.schemas[$schemaName]
+        }
+    }
+    $existingTagNames = @{}
+    foreach ($t in $resources.tags) { $existingTagNames[$t.name] = $true }
+    foreach ($t in $descriptors.tags) {
+        if (-not $existingTagNames.ContainsKey($t.name)) {
+            $resources.tags += $t
+        }
+    }
+
+    # Drop required arrays on Homograph* schemas so the generichost-library generator omits its
+    # throw-on-missing-required validation. The smoke test tool's data factory cannot populate
+    # required props on these extension models, and the server-side spec still enforces them.
+    foreach ($schemaName in @($resources.components.schemas.Keys)) {
+        if ($schemaName.StartsWith('Homograph')) {
+            $schema = $resources.components.schemas[$schemaName]
+            if ($schema -is [System.Collections.IDictionary] -and $schema.ContainsKey('required')) {
+                $schema.Remove('required')
+            }
+        }
+    }
+
+    return $resources
+}
+
+function GenerateSdk {
+    param (
+        [string]$ApiPackage,
+        [string]$ModelPackage,
+        [System.Collections.IDictionary]$Spec
+    )
+
+    # Rewrite tags on non-ed-fi paths whose tag also appears on /ed-fi/* paths. Without this,
+    # /ed-fi/contacts and /homograph/contacts share tag 'contacts' and land on the same
+    # ContactsApi, which the smoke test tool's "one Post per Api class" categorizer can't
+    # disambiguate. The generator emits a distinct *Api class per tag, so prefixing the tag
+    # with the namespace splits the colliding endpoints into separate classes.
+    $coreTags = @{}
+    foreach ($pathName in @($Spec.paths.Keys)) {
+        if ($pathName.StartsWith('/ed-fi/')) {
+            foreach ($verb in @($Spec.paths[$pathName].Keys)) {
+                $op = $Spec.paths[$pathName][$verb]
+                if ($op -is [System.Collections.IDictionary] -and $op.ContainsKey('tags') -and $op['tags']) {
+                    foreach ($t in $op['tags']) { $coreTags[$t] = $true }
+                }
+            }
+        }
+    }
+    foreach ($pathName in @($Spec.paths.Keys)) {
+        if ($pathName -match '^/(?<ns>[^/]+)/' -and $matches.ns -ne 'ed-fi') {
+            $nsSafe = ($matches.ns -replace '[^A-Za-z0-9]', '')
+            foreach ($verb in @($Spec.paths[$pathName].Keys)) {
+                $op = $Spec.paths[$pathName][$verb]
+                if ($op -is [System.Collections.IDictionary] -and $op.ContainsKey('tags') -and $op['tags']) {
+                    $op['tags'] = @($op['tags'] | ForEach-Object { if ($coreTags.ContainsKey($_)) { "${nsSafe}_$_" } else { $_ } })
+                }
+            }
+        }
+    }
+
+    # Build --operation-id-name-mappings for underscore-bearing operationIds so the generator
+    # preserves the namespace separator in C# method names (post_HomographContact stays
+    # Post_HomographContact rather than collapsing to PostHomographContact).
+    $operationIds = @()
+    foreach ($pathOps in $Spec.paths.Values) {
+        foreach ($op in $pathOps.Values) {
+            if ($op -is [System.Collections.IDictionary] -and $op.ContainsKey('operationId') -and $op.operationId -like "*_*") {
+                $operationIds += $op.operationId
+            }
+        }
+    }
+
     function Normalize-OperationId {
         param($opId)
         $parts = $opId -split '_'
-        $camel = $parts[0] + ($parts[1..($parts.Count-1)] | ForEach-Object { $_.Substring(0,1).ToUpper() + $_.Substring(1) } | ForEach-Object { $_ }) -join ''
+        $camel = $parts[0] + (($parts[1..($parts.Count-1)] | ForEach-Object { $_.Substring(0,1).ToUpper() + $_.Substring(1) }) -join '')
         return $camel
     }
-
-    # Capitalize the first character of the string
     function Capitalize-FirstChar {
         param($s)
         if ($s.Length -eq 0) { return $s }
         return $s.Substring(0,1).ToUpper() + $s.Substring(1)
     }
-
-    # Build mappings string: left = normalized, right = original with first char uppercased
     $mappings = ($operationIds | Sort-Object -Unique | ForEach-Object { "$(Normalize-OperationId $_)=$(Capitalize-FirstChar $_)" }) -join ","
-    # Example --operation-id-name-mappings deleteHomographContactsById=Delete_HomographContactsById
 
-    # Merge in any extra mappings provided by the caller (e.g. to resolve cross-spec operationId collisions)
-    if ($ExtraOperationIdMappings -ne "") {
-        if ($mappings -ne "") {
-            $mappings = "$mappings,$ExtraOperationIdMappings"
-        } else {
-            $mappings = $ExtraOperationIdMappings
-        }
+    $specTempPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), "openapi-spec-$([System.Guid]::NewGuid()).json")
+    $Spec | ConvertTo-Json -Depth 100 -Compress | Set-Content -Path $specTempPath -Encoding UTF8NoBOM
+
+    try {
+        & java -Xmx5g -jar $openApiGeneratorJar generate `
+        -g csharp `
+        -i $specTempPath `
+        --api-package $ApiPackage `
+        --model-package $ModelPackage `
+        -o $OutputFolder `
+        --operation-id-name-mappings $mappings `
+        --additional-properties "packageName=$PackageName,targetFramework=net10.0,netCoreProjectFile=true" `
+        --global-property modelTests=false `
+        --global-property apiTests=false `
+        --global-property apiDocs=false `
+        --global-property modelDocs=false `
+        --skip-validate-spec
     }
-
-    & java -Xmx5g -jar $openApiGeneratorJar generate `
-    -g csharp `
-    -i $Endpoint `
-    --api-package $ApiPackage `
-    --model-package $ModelPackage `
-    -o $OutputFolder `
-    --operation-id-name-mappings $mappings `
-    --additional-properties "packageName=$PackageName,targetFramework=net10.0,netCoreProjectFile=true" `
-    --global-property modelTests=false `
-    --global-property apiTests=false `
-    --global-property apiDocs=false `
-    --global-property modelDocs=false `
-    --skip-validate-spec
-
+    finally {
+        Remove-Item $specTempPath -ErrorAction SilentlyContinue
+    }
 }
 
 function BuildSdk {
@@ -210,67 +303,20 @@ function PushPackage {
     }
 }
 
-function Get-OperationIds {
-    param([string]$Endpoint)
-    $spec = Invoke-WebRequest -Uri $Endpoint | ConvertFrom-Json
-    $ids = $spec.paths.PSObject.Properties.Value | ForEach-Object {
-        $_.PSObject.Properties.Value | Where-Object { $_.operationId } | ForEach-Object { $_.operationId }
-    }
-    return ($ids | Sort-Object -Unique)
-}
-
-function Build-CollisionMappings {
-    param(
-        [string[]]$ResourcesIds,
-        [string[]]$DescriptorsIds
-    )
-    # Find operationIds present in both specs (collisions that would produce duplicate C# names)
-    $collisions = $DescriptorsIds | Where-Object { $ResourcesIds -contains $_ }
-    if ($collisions.Count -eq 0) {
-        return ""
-    }
-    # For each colliding descriptor operationId, insert "Descriptor" before any "ById" suffix
-    # or replace a trailing "s" with "Descriptors", otherwise append "Descriptor".
-    # Examples:  getGradingPeriods        -> getGradingPeriodDescriptors
-    #            deleteGradingPeriodsById -> deleteGradingPeriodDescriptorsById
-    #            postGradingPeriod        -> postGradingPeriodDescriptor
-    #            putGradingPeriod         -> putGradingPeriodDescriptor
-    $mappings = $collisions | ForEach-Object {
-        $old = $_
-        if ($old -match 'ById$') {
-            $new = $old -replace 'ById$', 'DescriptorById'
-        } elseif ($old -match 's$') {
-            $new = $old -replace 's$', 'Descriptors'
-        } else {
-            $new = "${old}Descriptor"
-        }
-        "$old=$new"
-    }
-    return ($mappings -join ",")
-}
-
 function Invoke-BuildAndGenerateSdk {
     Invoke-Step { DownloadCodeGen }
 
-    if ($PackageName -eq "EdFi.DmsApi.TestSdk") {
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
-        # Detect operationId collisions between the two specs and remap the descriptor-side ones to
-        # avoid duplicate C# type names when both specs are merged into the same Apis.All namespace.
-        $resourcesIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json"
-        $descriptorsIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json"
-        $collisionMappings = Build-CollisionMappings -ResourcesIds $resourcesIds -DescriptorsIds $descriptorsIds
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" -ExtraOperationIdMappings $collisionMappings }
-    } elseif ($PackageName -eq "EdFi.DmsApi.Sdk") {
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
-        # Apply the same collision-avoidance logic as TestSdk so that GradingPeriodDescriptors
-        # response interfaces do not duplicate those from the GradingPeriods resources spec.
-        $resourcesIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json"
-        $descriptorsIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json"
-        $collisionMappings = Build-CollisionMappings -ResourcesIds $resourcesIds -DescriptorsIds $descriptorsIds
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" -ExtraOperationIdMappings $collisionMappings }
-    } else {
-        throw "Unknown PackageName value: $PackageName"
+    $mergedSpec = Merge-DmsSpecs `
+        -ResourcesEndpoint "$DmsUrl/metadata/specifications/resources-spec.json" `
+        -DescriptorsEndpoint "$DmsUrl/metadata/specifications/descriptors-spec.json"
+
+    $packagePair = switch ($PackageName) {
+        "EdFi.DmsApi.TestSdk" { @{ Api = "Apis.All"; Model = "Models.All" } }
+        "EdFi.DmsApi.Sdk"     { @{ Api = "Apis.Ed_Fi"; Model = "Models.Ed_Fi" } }
+        default               { throw "Unknown PackageName value: $PackageName" }
     }
+
+    Invoke-Step { GenerateSdk -ApiPackage $packagePair.Api -ModelPackage $packagePair.Model -Spec $mergedSpec }
 
     Invoke-Step { BuildSdk }
 }

--- a/build-sdk.ps1
+++ b/build-sdk.ps1
@@ -77,13 +77,16 @@ param(
 
 Import-Module -Name "$PSScriptRoot/eng/build-helpers.psm1" -Force
 
+$openApiGeneratorVersion = "7.19.0"
+$openApiGeneratorJar = "openApi-codegen-cli-$openApiGeneratorVersion.jar"
+
 $solutionRoot = "$PSScriptRoot/$OutputFolder"
 $projectPath = "$solutionRoot/src/$PackageName/$PackageName.csproj"
 $nuspecPath = "$PSScriptRoot/eng/sdkGen/$PackageName.nuspec"
 
 function DownloadCodeGen {
-    if (-not (Test-Path -Path openApi-codegen-cli.jar)) {
-        Invoke-WebRequest -OutFile openApi-codegen-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.9.0/openapi-generator-cli-7.9.0.jar
+    if (-not (Test-Path -Path $openApiGeneratorJar)) {
+        Invoke-WebRequest -OutFile $openApiGeneratorJar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$openApiGeneratorVersion/openapi-generator-cli-$openApiGeneratorVersion.jar
     }
 }
 
@@ -96,7 +99,10 @@ function GenerateSdk {
         $ModelPackage,
 
         [string]
-        $Endpoint
+        $Endpoint,
+
+        [string]
+        $ExtraOperationIdMappings = ""
     )
 
     # Download and parse OpenAPI spec
@@ -126,14 +132,23 @@ function GenerateSdk {
     $mappings = ($operationIds | Sort-Object -Unique | ForEach-Object { "$(Normalize-OperationId $_)=$(Capitalize-FirstChar $_)" }) -join ","
     # Example --operation-id-name-mappings deleteHomographContactsById=Delete_HomographContactsById
 
-    & java -Xmx5g -jar openApi-codegen-cli.jar generate `
+    # Merge in any extra mappings provided by the caller (e.g. to resolve cross-spec operationId collisions)
+    if ($ExtraOperationIdMappings -ne "") {
+        if ($mappings -ne "") {
+            $mappings = "$mappings,$ExtraOperationIdMappings"
+        } else {
+            $mappings = $ExtraOperationIdMappings
+        }
+    }
+
+    & java -Xmx5g -jar $openApiGeneratorJar generate `
     -g csharp `
     -i $Endpoint `
     --api-package $ApiPackage `
     --model-package $ModelPackage `
     -o $OutputFolder `
     --operation-id-name-mappings $mappings `
-    --additional-properties "packageName=$PackageName,targetFramework=net8.0,netCoreProjectFile=true" `
+    --additional-properties "packageName=$PackageName,targetFramework=net10.0,netCoreProjectFile=true" `
     --global-property modelTests=false `
     --global-property apiTests=false `
     --global-property apiDocs=false `
@@ -195,15 +210,64 @@ function PushPackage {
     }
 }
 
+function Get-OperationIds {
+    param([string]$Endpoint)
+    $spec = Invoke-WebRequest -Uri $Endpoint | ConvertFrom-Json
+    $ids = $spec.paths.PSObject.Properties.Value | ForEach-Object {
+        $_.PSObject.Properties.Value | Where-Object { $_.operationId } | ForEach-Object { $_.operationId }
+    }
+    return ($ids | Sort-Object -Unique)
+}
+
+function Build-CollisionMappings {
+    param(
+        [string[]]$ResourcesIds,
+        [string[]]$DescriptorsIds
+    )
+    # Find operationIds present in both specs (collisions that would produce duplicate C# names)
+    $collisions = $DescriptorsIds | Where-Object { $ResourcesIds -contains $_ }
+    if ($collisions.Count -eq 0) {
+        return ""
+    }
+    # For each colliding descriptor operationId, insert "Descriptor" before any "ById" suffix
+    # or replace a trailing "s" with "Descriptors", otherwise append "Descriptor".
+    # Examples:  getGradingPeriods        -> getGradingPeriodDescriptors
+    #            deleteGradingPeriodsById -> deleteGradingPeriodDescriptorsById
+    #            postGradingPeriod        -> postGradingPeriodDescriptor
+    #            putGradingPeriod         -> putGradingPeriodDescriptor
+    $mappings = $collisions | ForEach-Object {
+        $old = $_
+        if ($old -match 'ById$') {
+            $new = $old -replace 'ById$', 'DescriptorById'
+        } elseif ($old -match 's$') {
+            $new = $old -replace 's$', 'Descriptors'
+        } else {
+            $new = "${old}Descriptor"
+        }
+        "$old=$new"
+    }
+    return ($mappings -join ",")
+}
+
 function Invoke-BuildAndGenerateSdk {
     Invoke-Step { DownloadCodeGen }
 
     if ($PackageName -eq "EdFi.DmsApi.TestSdk") {
         Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" }
+        # Detect operationId collisions between the two specs and remap the descriptor-side ones to
+        # avoid duplicate C# type names when both specs are merged into the same Apis.All namespace.
+        $resourcesIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json"
+        $descriptorsIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json"
+        $collisionMappings = Build-CollisionMappings -ResourcesIds $resourcesIds -DescriptorsIds $descriptorsIds
+        Invoke-Step { GenerateSdk -ApiPackage "Apis.All" -ModelPackage "Models.All" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" -ExtraOperationIdMappings $collisionMappings }
     } elseif ($PackageName -eq "EdFi.DmsApi.Sdk") {
         Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json" }
-        Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" }
+        # Apply the same collision-avoidance logic as TestSdk so that GradingPeriodDescriptors
+        # response interfaces do not duplicate those from the GradingPeriods resources spec.
+        $resourcesIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/resources-spec.json"
+        $descriptorsIds = Get-OperationIds -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json"
+        $collisionMappings = Build-CollisionMappings -ResourcesIds $resourcesIds -DescriptorsIds $descriptorsIds
+        Invoke-Step { GenerateSdk -ApiPackage "Apis.Ed_Fi" -ModelPackage "Models.Ed_Fi" -Endpoint "$DmsUrl/metadata/specifications/descriptors-spec.json" -ExtraOperationIdMappings $collisionMappings }
     } else {
         throw "Unknown PackageName value: $PackageName"
     }

--- a/eng/Package-Management.psm1
+++ b/eng/Package-Management.psm1
@@ -123,6 +123,16 @@ function Get-NugetPackage {
         $PreRelease
     )
 
+    $lowerId = $PackageName.ToLower()
+    $packagesDir = ".packages"
+
+    if (-not [string]::IsNullOrWhiteSpace($PackageVersion) -and $PackageVersion.Split('.').Length -ge 3) {
+        $cachedPackage = Join-Path -Path $packagesDir -ChildPath "$lowerId.$PackageVersion"
+        if (Test-Path -Path $cachedPackage) {
+            return $cachedPackage
+        }
+    }
+
     # Pre-releases
     $nugetServicesURL = $ReleaseServiceIndex
     if ($PreRelease) {
@@ -136,7 +146,6 @@ function Get-NugetPackage {
                         | Where-Object { $_."@type" -like "PackageBaseAddress*" } `
                         | Select-Object -Property "@id" -ExpandProperty "@id"
 
-    $lowerId = $PackageName.ToLower()
     # Lookup available packages
     $package = Invoke-RestMethod "$($packageService)$($lowerId)/index.json"
     # Sort by SemVer
@@ -165,7 +174,6 @@ function Get-NugetPackage {
 
     $file = "$($lowerId).$($version)"
     $zip = "$($file).zip"
-    $packagesDir = ".packages"
     New-Item -Path $packagesDir -Force -ItemType Directory | Out-Null
 
     Push-Location $packagesDir

--- a/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
@@ -13,16 +13,16 @@
     <copyright>Copyright @ $year$ Ed-Fi Alliance, LLC and Contributors</copyright>
     <tags>Ed-Fi Data Management Service SDK</tags>
     <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="NewtonSoft.Json" version="13.0.3" />
-        <dependency id="JsonSubTypes" version="2.0.1" />
-        <dependency id="RestSharp" version="112.0.0" />
-        <dependency id="Polly" version="8.1.0" />
+      <group targetFramework="net10.0">
+        <dependency id="Microsoft.Extensions.Http" version="10.0.1" />
+        <dependency id="Microsoft.Extensions.Hosting" version="10.0.1" />
+        <dependency id="Microsoft.Extensions.Http.Polly" version="10.0.1" />
+        <dependency id="Microsoft.Net.Http.Headers" version="10.0.1" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.DmsApi.Sdk\bin\Release\net8.0\EdFi.DmsApi.Sdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.Sdk\bin\Release\net10.0\EdFi.DmsApi.Sdk.dll" target="lib\net10.0" />
   </files>
 </package>

--- a/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
@@ -13,16 +13,16 @@
     <copyright>Copyright @ $year$ Ed-Fi Alliance, LLC and Contributors</copyright>
     <tags>Ed-Fi Data Management Service TestSdk</tags>
     <dependencies>
-      <group targetFramework="net8.0">
-        <dependency id="NewtonSoft.Json" version="13.0.3" />
-        <dependency id="JsonSubTypes" version="2.0.1" />
-        <dependency id="RestSharp" version="112.0.0" />
-        <dependency id="Polly" version="8.1.0" />
+      <group targetFramework="net10.0">
+        <dependency id="Microsoft.Extensions.Http" version="10.0.1" />
+        <dependency id="Microsoft.Extensions.Hosting" version="10.0.1" />
+        <dependency id="Microsoft.Extensions.Http.Polly" version="10.0.1" />
+        <dependency id="Microsoft.Net.Http.Headers" version="10.0.1" />
       </group>
     </dependencies>
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.DmsApi.TestSdk\bin\Release\net8.0\EdFi.DmsApi.TestSdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.TestSdk\bin\Release\net10.0\EdFi.DmsApi.TestSdk.dll" target="lib\net10.0" />
   </files>
 </package>

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -40,7 +40,7 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20144' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveApiTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveApiTests.ps1
@@ -23,7 +23,7 @@ $ErrorActionPreference = "Stop"
 Import-Module ../Package-Management.psm1 -Force
 Import-Module ./modules/SmokeTest.psm1
 
-$path = Get-SmokeTestTool -PackageVersion '7.2.413'
+$path = Get-SmokeTestTool -PackageVersion '7.3.20144' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -40,7 +40,7 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20144' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -9,6 +9,31 @@ $ErrorActionPreference = "Stop"
 # Import the Dms-Management module for vendor/application management
 Import-Module "$PSScriptRoot/../../Dms-Management.psm1" -Force
 
+function Get-SmokeTestConsolePath {
+    param (
+        [string]
+        [Parameter(Mandatory = $True)]
+        $ToolPath
+    )
+
+    $toolsPath = Join-Path -Path ($ToolPath).Trim() -ChildPath "tools"
+    $frameworkDirectory = Get-ChildItem -Path $toolsPath -Directory |
+        Where-Object { $_.Name -match '^net\d+(\.\d+)?$' } |
+        Sort-Object { [version]($_.Name -replace '^net', '') } -Descending |
+        Select-Object -First 1
+
+    if ($null -eq $frameworkDirectory) {
+        throw "No supported .NET tool framework directory found in '$toolsPath'."
+    }
+
+    $consolePath = Join-Path -Path $frameworkDirectory.FullName -ChildPath "any/EdFi.SmokeTest.Console.dll"
+    if (-not (Test-Path $consolePath)) {
+        throw "Smoke test console not found at '$consolePath'."
+    }
+
+    return $consolePath
+}
+
 function Invoke-SmokeTestUtility {
 
     [CmdletBinding()]
@@ -36,13 +61,21 @@ function Invoke-SmokeTestUtility {
         [string]
         $SdkPath,
 
+        [string]
+        $OAuthUrl,
+
         [ValidateSet("EdFi.DmsApi.TestSdk", "EdFi.DmsApi.Sdk", "EdFi.OdsApi.Sdk")]
         [string]
         $SdkNamespace = "EdFi.DmsApi.TestSdk"
     )
 
+    if ([string]::IsNullOrWhiteSpace($OAuthUrl)) {
+        $OAuthUrl = "$($BaseUrl.TrimEnd('/'))/oauth/token"
+    }
+
     $options = @(
         "-b", $BaseUrl,
+        "-o", $OAuthUrl,
         "-k", $Key,
         "-s", $Secret,
         "-t", $TestSet,
@@ -64,7 +97,7 @@ function Invoke-SmokeTestUtility {
     Write-Output $ToolPath $options
     $host.UI.RawUI.ForegroundColor = $previousForegroundColor
 
-    $path = (Join-Path -Path ($ToolPath).Trim() -ChildPath "tools/net8.0/any/EdFi.SmokeTest.Console.dll")
+    $path = Get-SmokeTestConsolePath -ToolPath $ToolPath
     &dotnet $path $options
 }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
@@ -19,10 +19,17 @@ public class CoreEndpointModule(IOptions<AppSettings> appSettings) : IEndpointMo
             appSettings.Value.MultiTenancy
         );
 
-        endpoints.MapPost(routePattern, Upsert);
-        endpoints.MapGet(routePattern, Get);
-        endpoints.MapPut(routePattern, UpdateById);
-        endpoints.MapDelete(routePattern, DeleteById);
+        // /data/v3 alias for parity with ODS API URLs so SDK consumers (e.g. EdFi.LoadTools'
+        // SdkConfigurationFactory) that hardcode the historical /data/v3 base reach the same handlers.
+        string v3AliasPattern = routePattern.Replace("/data/{**dmsPath}", "/data/v3/{**dmsPath}");
+
+        foreach (var pattern in new[] { routePattern, v3AliasPattern })
+        {
+            endpoints.MapPost(pattern, Upsert);
+            endpoints.MapGet(pattern, Get);
+            endpoints.MapPut(pattern, UpdateById);
+            endpoints.MapDelete(pattern, DeleteById);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Unblocks all three smoke suites end-to-end against a local DMS stack after the OpenAPI Generator 7.19.0 and smoke test tool upgrade. The two non-destructive suites now exit 0; `DestructiveSdk` runs to completion (no categorizer / token-exchange / SDK-generation blockers) and exits 1 only on a pre-existing tool ↔ DMS mismatch documented below.

| Suite | OK | Skipped | Errors | Exit |
|---|---|---|---|---|
| `NonDestructiveApi` | 1290 | 296 | 0 | **0** |
| `NonDestructiveSdk` | 1356 | 222 | 0 | **0** |
| `DestructiveSdk` | 1549 | 8 | 4 | **1** |

Prior state was exit 1 across the board: `Multiple matching Post methods were found on type 'ContactsApi'` blocking the SDK suites at categorization time, and a 502 Bad Gateway blocking the API suite at token-exchange time.

## Changes

**Permanent improvements**

- `build-sdk.ps1` — single-pass merged-spec generation. New `Merge-DmsSpecs` unions the resources and descriptors specs into one OpenAPI document so the generator runs once and emits a complete `HostConfiguration.cs`/`IApi.cs`. The prior two-pass flow let the descriptors pass clobber the resources-pass `HostConfiguration`, leaving every resource-side `IxxxApi` DI registration absent (232 descriptor registrations only). With the merge in place, all 396 registrations (resources + descriptors) survive into the SDK. `Get-OperationIds` and `Build-CollisionMappings` deleted as dead code.
- `eng/smoke_test/Invoke-*Tests.ps1` — pin all three wrappers to `EdFi.SmokeTest.Console 7.3.20144 -PreRelease`. Future tool bumps touch one number.
- `eng/smoke_test/modules/SmokeTest.psm1` — `Get-SmokeTestConsolePath` discovers the latest `netX.Y` framework directory under `tools/` instead of hardcoding `net8.0`. Adds an explicit `-OAuthUrl` option so callers can route the token endpoint independently of `BaseUrl`.
- `eng/Package-Management.psm1` — `Get-NugetPackage` short-circuits when the requested `lowerId.version` directory is already cached under `.packages/`, avoiding a redundant remote round-trip.

**Temporary workarounds** (each ties to a specific upstream story; once that lands, the corresponding hunk becomes dead code)

| Workaround | Why it exists | Removable when |
|---|---|---|
| `build-sdk.ps1` extension tag rewrite (`coreTags` + tag-rewrite loops in `GenerateSdk`) | MetaEd.js emits `tag: contacts` for both `/ed-fi/contacts` and `/homograph/contacts`. Without the rewrite, the generator emits a single `ContactsApi` with two `Post` methods and the smoke test tool's categorizer fails. | `metaed-extension-openapi-tag-prefix` lands and DMS picks up the new ApiSchema package. |
| `build-sdk.ps1` descriptor operationId rename (`Rename-DescriptorOperationId` + descriptor loop in `Merge-DmsSpecs`) | MetaEd.js emits the same operationId on resources and descriptor variants of the same entity (e.g. `getGradingPeriods` on both `/ed-fi/gradingPeriods` and `/ed-fi/gradingPeriodDescriptors`); once merged, duplicate operationIds produce duplicate C# method names. | Epic-08 `disambiguate-descriptor-operationids` lands and descriptor operationIds carry the `Descriptor`/`Descriptors` suffix in MetaEd.js output. |
| `build-sdk.ps1` `Homograph` `required` strip (end of `Merge-DmsSpecs`) | OpenAPI Generator 7.19.0 `generichost` library throws `ArgumentException` at deserialization when required reference types are absent; the smoke test tool's reflection-based data factory does not populate constructor-required reference types on the five affected `Homograph*` models. | The `generichost` template adds an opt-out for throw-on-missing-required validation, or `EdFi.LoadTools.SmokeTest` updates its data factory for extension models. |
| `src/dms/.../CoreEndpointModule.cs` `/data/v3` parallel route | `EdFi.SmokeTest.Console 7.3.20144` hardcodes `/data/v3` as the SDK `BaseAddress` suffix with no CLI/env/appsettings override. Without the alias, every SDK call hits `/data/v3/ed-fi/<resource>` and DMS returns 400. | `ods-loadtools-data-path-configurable` lands and DMS picks up a tool version that lets the smoke test wrapper override `--data-path`. |

Inline review comments on this PR call out each workaround and its specific upstream story.

## `DestructiveSdk` Residual Errors — Out of Scope, Tracked Upstream

The four `DestructiveSdk` errors are not addressed in this PR. Root cause (verified 2026-05-13 by decompiling `EdFi.LoadTools.dll` and correlating its log with DMS container traces and direct curl reproduction):

`EdFi.LoadTools.SmokeTest.PropertyBuilders.BaseBuilder.BuildRandomNumber` starts a counter at **1000** and increments per call as the default for required `int`/`long`/`double` properties when the OpenAPI spec it fetches at runtime carries no `minimum`/`maximum`. The DMS-published OpenAPI spec emits required numeric fields as plain `type: number, format: double` with no bounds (the per-field precision rules live in `decimalPropertyValidationInfos` on each `resourceSchemas` entry, not in the OpenAPI fragment). On `Sample.BusRoute.hoursPerWeek` and `Sample.StudentGraduationPlanAssociation.hoursPerWeek` — both required `double` properties with `totalDigits=5, decimalPlaces=2` (cap ±999.99) — the factory's ≥ 1000 default trips DMS's `ValidateDecimalMiddleware`, producing 400 responses with body `{"$.hoursPerWeek":["hoursPerWeek must be between -999.99 and 999.99."]}` (320 bytes, matching the smoke test log's `Raw content length: 320` byte-for-byte). The two `GetAllTest` failures cascade — no row created → empty 200 → "expected at least one".

This is a pre-existing tool ↔ server mismatch, not a regression introduced by DMS-912's enablement work. The mismatch only became *observable* on this branch because the categorizer fix (item 1 in the workaround table above) lets the destructive suite reach individual `PostTest`s for the first time. Manual POSTs against the same DMS endpoints with `hoursPerWeek ≤ 999.99` succeed (201 Created), and POSTs with `hoursPerWeek ≥ 1000` reproduce the exact 400 the tool sees — confirming the factory's default range is the sole rejection criterion.

Fix tracked as a separate upstream story against `Ed-Fi-Alliance-OSS/Ed-Fi-ODS`: `docs/stories/ods-loadtools-decimal-validation-aware-defaults.md` (uncommitted; sibling to the other upstream-story drafts in `docs/stories/`). The story asks LoadTools to use a numeric fallback that stays within commonly-tight Ed-Fi decimal caps when the served spec under-specifies bounds, and notes the complementary DMS-side option (project `decimalPropertyValidationInfos` onto the published spec) as the server-side counterpart — landing either or both removes these four errors.

## Test plan

- [ ] Bring up local stack: `pwsh start-local-dms.ps1 -EnableConfig -EnableSwaggerUI -LoadSeedData -AddSmokeTestCredentials -IdentityProvider self-contained -SearchEngine OpenSearch`
- [ ] Regenerate SDK: `pwsh ./build-sdk.ps1 BuildAndGenerateSdk -PackageName EdFi.DmsApi.TestSdk -DmsUrl http://localhost:8080` (single merged invocation; `HostConfiguration.cs` contains both resources and descriptors registrations)
- [ ] `pwsh ./Invoke-NonDestructiveApiTests.ps1 -BaseUrl http://localhost:8080 -Key $KEY -Secret $SECRET` -> `Exit Code is 0`
- [ ] `pwsh ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl http://localhost:8080 -Key $KEY -Secret $SECRET -SdkPath <TestSdk.dll>` -> `Exit Code is 0`
- [ ] `pwsh ./Invoke-DestructiveSdkTests.ps1 -BaseUrl http://localhost:8080 -Key $KEY -Secret $SECRET -SdkPath <TestSdk.dll>` -> runs to completion; expected exactly 4 errors on `Sample.BusRoute` + `Sample.StudentGraduationPlanAssociation` `hoursPerWeek` cap, tracked by `ods-loadtools-decimal-validation-aware-defaults`
