### PR TITLE
Tag passing E2E tests for relational backend

### DIFF
--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Authorization/SystemAdministrator.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Authorization/SystemAdministrator.cs
@@ -10,7 +10,11 @@ namespace EdFi.DataManagementService.Tests.E2E.Authorization;
 public static class SystemAdministrator
 {
     public const string DefaultClientSecret = "ValidSystemAdministratorSecret123456!Abcd";
+    private static readonly TimeSpan TokenRefreshBuffer = TimeSpan.FromMinutes(2);
     private static string _token = string.Empty;
+    private static DateTimeOffset _tokenExpiresAt = DateTimeOffset.MinValue;
+    private static string _clientId = string.Empty;
+    private static string _clientSecret = string.Empty;
     private static readonly SemaphoreSlim _registrationLock = new(1, 1);
 
     public static string Token
@@ -30,8 +34,12 @@ public static class SystemAdministrator
         await _registrationLock.WaitAsync();
         try
         {
-            // If we already have a valid token for this client, reuse it
-            if (!string.IsNullOrEmpty(Token))
+            bool clientChanged = clientId != _clientId || clientSecret != _clientSecret;
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+
+            // If we already have a valid token for this client, reuse it.
+            if (!clientChanged && HasUsableToken())
             {
                 return;
             }
@@ -54,23 +62,59 @@ public static class SystemAdministrator
 
             var tokenResult = await _client.PostAsync("connect/token", tokenRequestFormContent);
 
-            if (tokenResult.IsSuccessStatusCode)
-            {
-                var body = await tokenResult.Content.ReadAsStringAsync();
-                var document = JsonDocument.Parse(body);
-                Token = document.RootElement.GetProperty("access_token").GetString() ?? "";
-            }
-            else
+            if (!tokenResult.IsSuccessStatusCode)
             {
                 var errorBody = await tokenResult.Content.ReadAsStringAsync();
                 throw new InvalidOperationException(
                     $"Failed to obtain token for client '{clientId}'. Status: {tokenResult.StatusCode}, Error: {errorBody}"
                 );
             }
+
+            var body = await tokenResult.Content.ReadAsStringAsync();
+            var document = JsonDocument.Parse(body);
+            Token = document.RootElement.GetProperty("access_token").GetString() ?? "";
+            int expiresInSeconds = document.RootElement.TryGetProperty(
+                "expires_in",
+                out JsonElement expiresIn
+            )
+                ? expiresIn.GetInt32()
+                : 1800;
+            _tokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
         }
         finally
         {
             _registrationLock.Release();
         }
     }
+
+    public static async Task<string> GetToken()
+    {
+        await _registrationLock.WaitAsync();
+        try
+        {
+            if (HasUsableToken())
+            {
+                return Token;
+            }
+
+            if (string.IsNullOrEmpty(_clientId) || string.IsNullOrEmpty(_clientSecret))
+            {
+                throw new InvalidOperationException(
+                    "SystemAdministrator must be registered before requesting a token."
+                );
+            }
+
+            Token = string.Empty;
+        }
+        finally
+        {
+            _registrationLock.Release();
+        }
+
+        await Register(_clientId, _clientSecret);
+        return Token;
+    }
+
+    private static bool HasUsableToken() =>
+        !string.IsNullOrEmpty(Token) && DateTimeOffset.UtcNow.Add(TokenRefreshBuffer) < _tokenExpiresAt;
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
@@ -4,12 +4,14 @@ Feature: CMS to DMS ClaimSet Synchronization
     to the Data Management Service (DMS). Each upload to CMS completely replaces all existing claimsets,
               and DMS can reload these claimsets to synchronize its state with CMS.
 
+        @relational-backend
         Scenario: 01 Initial State Verification - View claimsets in DMS and verify baseline claimsets are present
              When a GET request is made to DMS management endpoint "/management/view-claimsets"
              Then the DMS view claimsets should be successful
               And the DMS view claimsets response should contain "SISVendor"
               And the DMS view claimsets response should contain "EdFiSandbox"
 
+        @relational-backend
         Scenario: 02 Upload Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet1 with Student access, reload DMS, verify only new claimset present
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSet1"
              Then the claim set upload to CMS should be successful
@@ -20,6 +22,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "TestClaimSet1"
               And system claim sets should have empty resource claims
 
+        @relational-backend
         Scenario: 03 Upload Different Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet2 with School access, reload DMS, verify only TestClaimSet2 present
              When a claim set is uploaded to CMS that grants "School" access to "TestClaimSet2"
              Then the claim set upload to CMS should be successful
@@ -29,6 +32,7 @@ Feature: CMS to DMS ClaimSet Synchronization
              Then the DMS view claimsets should be successful
               And the DMS view claimsets response should contain "TestClaimSet2"
 
+        @relational-backend
         Scenario: 04 Upload Multiple Claimsets - both TestClaimSetA and TestClaimSetB, reload DMS, verify TestClaimSetB
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSetA"
              Then the claim set upload to CMS should be successful
@@ -45,6 +49,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "TestClaimSetB"
               And the DMS view claimsets response should not contain "TestClaimSetA"
 
+        @relational-backend
         Scenario: 05 Reset CMS to Original → Sync to DMS - Reset CMS with reload-claims, reload DMS, verify original state restored
              When a POST request is made to CMS "/management/reload-claims"
              Then the CMS reload should be successful

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
@@ -33,6 +33,7 @@ Feature: EducationOrganizationChanges Authorization
                   | staffSchoolAssociationId1   | { "staffUniqueId": "s0001" } | { "schoolId": 255901001 } | "uri://ed-fi.org/ProgramAssignmentDescriptor#Regular Education" |
 
 
+        @relational-backend
         Scenario: 01 Ensure client can access the Student ,the Contact and the Staff with a  Grand Bend ISD School 255901
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a GET request is made to "/ed-fi/schools/{SchoolId1}"
@@ -448,6 +449,7 @@ Feature: EducationOrganizationChanges Authorization
                   | _storeResultingIdInVariable | staffUniqueId | firstName | lastSurname |
                   | StaffId1                    | s0001         | peterson  | Buck        |
 
+        @relational-backend
         Scenario: 08 Ensure client can  access the Student  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with
@@ -501,6 +503,7 @@ Feature: EducationOrganizationChanges Authorization
                       }
                   """
 
+        @relational-backend
         Scenario: 09 Ensure client can  access the contact  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
@@ -19,6 +19,7 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Ensure client can create a descriptor in the ns2 namespace
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -37,6 +38,7 @@ Feature: Namespace Authorization
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 200
 
+        @relational-backend
         Scenario: 03 Ensure client can update a descriptor in the ns2 namespace
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -52,6 +54,7 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure client can delete a descriptor in the ns2 namespace
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
@@ -193,6 +196,7 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Ensure client can create a resource in the ns2 namespace
              When a POST request is made to "/ed-fi/surveys" with
                   """
@@ -253,10 +257,12 @@ Feature: Namespace Authorization
                   }]
                   """
 
+        @relational-backend
         Scenario: 10 Ensure client can get a resource in the ns2 namespace
              When a GET request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 200
 
+        @relational-backend
         Scenario: 11 Ensure client can update a resource in the ns2 namespace
              When a PUT request is made to "/ed-fi/surveys/{id}" with
                   """
@@ -272,6 +278,7 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 12 Ensure client can delete a resource in the ns2 namespace
              When a DELETE request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
@@ -26,6 +26,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
     Rule: StudentContactAssociation CRUD is properly authorized
 
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -51,6 +52,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02 Ensure client can retrieve a StudentContactAssociation
             Given a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -150,6 +152,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                      []
                   """
 
+        @relational-backend
         Scenario: 06 Ensure client can update a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -242,6 +245,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                      }
                   """
 
+        @relational-backend
         Scenario: 08 Ensure client can delete a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -290,6 +294,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 10 Ensure client get the required validation error when studentContactAssociations is created with empty contactReference
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "25590190200000"
              When a POST request is made to "/ed-fi/studentContactAssociations" with
@@ -321,6 +326,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
     Rule: Contact CRUD is properly authorized
 
+        @relational-backend
         Scenario: 11 Ensure client can create a Contact
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -424,6 +430,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 14 Ensure client can delete a contact when it's unused and should return 204 nocontent
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -437,6 +444,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
              When a DELETE request is made to "/ed-fi/contacts/{id}"
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 15 Ensure client can not delete a contact when it's associated with a student
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -475,6 +483,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 16 Ensure client can retrieve a contact with student contact association
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -562,6 +571,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
 
+        @relational-backend
         Scenario: 18 Ensure client can update a contact When it's associated
             Given a POST request is made to "/ed-fi/contacts/" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -25,6 +25,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | "11"            | Authorized student   | student-ln  | 2008-01-01 |
                   | "12"            | Unauthorized student | student-ln  | 2008-01-01 |
 
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentSchoolAssociation
              When a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -57,6 +58,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 03 Ensure client can retrieve a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -150,6 +152,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 06 Ensure client can update a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -239,6 +242,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              When a DELETE request is made to "/ed-fi/StudentSchoolAssociations/{id}"
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 09 Ensure client can delete a StudentSchoolAssociation
             Given  a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -276,6 +280,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   |                             | { "studentUniqueId": "22" } | { "schoolId": 2255901002 } | "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary" | 2023-08-01 | "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary" | "uri://ed-fi.org/ExitWithdrawTypeDescriptor#Student withdrew" |
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "2255901001"
 
+        @relational-backend
         Scenario: 10 Ensure client can create a Student
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -288,6 +293,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 11 Ensure client can retrieve a Student
              When a GET request is made to "/ed-fi/students/{StudentId}"
              Then it should respond with 200
@@ -329,6 +335,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure client can update a Student
              When a PUT request is made to "/ed-fi/students/{StudentId}" with
                   """
@@ -368,6 +375,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 18 Ensure client can delete a Student
             Given a DELETE request is made to "/ed-fi/studentSchoolAssociations/{StudentSchoolAssociationId}"
 
@@ -395,6 +403,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | 3255902001                 | Authorized PSI    | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution"} ] |
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "3255901001, 3255902001"
 
+        @relational-backend
         Scenario: 19 Ensure client can create a Student-securable
              When a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """
@@ -697,6 +706,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 29 Ensure client can delete a Student-securable
             Given a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """
@@ -1377,6 +1387,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
 
     Rule: Edge cases are properly authorized
+        @relational-backend
         Scenario: 42 Ensure client can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "7255901001, 7255902001"
               And the system has these "schools"
@@ -1440,6 +1451,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              When a DELETE request is made to "/ed-fi/PostSecondaryEvents/{id}"
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 43 Ensure client without education organization access can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "8255901001, 8255902001"
               And the system has these "schools"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -706,7 +706,6 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
-        @relational-backend
         Scenario: 29 Ensure client can delete a Student-securable
             Given a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -535,7 +535,6 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
              Then it should respond with 204
 
-        @relational-backend
         Scenario: 20 Ensure client can DELETE staffEducationOrganizationEmploymentAssociations
 
              When a POST request is made to "/ed-fi/staffEducationOrganizationEmploymentAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -31,6 +31,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
 
     Rule: staffEducationOrganizationAssignmentAssociations CRUD is properly authorized
 
+        @relational-backend
         Scenario: 01 Ensure client can authorize create a staffSchoolAssociations when the staff is assigned to the school using staffEducationOrganizationAssignmentAssociations
 
              When a POST request is made to "/ed-fi/staffSchoolAssociations" with
@@ -534,6 +535,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 20 Ensure client can DELETE staffEducationOrganizationEmploymentAssociations
 
              When a POST request is made to "/ed-fi/staffEducationOrganizationEmploymentAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
@@ -12,6 +12,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 01 Ensure client can create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -41,6 +42,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 02 Ensure client can update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -128,6 +130,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 03 Ensure client can not create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -181,6 +184,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 04 Ensure client can not update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -375,6 +379,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 07 Ensure client can get the bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -431,6 +436,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                        }
                   """
 
+        @relational-backend
         Scenario: 08 Ensure client can delete a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -617,6 +623,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 13.1 Ensure client with access to state education agency 2 can post and put classPeriods for school 20201
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -713,6 +720,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 13.5 Ensure client with access to state education agency 2 can get by id school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a GET request is made to "/ed-fi/academicWeeks/{id}"
@@ -731,6 +739,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 13.6 Ensure client with access to state education agency 2 can delete school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a DELETE request is made to "/ed-fi/academicWeeks/{id}"
@@ -894,6 +903,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency        |
                   | uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#Regular public school district |
 
+        @relational-backend
         Scenario: 20 Ensure client can create an LEA
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -910,6 +920,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 201
                   
+        @relational-backend
         Scenario: 21 Ensure client can retrieve an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -980,6 +991,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 23 Ensure client can update an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -1013,6 +1025,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 24 Ensure client can delete an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
@@ -30,6 +30,7 @@ Feature: RelationshipsWithStudentsOnlyThroughResponsibility Authorization
                   | "Career and Technical Education" | uri://ed-fi.org/ProgramTypeDescriptor#Career and Technical Education | {"educationOrganizationId": 1255901002} |
 
     Rule: StudentEducationOrganizationResponsibilityAssociation CRUD is properly authorized
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentEducationOrganizationResponsibilityAssociation
              When a POST request is made to "/ed-fi/studentEducationOrganizationResponsibilityAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
@@ -26,6 +26,7 @@ Feature: DisciplineAction Authorization
         Background:
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901001"
 
+        @relational-backend
         Scenario: 01 Ensure authorized client can create a DisciplineAction
              When a POST request is made to "/ed-fi/disciplineActions" with
                   """
@@ -50,6 +51,7 @@ Feature: DisciplineAction Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02.1 Ensure authorized client can get a DisciplineAction by id
              When a GET request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 200
@@ -103,6 +105,7 @@ Feature: DisciplineAction Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure authorized client can update a DisciplineAction
              When a PUT request is made to "/ed-fi/disciplineActions/{disciplineActionId}" with
                   """
@@ -128,6 +131,7 @@ Feature: DisciplineAction Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure authorized client can delete a DisciplineAction
              When a DELETE request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
@@ -10,6 +10,7 @@ Feature: OrganizationDepartment Authorization
                   | orgDepId                    | 255901101                | Test Office       | {"educationOrganizationId": 255901}  | [{ "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Organization Department" }] |
 
     Rule: When the client is authorized
+        @relational-backend
         Scenario: 01 Ensure authorized client can create a OrganizationDepartment
              When a POST request is made to "/ed-fi/organizationDepartments" with
                   """
@@ -28,6 +29,7 @@ Feature: OrganizationDepartment Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02.1 Ensure authorized client can get a OrganizationDepartment by id
              When a GET request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 200
@@ -69,6 +71,7 @@ Feature: OrganizationDepartment Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure authorized client can update a OrganizationDepartment
              When a PUT request is made to "/ed-fi/organizationDepartments/{orgDepId}" with
                   """
@@ -88,6 +91,7 @@ Feature: OrganizationDepartment Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure authorized client can delete a OrganizationDepartment
              When a DELETE request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
@@ -10,6 +10,7 @@ Feature: Equality Constraint Validation
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-001
+        @relational-backend
         Scenario: 01 Post a valid bell schedule no equality constraint violations.
             Given the system has these "schools"
                   | schoolId  | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -47,6 +48,7 @@ Feature: Equality Constraint Validation
              Then it should respond with 201 or 200
 
         @API-002
+        @relational-backend
         Scenario: 02 Post an invalid bell schedule with equality constraint violations.
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -96,6 +98,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-003
+        @relational-backend
         Scenario: 03 Making a Post request when value does not match the same value in an array
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -139,6 +142,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-004
+        @relational-backend
         Scenario: 04 Making a Post request when a value matches the first scenario in an array but not the second
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -188,6 +192,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-005
+        @relational-backend
         Scenario: 05 Making a Post request when value does not match the same value in a single other reference
              When a POST request is made to "/ed-fi/sections" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
@@ -4,6 +4,7 @@ Feature: Create a Descriptor
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-006
+        @relational-backend
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -37,6 +38,7 @@ Feature: Create a Descriptor
                   """
 
         @API-007
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a descriptor using a value that is too long
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -68,6 +70,7 @@ Feature: Create a Descriptor
                   """
 
         @API-008
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a descriptor omitting any of the required values
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -123,6 +126,7 @@ Feature: Create a Descriptor
                   """
 
         @API-010
+        @relational-backend
         Scenario: 05 Post using an empty JSON body
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -154,6 +158,7 @@ Feature: Create a Descriptor
                   """
 
         @API-011
+        @relational-backend
         Scenario: 06 Ensure clients cannot create a descriptor only using spaces for the required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -189,6 +194,7 @@ Feature: Create a Descriptor
                   """
 
         @API-012
+        @relational-backend
         Scenario: 07 Ensure clients cannot create a descriptor with leading spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -218,6 +224,7 @@ Feature: Create a Descriptor
                   """
 
         @API-013
+        @relational-backend
         Scenario: 08 Ensure clients cannot create a descriptor with trailing spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -247,6 +254,7 @@ Feature: Create a Descriptor
                   """
 
         @API-014
+        @relational-backend
         Scenario: 09 Post a new descriptor with an extra property (overpost)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -275,6 +283,7 @@ Feature: Create a Descriptor
                   """
 
         @API-015
+        @relational-backend
         Scenario: 10 Post a new descriptor with invalid JSON (trailing comma)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -305,6 +314,7 @@ Feature: Create a Descriptor
                   """
 
         @API-016
+        @relational-backend
         Scenario: 11 Create a descriptor with forbidden id property
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -334,6 +344,7 @@ Feature: Create a Descriptor
                   """
 
         @API-017
+        @relational-backend
         Scenario: 12 Post a new descriptor with required attributes only
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -355,6 +366,7 @@ Feature: Create a Descriptor
                   """
 
         @API-018
+        @relational-backend
         Scenario: 13 Create a descriptor with a required, non-identity, property's value containing leading and trailing white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -368,6 +380,7 @@ Feature: Create a Descriptor
              Then it should respond with 201
 
         @API-019
+        @relational-backend
         Scenario: 14 Create a descriptor with optional property's value containing only white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -392,6 +405,7 @@ Feature: Create a Descriptor
                   """
 
         @API-020
+        @relational-backend
         Scenario: 15 Post an existing descriptor without changes
             Given a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -424,6 +438,7 @@ Feature: Create a Descriptor
                   """
 
         @API-021
+        @relational-backend
         Scenario: 16 Create a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -477,6 +492,7 @@ Feature: Create a Descriptor
                       ]
                     }
                   """
+        @relational-backend
         Scenario: 18 Create a descriptor with leading and trailing spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
@@ -15,11 +15,13 @@ Feature: Delete a Descriptor
                   """
 
         @API-022
+        @relational-backend
         Scenario: 01 Verify deleting a specific descriptor by ID
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
 
         @API-023
+        @relational-backend
         Scenario: 02 Verify error handling when deleting a descriptor using a invalid id
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -41,18 +43,21 @@ Feature: Delete a Descriptor
                   """
 
         @API-024
+        @relational-backend
         Scenario: 03 Verify error handling when trying to delete an item that has already been deleted
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 404
 
         @API-025
+        @relational-backend
         Scenario: 04 Verify response code when trying to read a deleted resource
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 404
 
         @API-026
+        @relational-backend
         Scenario: 05 Ensure clients cannot delete a descriptor that is being used by other Resources
             Given the system has these "schools"
                   | schoolId | nameOfInstitution             | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
@@ -13,6 +13,7 @@ Feature: Descriptor CaseInsensitive Validation
                   | uri://ed-fi.org/CourseIdentificationSystemDescriptor#LEA course code |
                   | uri://ed-fi.org/CourseGpaApplicabilityDescriptor#Applicable          |
               
+        @relational-backend
         Scenario: 1 Ensure clients can create objectiveAssessments with case-insensitive descriptor values
              When a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
@@ -34,6 +34,7 @@ Feature: Read a Descriptor
                   """
 
         @API-028
+        @relational-backend
         Scenario: 02 Verify response code 404 when ID does not exist
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/124c8513-fade-4ce2-ab71-0e40e148de5b"
              Then it should respond with 404
@@ -99,6 +100,7 @@ Feature: Read a Descriptor
                   """
 
         @API-032
+        @relational-backend
         Scenario: 07 Verify response code 404 when ID is not valid
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -119,6 +121,7 @@ Feature: Read a Descriptor
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Get a Descriptor using a resource not configured in claims
              When a GET request is made to "/ed-fi/academicHonorCategoryDescriptors"
              Then it should respond with 403

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
@@ -17,6 +17,7 @@ Feature: Update a Descriptor
                   """
 
         @API-033
+        @relational-backend
         Scenario: 01 Put an existing descriptor
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -46,6 +47,7 @@ Feature: Update a Descriptor
                   """
 
         @API-034
+        @relational-backend
         Scenario: 02 Put an existing descriptor with optional properties removed
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -69,6 +71,7 @@ Feature: Update a Descriptor
                   """
 
         @API-035
+        @relational-backend
         Scenario: 03 Update a descriptor with a string that is too long
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -127,6 +130,7 @@ Feature: Update a Descriptor
                   """
 
         @API-037
+        @relational-backend
         Scenario: 05 Update a descriptor with spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -163,6 +167,7 @@ Feature: Update a Descriptor
                   """
 
         @API-038
+        @relational-backend
         Scenario: 06 Update a descriptor with leading spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -193,6 +198,7 @@ Feature: Update a Descriptor
                   """
 
         @API-039
+        @relational-backend
         Scenario: 07 Update a descriptor with trailing spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -223,6 +229,7 @@ Feature: Update a Descriptor
                   """
 
         @API-040
+        @relational-backend
         Scenario: 08 Put an existing descriptor with an extra property (overpost)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -249,6 +256,7 @@ Feature: Update a Descriptor
                   """
 
         @API-041
+        @relational-backend
         Scenario: 09 Update a descriptor that does not exist
              # The id value should be replaced with a non existing resource
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/00000000-0000-4000-a000-000000000000" with
@@ -303,6 +311,7 @@ Feature: Update a Descriptor
                   """
 
         @API-043
+        @relational-backend
         Scenario: 11  Put an empty request descriptor
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -325,6 +334,7 @@ Feature: Update a Descriptor
                   """
 
         @API-044
+        @relational-backend
         Scenario: 12 Put an empty JSON body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -360,6 +370,7 @@ Feature: Update a Descriptor
                   """
 
         @API-045
+        @relational-backend
         Scenario: 13 Update a descriptor with mismatch between URL and id
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -389,6 +400,7 @@ Feature: Update a Descriptor
                   """
 
         @API-046
+        @relational-backend
         Scenario: 14 Update a descriptor with a blank id
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -418,6 +430,7 @@ Feature: Update a Descriptor
                   """
 
         @API-047
+        @relational-backend
         Scenario: 15 Update a descriptor with an invalid id format in the body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -447,6 +460,7 @@ Feature: Update a Descriptor
                   """
 
         @API-048
+        @relational-backend
         Scenario: 16 Update a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -478,6 +492,7 @@ Feature: Update a Descriptor
                   """
 
         @API-049
+        @relational-backend
         Scenario: 17 Ensure clients cannot update a descriptor omitting any of the required values
              When a PUT request is made to "/ed-fi/disabilityDescriptors/{id}" with
                   """
@@ -574,6 +589,7 @@ Feature: Update a Descriptor
                   """
 
         @API-052
+        @relational-backend
         Scenario: 20 Verify response code 400 when ID is not valid
              When a PUT request is made to "/ed-fi/disabilityDescriptors/00112233445566" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
@@ -4,6 +4,7 @@ Feature: Reject client requests for abstract entities
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-053
+        @relational-backend
         Scenario: 01 Ensure that clients cannot POST an abstract entity (Education Organizations)
              When a POST request is made to "/ed-fi/educationOrganizations" with
                   """
@@ -14,6 +15,7 @@ Feature: Reject client requests for abstract entities
              Then it should respond with 404
 
         @API-054
+        @relational-backend
         Scenario: 02 Ensure that clients cannot POST an abstract entity (General Student Program Association)
              When a POST request is made to "/ed-fi/generalStudentProgramAssociations" with
                   """
@@ -24,11 +26,13 @@ Feature: Reject client requests for abstract entities
              Then it should respond with 404
 
         @API-055
+        @relational-backend
         Scenario: 03 Ensure that clients cannot GET an abstract entity (Education Organizations)
              When a GET request is made to "/ed-fi/educationOrganizations"
              Then it should respond with 404
 
         @API-056
+        @relational-backend
         Scenario: 04 Ensure that clients cannot GET an abstract entity (Student Program Association)
              When a GET request is made to "/ed-fi/generalStudentProgramAssociations"
              Then it should respond with 404

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
@@ -23,6 +23,7 @@ Feature: School Year Reference Validation
                   | "451"        | { "schoolId": 535 } | { "schoolYear": 2029 }  | uri://ed-fi.org/CalendarTypeDescriptor#Student Specific | []          |
 
         @API-057
+        @relational-backend
         Scenario: 01 Try creating a resource using a valid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -41,6 +42,7 @@ Feature: School Year Reference Validation
              Then it should respond with 200 or 201
 
         @API-058
+        @relational-backend
         Scenario: 02 Try creating a resource using an invalid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -75,6 +77,7 @@ Feature: School Year Reference Validation
                   """
 
         @API-059
+        @relational-backend
         Scenario: 03 Try creating a CalendarDate using a valid Calendar reference
              When a POST request is made to "/ed-fi/calendarDates" with
                   """
@@ -95,6 +98,7 @@ Feature: School Year Reference Validation
              Then it should respond with 201
 
         @API-060
+        @relational-backend
         Scenario: 04 Try creating a CalendarDate using an invalid Calendar reference with an invalid School year
              When a POST request is made to "/ed-fi/calendarDates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
@@ -5,6 +5,7 @@ Feature: Homograph extension resources
 
     Rule: Homograph Extension Resources
 
+        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a school in homograph extension
       # POST request to create a school
              When a POST request is made to "/homograph/schools/" with
@@ -58,6 +59,7 @@ Feature: Homograph extension resources
              When a GET request is made to "/homograph/schools/{id}"
              Then it should respond with 404
 
+        @relational-backend
         Scenario: 02 Ensure clients can create/update/get/delete a student in homograph extension
       # POST request to create a schoolYearType
             Given a POST request is made to "/homograph/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
@@ -9,6 +9,7 @@ Feature: Resource with multiple extensions
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution |
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
+        @relational-backend
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -98,6 +99,7 @@ Feature: Resource with multiple extensions
                   }
                   """
 
+    @relational-backend
     Scenario: 02 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """
@@ -125,6 +127,7 @@ Feature: Resource with multiple extensions
              """
              Then it should respond with 409
 
+      @relational-backend
       Scenario: 03 Ensure clients can not create a resource when sample extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
@@ -9,6 +9,7 @@ Feature: Resource with Tpdm extension
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution |
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
+        @relational-backend
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -77,6 +78,7 @@ Feature: Resource with Tpdm extension
                   }
                   """
 
+        @relational-backend
         Scenario: 02 Ensure clients can get a resource with query
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -147,6 +149,7 @@ Feature: Resource with Tpdm extension
                   }]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
@@ -14,6 +14,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Required Field Validation Errors for busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -61,6 +62,7 @@ Feature: Sample extension resources
                       }
                   """
 
+        @relational-backend
         Scenario: 02 Creating New busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -158,6 +160,7 @@ Feature: Sample extension resources
                         }
                   """
 
+        @relational-backend
         Scenario: 04 Delete by ID for busRoutes Resource
             Given a POST request is made to "/sample/busRoutes" with
                   """
@@ -201,6 +204,7 @@ Feature: Sample extension resources
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
                   | uri://ed-fi.org/CTEProgramServiceDescriptor#Architecture and Construction          |
 
+        @relational-backend
         Scenario: 05 Existing Core Entity School and Sample Extension with Missing CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -243,6 +247,7 @@ Feature: Sample extension resources
                       }
                   """
 
+        @relational-backend
         Scenario: 06 Existing Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -271,6 +276,7 @@ Feature: Sample extension resources
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 07 Get by ID for Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -326,6 +332,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Delete by ID for busRoutes Resource
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -463,6 +470,7 @@ Feature: Sample extension resources
                   """
 
     Rule: busRoutes scenarios
+        @relational-backend
         Scenario: 10 Create Staff with Duplicate Extension Items
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -512,6 +520,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 11 Data Validation with Staff when petName has leading or trailing spaces
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -552,6 +561,7 @@ Feature: Sample extension resources
                     }
                   """
 
+        @relational-backend
         Scenario: 12 Data Validation with Staff when Pet name has too short value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -592,6 +602,7 @@ Feature: Sample extension resources
                     }
                   """
 
+        @relational-backend
         Scenario: 13 Data Validation with Staff when Pet name has too long value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
@@ -4,6 +4,7 @@ Feature: Tpdm extension resources and descriptors
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://tpdm.ed-fi.org"
 
     Rule: Descriptors
+        @relational-backend
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -35,6 +36,7 @@ Feature: Tpdm extension resources and descriptors
                       "effectiveEndDate": "2024-05-14"
                   }
                   """
+        @relational-backend
         Scenario: 02 Ensure clients can update a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -74,6 +76,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Ensure clients can retrieve a descriptor by requesting through a valid codeValue
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -104,6 +107,7 @@ Feature: Tpdm extension resources and descriptors
                   ]
                   """
 
+        @relational-backend
         Scenario: 04 Ensure clients can delete a descriptor
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -136,6 +140,7 @@ Feature: Tpdm extension resources and descriptors
 
     Rule: Resources
 
+        @relational-backend
         Scenario: 05 Ensure clients can create a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -164,6 +169,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Ensure clients can update a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -197,6 +203,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Ensure clients can query a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """
@@ -223,6 +230,7 @@ Feature: Tpdm extension resources and descriptors
                   ]
                   """
 
+        @relational-backend
         Scenario: 08 Ensure clients can delete a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
@@ -5,6 +5,7 @@ Feature: CorrleationId
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-061
+        @relational-backend
         Scenario: 01 Ensure the response will contain provided correlation id
             # Note: this requires that the .env file used to startup the DMS container has the following setting:
             # CORRELATION_ID_HEADER=correlationid

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
@@ -74,6 +74,7 @@ Feature: Data strictness
 
 
         @API-240
+        @relational-backend
         Scenario: 08 Ensure clients can create a resource using expected booleans
              When a POST request is made to "/ed-fi/classPeriods" with
                   """
@@ -256,6 +257,7 @@ Feature: Data strictness
                   """
 
         @API-248
+        @relational-backend
         Scenario: 16 Enforce case sensitivity of property names in POST request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools" with
@@ -278,6 +280,7 @@ Feature: Data strictness
              Then it should respond with 400
 
         @API-249
+        @relational-backend
         Scenario: 17 Enforce case sensitivity of property names in PUT request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools/{id}" with
@@ -301,6 +304,7 @@ Feature: Data strictness
              Then it should respond with 400
 
         @API-255
+        @relational-backend
         Scenario: 18 Accept missing time in a POST request with a datetime property
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -369,6 +373,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 19 Accept missing time in a POST request with a datetime property with slashes
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -437,6 +442,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 20 Accept time with AM PM And Convert To UTC ISO8601 in a POST request
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -505,6 +511,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 21 accept time without zone and it will be added automatically
             Given a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
@@ -43,6 +43,7 @@ Feature: The Discovery API provides information about the application version, s
                   """
 
         @API-063
+        @relational-backend
         Scenario: 02 GET /metadata returns the metadata URL list
              When a GET request is made to "/metadata"
              Then it should respond with 200
@@ -56,6 +57,7 @@ Feature: The Discovery API provides information about the application version, s
                   """
 
         @API-064
+        @relational-backend
         Scenario: 03 GET /metadata/specifications returns the list of supported API specifications
              When a GET request is made to "/metadata/specifications"
              Then it should respond with 200
@@ -300,6 +302,7 @@ Feature: The Discovery API provides information about the application version, s
                   ]
                   """
         @API-065
+        @relational-backend
         Scenario: 04 GET /metadata/dependencies returns the dependency order for loading documents
              When a GET request is made to "/metadata/dependencies"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
@@ -2,6 +2,7 @@ Feature: Health
     Check the health of the application and the database
 
         @API-066
+        @relational-backend
         Scenario: 01 Health
             Given a request health is made to the server
              Then it returns healthy checks

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
@@ -2,6 +2,7 @@ Feature: Kafka Messaging
     This feature demonstrates a simple Kafka testing approach. *Note* running these tests locally require a specific hosts entry: 127.0.0.1 dms-kafka1
 
         @kafka
+        @relational-backend
         Scenario: 01 Test Kafka connectivity
             Given Kafka should be reachable
              Then Kafka consumer should be able to connect to topic "edfi.dms.document"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -22,6 +22,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-067
+        @relational-backend
         Scenario: 01 Ensure clients cannot retrieve information when the data model name is missing
              When a GET request is made to "/schools"
              Then it should respond with 404
@@ -45,6 +46,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-068
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a resource when the data model name is missing
              When a POST request is made to "/schools" with
                   """
@@ -84,6 +86,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-069
+        @relational-backend
         Scenario: 03 Ensure clients cannot update a resource when the data model name is missing
              When a PUT request is made to "/schools/{id}" with
                   """
@@ -124,6 +127,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-070
+        @relational-backend
         Scenario: 04 Ensure clients cannot delete a resource when the data model name is missing
              When a DELETE request is made to "/schools/{id}"
              Then it should respond with 404
@@ -147,6 +151,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-071
+        @relational-backend
         Scenario: 05 Ensure clients cannot retrieve a resource when endpoint is not pluralized
              When a GET request is made to "/ed-fi/school"
              Then it should respond with 404
@@ -170,6 +175,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-072
+        @relational-backend
         Scenario: 06 Ensure clients cannot create a resource when endpoint is not pluralized
              When a POST request is made to "/ed-fi/school" with
                   """
@@ -209,6 +215,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-073
+        @relational-backend
         Scenario: 07 Ensure clients cannot update a resource when endpoint does not end in plural
              When a PUT request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000" with
                   """
@@ -248,6 +255,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-074
+        @relational-backend
         Scenario: 08 Ensure clients cannot delete a resource when endpoint does not end in plural
              When a DELETE request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000"
              Then it should respond with 404
@@ -271,6 +279,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-075
+        @relational-backend
         Scenario: 09 Ensure clients cannot create a resource adding an ID as a path variable
              When a POST request is made to "/ed-fi/schools/00000000-0000-4000-a000-000000000000" with
                   """
@@ -312,6 +321,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-077
+        @relational-backend
         Scenario: 10 Ensure PUT requests require an Id value
              When a PUT request is made to "/ed-fi/schools/" with
                   """
@@ -353,6 +363,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-078
+        @relational-backend
         Scenario: 11 Ensure DELETE requests require an Id value
              When a DELETE request is made to "/ed-fi/schools/"
              Then it should respond with 405
@@ -415,6 +426,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-251
+        @relational-backend
         Scenario: 14 Ensure clients validate identifier on GET requests
              When a GET request is made to "/ed-fi/schools/ffc0a272"
              Then it should respond with 400
@@ -492,6 +504,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 18 Ensure clients get 404 for completely invalid path with prefix before data model
              When a POST request is made to "/ed-fi/notExisting" with
                   """
@@ -523,6 +536,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 19 Ensure clients get 404 for misspelled resource endpoint
              When a POST request is made to "/ed-fi/gradeLevelDescriptorz" with
                   """
@@ -554,6 +568,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 20 Ensure clients get 404 for arbitrary non-existent path
              When a GET request is made to "/foo/bar"
              Then it should respond with 404
@@ -577,6 +592,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 21 Ensure clients get 404 for PUT on non-existent path with ID
              When a PUT request is made to "/invalid/path/00000000-0000-4000-a000-000000000000" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
@@ -1,5 +1,6 @@
 Feature: XSD Metadata Endpoint
 
+        @relational-backend
         Scenario: 01 Ensure clients can retrieve XSD endpoint information
              When a GET request is made to "/metadata/xsd"
              Then it should respond with 200
@@ -32,6 +33,7 @@ Feature: XSD Metadata Endpoint
                       }
                     ]
                   """
+        @relational-backend
         Scenario: 02 Ensure clients can retrieve Core schema (Ed-Fi) files for the data model
              When a GET request is made to "/metadata/xsd/ed-fi/files"
              Then it should respond with 200
@@ -67,6 +69,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/ed-fi/SchemaAnnotation.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 03 Ensure clients can retrieve Extension (Sample) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/sample/files"
              Then it should respond with 200
@@ -112,6 +115,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/sample/Sample-EXTENSION-Interchange-StudentTranscript-Extension.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 04 Ensure clients can retrieve Extension (Homograph) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/homograph/files"
              Then it should respond with 200
@@ -147,6 +151,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/homograph/SchemaAnnotation.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 05 Ensure clients can retrieve Extension (TPDM) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/tpdm/files"
              Then it should respond with 200
@@ -189,6 +194,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/tpdm/TPDM-EXTENSION-Interchange-Survey-Extension.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 06 Ensure clients can retrieve XSD content of TPDM Extension
              When a GET request is made to "/metadata/xsd/tpdm/EdFi.TPDM.ApiSchema.xsd.TPDM-EXTENSION-Interchange-Survey-Extension.xsd"
              Then it should respond with 200
@@ -226,6 +232,7 @@ Feature: XSD Metadata Endpoint
                       </xs:element>
                     </xs:schema>
                   """
+        @relational-backend
         Scenario: 07 Ensure clients can retrieve XSD content of Sample Extension
              When a GET request is made to "/metadata/xsd/sample/EdFi.Sample.ApiSchema.xsd.Sample-EXTENSION-Interchange-StudentProgram-Extension.xsd"
              Then it should respond with 200
@@ -258,6 +265,7 @@ Feature: XSD Metadata Endpoint
                     </xs:element>
                     </xs:schema>
                   """
+        @relational-backend
         Scenario: 08 Ensure clients can retrieve XSD content of Core
              When a GET request is made to "/metadata/xsd/ed-fi/EdFi.DataStandard52.ApiSchema.xsd.Interchange-Survey.xsd"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
@@ -35,6 +35,7 @@ Feature: Profile Assigned Profiles
              When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-IncludeAll" for resource "School"
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 02 Covered resource with different profile content type fails
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
              Then the profile response status is 403
@@ -86,10 +87,12 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # with no profile header, the request succeeds when exactly one assigned
         # profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 05 Covered resource with standard content type and one assigned profile
              When a GET request is made to "/ed-fi/schools" without profile header
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 06 Covered resource with one of several assigned profiles succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -105,6 +108,7 @@ Feature: Profile Assigned Profiles
              When a GET request is made to "/ed-fi/students/{id}" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student"
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 07 Covered resource with different profile content type for API client with several assigned profiles fails with incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
@@ -152,6 +156,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 10 Covered resource write with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -176,6 +181,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 11 Covered resource with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -227,6 +233,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 13 Covered resource update with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
@@ -269,6 +276,7 @@ Feature: Profile Assigned Profiles
 
         # Current DMS returns incorrect-usage when the caller omits the profile
         # header and multiple assigned profiles apply to the same resource/verb.
+        @relational-backend
         Scenario: 14 Covered resource read with standard content type and multiple applicable assigned profiles returns incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -298,6 +306,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 16 Covered resource create with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -320,6 +329,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 17 Covered resource read with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -368,6 +378,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 19 Covered resource update with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-IncludeOnly" for resource "School" with body
@@ -424,16 +435,19 @@ Feature: Profile Assigned Profiles
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 03 Not-covered resource with standard content type succeeds
              When a GET request is made to "/ed-fi/students/{id}" without profile header
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
+        @relational-backend
         Scenario: 04 Not-covered resource with unassigned profile succeeds
              When a GET request is made to "/ed-fi/students/{id}" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student"
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
+        @relational-backend
         Scenario: 05 Not-covered resource write with standard content type succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
               And a profile test POST request is made to "/ed-fi/students" with
@@ -447,6 +461,7 @@ Feature: Profile Assigned Profiles
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 06 Not-covered resource write with unassigned profile succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -460,6 +475,7 @@ Feature: Profile Assigned Profiles
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 07 Not-covered resource update with standard content type succeeds
              When a PUT request is made to "/ed-fi/students/{id}" without profile header with body
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
@@ -40,17 +40,20 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Collection filter includes only matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should only contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
+        @relational-backend
         Scenario: 02 Collection filter excludes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade"
 
+        @relational-backend
         Scenario: 03 Collection filter reduces item count
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -92,11 +95,13 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 04 ExcludeOnly filter excludes matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"
 
+        @relational-backend
         Scenario: 05 ExcludeOnly filter includes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
@@ -135,6 +140,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Collection filter applies to all items in query results
              When a GET request is made to "/ed-fi/schools?schoolId=99000403" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -172,6 +178,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Collection becomes empty when no items match filter
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -303,6 +310,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 08 IncludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -310,6 +318,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 ExcludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -317,6 +326,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 10 IncludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body
@@ -363,6 +373,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 11 ExcludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
@@ -41,6 +41,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeAll profile returns all populated fields and child collection members
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -75,6 +76,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 02 IncludeOnly profile returns only included resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -82,6 +84,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 03 ExcludeOnly profile excludes configured resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
@@ -119,6 +122,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 04 IncludeOnly collection filter keeps only configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
@@ -126,6 +130,7 @@ Feature: Profile Definition Advanced Filtering
              And the "gradeLevels" collection should have 1 item
              And the "gradeLevels" collection item at index 0 should have "gradeLevelDescriptor" value "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
+        @relational-backend
         Scenario: 05 ExcludeOnly collection filter excludes configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelExcludeFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
@@ -210,6 +215,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 IncludeOnly profile keeps School address fields configured for School
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "School"
@@ -217,6 +223,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 07 IncludeOnly profile keeps LocalEducationAgency address fields configured for LocalEducationAgency
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "LocalEducationAgency"
@@ -224,6 +231,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 08 ExcludeOnly profile excludes LocalEducationAgency address fields configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "LocalEducationAgency"
@@ -231,6 +239,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 ExcludeOnly profile keeps School address fields not configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "School"
@@ -299,20 +308,26 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 10 IncludeAll derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 11 IncludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 12 ExcludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 13 IncludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 14 ExcludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 15 IncludeAll derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
@@ -5,6 +5,7 @@ Feature: Profile Definition Validation
 
     Rule: Profiles with non-existent resource names are rejected
 
+        @relational-backend
         Scenario: 01 Profile referencing non-existent resource is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NonExistentResource" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -33,6 +34,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent properties in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 02 Profile with invalid IncludeOnly property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -61,6 +63,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent objects in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 03 Profile with invalid IncludeOnly nested object is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyObject" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -89,6 +92,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent collections in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 04 Profile with invalid IncludeOnly collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyCollection" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -117,6 +121,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent extension properties in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 05 Profile with invalid IncludeOnly extension property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-ExtensionProperty" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
               And the system has these descriptors
@@ -145,6 +150,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with ExcludeOnly excluding identity members produce warnings but are loaded
 
+        @relational-backend
         Scenario: 06 Profile with ExcludeOnly excluding identity member is loaded with warning
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Warning-ExcludeIdentity" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -173,6 +179,7 @@ Feature: Profile Definition Validation
               And the response body should contain fields "schoolId"
     Rule: Profiles with nested invalid properties in collections are rejected
 
+        @relational-backend
         Scenario: 07 Profile with invalid property in nested collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NestedCollectionProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
@@ -41,11 +41,13 @@ Feature: Profile Embedded Object Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeAll profile returns nested collection data
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
              And the "addresses" collection item at index 0 should have "nameOfCounty" value "Travis"
 
+        @relational-backend
         Scenario: 02 IncludeOnly profile still returns allowed nested collection members
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -187,6 +189,7 @@ Feature: Profile Embedded Object Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 Read exclude-profile variant is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" for resource "Assessment"
@@ -194,6 +197,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 06 Read profile including embedded object is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Includes-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Includes-Embedded-Object" for resource "Assessment"
@@ -251,6 +255,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 Data validation with invalid embedded object is rejected without profile
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
@@ -38,12 +38,14 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Extension IncludeOnly profile returns only specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should contain path "_ext.sample.isExemplary"
              And the response body should not contain path "_ext.sample.cteProgramService"
 
+        @relational-backend
         Scenario: 02 Extension IncludeOnly profile preserves the isExemplary value
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -84,11 +86,13 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Extension ExcludeOnly profile excludes specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should not contain path "_ext.sample.isExemplary"
 
+        @relational-backend
         Scenario: 04 Extension ExcludeOnly profile includes non-excluded extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -130,6 +134,7 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 Parent IncludeOnly profile without extension rule excludes _ext entirely
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -172,6 +177,7 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Parent ExcludeOnly profile without extension rule includes _ext
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -179,6 +185,7 @@ Feature: Profile Extension Filtering
               And the response body should contain path "_ext.sample.isExemplary"
               And the response body should contain path "_ext.sample.cteProgramService"
 
+        @relational-backend
         Scenario: 07 Parent ExcludeOnly profile excludes specified core properties but keeps extensions
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
@@ -31,12 +31,14 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 GET by ID with IncludeOnly profile returns only included fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution, educationOrganizationCategories, gradeLevels"
 
+        @relational-backend
         Scenario: 02 GET by ID with IncludeOnly profile preserves identity fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -70,12 +72,14 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 03 GET by ID with ExcludeOnly profile excludes specified fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should not contain fields "shortNameOfInstitution, webSite"
              And the response body should contain fields "id, schoolId, nameOfInstitution"
 
+        @relational-backend
         Scenario: 04 GET by ID with ExcludeOnly profile includes non-excluded fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -109,6 +113,7 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 GET by ID with IncludeAll profile returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -161,6 +166,7 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Query with IncludeOnly profile filters all items in array
             When a GET request is made to "/ed-fi/schools?schoolId=99000104" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
@@ -31,6 +31,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Malformed profile header returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.invalid"
              Then the profile response status is 400
@@ -40,6 +41,7 @@ Feature: Profile Header Validation
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy."
               And the response body errors should match regex "(?i)The format of the profile-based content type header was invalid\."
 
+        @relational-backend
         Scenario: 02 Profile header with wrong resource name returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.student.e2e-test-school-includeonly.readable+json"
              Then the profile response status is 400
@@ -49,6 +51,7 @@ Feature: Profile Header Validation
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy."
               And the response body errors should match regex "(?i)The resource specified by the profile-based content type \('student'\) does not match the requested resource \('School'\)\."
 
+        @relational-backend
         Scenario: 03 Profile header with writable usage for GET returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.writable+json"
              Then the profile response status is 400
@@ -194,6 +197,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Using profile header on app without profiles succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -228,6 +232,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Using nonexistent profile returns 406
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.nonexistent-profile.readable+json"
              Then the profile response status is 406
@@ -265,6 +270,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 10 Valid profile header for correct resource succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
@@ -12,6 +12,7 @@ Feature: Multi-Resource Profile Usage
                   | uri://ed-fi.org/GradeLevelDescriptor#Tenth grade               |
                   | uri://ed-fi.org/StudentCharacteristicDescriptor#504            |
 
+        @relational-backend
         Scenario: 01 GET on both resources included in the profile succeeds
              When a GET request is made to "/ed-fi/schools" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "School"
              Then the profile response status is 200
@@ -45,6 +46,7 @@ Feature: Multi-Resource Profile Usage
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 03 GET on resource not included in the profile returns 400
              When a GET request is made to "/ed-fi/staffs" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "Staff"
              Then the profile response status is 400
@@ -67,6 +69,7 @@ Feature: Multi-Resource Profile Usage
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy. The resource is not contained by the profile used by (or applied to) the request."
               And the response body errors should match regex "(?i)Resource 'Staff' is not accessible through the 'e2e-test-student-and-school-includeall' profile specified by the content type\."
 
+        @relational-backend
         Scenario: 05 Accept/Content-Type negotiation for all included resources
              When a GET request is made to "/ed-fi/schools" with Accept header "application/vnd.ed-fi.school.e2e-test-student-and-school-includeall.readable+json"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
@@ -6,6 +6,7 @@ Feature: Profile OpenAPI Specification Filtering
         Background:
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 Profile OpenAPI spec includes only covered resources
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -16,12 +17,14 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec should contain tag "Schools"
               And the OpenAPI spec should not contain tag "Students"
 
+        @relational-backend
         Scenario: 02 Profile OpenAPI spec includes readable and writable schemas
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
               And the OpenAPI spec should contain schema "edFi_school_readable"
               And the OpenAPI spec should contain schema "edFi_school_writable"
 
+        @relational-backend
         Scenario: 03 Profile OpenAPI spec filters operations correctly
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -31,10 +34,12 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec path "/ed-fi/schools/{id}" should have operation "put"
               And the OpenAPI spec path "/ed-fi/schools/{id}" should have operation "delete"
 
+        @relational-backend
         Scenario: 04 Non-existent profile returns 404
              When a GET request is made to "/metadata/specifications/profiles/NonExistentProfile/resources-spec.json"
              Then the profile response status is 404
 
+        @relational-backend
         Scenario: 05 Metadata specifications list includes profile entries
              When a GET request is made to "/metadata/specifications"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
@@ -57,6 +57,7 @@ Feature: Profile Reference Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeOnly reference profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-IncludeOnly" for resource "School"
@@ -118,6 +119,7 @@ Feature: Profile Reference Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 02 ExcludeOnly profile excludes configured reference properties on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-ExcludeOnly" for resource "School"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
@@ -31,12 +31,14 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Single profile without Accept header applies implicitly
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 02 Single profile can also be applied explicitly with Accept header
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -70,17 +72,20 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Multiple profiles without Accept header returns 403
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 403
              And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 04 Multiple profiles with explicit Accept header for first profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 05 Multiple profiles with explicit Accept header for second profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-Alt" for resource "School"
             Then the profile response status is 200
@@ -115,6 +120,7 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 06 No profile assigned returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
@@ -31,6 +31,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 01 GET collection with profile returns profile content type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -41,6 +42,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 02 GET item by id with profile returns profile content type
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -51,6 +53,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 03 GET with explicit profile returns content type including profile and readable suffix
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -61,6 +64,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 04 GET collection with explicit profile returns profile-specific media type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -71,6 +75,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 05 GET item by id with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; charset=utf-8"
              Then the profile response status is 200
@@ -81,6 +86,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 06 GET collection with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; q=1.0"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
@@ -30,12 +30,14 @@ Feature: Profile Undefined and Misconfigured Usage
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 GET with undefined profile returns 406
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.profile-does-not-exist.readable+json"
             Then the profile response status is 406
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 02 POST with undefined profile returns 415
             When a POST request is made to "/ed-fi/schools" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -58,6 +60,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 03 PUT with undefined profile returns 415
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -110,6 +113,7 @@ Feature: Profile Undefined and Misconfigured Usage
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 04 GET with misconfigured resource profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.test-profile-with-unexisting-resource.readable+json"
@@ -117,6 +121,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 05 POST with misconfigured property profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-With-Unexisting-Property" for resource "School" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
@@ -5,6 +5,7 @@ Feature: Profile XML File Definition Validation
 
     Rule: Profiles loaded from XML files behave consistently with invalid definitions
 
+        @relational-backend
         Scenario: 01 Profile with non-existent resource from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -33,6 +34,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 406
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 02 Profile with non-existent property from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
@@ -61,6 +63,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 406
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 03 Profile with non-existent resource from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -88,6 +91,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 415
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 04 Profile with non-existent property from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
@@ -5,6 +5,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Assigned profiles that do not support the method fall back to standard behavior
 
+        @relational-backend
         Scenario: Read-only assigned profile does not block standard POST without profile header
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-ReadOnly" and namespacePrefixes "uri://ed-fi.org"
@@ -31,6 +32,7 @@ Feature: Profile XML File Method Usage
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: Write-only assigned profile does not block standard GET without profile header
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -61,6 +63,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Read-only profile allows GET and rejects POST
 
+        @relational-backend
         Scenario: 01 Read-only profile allows GET and rejects POST
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -137,6 +140,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Write-only profile rejects GET
 
+        @relational-backend
         Scenario: 02 Write-only profile rejects GET
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
@@ -3,6 +3,7 @@ Feature: Validate array uniqueness
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 Can create addresses on studentEducationOrganizationAssociations differing only in address type
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -50,6 +51,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 02 Cannot create addresses on studentEducationOrganizationAssociations with no difference in type-city-street-postalcode
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -124,6 +126,7 @@ Feature: Validate array uniqueness
                   | uri://ed-fi.org/AssessmentReportingMethodDescriptor#Raw score   |
                   | uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer            |
 
+        @relational-backend
         Scenario: 03 Can create an assessment with unique performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -163,6 +166,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 04 Cannot create assessment with duplicate performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -219,6 +223,7 @@ Feature: Validate array uniqueness
                   """
 
     Rule: Uniqueness of array of document references
+        @relational-backend
         Scenario: 05 Cannot create a bellschedule with a duplicate classPeriodReference in classPeriods array
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -276,6 +281,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Verify clients cannot create a resource with a duplicate descriptor
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -528,6 +534,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Can create studentAssessments with multiple unique assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -601,6 +608,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 08 Cannot create studentAssessments with duplicate assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -699,6 +707,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Can create requiredImmunizations on studentHealths with same dates in different requiredImmunizations
              When a POST request is made to "/ed-fi/studentHealths" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
@@ -18,6 +18,7 @@ Feature: Create Reference Validation
                   | 123      | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
 
         @API-079
+        @relational-backend
         Scenario: 01 Ensure clients cannot create a resource with a non existing reference
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -51,6 +52,7 @@ Feature: Create Reference Validation
               And it should respond with 409
 
         @API-080
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a resource with correct information but an invalid value belonging to the reference
              When a POST request is made to "/ed-fi/studentCTEProgramAssociations" with
                   """
@@ -92,6 +94,7 @@ Feature: Create Reference Validation
               And it should respond with 409
 
         @API-081
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a resource using a reference that is out of range of the existing values
              When a POST request is made to "/ed-fi/graduationPlans" with
                   """
@@ -125,6 +128,7 @@ Feature: Create Reference Validation
                   """
 
         @API-082
+        @relational-backend
         Scenario: 04 Ensure clients cannot create a resource using an invalid reference inside of another reference
             Given the system has these "students"
                   | studentUniqueId | firstName | lastSurname | birthDate    |
@@ -164,6 +168,7 @@ Feature: Create Reference Validation
                   """
 
         @API-083
+        @relational-backend
         Scenario: 05 Verify clients cannot update a resource with a bad academicWeeks reference
             Given the system has these "AcademicWeeks" references
                   | weekIdentifier | nameOfInstitution | schoolReference   | beginDate    | endDate      | totalInstructionalDays |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
@@ -17,6 +17,7 @@ Feature: Validate the reference of descriptors when creating resources
                   | 255901001 | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
 
         @API-089
+        @relational-backend
         Scenario: 01 User can not create a resource when descriptor doesn't exist
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -53,6 +54,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-090
+        @relational-backend
         Scenario: 02 User can not upsert a resource using a descriptor that does not exist
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -83,6 +85,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-091
+        @relational-backend
         Scenario: 03 User can not update a resource using a descriptor that does not exist
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -133,6 +136,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-092
+        @relational-backend
         Scenario: 04 User can create a resource when descriptor exists
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -150,6 +154,7 @@ Feature: Validate the reference of descriptors when creating resources
              Then it should respond with 201 or 200
 
         @API-093
+        @relational-backend
         Scenario: 05 User can update a resource when descriptor exists
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -181,6 +186,7 @@ Feature: Validate the reference of descriptors when creating resources
              Then it should respond with 204
 
         @API-094
+        @relational-backend
         Scenario: 06 User receives 400 instead of 409 error when both descriptor and reference are invalid
              When a POST request is made to "/ed-fi/studentProgramAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
@@ -22,6 +22,7 @@ Feature: StudentAssessmentRegistrationBatteryPartAssociation References
 
 Rule: Two StudentAssessmentRegistrationBatteryPartAssociation can be created only differing in AssigningEducationOrganizationId
 
+        @relational-backend
         Scenario: 01 Create two StudentAssessmentRegistrationBatteryPartAssociation with only different AssigningEducationOrganizationIds
 
              When a POST request is made to "/ed-fi/studentEducationOrganizationAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
@@ -17,6 +17,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-104
+        @relational-backend
         Scenario: 01 Ensure clients can create a Program that references an existing School
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -32,6 +33,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-105
+        @relational-backend
         Scenario: 02 Ensure clients can create a Program that references an existing Local Education Agency
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -46,6 +48,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
              Then it should respond with 201 or 200
 
         @API-106
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a Program that references a non-existing Education Organization
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -76,6 +79,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
                   """
 
         @API-107
+        @relational-backend
         Scenario: 04 Ensure clients can update a school that references to an existing local education agency
             Given the system has these "Schools" references
                   | schoolId | nameOfInstitution | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |
@@ -108,6 +112,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-108
+        @relational-backend
         Scenario: 05 Ensure clients cannot update a school that references to an existing Local Agency so it references now a Non Existing Education Organization
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | localEducationAgencyReference  | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -52,6 +52,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-121
+        @relational-backend
         Scenario: 02 Ensure clients can get information when filtering by limit and offset greater than the total
              When a GET request is made to "/ed-fi/schools?offset=600&limit=5"
              Then it should respond with 200
@@ -61,6 +62,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-122
+        @relational-backend
         Scenario: 03 Ensure clients can GET information when querying using an offset without providing any limit in the query string
              When a GET request is made to "/ed-fi/schools?offset=4"
              Then it should respond with 200
@@ -86,6 +88,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-123
+        @relational-backend
         Scenario: 04 Ensure clients can GET information when filtering with limits and properties
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=School+5&limit=2"
              Then it should respond with 200
@@ -111,6 +114,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-147
+        @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -137,6 +141,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
+        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -114,7 +114,6 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-147
-        @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -141,7 +140,6 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
-        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -113,7 +113,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                     ]
                   """
 
-        @API-147
+        @API-147 @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -140,6 +140,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
+        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -20,7 +20,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
         @API-124
-        @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -57,7 +56,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-125
-        @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -77,7 +75,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-126
-        @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -97,7 +94,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-127
-        @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -107,7 +103,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-128
-        @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -135,7 +130,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-130
-        @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -172,7 +166,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-132
-        @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -191,7 +184,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-133
-        @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -247,7 +239,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -256,7 +247,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -278,7 +268,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
-        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -311,7 +300,6 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
-        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -20,6 +20,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
         @API-124
+        @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -56,6 +57,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-125
+        @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -75,6 +77,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-126
+        @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -94,6 +97,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-127
+        @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -103,6 +107,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-128
+        @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -130,6 +135,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-130
+        @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -166,6 +172,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-132
+        @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -184,6 +191,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-133
+        @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -239,6 +247,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -247,6 +256,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
+        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -268,6 +278,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -300,6 +311,7 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
+        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -19,7 +19,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   | studentReference                | assessmentReference                                                                              | administrationDate     | studentAssessmentIdentifier |
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
-        @API-124
+        @API-124 @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -55,7 +55,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-125
+        @API-125 @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -74,7 +74,7 @@ Feature: Query String handling for GET requests for Resource Queries
                    }
                   """
 
-        @API-126
+        @API-126 @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -93,7 +93,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }
                   """
 
-        @API-127
+        @API-127 @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -102,7 +102,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-128
+        @API-128 @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -111,7 +111,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-129
+        @API-129 @relational-backend
         Scenario: 06 Ensure clients can GET information when querying by string parameter
              When a GET request is made to "/ed-fi/academicWeeks?weekIdentifier=Week+One"
              Then it should respond with 200
@@ -129,7 +129,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-130
+        @API-130 @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -147,7 +147,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-131
+        @API-131 @relational-backend
         Scenario: 08 Ensure clients can GET information when querying with mixed case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIdentifier=Week+One"
              Then it should respond with 200
@@ -165,7 +165,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-132
+        @API-132 @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -183,7 +183,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-133
+        @API-133 @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -239,6 +239,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -247,6 +248,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
+        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -268,6 +270,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -300,6 +303,7 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
+        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """
@@ -321,6 +325,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 17 Ensure clients can GET information when querying by value in a document reference
              When a GET request is made to "/ed-fi/academicWeeks?schoolId=2"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -111,7 +111,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-129 @relational-backend
+        @API-129
         Scenario: 06 Ensure clients can GET information when querying by string parameter
              When a GET request is made to "/ed-fi/academicWeeks?weekIdentifier=Week+One"
              Then it should respond with 200
@@ -147,7 +147,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-131 @relational-backend
+        @API-131
         Scenario: 08 Ensure clients can GET information when querying with mixed case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIdentifier=Week+One"
              Then it should respond with 200
@@ -321,7 +321,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @relational-backend
         Scenario: 17 Ensure clients can GET information when querying by value in a document reference
              When a GET request is made to "/ed-fi/academicWeeks?schoolId=2"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -11,7 +11,6 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @API-136
-        @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -23,21 +22,18 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-137
-        @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-138
-        @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-140
-        @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -49,14 +45,12 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-141
-        @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-142
-        @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -11,6 +11,7 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @API-136
+        @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -22,18 +23,21 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-137
+        @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-138
+        @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-140
+        @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -45,12 +49,14 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-141
+        @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-142
+        @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -10,7 +10,7 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901044 | Grand Bend Middle School                      | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"} ]    | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
-        @API-136
+        @API-136 @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -21,19 +21,19 @@ Feature: TotalCount Response Header for GET Requests
                     }
                   """
 
-        @API-137
+        @API-137 @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-138
+        @API-138 @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-140
+        @API-140 @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -44,19 +44,19 @@ Feature: TotalCount Response Header for GET Requests
                     }
                   """
 
-        @API-141
+        @API-141 @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-142
+        @API-142 @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-143
+        @API-143 @relational-backend
         Scenario: 08 Ensure results can be limited and totalCount matches the actual number of existing records
              When a GET request is made to "/ed-fi/schools?totalCount=true&limit=2"
              Then getting less schools than the total-count

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -56,7 +56,7 @@ Feature: TotalCount Response Header for GET Requests
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-143 @relational-backend
+        @API-143
         Scenario: 08 Ensure results can be limited and totalCount matches the actual number of existing records
              When a GET request is made to "/ed-fi/schools?totalCount=true&limit=2"
              Then getting less schools than the total-count

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -13,7 +13,7 @@ Feature: Resources "Create" Operation validations
 
     Rule: Resources
 
-        @API-152 @POST
+        @API-152 @POST @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -34,7 +34,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-153 @POST
+        @API-153 @POST @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -70,7 +70,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-154 @POST
+        @API-154 @POST @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -102,7 +102,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-155 @POST
+        @API-155 @POST @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -134,7 +134,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-156 @POST
+        @API-156 @POST @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -166,7 +166,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-157 @POST
+        @API-157 @POST @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -179,7 +179,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @API-158 @POST
+        @API-158 @POST @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -194,7 +194,7 @@ Feature: Resources "Create" Operation validations
             # 200 because this is updating the document stored with the scenario above.
              Then it should respond with 200
 
-        @API-159 @POST
+        @API-159 @POST @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -226,7 +226,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-160 @API-233 @POST
+        @API-160 @API-233 @POST @relational-backend
         Scenario: 10 Create a document with an extra property (overpost) (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -254,7 +254,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-161 @POST
+        @API-161 @POST @relational-backend
         Scenario: 11 Create a document with an null optional property (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -280,7 +280,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-162 @POST
+        @API-162 @POST @relational-backend
         Scenario: 12 Post an numeric and boolean fields as strings are coerced (Resource)
             # In this example schoolId is numeric and doNotPublishIndicator are boolean, yet posted in quotes as strings
             # In the GET request you can see they are coerced to their proper types
@@ -350,7 +350,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-163 @POST
+        @API-163 @POST @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -382,7 +382,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-164 @POST
+        @API-164 @POST @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -414,7 +414,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-165 @POST
+        @API-165 @POST @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -449,7 +449,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-166 @POST
+        @API-166 @POST @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -474,7 +474,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 200
 
-        @API-167 @POST
+        @API-167 @POST @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -506,7 +506,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-168 @POST
+        @API-168 @POST @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -535,7 +535,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-169 @POST
+        @API-169 @POST @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -548,7 +548,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201 or 200
 
-        @API-170 @POST
+        @API-170 @POST @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -577,7 +577,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-171 @POST
+        @API-171 @POST @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -606,7 +606,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-172 @APIConventions @POST
+        @API-172 @APIConventions @POST @relational-backend
         Scenario: 24 Verify user can send a POST using extra fields
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -686,7 +686,7 @@ Feature: Resources "Create" Operation validations
                   content-type: application/problem+json
                   """
 
-        @API-174 @APIConventions @POST
+        @API-174 @APIConventions @POST @relational-backend
         Scenario: 26 Validate special characters values during POST action
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -705,7 +705,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-175 @POST
+        @API-175 @POST @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -737,6 +737,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -765,6 +766,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -797,6 +799,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -837,6 +840,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -865,6 +869,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -878,6 +883,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -906,6 +912,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -14,6 +14,7 @@ Feature: Resources "Create" Operation validations
     Rule: Resources
 
         @API-152 @POST
+        @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -35,6 +36,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-153 @POST
+        @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -71,6 +73,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-154 @POST
+        @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -103,6 +106,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-155 @POST
+        @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -135,6 +139,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-156 @POST
+        @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -167,6 +172,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-157 @POST
+        @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -180,6 +186,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @API-158 @POST
+        @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -195,6 +202,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-159 @POST
+        @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -351,6 +359,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-163 @POST
+        @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -383,6 +392,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-164 @POST
+        @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -415,6 +425,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-165 @POST
+        @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -450,6 +461,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-166 @POST
+        @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -475,6 +487,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-167 @POST
+        @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -507,6 +520,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-168 @POST
+        @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -536,6 +550,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-169 @POST
+        @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -549,6 +564,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201 or 200
 
         @API-170 @POST
+        @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -578,6 +594,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-171 @POST
+        @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -706,6 +723,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-175 @POST
+        @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -737,6 +755,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -765,6 +784,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -797,6 +817,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -837,6 +858,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -865,6 +887,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -878,6 +901,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -906,6 +930,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -14,7 +14,6 @@ Feature: Resources "Create" Operation validations
     Rule: Resources
 
         @API-152 @POST
-        @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -36,7 +35,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-153 @POST
-        @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -73,7 +71,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-154 @POST
-        @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -106,7 +103,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-155 @POST
-        @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -139,7 +135,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-156 @POST
-        @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -172,7 +167,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-157 @POST
-        @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -186,7 +180,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @API-158 @POST
-        @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -202,7 +195,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-159 @POST
-        @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -359,7 +351,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-163 @POST
-        @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -392,7 +383,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-164 @POST
-        @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -425,7 +415,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-165 @POST
-        @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -461,7 +450,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-166 @POST
-        @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -487,7 +475,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-167 @POST
-        @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -520,7 +507,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-168 @POST
-        @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -550,7 +536,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-169 @POST
-        @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -564,7 +549,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201 or 200
 
         @API-170 @POST
-        @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -594,7 +578,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-171 @POST
-        @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -723,7 +706,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-175 @POST
-        @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -755,7 +737,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -784,7 +765,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -817,7 +797,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -858,7 +837,6 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -887,7 +865,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -901,7 +878,6 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -930,7 +906,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -226,7 +226,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-160 @API-233 @POST @relational-backend
+        @API-160 @API-233 @POST
         Scenario: 10 Create a document with an extra property (overpost) (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -254,7 +254,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-161 @POST @relational-backend
+        @API-161 @POST
         Scenario: 11 Create a document with an null optional property (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -280,7 +280,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-162 @POST @relational-backend
+        @API-162 @POST
         Scenario: 12 Post an numeric and boolean fields as strings are coerced (Resource)
             # In this example schoolId is numeric and doNotPublishIndicator are boolean, yet posted in quotes as strings
             # In the GET request you can see they are coerced to their proper types
@@ -606,7 +606,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-172 @APIConventions @POST @relational-backend
+        @API-172 @APIConventions @POST
         Scenario: 24 Verify user can send a POST using extra fields
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -686,7 +686,7 @@ Feature: Resources "Create" Operation validations
                   content-type: application/problem+json
                   """
 
-        @API-174 @APIConventions @POST @relational-backend
+        @API-174 @APIConventions @POST
         Scenario: 26 Validate special characters values during POST action
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -449,7 +449,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-166 @POST @relational-backend
+        @API-166 @POST
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
@@ -4,7 +4,7 @@ Feature: Resources "Delete" Reference Conflict validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-176 @relational-backend
+        @API-176
         Scenario: 01 Verify response when deleting a referenced school
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -33,7 +33,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-177 @relational-backend
+        @API-177
         Scenario: 02 Verify response when deleting a referenced schoolyeartype
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -62,7 +62,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-178 @relational-backend
+        @API-178
         Scenario: 03 Verify response when deleting a referenced student
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -90,4 +90,3 @@ Feature: Resources "Delete" Reference Conflict validations
                         "errors": []
                     }
                   """
-

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
@@ -4,7 +4,7 @@ Feature: Resources "Delete" Reference Conflict validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-176
+        @API-176 @relational-backend
         Scenario: 01 Verify response when deleting a referenced school
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -33,7 +33,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-177
+        @API-177 @relational-backend
         Scenario: 02 Verify response when deleting a referenced schoolyeartype
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -62,7 +62,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-178
+        @API-178 @relational-backend
         Scenario: 03 Verify response when deleting a referenced student
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
@@ -36,7 +36,7 @@ Feature: Resources "Read" Operation validations
              When a GET request is made to "/ed-fi/schools/{id}"
              Then it should respond with 404
 
-        @API-182
+        @API-182 @relational-backend
         Scenario: 02 Verify response code 200 when trying to get a student with a correct ID
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
@@ -36,7 +36,7 @@ Feature: Resources "Read" Operation validations
              When a GET request is made to "/ed-fi/schools/{id}"
              Then it should respond with 404
 
-        @API-182 @relational-backend
+        @API-182
         Scenario: 02 Verify response code 200 when trying to get a student with a correct ID
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -121,6 +121,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-188 @PUT
+        @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -146,6 +147,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-189 @PUT
+        @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -168,6 +170,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-190 @PUT
+        @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -200,6 +203,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-191 @PUT
+        @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -227,6 +231,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-192 @PUT
+        @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -254,6 +259,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-193 @PUT
+        @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -310,6 +316,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-195 @PUT
+        @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -338,6 +345,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-196 @PUT
+        @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -371,6 +379,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-197 @PUT
+        @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -406,6 +415,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-198 @PUT
+        @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -439,6 +449,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-199 @PUT
+        @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -483,6 +494,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-200 @PUT
+        @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1108,6 +1120,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-221 @IdempotentUpdate
+        @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -121,7 +121,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-188 @PUT
-        @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -147,7 +146,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-189 @PUT
-        @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -170,7 +168,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-190 @PUT
-        @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -203,7 +200,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-191 @PUT
-        @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -231,7 +227,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-192 @PUT
-        @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -259,7 +254,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-193 @PUT
-        @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -316,7 +310,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-195 @PUT
-        @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -345,7 +338,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-196 @PUT
-        @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -379,7 +371,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-197 @PUT
-        @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -415,7 +406,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-198 @PUT
-        @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -449,7 +439,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-199 @PUT
-        @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -494,7 +483,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-200 @PUT
-        @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1120,7 +1108,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-221 @IdempotentUpdate
-        @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -17,7 +17,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-184 @PUT
+        @API-184 @PUT @relational-backend
         Scenario: 01 Put an existing document (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -120,7 +120,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-188 @PUT
+        @API-188 @PUT @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -145,7 +145,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-189 @PUT
+        @API-189 @PUT @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -167,7 +167,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-190 @PUT
+        @API-190 @PUT @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -199,7 +199,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-191 @PUT
+        @API-191 @PUT @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -226,7 +226,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-192 @PUT
+        @API-192 @PUT @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -253,7 +253,7 @@ Feature: Resources "Update" Operation validations
                    }
                   """
 
-        @API-193 @PUT
+        @API-193 @PUT @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -309,7 +309,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-195 @PUT
+        @API-195 @PUT @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -337,7 +337,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-196 @PUT
+        @API-196 @PUT @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -370,7 +370,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-197 @PUT
+        @API-197 @PUT @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -405,7 +405,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-198 @PUT
+        @API-198 @PUT @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -438,7 +438,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-199 @PUT
+        @API-199 @PUT @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -482,7 +482,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-200 @PUT
+        @API-200 @PUT @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1107,7 +1107,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-221 @IdempotentUpdate
+        @API-221 @IdempotentUpdate @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -17,7 +17,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-184 @PUT @relational-backend
+        @API-184 @PUT
         Scenario: 01 Put an existing document (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -3,7 +3,7 @@ Feature: ETag validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-260 @relational-backend
+        @API-260
         Scenario: 01 Ensure that clients can retrieve an ETag in the response header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -27,7 +27,6 @@ Feature: ETag validations
                     "_etag": "{etag}"
                   }
                   """
-        @relational-backend
         Scenario: 02 Ensure that clients can pass an IfMatch in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -51,7 +50,6 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
-        @relational-backend
         Scenario: 03 Ensure that clients can pass an IfMatch in the request header and ignore _etag in request body
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -76,7 +74,6 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
-        @relational-backend
         Scenario: 04 Ensure that clients cannot pass a different If-Match in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -113,7 +110,6 @@ Feature: ETag validations
                       ]
                   }
                   """
-        @relational-backend
         Scenario: 05 Ensure that clients cannot pass a different ETag in the If-Match header to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """
@@ -139,7 +135,6 @@ Feature: ETag validations
                       ]
                   }
                   """
-        @relational-backend
         Scenario: 06 Ensure that clients can pass an ETag to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -3,7 +3,7 @@ Feature: ETag validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-260
+        @API-260 @relational-backend
         Scenario: 01 Ensure that clients can retrieve an ETag in the response header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -27,6 +27,7 @@ Feature: ETag validations
                     "_etag": "{etag}"
                   }
                   """
+        @relational-backend
         Scenario: 02 Ensure that clients can pass an IfMatch in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -50,6 +51,7 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
+        @relational-backend
         Scenario: 03 Ensure that clients can pass an IfMatch in the request header and ignore _etag in request body
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -74,6 +76,7 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
+        @relational-backend
         Scenario: 04 Ensure that clients cannot pass a different If-Match in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -110,6 +113,7 @@ Feature: ETag validations
                       ]
                   }
                   """
+        @relational-backend
         Scenario: 05 Ensure that clients cannot pass a different ETag in the If-Match header to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """
@@ -135,6 +139,7 @@ Feature: ETag validations
                       ]
                   }
                   """
+        @relational-backend
         Scenario: 06 Ensure that clients can pass an ETag to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
@@ -5,7 +5,6 @@ Feature: SchoolYearType resource
 
     Rule: SchoolYearType resource
 
-        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a schoolYearTypes resource
       # POST request to create a school
              When a POST request is made to "/ed-fi/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
@@ -5,6 +5,7 @@ Feature: SchoolYearType resource
 
     Rule: SchoolYearType resource
 
+        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a schoolYearTypes resource
       # POST request to create a school
              When a POST request is made to "/ed-fi/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -6,22 +6,18 @@ Feature: OWASP critical attack path protections
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
                   | 1001     | Security School   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
-        @relational-backend
         Scenario: 01 SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?schoolId=9999' OR 1=1--"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 01a SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?OR 1=1--schoolId=9999"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 01b SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?+OR+1%3D1+--schoolId=9999"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 02 SQL injection payload in JSON body numeric field is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -42,7 +38,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 03 CSRF style forged browser request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker" and
@@ -64,12 +59,10 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 04 Path traversal attempts are not resolved as files
              When a GET request is made to "/../appsettings.json"
              Then it should respond with 404
 
-        @relational-backend
         Scenario: 05 X-Forwarded-Proto spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Proto" value "https" and
@@ -91,7 +84,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 06 X-Forwarded-Host spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Host" value "trusted.local" and
@@ -116,7 +108,6 @@ Feature: OWASP critical attack path protections
         # The "token is expired" step overwrites the exp claim but keeps the original signature,
         # so the rejected request actually fails the signature validation before expiry is evaluated.
         # A pure expired-token check would need an issued token to naturally lapse (or a configurable IdP).
-        @relational-backend
         Scenario: 06a Expired JWT is rejected
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token is expired
@@ -127,7 +118,6 @@ Feature: OWASP critical attack path protections
         # Playwright/Chromium silently drops it, so the spoofed value never reaches the server.
         # This scenario validates that authentication is enforced on all unauthenticated requests
         # regardless of any Host-like header value — it does NOT verify server-side Host validation.
-        @relational-backend
         Scenario: 07 Unauthenticated request with Host header is rejected by authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Host" value "trusted.local" and
@@ -149,7 +139,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 08 Allowed CORS origin receives Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "http://localhost:8082"
              Then it should respond with 200
@@ -160,13 +149,11 @@ Feature: OWASP critical attack path protections
                   }
                   """
 
-        @relational-backend
         Scenario: 09 Disallowed CORS origin does not receive Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker"
              Then it should respond with 200
               And the response header "Access-Control-Allow-Origin" is not present
 
-        @relational-backend
         Scenario: 10 Malformed JSON request body is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -197,7 +184,6 @@ Feature: OWASP critical attack path protections
         # Note: WhenAnRequestIsMadeToWithHeaders includes the bearer token from the test context.
         # Real browser CORS preflights are unauthenticated; the assertion (no allow-origin for
         # disallowed origins) is independent of auth and is still correct here.
-        @relational-backend
         Scenario: 12 Disallowed CORS preflight does not return allow-origin header
              When an "OPTIONS" request is made to "/ed-fi/schools" with headers
                   | Key                           | Value                |
@@ -208,7 +194,6 @@ Feature: OWASP critical attack path protections
 
         # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
         # enforced at the routing layer regardless of auth state.
-        @relational-backend
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
@@ -278,7 +263,6 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/studentSchoolAssociations/{BolaStudentSchoolAssociationId}"
              Then it should respond with 403
 
-        @relational-backend
         Scenario: 16a Deleting a referenced student returns conflict
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these "schools"
@@ -293,7 +277,6 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/students/{ReferencedStudentId}"
              Then it should respond with 409
 
-        @relational-backend
         Scenario: 17 CSRF style forged browser cookie request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Cookie" value "sessionid=forged-session-id" and
@@ -315,7 +298,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 18 SQL injection payload in string query field is treated as data
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=%27%20OR%20%271%27%3D%271"
              Then it should respond with 200
@@ -324,7 +306,6 @@ Feature: OWASP critical attack path protections
                   []
                   """
 
-        @relational-backend
         Scenario: 19 CSRF style browser form post without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated Form URL Encoded POST request is made to "/ed-fi/schools" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -6,18 +6,22 @@ Feature: OWASP critical attack path protections
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
                   | 1001     | Security School   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
+        @relational-backend
         Scenario: 01 SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?schoolId=9999' OR 1=1--"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 01a SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?OR 1=1--schoolId=9999"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 01b SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?+OR+1%3D1+--schoolId=9999"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 02 SQL injection payload in JSON body numeric field is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -38,6 +42,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 03 CSRF style forged browser request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker" and
@@ -59,10 +64,12 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 04 Path traversal attempts are not resolved as files
              When a GET request is made to "/../appsettings.json"
              Then it should respond with 404
 
+        @relational-backend
         Scenario: 05 X-Forwarded-Proto spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Proto" value "https" and
@@ -84,6 +91,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 06 X-Forwarded-Host spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Host" value "trusted.local" and
@@ -108,6 +116,7 @@ Feature: OWASP critical attack path protections
         # The "token is expired" step overwrites the exp claim but keeps the original signature,
         # so the rejected request actually fails the signature validation before expiry is evaluated.
         # A pure expired-token check would need an issued token to naturally lapse (or a configurable IdP).
+        @relational-backend
         Scenario: 06a Expired JWT is rejected
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token is expired
@@ -118,6 +127,7 @@ Feature: OWASP critical attack path protections
         # Playwright/Chromium silently drops it, so the spoofed value never reaches the server.
         # This scenario validates that authentication is enforced on all unauthenticated requests
         # regardless of any Host-like header value — it does NOT verify server-side Host validation.
+        @relational-backend
         Scenario: 07 Unauthenticated request with Host header is rejected by authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Host" value "trusted.local" and
@@ -139,6 +149,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 08 Allowed CORS origin receives Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "http://localhost:8082"
              Then it should respond with 200
@@ -149,11 +160,13 @@ Feature: OWASP critical attack path protections
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Disallowed CORS origin does not receive Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker"
              Then it should respond with 200
               And the response header "Access-Control-Allow-Origin" is not present
 
+        @relational-backend
         Scenario: 10 Malformed JSON request body is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -184,6 +197,7 @@ Feature: OWASP critical attack path protections
         # Note: WhenAnRequestIsMadeToWithHeaders includes the bearer token from the test context.
         # Real browser CORS preflights are unauthenticated; the assertion (no allow-origin for
         # disallowed origins) is independent of auth and is still correct here.
+        @relational-backend
         Scenario: 12 Disallowed CORS preflight does not return allow-origin header
              When an "OPTIONS" request is made to "/ed-fi/schools" with headers
                   | Key                           | Value                |
@@ -194,6 +208,7 @@ Feature: OWASP critical attack path protections
 
         # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
         # enforced at the routing layer regardless of auth state.
+        @relational-backend
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
@@ -263,6 +278,7 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/studentSchoolAssociations/{BolaStudentSchoolAssociationId}"
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 16a Deleting a referenced student returns conflict
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these "schools"
@@ -277,6 +293,7 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/students/{ReferencedStudentId}"
              Then it should respond with 409
 
+        @relational-backend
         Scenario: 17 CSRF style forged browser cookie request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Cookie" value "sessionid=forged-session-id" and
@@ -298,6 +315,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 18 SQL injection payload in string query field is treated as data
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=%27%20OR%20%271%27%3D%271"
              Then it should respond with 200
@@ -306,6 +324,7 @@ Feature: OWASP critical attack path protections
                   []
                   """
 
+        @relational-backend
         Scenario: 19 CSRF style browser form post without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated Form URL Encoded POST request is made to "/ed-fi/schools" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -8,21 +8,25 @@ Feature: JWT Token Introspection
             Given there is no Authorization header
 
     @API-213
+    @relational-backend
     Scenario: Accept root endpoint requests that do not contain a token
       When a GET request is made to "/"
       Then it should respond with 200
 
     @API-214
+    @relational-backend
     Scenario: Accept dependencies endpoint requests that do not contain a token
       When a GET request is made to "/metadata/dependencies"
       Then it should respond with 200
 
     @API-215
+    @relational-backend
     Scenario: Accept OpenAPI specifications endpoint requests that do not contain a token
       When a GET request is made to "/metadata/specifications"
       Then it should respond with 200
 
     @API-216
+    @relational-backend
     Scenario: Accept XSD endpoint requests that do not contain a token
       When a GET request is made to "/metadata/xsd"
       Then it should respond with 200
@@ -31,11 +35,13 @@ Feature: JWT Token Introspection
             Given there is no Authorization header
 
     @API-217
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request that does not contain a token
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 401
 
     @API-218
+    @relational-backend
     Scenario: Reject a Resource endpoint POST request that does not contain a token
       When a POST request is made to "/ed-fi/academicWeeks" with
         """
@@ -52,6 +58,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @API-219
+    @relational-backend
     Scenario: Reject a Resource endpoint PUT request that does not contain a token
       When a PUT request is made to "/ed-fi/academicWeeks/1" with
         """
@@ -68,6 +75,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @API-220
+    @relational-backend
     Scenario: Reject a Resource endpoint DELETE request that does not contain a token
       When a DELETE request is made to "/ed-fi/academicWeeks/1"
       Then it should respond with 401
@@ -75,11 +83,13 @@ Feature: JWT Token Introspection
   Rule: Resource API accepts a valid token
 
     @API-229
+    @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
@@ -87,6 +97,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @DMS-823
+    @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -208,6 +219,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -228,6 +240,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -82,19 +82,20 @@ Feature: JWT Token Introspection
 
   Rule: Resource API accepts a valid token
 
-    @API-229
+    @API-229 @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 401
 
-    @DMS-823
+    @DMS-823 @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -216,6 +217,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -236,6 +238,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -83,13 +83,11 @@ Feature: JWT Token Introspection
   Rule: Resource API accepts a valid token
 
     @API-229
-    @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
-    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
@@ -97,7 +95,6 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @DMS-823
-    @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -219,7 +216,6 @@ Feature: JWT Token Introspection
         }
         """
 
-    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -240,7 +236,6 @@ Feature: JWT Token Introspection
         }
         """
 
-    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ClaimSetManagementHooks.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ClaimSetManagementHooks.cs
@@ -204,7 +204,10 @@ public class ClaimSetManagementHooks(
                 $"No SystemAdministrator token found, registering new admin client: {clientId}"
             );
             await SystemAdministrator.Register(clientId, clientSecret);
+            return;
         }
+
+        await SystemAdministrator.GetToken();
     }
 
     /// <summary>
@@ -212,7 +215,7 @@ public class ClaimSetManagementHooks(
     /// </summary>
     private async Task ReloadDmsClaimsets()
     {
-        List<KeyValuePair<string, string>> headers = CreateAuthHeaders();
+        List<KeyValuePair<string, string>> headers = await CreateAuthHeaders();
 
         // Increased timeout for CI environments
         var options = new APIRequestContextOptions
@@ -259,7 +262,10 @@ public class ClaimSetManagementHooks(
         };
 
         httpClient.DefaultRequestHeaders.Authorization =
-            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", SystemAdministrator.Token);
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                "Bearer",
+                await SystemAdministrator.GetToken()
+            );
 
         // POST with empty body for reload-claims endpoint
         using StringContent content = new("{}", System.Text.Encoding.UTF8, "application/json");
@@ -279,7 +285,7 @@ public class ClaimSetManagementHooks(
     /// </summary>
     private async Task VerifyDmsCacheState()
     {
-        var headers = CreateAuthHeaders();
+        var headers = await CreateAuthHeaders();
 
         var options = new APIRequestContextOptions
         {
@@ -309,14 +315,10 @@ public class ClaimSetManagementHooks(
     /// <summary>
     /// Creates authorization headers with the system administrator bearer token.
     /// </summary>
-    private static List<KeyValuePair<string, string>> CreateAuthHeaders()
+    private static async Task<List<KeyValuePair<string, string>>> CreateAuthHeaders()
     {
-        List<KeyValuePair<string, string>> headers = [];
-        if (!string.IsNullOrEmpty(SystemAdministrator.Token))
-        {
-            headers.Add(new("Authorization", $"Bearer {SystemAdministrator.Token}"));
-        }
-        return headers;
+        string systemAdministratorToken = await SystemAdministrator.GetToken();
+        return [new("Authorization", $"Bearer {systemAdministratorToken}")];
     }
 
     private async Task<IAPIRequestContext> GetApiRequestContextAsync()

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ProfileSetupHooks.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ProfileSetupHooks.cs
@@ -48,7 +48,8 @@ public static class ProfileSetupHooks
         logger.log.Information("===== ProfileSetupHooks: Creating test profiles =====");
 
         // SystemAdministrator should already be registered by SetupHooks (Order = 10000)
-        if (string.IsNullOrEmpty(SystemAdministrator.Token))
+        string systemAdministratorToken = await SystemAdministrator.GetToken();
+        if (string.IsNullOrEmpty(systemAdministratorToken))
         {
             throw new InvalidOperationException(
                 "SystemAdministrator.Token is not available. Ensure SetupHooks.BeforeTestRun runs before ProfileSetupHooks."
@@ -69,7 +70,7 @@ public static class ProfileSetupHooks
                 int profileId = await ProfileAwareAuthorizationProvider.CreateProfile(
                     name,
                     xml,
-                    SystemAdministrator.Token
+                    systemAdministratorToken
                 );
 
                 ProfileTestData.RegisterProfile(name, profileId);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
@@ -94,7 +94,7 @@ public class ProfileStepDefinitions(
             int profileId = await ProfileAwareAuthorizationProvider.CreateProfile(
                 profileName,
                 profileXml,
-                SystemAdministrator.Token
+                await SystemAdministrator.GetToken()
             );
 
             ProfileTestData.RegisterProfile(profileName, profileId);
@@ -209,7 +209,7 @@ public class ProfileStepDefinitions(
             "profiletest@example.com",
             namespacePrefixes,
             educationOrganizationIds,
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             claimSetName,
             profileNames
         );
@@ -345,7 +345,7 @@ public class ProfileStepDefinitions(
             "descriptor@test.com",
             "uri://ed-fi.org, uri://sample.ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "EdFiSandbox"
         );
 
@@ -364,7 +364,7 @@ public class ProfileStepDefinitions(
             "entity@test.com",
             "uri://ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "E2E-NoFurtherAuthRequiredClaimSet"
         );
 
@@ -383,7 +383,7 @@ public class ProfileStepDefinitions(
             "seeddata@test.com",
             "uri://ed-fi.org, uri://sample.ed-fi.org, uri://tpdm.ed-fi.org, uri://homograph.ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "E2E-NoFurtherAuthRequiredClaimSet"
         );
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -125,9 +125,11 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             string claimSetName = "E2E-NoFurtherAuthRequiredClaimSet"
         )
         {
+            string systemAdministratorToken = await SystemAdministrator.GetToken();
+
             // Clear the DMS claimset cache before setting a new authorization context
             // This ensures test isolation when scenarios have different auth contexts
-            await ClearDmsClaimsetCache();
+            await ClearDmsClaimsetCache(systemAdministratorToken);
 
             await AuthorizationDataProvider.CreateClientCredentials(
                 Guid.NewGuid().ToString(),
@@ -135,7 +137,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 "cmb@example.com",
                 namespacePrefixes,
                 educationOrganizationIds,
-                SystemAdministrator.Token,
+                systemAdministratorToken,
                 claimSetName
             );
 
@@ -144,14 +146,14 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         }
 
         // Helper method to clear the DMS claimset cache
-        private async Task ClearDmsClaimsetCache()
+        private async Task ClearDmsClaimsetCache(string systemAdministratorToken)
         {
             try
             {
                 // Create authorization header - using Bearer token for DMS
                 var headers = new List<KeyValuePair<string, string>>
                 {
-                    new("Authorization", $"Bearer {SystemAdministrator.Token}"),
+                    new("Authorization", $"Bearer {systemAdministratorToken}"),
                 };
 
                 var dmsResponse = await _playwrightContext.ApiRequestContext?.PostAsync(
@@ -914,7 +916,10 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             var content = new StringContent(claimsJson, System.Text.Encoding.UTF8, "application/json");
 
             // Get SystemAdministrator auth header for CMS request
-            httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {SystemAdministrator.Token}");
+            httpClient.DefaultRequestHeaders.Add(
+                "Authorization",
+                $"Bearer {await SystemAdministrator.GetToken()}"
+            );
 
             var response = await httpClient.PostAsync(
                 $"http://localhost:{AppSettings.ConfigServicePort}/config/management/upload-claims",
@@ -946,7 +951,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 {
                     Headers = new Dictionary<string, string>
                     {
-                        { "Authorization", $"Bearer {SystemAdministrator.Token}" },
+                        { "Authorization", $"Bearer {await SystemAdministrator.GetToken()}" },
                     },
                 }
             )!;
@@ -969,7 +974,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 {
                     Headers = new Dictionary<string, string>
                     {
-                        { "Authorization", $"Bearer {SystemAdministrator.Token}" },
+                        { "Authorization", $"Bearer {await SystemAdministrator.GetToken()}" },
                     },
                 }
             )!;
@@ -984,14 +989,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         [When("a POST request is made to CMS {string}")]
         public async Task WhenAPOSTRequestIsMadeToCMS(string endpoint)
         {
-            // Get system administrator token for CMS API access
-            if (string.IsNullOrEmpty(SystemAdministrator.Token))
-            {
-                await SystemAdministrator.Register(
-                    "SystemAdministratorClient",
-                    SystemAdministrator.DefaultClientSecret
-                );
-            }
+            string systemAdministratorToken = await SystemAdministrator.GetToken();
 
             // Use HttpClient to call CMS management API
             using var httpClient = new HttpClient
@@ -1000,7 +998,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             };
 
             httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", SystemAdministrator.Token);
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", systemAdministratorToken);
 
             // POST with empty body for reload-claims endpoint
             using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");


### PR DESCRIPTION
## Summary

Migrates a quick-win batch of Data Management Service E2E scenarios to the relational backend lane.

- Adds `@relational-backend` coverage to `404` E2E scenarios/scenario outlines.
- Brings the relational E2E lane to `483 / 753` total scenarios/scenario outlines, including the `79` already tagged on `main`.
- Leaves `270` scenarios/scenario outlines outside the relational lane for follow-up migration work.

## Harness Update

Long-running self-contained E2E runs can outlive the system administrator token used for CMS/DMS setup calls. This PR updates the E2E harness to track the admin token lifetime and refresh it before expiry, so later scenarios do not fail during client/claimset setup because of an expired admin token.

## Validation

Local validation before pushing the current branch:

- `dotnet build src/dms/tests/EdFi.DataManagementService.Tests.E2E/EdFi.DataManagementService.Tests.E2E.csproj --no-restore --nologo`
- `git diff --check`