### PR TITLE
[DMS-1135] Parallelize relational E2E lane and harden harness

### DIFF
--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -657,13 +657,13 @@ jobs:
         run: docker rm -f dms-ci-mssql
 
   run-e2e-tests:
-    name: Run ${{ matrix.queryhandler }} E2E Tests (IdentityProvider ${{ matrix.identityprovider }})
+    name: Run PostgreSQL Relational E2E (${{ matrix.identityprovider }}, Shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         identityprovider: [keycloak, self-contained]
-        queryhandler: [postgresql]
+        shard: [1, 2, 3, 4]
     permissions:
       contents: read
     defaults:
@@ -729,19 +729,18 @@ jobs:
       - name: Add Kafka hostname to /etc/hosts
         run: echo "127.0.0.1 dms-kafka1" | sudo tee -a /etc/hosts
 
-      - name: Run ${{ matrix.queryhandler }} relational - IdentityProvider (${{ matrix.identityprovider }}) E2E Tests
+      - name: Run Relational E2E (IdentityProvider ${{ matrix.identityprovider }}, Shard ${{ matrix.shard }})
         id: relational_e2e
         if: success()
-        continue-on-error: true
         env:
           KAFKA_BOOTSTRAP_SERVERS: dms-kafka1:9092
         run: |
-          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e.relational' -TestFilter 'Category=@relational-backend'
+          ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e.relational' -TestFilter 'Category=@relational-backend&Category=@relational-ci-shard-${{ matrix.shard }}'
 
       - name: Export Relational Docker Logs
         if: always() && steps.relational_e2e.outcome == 'failure'
         run: |
-          $logDir = "${{ github.workspace }}/logs/relational"
+          $logDir = "${{ github.workspace }}/logs/relational-shard-${{ matrix.shard }}"
           Remove-Item -Path $logDir -Recurse -Force -ErrorAction SilentlyContinue
           New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 
@@ -762,27 +761,21 @@ jobs:
         if: always() && steps.relational_e2e.outcome == 'failure'
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: ${{ matrix.queryhandler }}-${{ matrix.identityprovider }}-relational-test-logs
+          name: postgresql-${{ matrix.identityprovider }}-relational-shard-${{ matrix.shard }}-test-logs
           path: |
-            ${{ github.workspace }}/logs/relational
+            ${{ github.workspace }}/logs/relational-shard-${{ matrix.shard }}
           retention-days: 10
 
       - name: Upload Relational Test Results
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
-        if: always() && hashFiles('TestResults/EdFi.DataManagementService.Tests.E2E.relational.trx') != ''
+        if: always() && hashFiles(format('TestResults/EdFi.DataManagementService.Tests.E2E.relational-shard-{0}.trx', matrix.shard)) != ''
         with:
-          name: E2E Test Results (${{ matrix.identityprovider }}, relational)
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.relational.trx
+          name: E2E Test Results (${{ matrix.identityprovider }}, relational, shard ${{ matrix.shard }})
+          path: TestResults/EdFi.DataManagementService.Tests.E2E.relational-shard-${{ matrix.shard }}.trx
           path-replace-backslashes: "true"
           reporter: dotnet-trx
           list-tests: failed
           use-actions-summary: "true"
-
-      - name: Fail if the E2E lane failed
-        if: always() && steps.relational_e2e.outcome == 'failure'
-        run: |
-          Write-Host "Relational lane outcome: ${{ steps.relational_e2e.outcome }}"
-          throw "Relational E2E lane failed."
 
   run-instance-management-e2e-tests:
     name: Run Instance Management E2E Tests (Route Qualifiers)

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -777,6 +777,21 @@ jobs:
           list-tests: failed
           use-actions-summary: "true"
 
+  relational-e2e-summary:
+    name: relational-e2e-summary
+    runs-on: ubuntu-latest
+    needs: run-e2e-tests
+    if: always()
+    steps:
+      - name: Check relational E2E matrix result
+        shell: pwsh
+        run: |
+          if ("${{ needs.run-e2e-tests.result }}" -ne "success") {
+            throw "One or more relational E2E matrix jobs failed."
+          }
+
+          Write-Host "All relational E2E matrix jobs passed."
+
   run-instance-management-e2e-tests:
     name: Run Instance Management E2E Tests (Route Qualifiers)
     runs-on: ubuntu-latest
@@ -1194,6 +1209,7 @@ jobs:
       [
         run-unit-tests,
         run-e2e-tests,
+        relational-e2e-summary,
         run-instance-management-e2e-tests,
         run-backend-mssql-integration-tests,
         run-backend-postgresql-integration-tests,

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -270,7 +270,13 @@ function Get-E2ETestResultSuffix {
         $TestFilter
     )
 
+    $normalizedTestFilter = ConvertTo-NormalizedTestFilter -TestFilter $TestFilter
+
     if ($UseRelationalBackend) {
+        if ($normalizedTestFilter -match '(?i)\b(?:TestCategory|Category)\s*=\s*relational-ci-shard-(\d+)\b') {
+            return "relational-shard-$($Matches[1])"
+        }
+
         return "relational"
     }
 

--- a/reference/design/backend-redesign/epics/13-test-migration/05-parallel-e2e-lanes-and-harness-hardening.md
+++ b/reference/design/backend-redesign/epics/13-test-migration/05-parallel-e2e-lanes-and-harness-hardening.md
@@ -3,46 +3,81 @@ jira: DMS-1135
 jira_url: https://edfi.atlassian.net/browse/DMS-1135
 ---
 
-# Story: Parallelize Legacy/Relational E2E Lanes and Harden Script-Output Assertions
+# Story: Parallelize Relational E2E CI Shards and Harden Script-Output Assertions
 
 ## Description
 
-Reduce E2E wall-clock time by running the legacy and relational backend lanes as independent matrix jobs instead of sequential steps inside the same workflow job.
+Reduce pull request E2E wall-clock time by running the relational backend E2E lane as several independent CI shard jobs.
 
-This story makes `lane` a first-class workflow dimension across:
+Legacy E2E coverage is not part of the pull request CI build and should not be reintroduced there. Legacy E2E tests continue to run on their existing schedule; this story does not optimize the scheduled legacy lane.
 
-- `.github/workflows/on-dms-pullrequest.yml`
-- `.github/workflows/scheduled-build.yml`
-- `.github/workflows/scheduled-pre-image-test.yml`
+The pull request workflow should run only relational backend E2E coverage:
 
-Each matrix lane should invoke `build-dms.ps1 E2ETest` exactly once using the lane-specific environment file and test filter, while preserving the current identity-provider split and published-image behavior where applicable.
+- environment file: `./.env.e2e.relational`
+- base filter: `Category=@relational-backend`
+- identity providers: `keycloak` and `self-contained`
+- additional shard filter: one shard-specific category such as `Category=@relational-ci-shard-1`
+
+The intended matrix is `identityprovider x shard`. With four shards, the pull request workflow runs eight independent relational E2E jobs. Each job starts its own Docker stack, provisions its own relational E2E database, and invokes `build-dms.ps1 E2ETest` exactly once for its assigned identity provider and shard.
+
+The shard split should be explicit and stable. Add shard tags to relational scenarios/scenario outlines, for example:
+
+- `@relational-ci-shard-1`
+- `@relational-ci-shard-2`
+- `@relational-ci-shard-3`
+- `@relational-ci-shard-4`
+
+Each scenario/scenario outline tagged `@relational-backend` should have exactly one shard tag. The workflow filter for each shard should preserve relational isolation by using `&`, for example:
+
+```powershell
+-TestFilter 'Category=@relational-backend&Category=@relational-ci-shard-1'
+```
+
+The initial shard assignment should balance measured runtime first and scenario count second. Profiles and other high-count/high-duration feature groups should be split across multiple shards rather than assigned as one large folder. If runtime data is not yet available, start with four roughly even shard buckets and rebalance after CI produces timing data.
 
 This story also hardens the PowerShell-backed test harness so unit tests do not assert on brittle host-formatted exception output. Assertions that currently depend on raw `pwsh` host formatting should normalize ANSI escape sequences and whitespace, disable formatting in the child process, or assert on smaller stable fragments / structured signals instead of contiguous formatted error text.
 
-This is a workflow and test-harness refactor. It does not change the logical coverage owned by the existing legacy vs relational lanes.
-
 ## Acceptance Criteria
 
-- The PR, scheduled-build, and scheduled pre-image workflows run legacy and relational backend E2E coverage as separate matrix jobs instead of sequential steps in one job.
-- Each matrix job invokes `build-dms.ps1 E2ETest` once for its assigned lane, using lane-specific values for:
-  - identity provider,
-  - environment file,
-  - test filter, and
-  - published-image mode where required.
-- Per-lane logs, test results, and uploaded artifacts are uniquely named by lane and identity provider so parallel jobs do not collide.
-- A failed lane is surfaced directly by GitHub as a failed matrix job; the workflow no longer relies on a same-job fail-fast wrapper to summarize multiple hidden lane results.
+- The pull request workflow does not run legacy E2E tests.
+- The pull request workflow runs relational E2E tests as matrix jobs over:
+  - identity provider, and
+  - relational CI shard.
+- Each relational shard job invokes `build-dms.ps1 E2ETest` exactly once using:
+  - `-EnvironmentFile './.env.e2e.relational'`,
+  - `-TestFilter 'Category=@relational-backend&Category=@relational-ci-shard-N'`, and
+  - the assigned identity provider.
+- The workflow uses `&` to narrow the relational lane. It does not use `|` or any filter that can mix relational and legacy tests.
+- Per-shard logs, test results, and uploaded artifacts are uniquely named by identity provider and shard so parallel jobs do not collide.
+- A failed shard is surfaced directly by GitHub as a failed matrix job.
 - If a single required status check is still needed, it is implemented as a lightweight summary job that depends on the matrix jobs rather than by forcing heavy E2E work back into one sequential job.
+- Every scenario/scenario outline tagged `@relational-backend` has exactly one `@relational-ci-shard-N` tag.
+- No scenario/scenario outline without `@relational-backend` has a relational CI shard tag.
+- Add or update guardrail tests that enforce the relational shard tagging rules.
+- Scheduled legacy E2E workflows are left in their current scheduled path unless a separate story changes them.
 - PowerShell-backed unit tests that validate provisioning-helper failures no longer depend on raw ANSI-colored / line-wrapped host output formatting and pass reliably across supported environments.
-- The workflows preserve the current logical lane split:
-  - legacy lane uses `./.env.e2e` with `Category!=@relational-backend`
-  - relational lane uses `./.env.e2e.relational` with `Category=@relational-backend`
+
+## Implementation Notes
+
+- Start with four relational shards unless CI capacity or measured runtime suggests a different number.
+- Keep the shard count configurable in the workflow matrix so it can be adjusted without redesigning the workflow.
+- Prefer shard tags over generated-test ordering, method-name ranges, or file-name globbing. Tags make the CI assignment explicit in the feature files and keep the `dotnet test` filter simple.
+- Use stable artifact names such as `postgresql-self-contained-relational-shard-1-test-logs` and `EdFi.DataManagementService.Tests.E2E.relational-shard-1.trx`.
+- If the existing build script cannot produce unique TRX names per shard, extend it with a small shard/result-name parameter rather than relying on jobs to overwrite the same file path.
+- Capture Docker image reuse as follow-up work if duplicated image build/setup time becomes the dominant cost after sharding.
 
 ## Tasks
 
-1. Refactor `.github/workflows/on-dms-pullrequest.yml` so `lane` is a matrix dimension alongside identity provider and each job runs one E2E lane.
-2. Apply the same lane-matrix pattern to `.github/workflows/scheduled-build.yml`.
-3. Apply the same lane-matrix pattern to `.github/workflows/scheduled-pre-image-test.yml`, preserving `-UsePublishedImage`.
-4. Consolidate duplicated E2E run, log-export, result-upload, and artifact-upload steps into single parameterized lane-aware steps.
-5. Remove the same-job lane aggregation/fail wrapper, or replace it with a lightweight summary job only if repository branch protection still requires a single roll-up check.
-6. Harden PowerShell-output assertions in the provisioning-helper unit tests by normalizing ANSI escape sequences and whitespace before asserting, or by asserting on smaller stable fragments / structured signals instead of host-formatted exception text.
-7. Capture any follow-up optimization work separately if duplicated image-build/setup time becomes the dominant cost after lane parallelization (for example, a producer job that uploads prebuilt Docker images for later `docker load` reuse).
+1. Refactor `.github/workflows/on-dms-pullrequest.yml` so the relational E2E job has a matrix dimension for `identityprovider` and `shard`.
+2. Remove legacy E2E execution from the pull request CI workflow if any remains.
+3. Add relational shard tags to every current `@relational-backend` scenario/scenario outline.
+4. Balance the initial shard assignment across four shards using current scenario counts and any available CI timing data.
+5. Update the E2E workflow run step to call `build-dms.ps1 E2ETest` once per matrix job with the relational environment file and the shard-specific filter.
+6. Make relational shard logs, TRX files, test-reporter names, and uploaded artifacts unique by identity provider and shard.
+7. Add or update unit/guardrail tests that verify:
+   - each relational scenario has exactly one shard tag,
+   - non-relational scenarios do not have shard tags, and
+   - relational E2E workflow filters cannot include legacy tests.
+8. Replace the same-job E2E fail wrapper with direct matrix job failure, or add a lightweight summary job only if branch protection requires one roll-up status.
+9. Harden PowerShell-output assertions in the provisioning-helper unit tests by normalizing ANSI escape sequences and whitespace before asserting, or by asserting on smaller stable fragments / structured signals instead of host-formatted exception text.
+10. Document follow-up optimization work separately if duplicated image-build/setup time remains the main bottleneck after relational sharding.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Authorization/SystemAdministrator.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Authorization/SystemAdministrator.cs
@@ -10,7 +10,11 @@ namespace EdFi.DataManagementService.Tests.E2E.Authorization;
 public static class SystemAdministrator
 {
     public const string DefaultClientSecret = "ValidSystemAdministratorSecret123456!Abcd";
+    private static readonly TimeSpan TokenRefreshBuffer = TimeSpan.FromMinutes(2);
     private static string _token = string.Empty;
+    private static DateTimeOffset _tokenExpiresAt = DateTimeOffset.MinValue;
+    private static string _clientId = string.Empty;
+    private static string _clientSecret = string.Empty;
     private static readonly SemaphoreSlim _registrationLock = new(1, 1);
 
     public static string Token
@@ -30,8 +34,12 @@ public static class SystemAdministrator
         await _registrationLock.WaitAsync();
         try
         {
-            // If we already have a valid token for this client, reuse it
-            if (!string.IsNullOrEmpty(Token))
+            bool clientChanged = clientId != _clientId || clientSecret != _clientSecret;
+            _clientId = clientId;
+            _clientSecret = clientSecret;
+
+            // If we already have a valid token for this client, reuse it.
+            if (!clientChanged && HasUsableToken())
             {
                 return;
             }
@@ -54,23 +62,59 @@ public static class SystemAdministrator
 
             var tokenResult = await _client.PostAsync("connect/token", tokenRequestFormContent);
 
-            if (tokenResult.IsSuccessStatusCode)
-            {
-                var body = await tokenResult.Content.ReadAsStringAsync();
-                var document = JsonDocument.Parse(body);
-                Token = document.RootElement.GetProperty("access_token").GetString() ?? "";
-            }
-            else
+            if (!tokenResult.IsSuccessStatusCode)
             {
                 var errorBody = await tokenResult.Content.ReadAsStringAsync();
                 throw new InvalidOperationException(
                     $"Failed to obtain token for client '{clientId}'. Status: {tokenResult.StatusCode}, Error: {errorBody}"
                 );
             }
+
+            var body = await tokenResult.Content.ReadAsStringAsync();
+            var document = JsonDocument.Parse(body);
+            Token = document.RootElement.GetProperty("access_token").GetString() ?? "";
+            int expiresInSeconds = document.RootElement.TryGetProperty(
+                "expires_in",
+                out JsonElement expiresIn
+            )
+                ? expiresIn.GetInt32()
+                : 1800;
+            _tokenExpiresAt = DateTimeOffset.UtcNow.AddSeconds(expiresInSeconds);
         }
         finally
         {
             _registrationLock.Release();
         }
     }
+
+    public static async Task<string> GetToken()
+    {
+        await _registrationLock.WaitAsync();
+        try
+        {
+            if (HasUsableToken())
+            {
+                return Token;
+            }
+
+            if (string.IsNullOrEmpty(_clientId) || string.IsNullOrEmpty(_clientSecret))
+            {
+                throw new InvalidOperationException(
+                    "SystemAdministrator must be registered before requesting a token."
+                );
+            }
+
+            Token = string.Empty;
+        }
+        finally
+        {
+            _registrationLock.Release();
+        }
+
+        await Register(_clientId, _clientSecret);
+        return Token;
+    }
+
+    private static bool HasUsableToken() =>
+        !string.IsNullOrEmpty(Token) && DateTimeOffset.UtcNow.Add(TokenRefreshBuffer) < _tokenExpiresAt;
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
@@ -5,6 +5,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               and DMS can reload these claimsets to synchronize its state with CMS.
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Initial State Verification - View claimsets in DMS and verify baseline claimsets are present
              When a GET request is made to DMS management endpoint "/management/view-claimsets"
              Then the DMS view claimsets should be successful
@@ -12,6 +13,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "EdFiSandbox"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Upload Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet1 with Student access, reload DMS, verify only new claimset present
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSet1"
              Then the claim set upload to CMS should be successful
@@ -23,6 +25,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And system claim sets should have empty resource claims
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Upload Different Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet2 with School access, reload DMS, verify only TestClaimSet2 present
              When a claim set is uploaded to CMS that grants "School" access to "TestClaimSet2"
              Then the claim set upload to CMS should be successful
@@ -33,6 +36,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "TestClaimSet2"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Upload Multiple Claimsets - both TestClaimSetA and TestClaimSetB, reload DMS, verify TestClaimSetB
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSetA"
              Then the claim set upload to CMS should be successful
@@ -50,6 +54,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should not contain "TestClaimSetA"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 05 Reset CMS to Original → Sync to DMS - Reset CMS with reload-claims, reload DMS, verify original state restored
              When a POST request is made to CMS "/management/reload-claims"
              Then the CMS reload should be successful

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/ClaimSetSynchronization.feature
@@ -4,12 +4,14 @@ Feature: CMS to DMS ClaimSet Synchronization
     to the Data Management Service (DMS). Each upload to CMS completely replaces all existing claimsets,
               and DMS can reload these claimsets to synchronize its state with CMS.
 
+        @relational-backend
         Scenario: 01 Initial State Verification - View claimsets in DMS and verify baseline claimsets are present
              When a GET request is made to DMS management endpoint "/management/view-claimsets"
              Then the DMS view claimsets should be successful
               And the DMS view claimsets response should contain "SISVendor"
               And the DMS view claimsets response should contain "EdFiSandbox"
 
+        @relational-backend
         Scenario: 02 Upload Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet1 with Student access, reload DMS, verify only new claimset present
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSet1"
              Then the claim set upload to CMS should be successful
@@ -20,6 +22,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "TestClaimSet1"
               And system claim sets should have empty resource claims
 
+        @relational-backend
         Scenario: 03 Upload Different Complete Claimset to CMS → Sync to DMS - Upload TestClaimSet2 with School access, reload DMS, verify only TestClaimSet2 present
              When a claim set is uploaded to CMS that grants "School" access to "TestClaimSet2"
              Then the claim set upload to CMS should be successful
@@ -29,6 +32,7 @@ Feature: CMS to DMS ClaimSet Synchronization
              Then the DMS view claimsets should be successful
               And the DMS view claimsets response should contain "TestClaimSet2"
 
+        @relational-backend
         Scenario: 04 Upload Multiple Claimsets - both TestClaimSetA and TestClaimSetB, reload DMS, verify TestClaimSetB
              When a claim set is uploaded to CMS that grants "Student" access to "TestClaimSetA"
              Then the claim set upload to CMS should be successful
@@ -45,6 +49,7 @@ Feature: CMS to DMS ClaimSet Synchronization
               And the DMS view claimsets response should contain "TestClaimSetB"
               And the DMS view claimsets response should not contain "TestClaimSetA"
 
+        @relational-backend
         Scenario: 05 Reset CMS to Original → Sync to DMS - Reset CMS with reload-claims, reload DMS, verify original state restored
              When a POST request is made to CMS "/management/reload-claims"
              Then the CMS reload should be successful

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
@@ -34,6 +34,7 @@ Feature: EducationOrganizationChanges Authorization
 
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can access the Student ,the Contact and the Staff with a  Grand Bend ISD School 255901
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a GET request is made to "/ed-fi/schools/{SchoolId1}"
@@ -450,6 +451,7 @@ Feature: EducationOrganizationChanges Authorization
                   | StaffId1                    | s0001         | peterson  | Buck        |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 08 Ensure client can  access the Student  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with
@@ -504,6 +506,7 @@ Feature: EducationOrganizationChanges Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 09 Ensure client can  access the contact  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/EducationOrganizationChanges.feature
@@ -33,6 +33,7 @@ Feature: EducationOrganizationChanges Authorization
                   | staffSchoolAssociationId1   | { "staffUniqueId": "s0001" } | { "schoolId": 255901001 } | "uri://ed-fi.org/ProgramAssignmentDescriptor#Regular Education" |
 
 
+        @relational-backend
         Scenario: 01 Ensure client can access the Student ,the Contact and the Staff with a  Grand Bend ISD School 255901
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a GET request is made to "/ed-fi/schools/{SchoolId1}"
@@ -448,6 +449,7 @@ Feature: EducationOrganizationChanges Authorization
                   | _storeResultingIdInVariable | staffUniqueId | firstName | lastSurname |
                   | StaffId1                    | s0001         | peterson  | Buck        |
 
+        @relational-backend
         Scenario: 08 Ensure client can  access the Student  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with
@@ -501,6 +503,7 @@ Feature: EducationOrganizationChanges Authorization
                       }
                   """
 
+        @relational-backend
         Scenario: 09 Ensure client can  access the contact  when a School updated to new LEA
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901"
              When a PUT request is made to "/ed-fi/schools/{SchoolId1}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
@@ -19,6 +19,7 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Ensure client can create a descriptor in the ns2 namespace
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -37,6 +38,7 @@ Feature: Namespace Authorization
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 200
 
+        @relational-backend
         Scenario: 03 Ensure client can update a descriptor in the ns2 namespace
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -52,6 +54,7 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure client can delete a descriptor in the ns2 namespace
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
@@ -193,6 +196,7 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Ensure client can create a resource in the ns2 namespace
              When a POST request is made to "/ed-fi/surveys" with
                   """
@@ -253,10 +257,12 @@ Feature: Namespace Authorization
                   }]
                   """
 
+        @relational-backend
         Scenario: 10 Ensure client can get a resource in the ns2 namespace
              When a GET request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 200
 
+        @relational-backend
         Scenario: 11 Ensure client can update a resource in the ns2 namespace
              When a PUT request is made to "/ed-fi/surveys/{id}" with
                   """
@@ -272,6 +278,7 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 12 Ensure client can delete a resource in the ns2 namespace
              When a DELETE request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
@@ -20,6 +20,7 @@ Feature: Namespace Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a descriptor in the ns2 namespace
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -39,6 +40,7 @@ Feature: Namespace Authorization
              Then it should respond with 200
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure client can update a descriptor in the ns2 namespace
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -55,6 +57,7 @@ Feature: Namespace Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Ensure client can delete a descriptor in the ns2 namespace
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
@@ -197,6 +200,7 @@ Feature: Namespace Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 09 Ensure client can create a resource in the ns2 namespace
              When a POST request is made to "/ed-fi/surveys" with
                   """
@@ -258,11 +262,13 @@ Feature: Namespace Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 10 Ensure client can get a resource in the ns2 namespace
              When a GET request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 200
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 11 Ensure client can update a resource in the ns2 namespace
              When a PUT request is made to "/ed-fi/surveys/{id}" with
                   """
@@ -279,6 +285,7 @@ Feature: Namespace Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 12 Ensure client can delete a resource in the ns2 namespace
              When a DELETE request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
@@ -27,6 +27,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
     Rule: StudentContactAssociation CRUD is properly authorized
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -53,6 +54,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Ensure client can retrieve a StudentContactAssociation
             Given a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -153,6 +155,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 06 Ensure client can update a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -246,6 +249,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 08 Ensure client can delete a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -295,6 +299,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 10 Ensure client get the required validation error when studentContactAssociations is created with empty contactReference
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "25590190200000"
              When a POST request is made to "/ed-fi/studentContactAssociations" with
@@ -327,6 +332,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
     Rule: Contact CRUD is properly authorized
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 11 Ensure client can create a Contact
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -431,6 +437,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 14 Ensure client can delete a contact when it's unused and should return 204 nocontent
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -445,6 +452,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 15 Ensure client can not delete a contact when it's associated with a student
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -484,6 +492,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 16 Ensure client can retrieve a contact with student contact association
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -572,6 +581,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 18 Ensure client can update a contact When it's associated
             Given a POST request is made to "/ed-fi/contacts/" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndContacts.feature
@@ -26,6 +26,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
     Rule: StudentContactAssociation CRUD is properly authorized
 
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -51,6 +52,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02 Ensure client can retrieve a StudentContactAssociation
             Given a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -150,6 +152,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                      []
                   """
 
+        @relational-backend
         Scenario: 06 Ensure client can update a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -242,6 +245,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                      }
                   """
 
+        @relational-backend
         Scenario: 08 Ensure client can delete a StudentContactAssociation
              When a POST request is made to "/ed-fi/studentContactAssociations" with
                   """
@@ -290,6 +294,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 10 Ensure client get the required validation error when studentContactAssociations is created with empty contactReference
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "25590190200000"
              When a POST request is made to "/ed-fi/studentContactAssociations" with
@@ -321,6 +326,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
 
     Rule: Contact CRUD is properly authorized
 
+        @relational-backend
         Scenario: 11 Ensure client can create a Contact
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -424,6 +430,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 14 Ensure client can delete a contact when it's unused and should return 204 nocontent
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -437,6 +444,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
              When a DELETE request is made to "/ed-fi/contacts/{id}"
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 15 Ensure client can not delete a contact when it's associated with a student
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -475,6 +483,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 16 Ensure client can retrieve a contact with student contact association
              When a POST request is made to "/ed-fi/contacts" with
                   """
@@ -562,6 +571,7 @@ Feature: RelationshipsWithEdOrgsAndContacts Authorization
                   """
 
 
+        @relational-backend
         Scenario: 18 Ensure client can update a contact When it's associated
             Given a POST request is made to "/ed-fi/contacts/" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -26,6 +26,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | "12"            | Unauthorized student | student-ln  | 2008-01-01 |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a StudentSchoolAssociation
              When a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -59,6 +60,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure client can retrieve a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -153,6 +155,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 06 Ensure client can update a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -243,6 +246,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 09 Ensure client can delete a StudentSchoolAssociation
             Given  a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -281,6 +285,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "2255901001"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 10 Ensure client can create a Student
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -294,6 +299,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 11 Ensure client can retrieve a Student
              When a GET request is made to "/ed-fi/students/{StudentId}"
              Then it should respond with 200
@@ -336,6 +342,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 15 Ensure client can update a Student
              When a PUT request is made to "/ed-fi/students/{StudentId}" with
                   """
@@ -376,6 +383,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 18 Ensure client can delete a Student
             Given a DELETE request is made to "/ed-fi/studentSchoolAssociations/{StudentSchoolAssociationId}"
 
@@ -404,6 +412,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "3255901001, 3255902001"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 19 Ensure client can create a Student-securable
              When a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """
@@ -1387,6 +1396,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
 
     Rule: Edge cases are properly authorized
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 42 Ensure client can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "7255901001, 7255902001"
               And the system has these "schools"
@@ -1451,6 +1461,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 43 Ensure client without education organization access can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "8255901001, 8255902001"
               And the system has these "schools"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -25,6 +25,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | "11"            | Authorized student   | student-ln  | 2008-01-01 |
                   | "12"            | Unauthorized student | student-ln  | 2008-01-01 |
 
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentSchoolAssociation
              When a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -57,6 +58,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 03 Ensure client can retrieve a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -150,6 +152,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 06 Ensure client can update a StudentSchoolAssociation
             Given a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -239,6 +242,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              When a DELETE request is made to "/ed-fi/StudentSchoolAssociations/{id}"
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 09 Ensure client can delete a StudentSchoolAssociation
             Given  a POST request is made to "/ed-fi/studentSchoolAssociations" with
                   """
@@ -276,6 +280,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   |                             | { "studentUniqueId": "22" } | { "schoolId": 2255901002 } | "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary" | 2023-08-01 | "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary" | "uri://ed-fi.org/ExitWithdrawTypeDescriptor#Student withdrew" |
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "2255901001"
 
+        @relational-backend
         Scenario: 10 Ensure client can create a Student
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -288,6 +293,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 11 Ensure client can retrieve a Student
              When a GET request is made to "/ed-fi/students/{StudentId}"
              Then it should respond with 200
@@ -329,6 +335,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure client can update a Student
              When a PUT request is made to "/ed-fi/students/{StudentId}" with
                   """
@@ -368,6 +375,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 18 Ensure client can delete a Student
             Given a DELETE request is made to "/ed-fi/studentSchoolAssociations/{StudentSchoolAssociationId}"
 
@@ -395,6 +403,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   | 3255902001                 | Authorized PSI    | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution"} ] |
               And the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "3255901001, 3255902001"
 
+        @relational-backend
         Scenario: 19 Ensure client can create a Student-securable
              When a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """
@@ -697,6 +706,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 29 Ensure client can delete a Student-securable
             Given a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """
@@ -1377,6 +1387,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
 
     Rule: Edge cases are properly authorized
+        @relational-backend
         Scenario: 42 Ensure client can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "7255901001, 7255902001"
               And the system has these "schools"
@@ -1440,6 +1451,7 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
              When a DELETE request is made to "/ed-fi/PostSecondaryEvents/{id}"
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 43 Ensure client without education organization access can CRUD a PostSecondaryEvent using the NoFurtherAuthorizationRequired strategy
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "8255901001, 8255902001"
               And the system has these "schools"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndPeople.feature
@@ -706,7 +706,6 @@ Feature: RelationshipsWithEdOrgsAndPeople Authorization
                   """
              Then it should respond with 403
 
-        @relational-backend
         Scenario: 29 Ensure client can delete a Student-securable
             Given a POST request is made to "/ed-fi/PostSecondaryEvents" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -535,7 +535,6 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
              Then it should respond with 204
 
-        @relational-backend
         Scenario: 20 Ensure client can DELETE staffEducationOrganizationEmploymentAssociations
 
              When a POST request is made to "/ed-fi/staffEducationOrganizationEmploymentAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -31,6 +31,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
 
     Rule: staffEducationOrganizationAssignmentAssociations CRUD is properly authorized
 
+        @relational-backend
         Scenario: 01 Ensure client can authorize create a staffSchoolAssociations when the staff is assigned to the school using staffEducationOrganizationAssignmentAssociations
 
              When a POST request is made to "/ed-fi/staffSchoolAssociations" with
@@ -534,6 +535,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 20 Ensure client can DELETE staffEducationOrganizationEmploymentAssociations
 
              When a POST request is made to "/ed-fi/staffEducationOrganizationEmploymentAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsAndStaffs.feature
@@ -32,6 +32,7 @@ Feature: RelationshipsWithEdOrgsAndStaff Authorization
     Rule: staffEducationOrganizationAssignmentAssociations CRUD is properly authorized
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can authorize create a staffSchoolAssociations when the staff is assigned to the school using staffEducationOrganizationAssignmentAssociations
 
              When a POST request is made to "/ed-fi/staffSchoolAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
@@ -13,6 +13,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -43,6 +44,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
              Then it should respond with 201 or 200
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Ensure client can update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -131,6 +133,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure client can not create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -185,6 +188,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Ensure client can not update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -380,6 +384,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 07 Ensure client can get the bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -437,6 +442,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 08 Ensure client can delete a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -624,6 +630,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 13.1 Ensure client with access to state education agency 2 can post and put classPeriods for school 20201
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -721,6 +728,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 13.5 Ensure client with access to state education agency 2 can get by id school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a GET request is made to "/ed-fi/academicWeeks/{id}"
@@ -740,6 +748,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 13.6 Ensure client with access to state education agency 2 can delete school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a DELETE request is made to "/ed-fi/academicWeeks/{id}"
@@ -904,6 +913,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#Regular public school district |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 20 Ensure client can create an LEA
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -921,6 +931,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
              Then it should respond with 201
                   
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 21 Ensure client can retrieve an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -992,6 +1003,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 23 Ensure client can update an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -1026,6 +1038,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 24 Ensure client can delete an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnly.feature
@@ -12,6 +12,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 01 Ensure client can create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -41,6 +42,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 02 Ensure client can update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -128,6 +130,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 03 Ensure client can not create a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -181,6 +184,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 04 Ensure client can not update a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -375,6 +379,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | 01 - Traditional | { "schoolId": 255901001 } |
                   | 02 - Traditional | { "schoolId": 255901001 } |
 
+        @relational-backend
         Scenario: 07 Ensure client can get the bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -431,6 +436,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                        }
                   """
 
+        @relational-backend
         Scenario: 08 Ensure client can delete a bellschedule with 255901001
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -617,6 +623,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   }
                   """
 
+        @relational-backend
         Scenario: 13.1 Ensure client with access to state education agency 2 can post and put classPeriods for school 20201
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -713,6 +720,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 13.5 Ensure client with access to state education agency 2 can get by id school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a GET request is made to "/ed-fi/academicWeeks/{id}"
@@ -731,6 +739,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                     }
                   """
 
+        @relational-backend
         Scenario: 13.6 Ensure client with access to state education agency 2 can delete school level classPeriods
             Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2"
              When a DELETE request is made to "/ed-fi/academicWeeks/{id}"
@@ -894,6 +903,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency        |
                   | uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#Regular public school district |
 
+        @relational-backend
         Scenario: 20 Ensure client can create an LEA
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -910,6 +920,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 201
                   
+        @relational-backend
         Scenario: 21 Ensure client can retrieve an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -980,6 +991,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 23 Ensure client can update an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -1013,6 +1025,7 @@ Feature: RelationshipsWithEdOrgsOnly Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 24 Ensure client can delete an LEA
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
@@ -31,6 +31,7 @@ Feature: RelationshipsWithStudentsOnlyThroughResponsibility Authorization
 
     Rule: StudentEducationOrganizationResponsibilityAssociation CRUD is properly authorized
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a StudentEducationOrganizationResponsibilityAssociation
              When a POST request is made to "/ed-fi/studentEducationOrganizationResponsibilityAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithStudentsOnlyThroughResponsibility.feature
@@ -30,6 +30,7 @@ Feature: RelationshipsWithStudentsOnlyThroughResponsibility Authorization
                   | "Career and Technical Education" | uri://ed-fi.org/ProgramTypeDescriptor#Career and Technical Education | {"educationOrganizationId": 1255901002} |
 
     Rule: StudentEducationOrganizationResponsibilityAssociation CRUD is properly authorized
+        @relational-backend
         Scenario: 01 Ensure client can create a StudentEducationOrganizationResponsibilityAssociation
              When a POST request is made to "/ed-fi/studentEducationOrganizationResponsibilityAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
@@ -27,6 +27,7 @@ Feature: DisciplineAction Authorization
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901001"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure authorized client can create a DisciplineAction
              When a POST request is made to "/ed-fi/disciplineActions" with
                   """
@@ -52,6 +53,7 @@ Feature: DisciplineAction Authorization
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02.1 Ensure authorized client can get a DisciplineAction by id
              When a GET request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 200
@@ -106,6 +108,7 @@ Feature: DisciplineAction Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure authorized client can update a DisciplineAction
              When a PUT request is made to "/ed-fi/disciplineActions/{disciplineActionId}" with
                   """
@@ -132,6 +135,7 @@ Feature: DisciplineAction Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Ensure authorized client can delete a DisciplineAction
              When a DELETE request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/DisciplineActionAuthorization.feature
@@ -26,6 +26,7 @@ Feature: DisciplineAction Authorization
         Background:
             Given the claimSet "EdFiSandbox" is authorized with educationOrganizationIds "255901001"
 
+        @relational-backend
         Scenario: 01 Ensure authorized client can create a DisciplineAction
              When a POST request is made to "/ed-fi/disciplineActions" with
                   """
@@ -50,6 +51,7 @@ Feature: DisciplineAction Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02.1 Ensure authorized client can get a DisciplineAction by id
              When a GET request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 200
@@ -103,6 +105,7 @@ Feature: DisciplineAction Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure authorized client can update a DisciplineAction
              When a PUT request is made to "/ed-fi/disciplineActions/{disciplineActionId}" with
                   """
@@ -128,6 +131,7 @@ Feature: DisciplineAction Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure authorized client can delete a DisciplineAction
              When a DELETE request is made to "/ed-fi/disciplineActions/{disciplineActionId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
@@ -10,6 +10,7 @@ Feature: OrganizationDepartment Authorization
                   | orgDepId                    | 255901101                | Test Office       | {"educationOrganizationId": 255901}  | [{ "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Organization Department" }] |
 
     Rule: When the client is authorized
+        @relational-backend
         Scenario: 01 Ensure authorized client can create a OrganizationDepartment
              When a POST request is made to "/ed-fi/organizationDepartments" with
                   """
@@ -28,6 +29,7 @@ Feature: OrganizationDepartment Authorization
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 02.1 Ensure authorized client can get a OrganizationDepartment by id
              When a GET request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 200
@@ -69,6 +71,7 @@ Feature: OrganizationDepartment Authorization
                   ]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure authorized client can update a OrganizationDepartment
              When a PUT request is made to "/ed-fi/organizationDepartments/{orgDepId}" with
                   """
@@ -88,6 +91,7 @@ Feature: OrganizationDepartment Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
         Scenario: 04 Ensure authorized client can delete a OrganizationDepartment
              When a DELETE request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RoleNamedSecurity/OrganizationDepartmentAuthorization.feature
@@ -11,6 +11,7 @@ Feature: OrganizationDepartment Authorization
 
     Rule: When the client is authorized
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure authorized client can create a OrganizationDepartment
              When a POST request is made to "/ed-fi/organizationDepartments" with
                   """
@@ -30,6 +31,7 @@ Feature: OrganizationDepartment Authorization
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02.1 Ensure authorized client can get a OrganizationDepartment by id
              When a GET request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 200
@@ -72,6 +74,7 @@ Feature: OrganizationDepartment Authorization
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure authorized client can update a OrganizationDepartment
              When a PUT request is made to "/ed-fi/organizationDepartments/{orgDepId}" with
                   """
@@ -92,6 +95,7 @@ Feature: OrganizationDepartment Authorization
              Then it should respond with 204
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Ensure authorized client can delete a OrganizationDepartment
              When a DELETE request is made to "/ed-fi/organizationDepartments/{orgDepId}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
@@ -11,6 +11,7 @@ Feature: Equality Constraint Validation
 
         @API-001
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Post a valid bell schedule no equality constraint violations.
             Given the system has these "schools"
                   | schoolId  | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -49,6 +50,7 @@ Feature: Equality Constraint Validation
 
         @API-002
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Post an invalid bell schedule with equality constraint violations.
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -99,6 +101,7 @@ Feature: Equality Constraint Validation
 
         @API-003
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Making a Post request when value does not match the same value in an array
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -143,6 +146,7 @@ Feature: Equality Constraint Validation
 
         @API-004
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Making a Post request when a value matches the first scenario in an array but not the second
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -193,6 +197,7 @@ Feature: Equality Constraint Validation
 
         @API-005
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Making a Post request when value does not match the same value in a single other reference
              When a POST request is made to "/ed-fi/sections" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Constraints/EqualityConstraintValidation.feature
@@ -10,6 +10,7 @@ Feature: Equality Constraint Validation
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-001
+        @relational-backend
         Scenario: 01 Post a valid bell schedule no equality constraint violations.
             Given the system has these "schools"
                   | schoolId  | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -47,6 +48,7 @@ Feature: Equality Constraint Validation
              Then it should respond with 201 or 200
 
         @API-002
+        @relational-backend
         Scenario: 02 Post an invalid bell schedule with equality constraint violations.
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -96,6 +98,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-003
+        @relational-backend
         Scenario: 03 Making a Post request when value does not match the same value in an array
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -139,6 +142,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-004
+        @relational-backend
         Scenario: 04 Making a Post request when a value matches the first scenario in an array but not the second
              When a POST request is made to "/ed-fi/sections" with
                   """
@@ -188,6 +192,7 @@ Feature: Equality Constraint Validation
                   """
 
         @API-005
+        @relational-backend
         Scenario: 05 Making a Post request when value does not match the same value in a single other reference
              When a POST request is made to "/ed-fi/sections" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
@@ -4,6 +4,7 @@ Feature: Create a Descriptor
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-006
+        @relational-backend
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -37,6 +38,7 @@ Feature: Create a Descriptor
                   """
 
         @API-007
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a descriptor using a value that is too long
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -68,6 +70,7 @@ Feature: Create a Descriptor
                   """
 
         @API-008
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a descriptor omitting any of the required values
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -123,6 +126,7 @@ Feature: Create a Descriptor
                   """
 
         @API-010
+        @relational-backend
         Scenario: 05 Post using an empty JSON body
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -154,6 +158,7 @@ Feature: Create a Descriptor
                   """
 
         @API-011
+        @relational-backend
         Scenario: 06 Ensure clients cannot create a descriptor only using spaces for the required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -189,6 +194,7 @@ Feature: Create a Descriptor
                   """
 
         @API-012
+        @relational-backend
         Scenario: 07 Ensure clients cannot create a descriptor with leading spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -218,6 +224,7 @@ Feature: Create a Descriptor
                   """
 
         @API-013
+        @relational-backend
         Scenario: 08 Ensure clients cannot create a descriptor with trailing spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -247,6 +254,7 @@ Feature: Create a Descriptor
                   """
 
         @API-014
+        @relational-backend
         Scenario: 09 Post a new descriptor with an extra property (overpost)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -275,6 +283,7 @@ Feature: Create a Descriptor
                   """
 
         @API-015
+        @relational-backend
         Scenario: 10 Post a new descriptor with invalid JSON (trailing comma)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -305,6 +314,7 @@ Feature: Create a Descriptor
                   """
 
         @API-016
+        @relational-backend
         Scenario: 11 Create a descriptor with forbidden id property
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -334,6 +344,7 @@ Feature: Create a Descriptor
                   """
 
         @API-017
+        @relational-backend
         Scenario: 12 Post a new descriptor with required attributes only
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -355,6 +366,7 @@ Feature: Create a Descriptor
                   """
 
         @API-018
+        @relational-backend
         Scenario: 13 Create a descriptor with a required, non-identity, property's value containing leading and trailing white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -368,6 +380,7 @@ Feature: Create a Descriptor
              Then it should respond with 201
 
         @API-019
+        @relational-backend
         Scenario: 14 Create a descriptor with optional property's value containing only white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -392,6 +405,7 @@ Feature: Create a Descriptor
                   """
 
         @API-020
+        @relational-backend
         Scenario: 15 Post an existing descriptor without changes
             Given a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -424,6 +438,7 @@ Feature: Create a Descriptor
                   """
 
         @API-021
+        @relational-backend
         Scenario: 16 Create a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -477,6 +492,7 @@ Feature: Create a Descriptor
                       ]
                     }
                   """
+        @relational-backend
         Scenario: 18 Create a descriptor with leading and trailing spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
@@ -5,6 +5,7 @@ Feature: Create a Descriptor
 
         @API-006
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -39,6 +40,7 @@ Feature: Create a Descriptor
 
         @API-007
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Ensure clients cannot create a descriptor using a value that is too long
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -71,6 +73,7 @@ Feature: Create a Descriptor
 
         @API-008
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Ensure clients cannot create a descriptor omitting any of the required values
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -127,6 +130,7 @@ Feature: Create a Descriptor
 
         @API-010
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Post using an empty JSON body
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -159,6 +163,7 @@ Feature: Create a Descriptor
 
         @API-011
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Ensure clients cannot create a descriptor only using spaces for the required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -195,6 +200,7 @@ Feature: Create a Descriptor
 
         @API-012
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Ensure clients cannot create a descriptor with leading spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -225,6 +231,7 @@ Feature: Create a Descriptor
 
         @API-013
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Ensure clients cannot create a descriptor with trailing spaces in required attributes
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -255,6 +262,7 @@ Feature: Create a Descriptor
 
         @API-014
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 09 Post a new descriptor with an extra property (overpost)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -284,6 +292,7 @@ Feature: Create a Descriptor
 
         @API-015
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 10 Post a new descriptor with invalid JSON (trailing comma)
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -315,6 +324,7 @@ Feature: Create a Descriptor
 
         @API-016
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 11 Create a descriptor with forbidden id property
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -345,6 +355,7 @@ Feature: Create a Descriptor
 
         @API-017
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 12 Post a new descriptor with required attributes only
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -367,6 +378,7 @@ Feature: Create a Descriptor
 
         @API-018
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 13 Create a descriptor with a required, non-identity, property's value containing leading and trailing white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -381,6 +393,7 @@ Feature: Create a Descriptor
 
         @API-019
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 14 Create a descriptor with optional property's value containing only white spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -406,6 +419,7 @@ Feature: Create a Descriptor
 
         @API-020
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 15 Post an existing descriptor without changes
             Given a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -439,6 +453,7 @@ Feature: Create a Descriptor
 
         @API-021
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 16 Create a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
@@ -493,6 +508,7 @@ Feature: Create a Descriptor
                     }
                   """
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 18 Create a descriptor with leading and trailing spaces
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
@@ -16,12 +16,14 @@ Feature: Delete a Descriptor
 
         @API-022
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Verify deleting a specific descriptor by ID
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
 
         @API-023
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Verify error handling when deleting a descriptor using a invalid id
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -44,6 +46,7 @@ Feature: Delete a Descriptor
 
         @API-024
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Verify error handling when trying to delete an item that has already been deleted
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
@@ -51,6 +54,7 @@ Feature: Delete a Descriptor
 
         @API-025
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Verify response code when trying to read a deleted resource
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
@@ -58,6 +62,7 @@ Feature: Delete a Descriptor
 
         @API-026
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Ensure clients cannot delete a descriptor that is being used by other Resources
             Given the system has these "schools"
                   | schoolId | nameOfInstitution             | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
@@ -15,11 +15,13 @@ Feature: Delete a Descriptor
                   """
 
         @API-022
+        @relational-backend
         Scenario: 01 Verify deleting a specific descriptor by ID
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
 
         @API-023
+        @relational-backend
         Scenario: 02 Verify error handling when deleting a descriptor using a invalid id
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -41,18 +43,21 @@ Feature: Delete a Descriptor
                   """
 
         @API-024
+        @relational-backend
         Scenario: 03 Verify error handling when trying to delete an item that has already been deleted
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 404
 
         @API-025
+        @relational-backend
         Scenario: 04 Verify response code when trying to read a deleted resource
             Given a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 404
 
         @API-026
+        @relational-backend
         Scenario: 05 Ensure clients cannot delete a descriptor that is being used by other Resources
             Given the system has these "schools"
                   | schoolId | nameOfInstitution             | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
@@ -13,6 +13,7 @@ Feature: Descriptor CaseInsensitive Validation
                   | uri://ed-fi.org/CourseIdentificationSystemDescriptor#LEA course code |
                   | uri://ed-fi.org/CourseGpaApplicabilityDescriptor#Applicable          |
               
+        @relational-backend
         Scenario: 1 Ensure clients can create objectiveAssessments with case-insensitive descriptor values
              When a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
@@ -14,6 +14,7 @@ Feature: Descriptor CaseInsensitive Validation
                   | uri://ed-fi.org/CourseGpaApplicabilityDescriptor#Applicable          |
               
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 1 Ensure clients can create objectiveAssessments with case-insensitive descriptor values
              When a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
@@ -17,6 +17,7 @@ Feature: Read a Descriptor
              Then it should respond with 201 or 200
 
         @API-027 @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Verify retrieving a single descriptor by ID
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 200
@@ -35,11 +36,13 @@ Feature: Read a Descriptor
 
         @API-028
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Verify response code 404 when ID does not exist
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/124c8513-fade-4ce2-ab71-0e40e148de5b"
              Then it should respond with 404
 
         @API-029 @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Read a descriptor that only contains required attributes
             Given a POST request is made to "/ed-fi/disabilityDescriptors" with
                   """
@@ -62,6 +65,7 @@ Feature: Read a Descriptor
                   """
 
         @API-030 @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Ensure clients cannot retrieve a descriptor by requesting through a non existing codeValue
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors?codeValue=Test"
              Then it should respond with 200
@@ -71,6 +75,7 @@ Feature: Read a Descriptor
                   """
 
         @API-031 @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Ensure clients cannot retrieve a descriptor by requesting through a non existing namespace
              When a GET request is made to "/ed-fi/disabilityDescriptors?namespace=uri://ed-fi.org/DoesNotExistDescriptor"
              Then it should respond with 200
@@ -80,6 +85,7 @@ Feature: Read a Descriptor
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Ensure clients cannot retrieve a descriptor by requesting a valid namespace with valid codeValue attached
         # Descriptors are referenced in resources by attaching the namespace and codeValue like so: uri://ed-fi.org/DisabilityDescriptor#Blindness
         # but you cannot search for a descriptor by using this combination.
@@ -101,6 +107,7 @@ Feature: Read a Descriptor
 
         @API-032
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Verify response code 404 when ID is not valid
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -122,6 +129,7 @@ Feature: Read a Descriptor
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Get a Descriptor using a resource not configured in claims
              When a GET request is made to "/ed-fi/academicHonorCategoryDescriptors"
              Then it should respond with 403
@@ -139,6 +147,7 @@ Feature: Read a Descriptor
                   """
 
         @DMS-994 @relational-backend
+        @relational-ci-shard-2
         Scenario: 09 Read and query a descriptor through the relational backend with readable profile projection
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/ReadDescriptorsValidation.feature
@@ -34,6 +34,7 @@ Feature: Read a Descriptor
                   """
 
         @API-028
+        @relational-backend
         Scenario: 02 Verify response code 404 when ID does not exist
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/124c8513-fade-4ce2-ab71-0e40e148de5b"
              Then it should respond with 404
@@ -99,6 +100,7 @@ Feature: Read a Descriptor
                   """
 
         @API-032
+        @relational-backend
         Scenario: 07 Verify response code 404 when ID is not valid
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/00112233445566"
              Then it should respond with 400
@@ -119,6 +121,7 @@ Feature: Read a Descriptor
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Get a Descriptor using a resource not configured in claims
              When a GET request is made to "/ed-fi/academicHonorCategoryDescriptors"
              Then it should respond with 403

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
@@ -17,6 +17,7 @@ Feature: Update a Descriptor
                   """
 
         @API-033
+        @relational-backend
         Scenario: 01 Put an existing descriptor
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -46,6 +47,7 @@ Feature: Update a Descriptor
                   """
 
         @API-034
+        @relational-backend
         Scenario: 02 Put an existing descriptor with optional properties removed
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -69,6 +71,7 @@ Feature: Update a Descriptor
                   """
 
         @API-035
+        @relational-backend
         Scenario: 03 Update a descriptor with a string that is too long
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -127,6 +130,7 @@ Feature: Update a Descriptor
                   """
 
         @API-037
+        @relational-backend
         Scenario: 05 Update a descriptor with spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -163,6 +167,7 @@ Feature: Update a Descriptor
                   """
 
         @API-038
+        @relational-backend
         Scenario: 06 Update a descriptor with leading spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -193,6 +198,7 @@ Feature: Update a Descriptor
                   """
 
         @API-039
+        @relational-backend
         Scenario: 07 Update a descriptor with trailing spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -223,6 +229,7 @@ Feature: Update a Descriptor
                   """
 
         @API-040
+        @relational-backend
         Scenario: 08 Put an existing descriptor with an extra property (overpost)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -249,6 +256,7 @@ Feature: Update a Descriptor
                   """
 
         @API-041
+        @relational-backend
         Scenario: 09 Update a descriptor that does not exist
              # The id value should be replaced with a non existing resource
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/00000000-0000-4000-a000-000000000000" with
@@ -303,6 +311,7 @@ Feature: Update a Descriptor
                   """
 
         @API-043
+        @relational-backend
         Scenario: 11  Put an empty request descriptor
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -325,6 +334,7 @@ Feature: Update a Descriptor
                   """
 
         @API-044
+        @relational-backend
         Scenario: 12 Put an empty JSON body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -360,6 +370,7 @@ Feature: Update a Descriptor
                   """
 
         @API-045
+        @relational-backend
         Scenario: 13 Update a descriptor with mismatch between URL and id
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -389,6 +400,7 @@ Feature: Update a Descriptor
                   """
 
         @API-046
+        @relational-backend
         Scenario: 14 Update a descriptor with a blank id
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -418,6 +430,7 @@ Feature: Update a Descriptor
                   """
 
         @API-047
+        @relational-backend
         Scenario: 15 Update a descriptor with an invalid id format in the body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -447,6 +460,7 @@ Feature: Update a Descriptor
                   """
 
         @API-048
+        @relational-backend
         Scenario: 16 Update a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -478,6 +492,7 @@ Feature: Update a Descriptor
                   """
 
         @API-049
+        @relational-backend
         Scenario: 17 Ensure clients cannot update a descriptor omitting any of the required values
              When a PUT request is made to "/ed-fi/disabilityDescriptors/{id}" with
                   """
@@ -574,6 +589,7 @@ Feature: Update a Descriptor
                   """
 
         @API-052
+        @relational-backend
         Scenario: 20 Verify response code 400 when ID is not valid
              When a PUT request is made to "/ed-fi/disabilityDescriptors/00112233445566" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
@@ -18,6 +18,7 @@ Feature: Update a Descriptor
 
         @API-033
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Put an existing descriptor
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -48,6 +49,7 @@ Feature: Update a Descriptor
 
         @API-034
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Put an existing descriptor with optional properties removed
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -72,6 +74,7 @@ Feature: Update a Descriptor
 
         @API-035
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Update a descriptor with a string that is too long
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -131,6 +134,7 @@ Feature: Update a Descriptor
 
         @API-037
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Update a descriptor with spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -168,6 +172,7 @@ Feature: Update a Descriptor
 
         @API-038
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Update a descriptor with leading spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -199,6 +204,7 @@ Feature: Update a Descriptor
 
         @API-039
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Update a descriptor with trailing spaces in required fields
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -230,6 +236,7 @@ Feature: Update a Descriptor
 
         @API-040
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Put an existing descriptor with an extra property (overpost)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -257,6 +264,7 @@ Feature: Update a Descriptor
 
         @API-041
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 09 Update a descriptor that does not exist
              # The id value should be replaced with a non existing resource
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/00000000-0000-4000-a000-000000000000" with
@@ -312,6 +320,7 @@ Feature: Update a Descriptor
 
         @API-043
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 11  Put an empty request descriptor
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -335,6 +344,7 @@ Feature: Update a Descriptor
 
         @API-044
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 12 Put an empty JSON body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -371,6 +381,7 @@ Feature: Update a Descriptor
 
         @API-045
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 13 Update a descriptor with mismatch between URL and id
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -401,6 +412,7 @@ Feature: Update a Descriptor
 
         @API-046
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 14 Update a descriptor with a blank id
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -431,6 +443,7 @@ Feature: Update a Descriptor
 
         @API-047
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 15 Update a descriptor with an invalid id format in the body
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -461,6 +474,7 @@ Feature: Update a Descriptor
 
         @API-048
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 16 Update a descriptor with duplicate properties
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
@@ -493,6 +507,7 @@ Feature: Update a Descriptor
 
         @API-049
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 17 Ensure clients cannot update a descriptor omitting any of the required values
              When a PUT request is made to "/ed-fi/disabilityDescriptors/{id}" with
                   """
@@ -590,6 +605,7 @@ Feature: Update a Descriptor
 
         @API-052
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 20 Verify response code 400 when ID is not valid
              When a PUT request is made to "/ed-fi/disabilityDescriptors/00112233445566" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
@@ -4,6 +4,7 @@ Feature: Reject client requests for abstract entities
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-053
+        @relational-backend
         Scenario: 01 Ensure that clients cannot POST an abstract entity (Education Organizations)
              When a POST request is made to "/ed-fi/educationOrganizations" with
                   """
@@ -14,6 +15,7 @@ Feature: Reject client requests for abstract entities
              Then it should respond with 404
 
         @API-054
+        @relational-backend
         Scenario: 02 Ensure that clients cannot POST an abstract entity (General Student Program Association)
              When a POST request is made to "/ed-fi/generalStudentProgramAssociations" with
                   """
@@ -24,11 +26,13 @@ Feature: Reject client requests for abstract entities
              Then it should respond with 404
 
         @API-055
+        @relational-backend
         Scenario: 03 Ensure that clients cannot GET an abstract entity (Education Organizations)
              When a GET request is made to "/ed-fi/educationOrganizations"
              Then it should respond with 404
 
         @API-056
+        @relational-backend
         Scenario: 04 Ensure that clients cannot GET an abstract entity (Student Program Association)
              When a GET request is made to "/ed-fi/generalStudentProgramAssociations"
              Then it should respond with 404

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/AbstractEntityValidation.feature
@@ -5,6 +5,7 @@ Feature: Reject client requests for abstract entities
 
         @API-053
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure that clients cannot POST an abstract entity (Education Organizations)
              When a POST request is made to "/ed-fi/educationOrganizations" with
                   """
@@ -16,6 +17,7 @@ Feature: Reject client requests for abstract entities
 
         @API-054
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure that clients cannot POST an abstract entity (General Student Program Association)
              When a POST request is made to "/ed-fi/generalStudentProgramAssociations" with
                   """
@@ -27,12 +29,14 @@ Feature: Reject client requests for abstract entities
 
         @API-055
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure that clients cannot GET an abstract entity (Education Organizations)
              When a GET request is made to "/ed-fi/educationOrganizations"
              Then it should respond with 404
 
         @API-056
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure that clients cannot GET an abstract entity (Student Program Association)
              When a GET request is made to "/ed-fi/generalStudentProgramAssociations"
              Then it should respond with 404

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
@@ -23,6 +23,7 @@ Feature: School Year Reference Validation
                   | "451"        | { "schoolId": 535 } | { "schoolYear": 2029 }  | uri://ed-fi.org/CalendarTypeDescriptor#Student Specific | []          |
 
         @API-057
+        @relational-backend
         Scenario: 01 Try creating a resource using a valid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -41,6 +42,7 @@ Feature: School Year Reference Validation
              Then it should respond with 200 or 201
 
         @API-058
+        @relational-backend
         Scenario: 02 Try creating a resource using an invalid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -75,6 +77,7 @@ Feature: School Year Reference Validation
                   """
 
         @API-059
+        @relational-backend
         Scenario: 03 Try creating a CalendarDate using a valid Calendar reference
              When a POST request is made to "/ed-fi/calendarDates" with
                   """
@@ -95,6 +98,7 @@ Feature: School Year Reference Validation
              Then it should respond with 201
 
         @API-060
+        @relational-backend
         Scenario: 04 Try creating a CalendarDate using an invalid Calendar reference with an invalid School year
              When a POST request is made to "/ed-fi/calendarDates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Entities/SchoolYearReferenceValidation.feature
@@ -24,6 +24,7 @@ Feature: School Year Reference Validation
 
         @API-057
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Try creating a resource using a valid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -43,6 +44,7 @@ Feature: School Year Reference Validation
 
         @API-058
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Try creating a resource using an invalid school year
              When a POST request is made to "/ed-fi/calendars" with
                   """
@@ -78,6 +80,7 @@ Feature: School Year Reference Validation
 
         @API-059
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Try creating a CalendarDate using a valid Calendar reference
              When a POST request is made to "/ed-fi/calendarDates" with
                   """
@@ -99,6 +102,7 @@ Feature: School Year Reference Validation
 
         @API-060
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Try creating a CalendarDate using an invalid Calendar reference with an invalid School year
              When a POST request is made to "/ed-fi/calendarDates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
@@ -5,6 +5,7 @@ Feature: Homograph extension resources
 
     Rule: Homograph Extension Resources
 
+        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a school in homograph extension
       # POST request to create a school
              When a POST request is made to "/homograph/schools/" with
@@ -58,6 +59,7 @@ Feature: Homograph extension resources
              When a GET request is made to "/homograph/schools/{id}"
              Then it should respond with 404
 
+        @relational-backend
         Scenario: 02 Ensure clients can create/update/get/delete a student in homograph extension
       # POST request to create a schoolYearType
             Given a POST request is made to "/homograph/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/HomographExtension.feature
@@ -6,6 +6,7 @@ Feature: Homograph extension resources
     Rule: Homograph Extension Resources
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Ensure clients can create/update/get/delete a school in homograph extension
       # POST request to create a school
              When a POST request is made to "/homograph/schools/" with
@@ -60,6 +61,7 @@ Feature: Homograph extension resources
              Then it should respond with 404
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Ensure clients can create/update/get/delete a student in homograph extension
       # POST request to create a schoolYearType
             Given a POST request is made to "/homograph/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
@@ -9,6 +9,7 @@ Feature: Resource with multiple extensions
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution |
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
+        @relational-backend
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -98,6 +99,7 @@ Feature: Resource with multiple extensions
                   }
                   """
 
+    @relational-backend
     Scenario: 02 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """
@@ -125,6 +127,7 @@ Feature: Resource with multiple extensions
              """
              Then it should respond with 409
 
+      @relational-backend
       Scenario: 03 Ensure clients can not create a resource when sample extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithMultipleExtension.feature
@@ -10,6 +10,7 @@ Feature: Resource with multiple extensions
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -100,6 +101,7 @@ Feature: Resource with multiple extensions
                   """
 
     @relational-backend
+    @relational-ci-shard-2
     Scenario: 02 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """
@@ -128,6 +130,7 @@ Feature: Resource with multiple extensions
              Then it should respond with 409
 
       @relational-backend
+      @relational-ci-shard-2
       Scenario: 03 Ensure clients can not create a resource when sample extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
              """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
@@ -9,6 +9,7 @@ Feature: Resource with Tpdm extension
                   | uri://ed-fi.org/EducationOrganizationCategoryDescriptor#Post Secondary Institution |
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
+        @relational-backend
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -77,6 +78,7 @@ Feature: Resource with Tpdm extension
                   }
                   """
 
+        @relational-backend
         Scenario: 02 Ensure clients can get a resource with query
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -147,6 +149,7 @@ Feature: Resource with Tpdm extension
                   }]
                   """
 
+        @relational-backend
         Scenario: 03 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/ResourceWithTpdmExtension.feature
@@ -10,6 +10,7 @@ Feature: Resource with Tpdm extension
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Ensure clients can create a resource with tpdm extension reference
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -79,6 +80,7 @@ Feature: Resource with Tpdm extension
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Ensure clients can get a resource with query
              When a POST request is made to "/ed-fi/postSecondaryInstitutions" with
                   """
@@ -150,6 +152,7 @@ Feature: Resource with Tpdm extension
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Ensure clients can not create a resource when tpdm extension reference is unavailable
              When a POST request is made to "/ed-fi/schools" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
@@ -15,6 +15,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Required Field Validation Errors for busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -63,6 +64,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Creating New busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -161,6 +163,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Delete by ID for busRoutes Resource
             Given a POST request is made to "/sample/busRoutes" with
                   """
@@ -205,6 +208,7 @@ Feature: Sample extension resources
                   | uri://ed-fi.org/CTEProgramServiceDescriptor#Architecture and Construction          |
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Existing Core Entity School and Sample Extension with Missing CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -248,6 +252,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Existing Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -277,6 +282,7 @@ Feature: Sample extension resources
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Get by ID for Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -333,6 +339,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Delete by ID for busRoutes Resource
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -471,6 +478,7 @@ Feature: Sample extension resources
 
     Rule: busRoutes scenarios
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 10 Create Staff with Duplicate Extension Items
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -521,6 +529,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 11 Data Validation with Staff when petName has leading or trailing spaces
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -562,6 +571,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 12 Data Validation with Staff when Pet name has too short value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -603,6 +613,7 @@ Feature: Sample extension resources
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 13 Data Validation with Staff when Pet name has too long value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/SampleExtension.feature
@@ -14,6 +14,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Required Field Validation Errors for busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -61,6 +62,7 @@ Feature: Sample extension resources
                       }
                   """
 
+        @relational-backend
         Scenario: 02 Creating New busRoutes Resource
              When a POST request is made to "/sample/busRoutes" with
                   """
@@ -158,6 +160,7 @@ Feature: Sample extension resources
                         }
                   """
 
+        @relational-backend
         Scenario: 04 Delete by ID for busRoutes Resource
             Given a POST request is made to "/sample/busRoutes" with
                   """
@@ -201,6 +204,7 @@ Feature: Sample extension resources
                   | uri://ed-fi.org/GradeLevelDescriptor#Postsecondary                                 |
                   | uri://ed-fi.org/CTEProgramServiceDescriptor#Architecture and Construction          |
 
+        @relational-backend
         Scenario: 05 Existing Core Entity School and Sample Extension with Missing CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -243,6 +247,7 @@ Feature: Sample extension resources
                       }
                   """
 
+        @relational-backend
         Scenario: 06 Existing Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -271,6 +276,7 @@ Feature: Sample extension resources
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 07 Get by ID for Core Entity School and Sample Extension with CTEProgramServiceDescriptor Field
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -326,6 +332,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Delete by ID for busRoutes Resource
             Given a POST request is made to "/ed-fi/schools" with
                   """
@@ -463,6 +470,7 @@ Feature: Sample extension resources
                   """
 
     Rule: busRoutes scenarios
+        @relational-backend
         Scenario: 10 Create Staff with Duplicate Extension Items
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -512,6 +520,7 @@ Feature: Sample extension resources
                   }
                   """
 
+        @relational-backend
         Scenario: 11 Data Validation with Staff when petName has leading or trailing spaces
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -552,6 +561,7 @@ Feature: Sample extension resources
                     }
                   """
 
+        @relational-backend
         Scenario: 12 Data Validation with Staff when Pet name has too short value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with
@@ -592,6 +602,7 @@ Feature: Sample extension resources
                     }
                   """
 
+        @relational-backend
         Scenario: 13 Data Validation with Staff when Pet name has too long value
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
              When a POST request is made to "/ed-fi/staffs" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
@@ -5,6 +5,7 @@ Feature: Tpdm extension resources and descriptors
 
     Rule: Descriptors
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -37,6 +38,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Ensure clients can update a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -77,6 +79,7 @@ Feature: Tpdm extension resources and descriptors
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Ensure clients can retrieve a descriptor by requesting through a valid codeValue
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -108,6 +111,7 @@ Feature: Tpdm extension resources and descriptors
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Ensure clients can delete a descriptor
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -141,6 +145,7 @@ Feature: Tpdm extension resources and descriptors
     Rule: Resources
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Ensure clients can create a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -170,6 +175,7 @@ Feature: Tpdm extension resources and descriptors
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Ensure clients can update a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -204,6 +210,7 @@ Feature: Tpdm extension resources and descriptors
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Ensure clients can query a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """
@@ -231,6 +238,7 @@ Feature: Tpdm extension resources and descriptors
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Ensure clients can delete a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
@@ -4,6 +4,7 @@ Feature: Tpdm extension resources and descriptors
             Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org, uri://tpdm.ed-fi.org"
 
     Rule: Descriptors
+        @relational-backend
         Scenario: 01 Ensure clients can create a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -35,6 +36,7 @@ Feature: Tpdm extension resources and descriptors
                       "effectiveEndDate": "2024-05-14"
                   }
                   """
+        @relational-backend
         Scenario: 02 Ensure clients can update a descriptor
              When a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -74,6 +76,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Ensure clients can retrieve a descriptor by requesting through a valid codeValue
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -104,6 +107,7 @@ Feature: Tpdm extension resources and descriptors
                   ]
                   """
 
+        @relational-backend
         Scenario: 04 Ensure clients can delete a descriptor
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """
@@ -136,6 +140,7 @@ Feature: Tpdm extension resources and descriptors
 
     Rule: Resources
 
+        @relational-backend
         Scenario: 05 Ensure clients can create a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -164,6 +169,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Ensure clients can update a resource
              When a POST request is made to "/tpdm/candidates" with
                   """
@@ -197,6 +203,7 @@ Feature: Tpdm extension resources and descriptors
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Ensure clients can query a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """
@@ -223,6 +230,7 @@ Feature: Tpdm extension resources and descriptors
                   ]
                   """
 
+        @relational-backend
         Scenario: 08 Ensure clients can delete a resource
             Given a POST request is made to "/tpdm/candidates" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
@@ -6,6 +6,7 @@ Feature: CorrleationId
 
         @API-061
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure the response will contain provided correlation id
             # Note: this requires that the .env file used to startup the DMS container has the following setting:
             # CORRELATION_ID_HEADER=correlationid

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/CorrelationId.feature
@@ -5,6 +5,7 @@ Feature: CorrleationId
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-061
+        @relational-backend
         Scenario: 01 Ensure the response will contain provided correlation id
             # Note: this requires that the .env file used to startup the DMS container has the following setting:
             # CORRELATION_ID_HEADER=correlationid

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
@@ -74,6 +74,7 @@ Feature: Data strictness
 
 
         @API-240
+        @relational-backend
         Scenario: 08 Ensure clients can create a resource using expected booleans
              When a POST request is made to "/ed-fi/classPeriods" with
                   """
@@ -256,6 +257,7 @@ Feature: Data strictness
                   """
 
         @API-248
+        @relational-backend
         Scenario: 16 Enforce case sensitivity of property names in POST request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools" with
@@ -278,6 +280,7 @@ Feature: Data strictness
              Then it should respond with 400
 
         @API-249
+        @relational-backend
         Scenario: 17 Enforce case sensitivity of property names in PUT request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools/{id}" with
@@ -301,6 +304,7 @@ Feature: Data strictness
              Then it should respond with 400
 
         @API-255
+        @relational-backend
         Scenario: 18 Accept missing time in a POST request with a datetime property
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -369,6 +373,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 19 Accept missing time in a POST request with a datetime property with slashes
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -437,6 +442,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 20 Accept time with AM PM And Convert To UTC ISO8601 in a POST request
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -505,6 +511,7 @@ Feature: Data strictness
                   }
                   """
 
+        @relational-backend
         Scenario: 21 accept time without zone and it will be added automatically
             Given a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DataStrictnessValidation.feature
@@ -75,6 +75,7 @@ Feature: Data strictness
 
         @API-240
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Ensure clients can create a resource using expected booleans
              When a POST request is made to "/ed-fi/classPeriods" with
                   """
@@ -258,6 +259,7 @@ Feature: Data strictness
 
         @API-248
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 16 Enforce case sensitivity of property names in POST request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools" with
@@ -281,6 +283,7 @@ Feature: Data strictness
 
         @API-249
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 17 Enforce case sensitivity of property names in PUT request bodies.
              # Uppercase GRADELEVELS
              When a POST request is made to "/ed-fi/schools/{id}" with
@@ -305,6 +308,7 @@ Feature: Data strictness
 
         @API-255
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 18 Accept missing time in a POST request with a datetime property
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -374,6 +378,7 @@ Feature: Data strictness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 19 Accept missing time in a POST request with a datetime property with slashes
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -443,6 +448,7 @@ Feature: Data strictness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 20 Accept time with AM PM And Convert To UTC ISO8601 in a POST request
             Given a POST request is made to "/ed-fi/assessments" with
                   """
@@ -512,6 +518,7 @@ Feature: Data strictness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 21 accept time without zone and it will be added automatically
             Given a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
@@ -43,6 +43,7 @@ Feature: The Discovery API provides information about the application version, s
                   """
 
         @API-063
+        @relational-backend
         Scenario: 02 GET /metadata returns the metadata URL list
              When a GET request is made to "/metadata"
              Then it should respond with 200
@@ -56,6 +57,7 @@ Feature: The Discovery API provides information about the application version, s
                   """
 
         @API-064
+        @relational-backend
         Scenario: 03 GET /metadata/specifications returns the list of supported API specifications
              When a GET request is made to "/metadata/specifications"
              Then it should respond with 200
@@ -300,6 +302,7 @@ Feature: The Discovery API provides information about the application version, s
                   ]
                   """
         @API-065
+        @relational-backend
         Scenario: 04 GET /metadata/dependencies returns the dependency order for loading documents
              When a GET request is made to "/metadata/dependencies"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
@@ -44,6 +44,7 @@ Feature: The Discovery API provides information about the application version, s
 
         @API-063
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 GET /metadata returns the metadata URL list
              When a GET request is made to "/metadata"
              Then it should respond with 200
@@ -58,6 +59,7 @@ Feature: The Discovery API provides information about the application version, s
 
         @API-064
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 GET /metadata/specifications returns the list of supported API specifications
              When a GET request is made to "/metadata/specifications"
              Then it should respond with 200
@@ -303,6 +305,7 @@ Feature: The Discovery API provides information about the application version, s
                   """
         @API-065
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 GET /metadata/dependencies returns the dependency order for loading documents
              When a GET request is made to "/metadata/dependencies"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
@@ -2,6 +2,7 @@ Feature: Health
     Check the health of the application and the database
 
         @API-066
+        @relational-backend
         Scenario: 01 Health
             Given a request health is made to the server
              Then it returns healthy checks

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/Health.feature
@@ -3,6 +3,7 @@ Feature: Health
 
         @API-066
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Health
             Given a request health is made to the server
              Then it returns healthy checks

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
@@ -3,6 +3,7 @@ Feature: Kafka Messaging
 
         @kafka
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Test Kafka connectivity
             Given Kafka should be reachable
              Then Kafka consumer should be able to connect to topic "edfi.dms.document"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/KafkaMessaging.feature
@@ -2,6 +2,7 @@ Feature: Kafka Messaging
     This feature demonstrates a simple Kafka testing approach. *Note* running these tests locally require a specific hosts entry: 127.0.0.1 dms-kafka1
 
         @kafka
+        @relational-backend
         Scenario: 01 Test Kafka connectivity
             Given Kafka should be reachable
              Then Kafka consumer should be able to connect to topic "edfi.dms.document"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -23,6 +23,7 @@ Feature: Validation of the structure of the URLs
 
         @API-067
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients cannot retrieve information when the data model name is missing
              When a GET request is made to "/schools"
              Then it should respond with 404
@@ -47,6 +48,7 @@ Feature: Validation of the structure of the URLs
 
         @API-068
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients cannot create a resource when the data model name is missing
              When a POST request is made to "/schools" with
                   """
@@ -87,6 +89,7 @@ Feature: Validation of the structure of the URLs
 
         @API-069
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients cannot update a resource when the data model name is missing
              When a PUT request is made to "/schools/{id}" with
                   """
@@ -128,6 +131,7 @@ Feature: Validation of the structure of the URLs
 
         @API-070
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients cannot delete a resource when the data model name is missing
              When a DELETE request is made to "/schools/{id}"
              Then it should respond with 404
@@ -152,6 +156,7 @@ Feature: Validation of the structure of the URLs
 
         @API-071
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Ensure clients cannot retrieve a resource when endpoint is not pluralized
              When a GET request is made to "/ed-fi/school"
              Then it should respond with 404
@@ -176,6 +181,7 @@ Feature: Validation of the structure of the URLs
 
         @API-072
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 Ensure clients cannot create a resource when endpoint is not pluralized
              When a POST request is made to "/ed-fi/school" with
                   """
@@ -216,6 +222,7 @@ Feature: Validation of the structure of the URLs
 
         @API-073
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 07 Ensure clients cannot update a resource when endpoint does not end in plural
              When a PUT request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000" with
                   """
@@ -256,6 +263,7 @@ Feature: Validation of the structure of the URLs
 
         @API-074
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Ensure clients cannot delete a resource when endpoint does not end in plural
              When a DELETE request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000"
              Then it should respond with 404
@@ -280,6 +288,7 @@ Feature: Validation of the structure of the URLs
 
         @API-075
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 09 Ensure clients cannot create a resource adding an ID as a path variable
              When a POST request is made to "/ed-fi/schools/00000000-0000-4000-a000-000000000000" with
                   """
@@ -322,6 +331,7 @@ Feature: Validation of the structure of the URLs
 
         @API-077
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 10 Ensure PUT requests require an Id value
              When a PUT request is made to "/ed-fi/schools/" with
                   """
@@ -364,6 +374,7 @@ Feature: Validation of the structure of the URLs
 
         @API-078
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 11 Ensure DELETE requests require an Id value
              When a DELETE request is made to "/ed-fi/schools/"
              Then it should respond with 405
@@ -408,6 +419,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-250 @relational-backend
+        @relational-ci-shard-4
         Scenario: 13 Ensure client can retrieve information through a case insensitive query parameter
              When a GET request is made to "/ed-fi/classPeriods?CLaSSperIODName=Class+Period+Test"
              Then it should respond with 200
@@ -427,6 +439,7 @@ Feature: Validation of the structure of the URLs
 
         @API-251
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 14 Ensure clients validate identifier on GET requests
              When a GET request is made to "/ed-fi/schools/ffc0a272"
              Then it should respond with 400
@@ -448,6 +461,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-252 @relational-backend
+        @relational-ci-shard-4
         # DMS-397
         Scenario: 15 Ensure client can retrieve information through case insensitive LIMIT parameter
              When a GET request is made to "/ed-fi/schools?liMIt=2"
@@ -480,6 +494,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-253 @relational-backend
+        @relational-ci-shard-4
         # DMS-397
         Scenario: 16 Ensure client can retrieve information through case insensitive OFFSET parameter
              # There is only one item, and offset=1 skips that one item.
@@ -491,6 +506,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-254 @relational-backend
+        @relational-ci-shard-4
         # DMS-397
         Scenario: 17 Ensure client can retrieve information through case insensitive TOTALCOUNT parameter
              When a GET request is made to "/ed-fi/SCHOOLS?tOtAlCoUnT=trUE"
@@ -505,6 +521,7 @@ Feature: Validation of the structure of the URLs
 
         @DMS-816
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 18 Ensure clients get 404 for completely invalid path with prefix before data model
              When a POST request is made to "/ed-fi/notExisting" with
                   """
@@ -537,6 +554,7 @@ Feature: Validation of the structure of the URLs
 
         @DMS-816
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 19 Ensure clients get 404 for misspelled resource endpoint
              When a POST request is made to "/ed-fi/gradeLevelDescriptorz" with
                   """
@@ -569,6 +587,7 @@ Feature: Validation of the structure of the URLs
 
         @DMS-816
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 20 Ensure clients get 404 for arbitrary non-existent path
              When a GET request is made to "/foo/bar"
              Then it should respond with 404
@@ -593,6 +612,7 @@ Feature: Validation of the structure of the URLs
 
         @DMS-816
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 21 Ensure clients get 404 for PUT on non-existent path with ID
              When a PUT request is made to "/invalid/path/00000000-0000-4000-a000-000000000000" with
                   """
@@ -622,6 +642,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-993 @relational-backend
+        @relational-ci-shard-4
         Scenario: 22 Ensure clients get 404 for PUT on unknown Ed-Fi resource collection
              When a PUT request is made to "/ed-fi/unknownResource" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -22,6 +22,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-067
+        @relational-backend
         Scenario: 01 Ensure clients cannot retrieve information when the data model name is missing
              When a GET request is made to "/schools"
              Then it should respond with 404
@@ -45,6 +46,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-068
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a resource when the data model name is missing
              When a POST request is made to "/schools" with
                   """
@@ -84,6 +86,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-069
+        @relational-backend
         Scenario: 03 Ensure clients cannot update a resource when the data model name is missing
              When a PUT request is made to "/schools/{id}" with
                   """
@@ -124,6 +127,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-070
+        @relational-backend
         Scenario: 04 Ensure clients cannot delete a resource when the data model name is missing
              When a DELETE request is made to "/schools/{id}"
              Then it should respond with 404
@@ -147,6 +151,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-071
+        @relational-backend
         Scenario: 05 Ensure clients cannot retrieve a resource when endpoint is not pluralized
              When a GET request is made to "/ed-fi/school"
              Then it should respond with 404
@@ -170,6 +175,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-072
+        @relational-backend
         Scenario: 06 Ensure clients cannot create a resource when endpoint is not pluralized
              When a POST request is made to "/ed-fi/school" with
                   """
@@ -209,6 +215,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-073
+        @relational-backend
         Scenario: 07 Ensure clients cannot update a resource when endpoint does not end in plural
              When a PUT request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000" with
                   """
@@ -248,6 +255,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-074
+        @relational-backend
         Scenario: 08 Ensure clients cannot delete a resource when endpoint does not end in plural
              When a DELETE request is made to "/ed-fi/school/00000000-0000-4000-a000-000000000000"
              Then it should respond with 404
@@ -271,6 +279,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-075
+        @relational-backend
         Scenario: 09 Ensure clients cannot create a resource adding an ID as a path variable
              When a POST request is made to "/ed-fi/schools/00000000-0000-4000-a000-000000000000" with
                   """
@@ -312,6 +321,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-077
+        @relational-backend
         Scenario: 10 Ensure PUT requests require an Id value
              When a PUT request is made to "/ed-fi/schools/" with
                   """
@@ -353,6 +363,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-078
+        @relational-backend
         Scenario: 11 Ensure DELETE requests require an Id value
              When a DELETE request is made to "/ed-fi/schools/"
              Then it should respond with 405
@@ -415,6 +426,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @API-251
+        @relational-backend
         Scenario: 14 Ensure clients validate identifier on GET requests
              When a GET request is made to "/ed-fi/schools/ffc0a272"
              Then it should respond with 400
@@ -492,6 +504,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 18 Ensure clients get 404 for completely invalid path with prefix before data model
              When a POST request is made to "/ed-fi/notExisting" with
                   """
@@ -523,6 +536,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 19 Ensure clients get 404 for misspelled resource endpoint
              When a POST request is made to "/ed-fi/gradeLevelDescriptorz" with
                   """
@@ -554,6 +568,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 20 Ensure clients get 404 for arbitrary non-existent path
              When a GET request is made to "/foo/bar"
              Then it should respond with 404
@@ -577,6 +592,7 @@ Feature: Validation of the structure of the URLs
                   """
 
         @DMS-816
+        @relational-backend
         Scenario: 21 Ensure clients get 404 for PUT on non-existent path with ID
              When a PUT request is made to "/invalid/path/00000000-0000-4000-a000-000000000000" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
@@ -1,6 +1,7 @@
 Feature: XSD Metadata Endpoint
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients can retrieve XSD endpoint information
              When a GET request is made to "/metadata/xsd"
              Then it should respond with 200
@@ -34,6 +35,7 @@ Feature: XSD Metadata Endpoint
                     ]
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients can retrieve Core schema (Ed-Fi) files for the data model
              When a GET request is made to "/metadata/xsd/ed-fi/files"
              Then it should respond with 200
@@ -70,6 +72,7 @@ Feature: XSD Metadata Endpoint
                     ]
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients can retrieve Extension (Sample) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/sample/files"
              Then it should respond with 200
@@ -116,6 +119,7 @@ Feature: XSD Metadata Endpoint
                     ]
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients can retrieve Extension (Homograph) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/homograph/files"
              Then it should respond with 200
@@ -152,6 +156,7 @@ Feature: XSD Metadata Endpoint
                     ]
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Ensure clients can retrieve Extension (TPDM) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/tpdm/files"
              Then it should respond with 200
@@ -195,6 +200,7 @@ Feature: XSD Metadata Endpoint
                     ]
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 Ensure clients can retrieve XSD content of TPDM Extension
              When a GET request is made to "/metadata/xsd/tpdm/EdFi.TPDM.ApiSchema.xsd.TPDM-EXTENSION-Interchange-Survey-Extension.xsd"
              Then it should respond with 200
@@ -233,6 +239,7 @@ Feature: XSD Metadata Endpoint
                     </xs:schema>
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 07 Ensure clients can retrieve XSD content of Sample Extension
              When a GET request is made to "/metadata/xsd/sample/EdFi.Sample.ApiSchema.xsd.Sample-EXTENSION-Interchange-StudentProgram-Extension.xsd"
              Then it should respond with 200
@@ -266,6 +273,7 @@ Feature: XSD Metadata Endpoint
                     </xs:schema>
                   """
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Ensure clients can retrieve XSD content of Core
              When a GET request is made to "/metadata/xsd/ed-fi/EdFi.DataStandard52.ApiSchema.xsd.Interchange-Survey.xsd"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/XSDMetadata.feature
@@ -1,5 +1,6 @@
 Feature: XSD Metadata Endpoint
 
+        @relational-backend
         Scenario: 01 Ensure clients can retrieve XSD endpoint information
              When a GET request is made to "/metadata/xsd"
              Then it should respond with 200
@@ -32,6 +33,7 @@ Feature: XSD Metadata Endpoint
                       }
                     ]
                   """
+        @relational-backend
         Scenario: 02 Ensure clients can retrieve Core schema (Ed-Fi) files for the data model
              When a GET request is made to "/metadata/xsd/ed-fi/files"
              Then it should respond with 200
@@ -67,6 +69,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/ed-fi/SchemaAnnotation.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 03 Ensure clients can retrieve Extension (Sample) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/sample/files"
              Then it should respond with 200
@@ -112,6 +115,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/sample/Sample-EXTENSION-Interchange-StudentTranscript-Extension.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 04 Ensure clients can retrieve Extension (Homograph) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/homograph/files"
              Then it should respond with 200
@@ -147,6 +151,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/homograph/SchemaAnnotation.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 05 Ensure clients can retrieve Extension (TPDM) blended with Core schema files for the data model
              When a GET request is made to "/metadata/xsd/tpdm/files"
              Then it should respond with 200
@@ -189,6 +194,7 @@ Feature: XSD Metadata Endpoint
                       "http://localhost:8080/metadata/xsd/tpdm/TPDM-EXTENSION-Interchange-Survey-Extension.xsd"
                     ]
                   """
+        @relational-backend
         Scenario: 06 Ensure clients can retrieve XSD content of TPDM Extension
              When a GET request is made to "/metadata/xsd/tpdm/EdFi.TPDM.ApiSchema.xsd.TPDM-EXTENSION-Interchange-Survey-Extension.xsd"
              Then it should respond with 200
@@ -226,6 +232,7 @@ Feature: XSD Metadata Endpoint
                       </xs:element>
                     </xs:schema>
                   """
+        @relational-backend
         Scenario: 07 Ensure clients can retrieve XSD content of Sample Extension
              When a GET request is made to "/metadata/xsd/sample/EdFi.Sample.ApiSchema.xsd.Sample-EXTENSION-Interchange-StudentProgram-Extension.xsd"
              Then it should respond with 200
@@ -258,6 +265,7 @@ Feature: XSD Metadata Endpoint
                     </xs:element>
                     </xs:schema>
                   """
+        @relational-backend
         Scenario: 08 Ensure clients can retrieve XSD content of Core
              When a GET request is made to "/metadata/xsd/ed-fi/EdFi.DataStandard52.ApiSchema.xsd.Interchange-Survey.xsd"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
@@ -35,6 +35,7 @@ Feature: Profile Assigned Profiles
              When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-IncludeAll" for resource "School"
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 02 Covered resource with different profile content type fails
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
              Then the profile response status is 403
@@ -86,10 +87,12 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # with no profile header, the request succeeds when exactly one assigned
         # profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 05 Covered resource with standard content type and one assigned profile
              When a GET request is made to "/ed-fi/schools" without profile header
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 06 Covered resource with one of several assigned profiles succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -105,6 +108,7 @@ Feature: Profile Assigned Profiles
              When a GET request is made to "/ed-fi/students/{id}" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student"
              Then the profile response status is 200
 
+        @relational-backend
         Scenario: 07 Covered resource with different profile content type for API client with several assigned profiles fails with incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
@@ -152,6 +156,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 10 Covered resource write with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -176,6 +181,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 11 Covered resource with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -227,6 +233,7 @@ Feature: Profile Assigned Profiles
         # Current DMS behavior follows the implicit-profile design:
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
+        @relational-backend
         Scenario: 13 Covered resource update with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
@@ -269,6 +276,7 @@ Feature: Profile Assigned Profiles
 
         # Current DMS returns incorrect-usage when the caller omits the profile
         # header and multiple assigned profiles apply to the same resource/verb.
+        @relational-backend
         Scenario: 14 Covered resource read with standard content type and multiple applicable assigned profiles returns incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -298,6 +306,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 16 Covered resource create with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -320,6 +329,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 17 Covered resource read with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -368,6 +378,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 19 Covered resource update with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-IncludeOnly" for resource "School" with body
@@ -424,16 +435,19 @@ Feature: Profile Assigned Profiles
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 03 Not-covered resource with standard content type succeeds
              When a GET request is made to "/ed-fi/students/{id}" without profile header
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
+        @relational-backend
         Scenario: 04 Not-covered resource with unassigned profile succeeds
              When a GET request is made to "/ed-fi/students/{id}" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student"
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
+        @relational-backend
         Scenario: 05 Not-covered resource write with standard content type succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
               And a profile test POST request is made to "/ed-fi/students" with
@@ -447,6 +461,7 @@ Feature: Profile Assigned Profiles
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 06 Not-covered resource write with unassigned profile succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -460,6 +475,7 @@ Feature: Profile Assigned Profiles
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 07 Not-covered resource update with standard content type succeeds
              When a PUT request is made to "/ed-fi/students/{id}" without profile header with body
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileAssignedProfiles.feature
@@ -13,6 +13,7 @@ Feature: Profile Assigned Profiles
                   | uri://ed-fi.org/GradeLevelDescriptor#Ninth grade               |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Covered resource with assigned profile content type succeeds
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
                   """
@@ -36,12 +37,14 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 200
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Covered resource with different profile content type fails
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
              Then the profile response status is 403
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Covered resource write with assigned profile content type succeeds
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
                   """
@@ -63,6 +66,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 Covered resource write with different profile content type fails
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School" with body
                   """
@@ -88,11 +92,13 @@ Feature: Profile Assigned Profiles
         # with no profile header, the request succeeds when exactly one assigned
         # profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Covered resource with standard content type and one assigned profile
              When a GET request is made to "/ed-fi/schools" without profile header
              Then the profile response status is 200
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 Covered resource with one of several assigned profiles succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -109,6 +115,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 200
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Covered resource with different profile content type for API client with several assigned profiles fails with incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "School"
@@ -116,6 +123,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 Covered resource write with one of several assigned profiles succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -133,6 +141,7 @@ Feature: Profile Assigned Profiles
         # with no profile header, the request succeeds when exactly one assigned
         # profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 Covered resource write with standard content type and one assigned profile succeeds
              When a POST request is made to "/ed-fi/schools" without profile header with body
                   """
@@ -157,6 +166,7 @@ Feature: Profile Assigned Profiles
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 Covered resource write with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -182,6 +192,7 @@ Feature: Profile Assigned Profiles
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 Covered resource with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -191,6 +202,7 @@ Feature: Profile Assigned Profiles
         # with no profile header, the request succeeds when exactly one assigned
         # profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 Covered resource update with standard content type and one assigned profile succeeds
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
                   """
@@ -234,6 +246,7 @@ Feature: Profile Assigned Profiles
         # even with multiple assigned profiles, the request succeeds when only one
         # assigned profile applies to the target resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 13 Covered resource update with standard content type and several assigned profiles succeeds when only one applies
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "Test-Profile-Resource-IncludeAll, Test-Profile-StudentOnly-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
@@ -277,6 +290,7 @@ Feature: Profile Assigned Profiles
         # Current DMS returns incorrect-usage when the caller omits the profile
         # header and multiple assigned profiles apply to the same resource/verb.
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 14 Covered resource read with standard content type and multiple applicable assigned profiles returns incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -284,6 +298,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 15 Covered resource create with standard content type and multiple applicable assigned profiles returns incorrect-usage
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -307,6 +322,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 16 Covered resource create with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" without profile header with body
@@ -330,6 +346,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 17 Covered resource read with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools" without profile header
@@ -337,6 +354,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 18 Covered resource update with standard content type and multiple applicable assigned profiles returns incorrect-usage
              When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-IncludeAll" for resource "School" with body
                   """
@@ -379,6 +397,7 @@ Feature: Profile Assigned Profiles
               And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 19 Covered resource update with standard content type and several assigned profiles returns incorrect-usage when multiple apply
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profiles "E2E-Test-School-IncludeOnly, E2E-Test-School-IncludeOnly-Alt" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-IncludeOnly" for resource "School" with body
@@ -436,18 +455,21 @@ Feature: Profile Assigned Profiles
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Not-covered resource with standard content type succeeds
              When a GET request is made to "/ed-fi/students/{id}" without profile header
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 Not-covered resource with unassigned profile succeeds
              When a GET request is made to "/ed-fi/students/{id}" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student"
              Then the profile response status is 200
               And the response body should contain fields "id, studentUniqueId, firstName, lastSurname"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Not-covered resource write with standard content type succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
               And a profile test POST request is made to "/ed-fi/students" with
@@ -462,6 +484,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 Not-covered resource write with unassigned profile succeeds
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
              When a POST request is made to "/ed-fi/students" with profile "Test-Profile-StudentOnly-Resource-IncludeAll" for resource "Student" with body
@@ -476,6 +499,7 @@ Feature: Profile Assigned Profiles
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Not-covered resource update with standard content type succeeds
              When a PUT request is made to "/ed-fi/students/{id}" without profile header with body
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
@@ -40,17 +40,20 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Collection filter includes only matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should only contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
+        @relational-backend
         Scenario: 02 Collection filter excludes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade"
 
+        @relational-backend
         Scenario: 03 Collection filter reduces item count
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -92,11 +95,13 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 04 ExcludeOnly filter excludes matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"
 
+        @relational-backend
         Scenario: 05 ExcludeOnly filter includes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
@@ -135,6 +140,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Collection filter applies to all items in query results
              When a GET request is made to "/ed-fi/schools?schoolId=99000403" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -172,6 +178,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Collection becomes empty when no items match filter
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -303,6 +310,7 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 08 IncludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -310,6 +318,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 ExcludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -317,6 +326,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 10 IncludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body
@@ -363,6 +373,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 11 ExcludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
@@ -41,12 +41,14 @@ Feature: Profile Collection Item Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Collection filter includes only matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should only contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Collection filter excludes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -54,6 +56,7 @@ Feature: Profile Collection Item Filtering
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Collection filter reduces item count
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -96,12 +99,14 @@ Feature: Profile Collection Item Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 ExcludeOnly filter excludes matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
               And the "gradeLevels" collection should not contain items where "gradeLevelDescriptor" is "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 ExcludeOnly filter includes non-matching items
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
              Then the profile response status is 200
@@ -141,6 +146,7 @@ Feature: Profile Collection Item Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 Collection filter applies to all items in query results
              When a GET request is made to "/ed-fi/schools?schoolId=99000403" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -179,6 +185,7 @@ Feature: Profile Collection Item Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Collection becomes empty when no items match filter
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
              Then the profile response status is 200
@@ -311,6 +318,7 @@ Feature: Profile Collection Item Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 IncludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -319,6 +327,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 ExcludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -327,6 +336,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 IncludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body
@@ -374,6 +384,7 @@ Feature: Profile Collection Item Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 ExcludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCreatabilityValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCreatabilityValidation.feature
@@ -13,6 +13,7 @@ Feature: Profile Creatability Validation
                   | uri://ed-fi.org/GradeLevelDescriptor#Ninth grade                      |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 POST with profile excluding required scalar field returns 400 with data-policy-enforced error
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-ExcludeRequired" for resource "School" with body
                   """
@@ -45,6 +46,7 @@ Feature: Profile Creatability Validation
                   | uri://ed-fi.org/GradeLevelDescriptor#Ninth grade                      |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 POST with IncludeOnly profile omitting required field returns 400 with data-policy-enforced error
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-IncludeOnlyMissingRequired" for resource "School" with body
                   """
@@ -77,6 +79,7 @@ Feature: Profile Creatability Validation
                   | uri://ed-fi.org/GradeLevelDescriptor#Ninth grade                      |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 POST with profile excluding required collection returns 400 with data-policy-enforced error
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-ExcludeRequiredCollection" for resource "School" with body
                   """
@@ -167,6 +170,7 @@ Feature: Profile Creatability Validation
                   | uri://ed-fi.org/GradeLevelDescriptor#Ninth grade                      |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 POST with IncludeAll profile succeeds
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-IncludeAll" for resource "School" with body
                   """
@@ -239,6 +243,7 @@ Feature: Profile Creatability Validation
                   | uri://ed-fi.org/AcademicSubjectDescriptor#English Language Arts                  |
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Profile with non-creatable child collection rule fails creation
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-Includes-Child-Collection-With-Non-Creatable-Items" for resource "School" with body
                   """
@@ -268,6 +273,7 @@ Feature: Profile Creatability Validation
              And the response body should have error type "urn:ed-fi:api:data-policy-enforced"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 Profile allows school creation when non-creatable child collection item is not supplied
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-Includes-Child-Collection-With-Non-Creatable-Items" for resource "School" with body
                   """
@@ -289,6 +295,7 @@ Feature: Profile Creatability Validation
             Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 PUT with non-creatable child collection item fails
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-Resource-Includes-Child-Collection-With-Non-Creatable-Items" for resource "School" with body
                   """
@@ -337,6 +344,7 @@ Feature: Profile Creatability Validation
              And the response body should have error type "urn:ed-fi:api:data-policy-enforced"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 Profile with non-creatable embedded object rule fails creation
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/assessments" with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" for resource "Assessment" with body
@@ -360,6 +368,7 @@ Feature: Profile Creatability Validation
              And the response body should have error type "urn:ed-fi:api:data-policy-enforced"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 Profile allows assessment creation when non-creatable embedded object is not supplied
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/assessments" with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" for resource "Assessment" with body
@@ -379,6 +388,7 @@ Feature: Profile Creatability Validation
             Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 PUT with non-creatable embedded object fails
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/assessments" with profile "Assessment-Writable-Includes-Non-Creatable-Embedded-Object" for resource "Assessment" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
@@ -42,6 +42,7 @@ Feature: Profile Definition Advanced Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 IncludeAll profile returns all populated fields and child collection members
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -77,6 +78,7 @@ Feature: Profile Definition Advanced Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 IncludeOnly profile returns only included resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -85,6 +87,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should not contain fields "shortNameOfInstitution"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 ExcludeOnly profile excludes configured resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
@@ -123,6 +126,7 @@ Feature: Profile Definition Advanced Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 IncludeOnly collection filter keeps only configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
@@ -131,6 +135,7 @@ Feature: Profile Definition Advanced Filtering
              And the "gradeLevels" collection item at index 0 should have "gradeLevelDescriptor" value "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 ExcludeOnly collection filter excludes configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelExcludeFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
@@ -216,6 +221,7 @@ Feature: Profile Definition Advanced Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 IncludeOnly profile keeps School address fields configured for School
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "School"
@@ -224,6 +230,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 IncludeOnly profile keeps LocalEducationAgency address fields configured for LocalEducationAgency
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "LocalEducationAgency"
@@ -232,6 +239,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 ExcludeOnly profile excludes LocalEducationAgency address fields configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "LocalEducationAgency"
@@ -240,6 +248,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 ExcludeOnly profile keeps School address fields not configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "School"
@@ -309,25 +318,31 @@ Feature: Profile Definition Advanced Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 IncludeAll derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 IncludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 ExcludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 13 IncludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 14 ExcludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 15 IncludeAll derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionAdvancedFiltering.feature
@@ -41,6 +41,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeAll profile returns all populated fields and child collection members
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -75,6 +76,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 02 IncludeOnly profile returns only included resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -82,6 +84,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 03 ExcludeOnly profile excludes configured resource properties
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
@@ -119,6 +122,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 04 IncludeOnly collection filter keeps only configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelFilter" for resource "School"
@@ -126,6 +130,7 @@ Feature: Profile Definition Advanced Filtering
              And the "gradeLevels" collection should have 1 item
              And the "gradeLevels" collection item at index 0 should have "gradeLevelDescriptor" value "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
 
+        @relational-backend
         Scenario: 05 ExcludeOnly collection filter excludes configured items
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-GradeLevelExcludeFilter" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-GradeLevelExcludeFilter" for resource "School"
@@ -210,6 +215,7 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 IncludeOnly profile keeps School address fields configured for School
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "School"
@@ -217,6 +223,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 07 IncludeOnly profile keeps LocalEducationAgency address fields configured for LocalEducationAgency
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-IncludeOnly" for resource "LocalEducationAgency"
@@ -224,6 +231,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 08 ExcludeOnly profile excludes LocalEducationAgency address fields configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/localEducationAgencies?localEducationAgencyId=99005007" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "LocalEducationAgency"
@@ -231,6 +239,7 @@ Feature: Profile Definition Advanced Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 ExcludeOnly profile keeps School address fields not configured for exclusion
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools?schoolId=99005006" with profile "Test-Profile-EdOrgs-Resources-Child-Collection-ExcludeOnly" for resource "School"
@@ -299,20 +308,26 @@ Feature: Profile Definition Advanced Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 10 IncludeAll derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 11 IncludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 12 ExcludeOnly derived association setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 13 IncludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 14 ExcludeOnly derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403
 
+        @relational-backend
         Scenario: 15 IncludeAll derived association write setup is currently blocked by authorization strategy
             Then it should respond with 403

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
@@ -6,6 +6,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with non-existent resource names are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Profile referencing non-existent resource is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NonExistentResource" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -35,6 +36,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with non-existent properties in IncludeOnly mode are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Profile with invalid IncludeOnly property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -64,6 +66,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with non-existent objects in IncludeOnly mode are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Profile with invalid IncludeOnly nested object is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyObject" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -93,6 +96,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with non-existent collections in IncludeOnly mode are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Profile with invalid IncludeOnly collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyCollection" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -122,6 +126,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with non-existent extension properties in IncludeOnly mode are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Profile with invalid IncludeOnly extension property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-ExtensionProperty" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
               And the system has these descriptors
@@ -151,6 +156,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with ExcludeOnly excluding identity members produce warnings but are loaded
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Profile with ExcludeOnly excluding identity member is loaded with warning
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Warning-ExcludeIdentity" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -180,6 +186,7 @@ Feature: Profile Definition Validation
     Rule: Profiles with nested invalid properties in collections are rejected
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Profile with invalid property in nested collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NestedCollectionProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileDefinitionValidation.feature
@@ -5,6 +5,7 @@ Feature: Profile Definition Validation
 
     Rule: Profiles with non-existent resource names are rejected
 
+        @relational-backend
         Scenario: 01 Profile referencing non-existent resource is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NonExistentResource" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -33,6 +34,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent properties in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 02 Profile with invalid IncludeOnly property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -61,6 +63,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent objects in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 03 Profile with invalid IncludeOnly nested object is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyObject" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -89,6 +92,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent collections in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 04 Profile with invalid IncludeOnly collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-IncludeOnlyCollection" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -117,6 +121,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with non-existent extension properties in IncludeOnly mode are rejected
 
+        @relational-backend
         Scenario: 05 Profile with invalid IncludeOnly extension property is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-ExtensionProperty" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
               And the system has these descriptors
@@ -145,6 +150,7 @@ Feature: Profile Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
     Rule: Profiles with ExcludeOnly excluding identity members produce warnings but are loaded
 
+        @relational-backend
         Scenario: 06 Profile with ExcludeOnly excluding identity member is loaded with warning
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Warning-ExcludeIdentity" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -173,6 +179,7 @@ Feature: Profile Definition Validation
               And the response body should contain fields "schoolId"
     Rule: Profiles with nested invalid properties in collections are rejected
 
+        @relational-backend
         Scenario: 07 Profile with invalid property in nested collection is not loaded
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Invalid-NestedCollectionProperty" and namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
@@ -41,11 +41,13 @@ Feature: Profile Embedded Object Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeAll profile returns nested collection data
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
              And the "addresses" collection item at index 0 should have "nameOfCounty" value "Travis"
 
+        @relational-backend
         Scenario: 02 IncludeOnly profile still returns allowed nested collection members
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -187,6 +189,7 @@ Feature: Profile Embedded Object Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 Read exclude-profile variant is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" for resource "Assessment"
@@ -194,6 +197,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 06 Read profile including embedded object is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Includes-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Includes-Embedded-Object" for resource "Assessment"
@@ -251,6 +255,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
         Scenario: 09 Data validation with invalid embedded object is rejected without profile
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileEmbeddedObjectFiltering.feature
@@ -42,12 +42,14 @@ Feature: Profile Embedded Object Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 IncludeAll profile returns nested collection data
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
              And the "addresses" collection item at index 0 should have "nameOfCounty" value "Travis"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 IncludeOnly profile still returns allowed nested collection members
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
@@ -128,6 +130,7 @@ Feature: Profile Embedded Object Filtering
              And the "addresses" collection item at index 0 should have "nameOfCounty" value "Travis"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Write profile including nested member persists nested update
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-Write-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Write-IncludeAll" for resource "School" with body
@@ -190,6 +193,7 @@ Feature: Profile Embedded Object Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Read exclude-profile variant is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Excludes-Embedded-Object-Unsupported" for resource "Assessment"
@@ -198,6 +202,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Read profile including embedded object is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Readable-Includes-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Readable-Includes-Embedded-Object" for resource "Assessment"
@@ -206,6 +211,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Write exclude-profile variant is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Excludes-Embedded-Object-Unsupported" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Writable-Excludes-Embedded-Object-Unsupported" for resource "Assessment" with body
@@ -231,6 +237,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Write profile including embedded object is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Includes-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Writable-Includes-Embedded-Object" for resource "Assessment" with body
@@ -256,6 +263,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 09 Data validation with invalid embedded object is rejected without profile
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with
@@ -279,6 +287,7 @@ Feature: Profile Embedded Object Filtering
             Then the profile response status is 400
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 10 Data validation with invalid embedded object profile is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Includes-Embedded-Object" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Writable-Includes-Embedded-Object" for resource "Assessment" with body
@@ -304,6 +313,7 @@ Feature: Profile Embedded Object Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 11 Data validation with invalid embedded object exclude-profile variant is currently unsupported by host
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Assessment-Writable-Excludes-Embedded-Object-Unsupported" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/assessments/{id}" with profile "Assessment-Writable-Excludes-Embedded-Object-Unsupported" for resource "Assessment" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
@@ -39,6 +39,7 @@ Feature: Profile Extension Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Extension IncludeOnly profile returns only specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -46,6 +47,7 @@ Feature: Profile Extension Filtering
              And the response body should not contain path "_ext.sample.cteProgramService"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Extension IncludeOnly profile preserves the isExemplary value
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -87,12 +89,14 @@ Feature: Profile Extension Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Extension ExcludeOnly profile excludes specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should not contain path "_ext.sample.isExemplary"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Extension ExcludeOnly profile includes non-excluded extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -135,6 +139,7 @@ Feature: Profile Extension Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Parent IncludeOnly profile without extension rule excludes _ext entirely
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -178,6 +183,7 @@ Feature: Profile Extension Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Parent ExcludeOnly profile without extension rule includes _ext
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -186,6 +192,7 @@ Feature: Profile Extension Filtering
               And the response body should contain path "_ext.sample.cteProgramService"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Parent ExcludeOnly profile excludes specified core properties but keeps extensions
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -221,6 +228,7 @@ Feature: Profile Extension Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Extension Not Included write profile is currently unsupported for write content type
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Sample-Staff-Extension-Not-Included" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
             When a PUT request is made to "/ed-fi/staffs/{id}" with profile "Sample-Staff-Extension-Not-Included" for resource "Staff" with body
@@ -285,6 +293,7 @@ Feature: Profile Extension Filtering
              And the response body path "_ext.sample.pets.0.isFixed" should have value "true"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 10 Extension Include-Only-Deeply write profile is currently unsupported for write content type
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Sample-Staff-Extension-Include-Only-Deeply" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
             When a PUT request is made to "/ed-fi/staffs/{id}" with profile "Sample-Staff-Extension-Include-Only-Deeply" for resource "Staff" with body
@@ -316,6 +325,7 @@ Feature: Profile Extension Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 11 Extension Exclude-Only-Deeply write profile is currently unsupported for write content type
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Sample-Staff-Extension-Exclude-Only-Deeply" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
             When a PUT request is made to "/ed-fi/staffs/{id}" with profile "Sample-Staff-Extension-Exclude-Only-Deeply" for resource "Staff" with body
@@ -347,6 +357,7 @@ Feature: Profile Extension Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 12 Extension Exclude-Everything write profile is currently unsupported for write content type
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Sample-Staff-Extension-Exclude-Everything" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
             When a PUT request is made to "/ed-fi/staffs/{id}" with profile "Sample-Staff-Extension-Exclude-Everything" for resource "Staff" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
@@ -38,12 +38,14 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Extension IncludeOnly profile returns only specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should contain path "_ext.sample.isExemplary"
              And the response body should not contain path "_ext.sample.cteProgramService"
 
+        @relational-backend
         Scenario: 02 Extension IncludeOnly profile preserves the isExemplary value
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -84,11 +86,13 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Extension ExcludeOnly profile excludes specified extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should not contain path "_ext.sample.isExemplary"
 
+        @relational-backend
         Scenario: 04 Extension ExcludeOnly profile includes non-excluded extension properties
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-Extension-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -130,6 +134,7 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 Parent IncludeOnly profile without extension rule excludes _ext entirely
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -172,6 +177,7 @@ Feature: Profile Extension Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Parent ExcludeOnly profile without extension rule includes _ext
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200
@@ -179,6 +185,7 @@ Feature: Profile Extension Filtering
               And the response body should contain path "_ext.sample.isExemplary"
               And the response body should contain path "_ext.sample.cteProgramService"
 
+        @relational-backend
         Scenario: 07 Parent ExcludeOnly profile excludes specified core properties but keeps extensions
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly-NoExtensionRule" for resource "School"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
@@ -32,6 +32,7 @@ Feature: Profile Response Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 GET by ID with IncludeOnly profile returns only included fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -39,6 +40,7 @@ Feature: Profile Response Filtering
              And the response body should not contain fields "shortNameOfInstitution, educationOrganizationCategories, gradeLevels"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 GET by ID with IncludeOnly profile preserves identity fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -73,6 +75,7 @@ Feature: Profile Response Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 GET by ID with ExcludeOnly profile excludes specified fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -80,6 +83,7 @@ Feature: Profile Response Filtering
              And the response body should contain fields "id, schoolId, nameOfInstitution"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 GET by ID with ExcludeOnly profile includes non-excluded fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -114,6 +118,7 @@ Feature: Profile Response Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 GET by ID with IncludeAll profile returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -167,6 +172,7 @@ Feature: Profile Response Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 Query with IncludeOnly profile filters all items in array
             When a GET request is made to "/ed-fi/schools?schoolId=99000104" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -202,6 +208,7 @@ Feature: Profile Response Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 07 Profiled GET and query preserve the full-resource etag
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}"
@@ -221,6 +228,7 @@ Feature: Profile Response Filtering
              And the response body path "0._etag" should equal variable "fullSchoolEtag"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 08 Profiled PUT succeeds with a profiled If-Match and returns the full-resource etag
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -254,6 +262,7 @@ Feature: Profile Response Filtering
              And the response body path "shortNameOfInstitution" should have value "PETS-UPD"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 09 Hidden field changes invalidate a stale profiled etag
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileFiltering.feature
@@ -31,12 +31,14 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 GET by ID with IncludeOnly profile returns only included fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution, educationOrganizationCategories, gradeLevels"
 
+        @relational-backend
         Scenario: 02 GET by ID with IncludeOnly profile preserves identity fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -70,12 +72,14 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 03 GET by ID with ExcludeOnly profile excludes specified fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should not contain fields "shortNameOfInstitution, webSite"
              And the response body should contain fields "id, schoolId, nameOfInstitution"
 
+        @relational-backend
         Scenario: 04 GET by ID with ExcludeOnly profile includes non-excluded fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-ExcludeOnly" for resource "School"
             Then the profile response status is 200
@@ -109,6 +113,7 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 05 GET by ID with IncludeAll profile returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeAll" for resource "School"
             Then the profile response status is 200
@@ -161,6 +166,7 @@ Feature: Profile Response Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Query with IncludeOnly profile filters all items in array
             When a GET request is made to "/ed-fi/schools?schoolId=99000104" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
@@ -31,6 +31,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Malformed profile header returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.invalid"
              Then the profile response status is 400
@@ -40,6 +41,7 @@ Feature: Profile Header Validation
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy."
               And the response body errors should match regex "(?i)The format of the profile-based content type header was invalid\."
 
+        @relational-backend
         Scenario: 02 Profile header with wrong resource name returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.student.e2e-test-school-includeonly.readable+json"
              Then the profile response status is 400
@@ -49,6 +51,7 @@ Feature: Profile Header Validation
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy."
               And the response body errors should match regex "(?i)The resource specified by the profile-based content type \('student'\) does not match the requested resource \('School'\)\."
 
+        @relational-backend
         Scenario: 03 Profile header with writable usage for GET returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.writable+json"
              Then the profile response status is 400
@@ -194,6 +197,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 08 Using profile header on app without profiles succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -228,6 +232,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Using nonexistent profile returns 406
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.nonexistent-profile.readable+json"
              Then the profile response status is 406
@@ -265,6 +270,7 @@ Feature: Profile Header Validation
                   }
                   """
 
+        @relational-backend
         Scenario: 10 Valid profile header for correct resource succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileHeaderValidation.feature
@@ -32,6 +32,7 @@ Feature: Profile Header Validation
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Malformed profile header returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.invalid"
              Then the profile response status is 400
@@ -42,6 +43,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)The format of the profile-based content type header was invalid\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Profile header with wrong resource name returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.student.e2e-test-school-includeonly.readable+json"
              Then the profile response status is 400
@@ -52,6 +54,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)The resource specified by the profile-based content type \('student'\) does not match the requested resource \('School'\)\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Profile header with writable usage for GET returns 400
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.writable+json"
              Then the profile response status is 400
@@ -62,6 +65,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)A profile-based content type that is writable cannot be used with GET requests\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 Malformed profile Content-Type header on POST returns 400
              When a POST request is made to "/ed-fi/schools" with Content-Type header "application/vnd.ed-fi.invalid" and body
                  """
@@ -88,6 +92,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)The format of the profile-based content type header was invalid\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Readable profile Content-Type on POST returns 400
              When a POST request is made to "/ed-fi/schools" with Content-Type header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json" and body
                  """
@@ -113,6 +118,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)A profile-based content type that is readable cannot be used with POST requests\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 Malformed profile Content-Type header on PUT returns 400
              When a PUT request is made to "/ed-fi/schools/{id}" with Content-Type header "application/vnd.ed-fi.invalid" and body
                  """
@@ -142,6 +148,7 @@ Feature: Profile Header Validation
               And the response body errors should match regex "(?i)The format of the profile-based content type header was invalid\."
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Readable profile Content-Type on PUT returns 400
              When a PUT request is made to "/ed-fi/schools/{id}" with Content-Type header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json" and body
                  """
@@ -198,6 +205,7 @@ Feature: Profile Header Validation
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 Using profile header on app without profiles succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -233,6 +241,7 @@ Feature: Profile Header Validation
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 Using nonexistent profile returns 406
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.nonexistent-profile.readable+json"
              Then the profile response status is 406
@@ -271,11 +280,13 @@ Feature: Profile Header Validation
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 Valid profile header for correct resource succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 Valid profile Content-Type with media-type parameters for POST succeeds
              When a POST request is made to "/ed-fi/schools" with Content-Type header "application/vnd.ed-fi.school.e2e-test-school-includeonly.writable+json; charset=utf-8" and body
                  """
@@ -297,6 +308,7 @@ Feature: Profile Header Validation
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 Valid profile Content-Type with media-type parameters for PUT succeeds
              When a PUT request is made to "/ed-fi/schools/{id}" with Content-Type header "application/vnd.ed-fi.school.e2e-test-school-includeonly.writable+json; charset=utf-8" and body
                  """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
@@ -13,6 +13,7 @@ Feature: Multi-Resource Profile Usage
                   | uri://ed-fi.org/StudentCharacteristicDescriptor#504            |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 GET on both resources included in the profile succeeds
              When a GET request is made to "/ed-fi/schools" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "School"
              Then the profile response status is 200
@@ -20,6 +21,7 @@ Feature: Multi-Resource Profile Usage
              Then the profile response status is 200
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 POST on both resources included in the profile succeeds
              When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "School" with body
                   """
@@ -47,6 +49,7 @@ Feature: Multi-Resource Profile Usage
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 GET on resource not included in the profile returns 400
              When a GET request is made to "/ed-fi/staffs" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "Staff"
              Then the profile response status is 400
@@ -55,6 +58,7 @@ Feature: Multi-Resource Profile Usage
               And the response body errors should match regex "(?i)Resource 'Staff' is not accessible through the 'e2e-test-student-and-school-includeall' profile specified by the content type\."
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 POST on resource not included in the profile returns 400
              When a POST request is made to "/ed-fi/staffs" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "Staff" with body
                   """
@@ -70,6 +74,7 @@ Feature: Multi-Resource Profile Usage
               And the response body errors should match regex "(?i)Resource 'Staff' is not accessible through the 'e2e-test-student-and-school-includeall' profile specified by the content type\."
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 05 Accept/Content-Type negotiation for all included resources
              When a GET request is made to "/ed-fi/schools" with Accept header "application/vnd.ed-fi.school.e2e-test-student-and-school-includeall.readable+json"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileMultiResourceUsage.feature
@@ -12,6 +12,7 @@ Feature: Multi-Resource Profile Usage
                   | uri://ed-fi.org/GradeLevelDescriptor#Tenth grade               |
                   | uri://ed-fi.org/StudentCharacteristicDescriptor#504            |
 
+        @relational-backend
         Scenario: 01 GET on both resources included in the profile succeeds
              When a GET request is made to "/ed-fi/schools" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "School"
              Then the profile response status is 200
@@ -45,6 +46,7 @@ Feature: Multi-Resource Profile Usage
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: 03 GET on resource not included in the profile returns 400
              When a GET request is made to "/ed-fi/staffs" with profile "E2E-Test-Student-And-School-IncludeAll" for resource "Staff"
              Then the profile response status is 400
@@ -67,6 +69,7 @@ Feature: Multi-Resource Profile Usage
               And the response body should have detail "The request construction was invalid with respect to usage of a data policy. The resource is not contained by the profile used by (or applied to) the request."
               And the response body errors should match regex "(?i)Resource 'Staff' is not accessible through the 'e2e-test-student-and-school-includeall' profile specified by the content type\."
 
+        @relational-backend
         Scenario: 05 Accept/Content-Type negotiation for all included resources
              When a GET request is made to "/ed-fi/schools" with Accept header "application/vnd.ed-fi.school.e2e-test-student-and-school-includeall.readable+json"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
@@ -6,6 +6,7 @@ Feature: Profile OpenAPI Specification Filtering
         Background:
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 Profile OpenAPI spec includes only covered resources
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -16,12 +17,14 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec should contain tag "Schools"
               And the OpenAPI spec should not contain tag "Students"
 
+        @relational-backend
         Scenario: 02 Profile OpenAPI spec includes readable and writable schemas
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
               And the OpenAPI spec should contain schema "edFi_school_readable"
               And the OpenAPI spec should contain schema "edFi_school_writable"
 
+        @relational-backend
         Scenario: 03 Profile OpenAPI spec filters operations correctly
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -31,10 +34,12 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec path "/ed-fi/schools/{id}" should have operation "put"
               And the OpenAPI spec path "/ed-fi/schools/{id}" should have operation "delete"
 
+        @relational-backend
         Scenario: 04 Non-existent profile returns 404
              When a GET request is made to "/metadata/specifications/profiles/NonExistentProfile/resources-spec.json"
              Then the profile response status is 404
 
+        @relational-backend
         Scenario: 05 Metadata specifications list includes profile entries
              When a GET request is made to "/metadata/specifications"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileOpenApiSpecification.feature
@@ -7,6 +7,7 @@ Feature: Profile OpenAPI Specification Filtering
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Profile OpenAPI spec includes only covered resources
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -18,6 +19,7 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec should not contain tag "Students"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Profile OpenAPI spec includes readable and writable schemas
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -25,6 +27,7 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec should contain schema "edFi_school_writable"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Profile OpenAPI spec filters operations correctly
              When a GET request is made to "/metadata/specifications/profiles/E2E-Test-School-IncludeOnly/resources-spec.json"
              Then the profile response status is 200
@@ -35,11 +38,13 @@ Feature: Profile OpenAPI Specification Filtering
               And the OpenAPI spec path "/ed-fi/schools/{id}" should have operation "delete"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Non-existent profile returns 404
              When a GET request is made to "/metadata/specifications/profiles/NonExistentProfile/resources-spec.json"
              Then the profile response status is 404
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 05 Metadata specifications list includes profile entries
              When a GET request is made to "/metadata/specifications"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfilePutMerge.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfilePutMerge.feature
@@ -100,6 +100,7 @@ Feature: Profile PUT Merge Functionality
                   | uri://ed-fi.org/GradeLevelDescriptor#Eleventh grade                   |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 PUT with collection item filter preserves filtered-out items from existing document
             # First create the school with all grade levels using IncludeAll profile (all ARE saved)
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-IncludeAll" for resource "School" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
@@ -58,6 +58,7 @@ Feature: Profile Reference Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 IncludeOnly reference profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-IncludeOnly" for resource "School"
@@ -120,6 +121,7 @@ Feature: Profile Reference Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 ExcludeOnly profile excludes configured reference properties on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-ExcludeOnly" for resource "School"
@@ -182,6 +184,7 @@ Feature: Profile Reference Filtering
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 IncludeOnly reference write profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-IncludeOnly" for resource "School" with body
@@ -217,6 +220,7 @@ Feature: Profile Reference Filtering
              And the response body should have error message "is not supported by this host"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 ExcludeOnly reference write profile excludes configured reference members
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-ExcludeOnly" for resource "School" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileReferenceFiltering.feature
@@ -57,6 +57,7 @@ Feature: Profile Reference Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 01 IncludeOnly reference profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-IncludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-IncludeOnly" for resource "School"
@@ -118,6 +119,7 @@ Feature: Profile Reference Filtering
                   }
                   """
 
+        @relational-backend
         Scenario: 02 ExcludeOnly profile excludes configured reference properties on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-References-ExcludeOnly" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with profile "Test-Profile-Resource-References-ExcludeOnly" for resource "School"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
@@ -32,6 +32,7 @@ Feature: Profile Resolution
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Single profile without Accept header applies implicitly
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200
@@ -39,6 +40,7 @@ Feature: Profile Resolution
              And the response body should not contain fields "shortNameOfInstitution"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 Single profile can also be applied explicitly with Accept header
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -73,12 +75,14 @@ Feature: Profile Resolution
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 Multiple profiles without Accept header returns 403
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 403
              And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Multiple profiles with explicit Accept header for first profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -86,6 +90,7 @@ Feature: Profile Resolution
              And the response body should not contain fields "shortNameOfInstitution"
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 Multiple profiles with explicit Accept header for second profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-Alt" for resource "School"
             Then the profile response status is 200
@@ -121,6 +126,7 @@ Feature: Profile Resolution
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 No profile assigned returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResolution.feature
@@ -31,12 +31,14 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 01 Single profile without Accept header applies implicitly
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 02 Single profile can also be applied explicitly with Accept header
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
@@ -70,17 +72,20 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 03 Multiple profiles without Accept header returns 403
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 403
              And the response body should have error type "urn:ed-fi:api:security:data-policy:incorrect-usage"
 
+        @relational-backend
         Scenario: 04 Multiple profiles with explicit Accept header for first profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
             Then the profile response status is 200
              And the response body should only contain fields "id, schoolId, nameOfInstitution, webSite"
              And the response body should not contain fields "shortNameOfInstitution"
 
+        @relational-backend
         Scenario: 05 Multiple profiles with explicit Accept header for second profile succeeds
             When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly-Alt" for resource "School"
             Then the profile response status is 200
@@ -115,6 +120,7 @@ Feature: Profile Resolution
                   }
                   """
 
+        @relational-backend
         Scenario: 06 No profile assigned returns all fields
             When a GET request is made to "/ed-fi/schools/{id}" without profile header
             Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
@@ -32,6 +32,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 GET collection with profile returns profile content type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -43,6 +44,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 02 GET item by id with profile returns profile content type
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -54,6 +56,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 03 GET with explicit profile returns content type including profile and readable suffix
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -65,6 +68,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 GET collection with explicit profile returns profile-specific media type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -76,6 +80,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 05 GET item by id with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; charset=utf-8"
              Then the profile response status is 200
@@ -87,6 +92,7 @@ Feature: Profile Response Content Types
                   """
 
         @relational-backend
+        @relational-ci-shard-2
         Scenario: 06 GET collection with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; q=1.0"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileResponseContentTypes.feature
@@ -31,6 +31,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 01 GET collection with profile returns profile content type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -41,6 +42,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 02 GET item by id with profile returns profile content type
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -51,6 +53,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 03 GET with explicit profile returns content type including profile and readable suffix
              When a GET request is made to "/ed-fi/schools/{id}" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -61,6 +64,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 04 GET collection with explicit profile returns profile-specific media type
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with profile "E2E-Test-School-IncludeOnly" for resource "School"
              Then the profile response status is 200
@@ -71,6 +75,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 05 GET item by id with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; charset=utf-8"
              Then the profile response status is 200
@@ -81,6 +86,7 @@ Feature: Profile Response Content Types
                   }
                   """
 
+        @relational-backend
         Scenario: 06 GET collection with profile Accept header and media-type parameters succeeds
              When a GET request is made to "/ed-fi/schools?schoolId=99002001" with Accept header "application/vnd.ed-fi.school.e2e-test-school-includeonly.readable+json; q=1.0"
              Then the profile response status is 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
@@ -30,12 +30,14 @@ Feature: Profile Undefined and Misconfigured Usage
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 GET with undefined profile returns 406
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.profile-does-not-exist.readable+json"
             Then the profile response status is 406
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 02 POST with undefined profile returns 415
             When a POST request is made to "/ed-fi/schools" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -58,6 +60,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 03 PUT with undefined profile returns 415
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -110,6 +113,7 @@ Feature: Profile Undefined and Misconfigured Usage
                   """
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 04 GET with misconfigured resource profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.test-profile-with-unexisting-resource.readable+json"
@@ -117,6 +121,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body status should equal the response status code
 
+        @relational-backend
         Scenario: 05 POST with misconfigured property profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-With-Unexisting-Property" for resource "School" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileUndefinedAndMisconfiguredUsage.feature
@@ -31,6 +31,7 @@ Feature: Profile Undefined and Misconfigured Usage
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 GET with undefined profile returns 406
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.profile-does-not-exist.readable+json"
             Then the profile response status is 406
@@ -38,6 +39,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body status should equal the response status code
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 POST with undefined profile returns 415
             When a POST request is made to "/ed-fi/schools" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -61,6 +63,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body status should equal the response status code
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 PUT with undefined profile returns 415
             When a PUT request is made to "/ed-fi/schools/{id}" with profile "Profile-Does-Not-Exist" for resource "School" with body
                   """
@@ -114,6 +117,7 @@ Feature: Profile Undefined and Misconfigured Usage
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "E2E-Test-School-IncludeAll" and namespacePrefixes "uri://ed-fi.org"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 GET with misconfigured resource profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/schools/{id}" with Accept header "application/vnd.ed-fi.school.test-profile-with-unexisting-resource.readable+json"
@@ -122,6 +126,7 @@ Feature: Profile Undefined and Misconfigured Usage
              And the response body status should equal the response status code
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 05 POST with misconfigured property profile returns 406
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
             When a POST request is made to "/ed-fi/schools" with profile "Test-Profile-With-Unexisting-Property" for resource "School" with body

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileWriteFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileWriteFiltering.feature
@@ -98,6 +98,7 @@ Feature: Profile Write Filtering
              And the response body should not contain fields "webSite, shortNameOfInstitution"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 POST with ExcludeOnly write profile preserves non-excluded fields
             When a POST request is made to "/ed-fi/schools" with profile "E2E-Test-School-Write-ExcludeOnly" for resource "School" with body
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
@@ -6,6 +6,7 @@ Feature: Profile XML File Definition Validation
     Rule: Profiles loaded from XML files behave consistently with invalid definitions
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Profile with non-existent resource from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -35,6 +36,7 @@ Feature: Profile XML File Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Profile with non-existent property from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
@@ -64,6 +66,7 @@ Feature: Profile XML File Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Profile with non-existent resource from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -92,6 +95,7 @@ Feature: Profile XML File Definition Validation
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Profile with non-existent property from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileDefinitionValidation.feature
@@ -5,6 +5,7 @@ Feature: Profile XML File Definition Validation
 
     Rule: Profiles loaded from XML files behave consistently with invalid definitions
 
+        @relational-backend
         Scenario: 01 Profile with non-existent resource from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -33,6 +34,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 406
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 02 Profile with non-existent property from XML file is rejected on use
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"
@@ -61,6 +63,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 406
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 03 Profile with non-existent resource from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Resource" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Resource" and namespacePrefixes "uri://ed-fi.org"
@@ -88,6 +91,7 @@ Feature: Profile XML File Definition Validation
              Then the profile response status is 415
               And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
 
+        @relational-backend
         Scenario: 04 Profile with non-existent property from XML file is rejected on write
             Given a profile "Test-Profile-With-Unexisting-Property" is created from XML file "Profiles/TestXmls/InvalidProfiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-With-Unexisting-Property" and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
@@ -6,6 +6,7 @@ Feature: Profile XML File Method Usage
     Rule: Assigned profiles that do not support the method fall back to standard behavior
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: Read-only assigned profile does not block standard POST without profile header
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-ReadOnly" and namespacePrefixes "uri://ed-fi.org"
@@ -33,6 +34,7 @@ Feature: Profile XML File Method Usage
              Then the profile response status is 201
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: Write-only assigned profile does not block standard GET without profile header
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -64,6 +66,7 @@ Feature: Profile XML File Method Usage
     Rule: Read-only profile allows GET and rejects POST
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Read-only profile allows GET and rejects POST
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -141,6 +144,7 @@ Feature: Profile XML File Method Usage
     Rule: Write-only profile rejects GET
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 Write-only profile rejects GET
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileXmlFileMethodUsage.feature
@@ -5,6 +5,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Assigned profiles that do not support the method fall back to standard behavior
 
+        @relational-backend
         Scenario: Read-only assigned profile does not block standard POST without profile header
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-ReadOnly" and namespacePrefixes "uri://ed-fi.org"
@@ -31,6 +32,7 @@ Feature: Profile XML File Method Usage
                   """
              Then the profile response status is 201
 
+        @relational-backend
         Scenario: Write-only assigned profile does not block standard GET without profile header
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -61,6 +63,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Read-only profile allows GET and rejects POST
 
+        @relational-backend
         Scenario: 01 Read-only profile allows GET and rejects POST
             Given a profile "Test-Profile-Resource-ReadOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"
@@ -137,6 +140,7 @@ Feature: Profile XML File Method Usage
 
     Rule: Write-only profile rejects GET
 
+        @relational-backend
         Scenario: 02 Write-only profile rejects GET
             Given a profile "Test-Profile-Resource-WriteOnly" is created from XML file "Profiles/TestXmls/Profiles.xml"
               And the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized without profiles and namespacePrefixes "uri://ed-fi.org"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
@@ -4,6 +4,7 @@ Feature: Validate array uniqueness
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Can create addresses on studentEducationOrganizationAssociations differing only in address type
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -52,6 +53,7 @@ Feature: Validate array uniqueness
              Then it should respond with 201 or 200
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Cannot create addresses on studentEducationOrganizationAssociations with no difference in type-city-street-postalcode
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -127,6 +129,7 @@ Feature: Validate array uniqueness
                   | uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer            |
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Can create an assessment with unique performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -167,6 +170,7 @@ Feature: Validate array uniqueness
              Then it should respond with 201 or 200
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Cannot create assessment with duplicate performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -224,6 +228,7 @@ Feature: Validate array uniqueness
 
     Rule: Uniqueness of array of document references
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Cannot create a bellschedule with a duplicate classPeriodReference in classPeriods array
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -282,6 +287,7 @@ Feature: Validate array uniqueness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 Verify clients cannot create a resource with a duplicate descriptor
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -535,6 +541,7 @@ Feature: Validate array uniqueness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 07 Can create studentAssessments with multiple unique assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -609,6 +616,7 @@ Feature: Validate array uniqueness
              Then it should respond with 201 or 200
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Cannot create studentAssessments with duplicate assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -708,6 +716,7 @@ Feature: Validate array uniqueness
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 09 Can create requiredImmunizations on studentHealths with same dates in different requiredImmunizations
              When a POST request is made to "/ed-fi/studentHealths" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/ArrayUniquenessValidation.feature
@@ -3,6 +3,7 @@ Feature: Validate array uniqueness
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
+        @relational-backend
         Scenario: 01 Can create addresses on studentEducationOrganizationAssociations differing only in address type
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -50,6 +51,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 02 Cannot create addresses on studentEducationOrganizationAssociations with no difference in type-city-street-postalcode
             Given the system has these descriptors
                   | descriptorValue                                                |
@@ -124,6 +126,7 @@ Feature: Validate array uniqueness
                   | uri://ed-fi.org/AssessmentReportingMethodDescriptor#Raw score   |
                   | uri://ed-fi.org/ResultDatatypeTypeDescriptor#Integer            |
 
+        @relational-backend
         Scenario: 03 Can create an assessment with unique performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -163,6 +166,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 04 Cannot create assessment with duplicate performanceLevels performanceLevelDescriptor+assessmentReportingMethodDescriptor
 
              When a POST request is made to "/ed-fi/assessments" with
@@ -219,6 +223,7 @@ Feature: Validate array uniqueness
                   """
 
     Rule: Uniqueness of array of document references
+        @relational-backend
         Scenario: 05 Cannot create a bellschedule with a duplicate classPeriodReference in classPeriods array
              When a POST request is made to "/ed-fi/bellschedules" with
                   """
@@ -276,6 +281,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 06 Verify clients cannot create a resource with a duplicate descriptor
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -528,6 +534,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 07 Can create studentAssessments with multiple unique assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -601,6 +608,7 @@ Feature: Validate array uniqueness
                   """
              Then it should respond with 201 or 200
 
+        @relational-backend
         Scenario: 08 Cannot create studentAssessments with duplicate assessmentItems including references
              When a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -699,6 +707,7 @@ Feature: Validate array uniqueness
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Can create requiredImmunizations on studentHealths with same dates in different requiredImmunizations
              When a POST request is made to "/ed-fi/studentHealths" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
@@ -18,6 +18,7 @@ Feature: Create Reference Validation
                   | 123      | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
 
         @API-079
+        @relational-backend
         Scenario: 01 Ensure clients cannot create a resource with a non existing reference
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -51,6 +52,7 @@ Feature: Create Reference Validation
               And it should respond with 409
 
         @API-080
+        @relational-backend
         Scenario: 02 Ensure clients cannot create a resource with correct information but an invalid value belonging to the reference
              When a POST request is made to "/ed-fi/studentCTEProgramAssociations" with
                   """
@@ -92,6 +94,7 @@ Feature: Create Reference Validation
               And it should respond with 409
 
         @API-081
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a resource using a reference that is out of range of the existing values
              When a POST request is made to "/ed-fi/graduationPlans" with
                   """
@@ -125,6 +128,7 @@ Feature: Create Reference Validation
                   """
 
         @API-082
+        @relational-backend
         Scenario: 04 Ensure clients cannot create a resource using an invalid reference inside of another reference
             Given the system has these "students"
                   | studentUniqueId | firstName | lastSurname | birthDate    |
@@ -164,6 +168,7 @@ Feature: Create Reference Validation
                   """
 
         @API-083
+        @relational-backend
         Scenario: 05 Verify clients cannot update a resource with a bad academicWeeks reference
             Given the system has these "AcademicWeeks" references
                   | weekIdentifier | nameOfInstitution | schoolReference   | beginDate    | endDate      | totalInstructionalDays |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/CreateReferenceValidation.feature
@@ -19,6 +19,7 @@ Feature: Create Reference Validation
 
         @API-079
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients cannot create a resource with a non existing reference
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -53,6 +54,7 @@ Feature: Create Reference Validation
 
         @API-080
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients cannot create a resource with correct information but an invalid value belonging to the reference
              When a POST request is made to "/ed-fi/studentCTEProgramAssociations" with
                   """
@@ -95,6 +97,7 @@ Feature: Create Reference Validation
 
         @API-081
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients cannot create a resource using a reference that is out of range of the existing values
              When a POST request is made to "/ed-fi/graduationPlans" with
                   """
@@ -129,6 +132,7 @@ Feature: Create Reference Validation
 
         @API-082
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients cannot create a resource using an invalid reference inside of another reference
             Given the system has these "students"
                   | studentUniqueId | firstName | lastSurname | birthDate    |
@@ -169,6 +173,7 @@ Feature: Create Reference Validation
 
         @API-083
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Verify clients cannot update a resource with a bad academicWeeks reference
             Given the system has these "AcademicWeeks" references
                   | weekIdentifier | nameOfInstitution | schoolReference   | beginDate    | endDate      | totalInstructionalDays |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DeleteReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DeleteReferenceValidation.feature
@@ -12,6 +12,7 @@ Feature: Delete reference validation
                   | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#First grade"} ] | 255901107 | Grand Bend Elementary School |
 
         @API-084 @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients cannot delete a year that is used by another item
             Given the system has these "schoolYearTypes" references
                   | schoolYear | currentSchoolYear | schoolYearDescription |
@@ -35,6 +36,7 @@ Feature: Delete reference validation
                   """
 
         @API-085 @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients cannot delete a descriptor that is used by another item
             Given a POST request is made to "ed-fi/educationOrganizationCategoryDescriptors/" with
                   """
@@ -60,6 +62,7 @@ Feature: Delete reference validation
                   """
 
         @API-086 @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients cannot delete a dependent element for an item
             Given the system has these "students" references
                   | studentUniqueId | birthDate    | firstName | lastSurname |
@@ -83,6 +86,7 @@ Feature: Delete reference validation
                   """
 
         @API-087 @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients cannot delete an element that is reference to an Education Organization that is used by another items
             Given the system has these "localEducationAgencies" references
                   | localEducationAgencyCategoryDescriptor                        | localEducationAgencyId | categories                                                                                                                  | nameOfInstitution |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
@@ -17,6 +17,7 @@ Feature: Validate the reference of descriptors when creating resources
                   | 255901001 | Test school       | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#school"} ] |
 
         @API-089
+        @relational-backend
         Scenario: 01 User can not create a resource when descriptor doesn't exist
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -53,6 +54,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-090
+        @relational-backend
         Scenario: 02 User can not upsert a resource using a descriptor that does not exist
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -83,6 +85,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-091
+        @relational-backend
         Scenario: 03 User can not update a resource using a descriptor that does not exist
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -133,6 +136,7 @@ Feature: Validate the reference of descriptors when creating resources
                   """
 
         @API-092
+        @relational-backend
         Scenario: 04 User can create a resource when descriptor exists
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -150,6 +154,7 @@ Feature: Validate the reference of descriptors when creating resources
              Then it should respond with 201 or 200
 
         @API-093
+        @relational-backend
         Scenario: 05 User can update a resource when descriptor exists
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -181,6 +186,7 @@ Feature: Validate the reference of descriptors when creating resources
              Then it should respond with 204
 
         @API-094
+        @relational-backend
         Scenario: 06 User receives 400 instead of 409 error when both descriptor and reference are invalid
              When a POST request is made to "/ed-fi/studentProgramAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/DescriptorReferenceValidation.feature
@@ -18,6 +18,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-089
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 User can not create a resource when descriptor doesn't exist
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -55,6 +56,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-090
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 User can not upsert a resource using a descriptor that does not exist
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -86,6 +88,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-091
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 User can not update a resource using a descriptor that does not exist
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -137,6 +140,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-092
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 User can create a resource when descriptor exists
              When a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -155,6 +159,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-093
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 User can update a resource when descriptor exists
             Given a POST request is made to "/ed-fi/localEducationAgencies" with
                   """
@@ -187,6 +192,7 @@ Feature: Validate the reference of descriptors when creating resources
 
         @API-094
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 User receives 400 instead of 409 error when both descriptor and reference are invalid
              When a POST request is made to "/ed-fi/studentProgramAssociations" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
@@ -23,6 +23,7 @@ Feature: StudentAssessmentRegistrationBatteryPartAssociation References
 Rule: Two StudentAssessmentRegistrationBatteryPartAssociation can be created only differing in AssigningEducationOrganizationId
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Create two StudentAssessmentRegistrationBatteryPartAssociation with only different AssigningEducationOrganizationIds
 
              When a POST request is made to "/ed-fi/studentEducationOrganizationAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/StudentAssessmentRegistrationBatteryPartAssociation.feature
@@ -22,6 +22,7 @@ Feature: StudentAssessmentRegistrationBatteryPartAssociation References
 
 Rule: Two StudentAssessmentRegistrationBatteryPartAssociation can be created only differing in AssigningEducationOrganizationId
 
+        @relational-backend
         Scenario: 01 Create two StudentAssessmentRegistrationBatteryPartAssociation with only different AssigningEducationOrganizationIds
 
              When a POST request is made to "/ed-fi/studentEducationOrganizationAssociations" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
@@ -18,6 +18,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
         @API-104
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients can create a Program that references an existing School
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -34,6 +35,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
         @API-105
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients can create a Program that references an existing Local Education Agency
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -49,6 +51,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
         @API-106
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients cannot create a Program that references a non-existing Education Organization
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -80,6 +83,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
         @API-107
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients can update a school that references to an existing local education agency
             Given the system has these "Schools" references
                   | schoolId | nameOfInstitution | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |
@@ -113,6 +117,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
         @API-108
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Ensure clients cannot update a school that references to an existing Local Agency so it references now a Non Existing Education Organization
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | localEducationAgencyReference  | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
@@ -17,6 +17,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-104
+        @relational-backend
         Scenario: 01 Ensure clients can create a Program that references an existing School
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -32,6 +33,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-105
+        @relational-backend
         Scenario: 02 Ensure clients can create a Program that references an existing Local Education Agency
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -46,6 +48,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
              Then it should respond with 201 or 200
 
         @API-106
+        @relational-backend
         Scenario: 03 Ensure clients cannot create a Program that references a non-existing Education Organization
              When a POST request is made to "/ed-fi/programs" with
                   """
@@ -76,6 +79,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
                   """
 
         @API-107
+        @relational-backend
         Scenario: 04 Ensure clients can update a school that references to an existing local education agency
             Given the system has these "Schools" references
                   | schoolId | nameOfInstitution | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |
@@ -108,6 +112,7 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
 
 
         @API-108
+        @relational-backend
         Scenario: 05 Ensure clients cannot update a school that references to an existing Local Agency so it references now a Non Existing Education Organization
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | localEducationAgencyReference  | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -52,6 +52,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-121
+        @relational-backend
         Scenario: 02 Ensure clients can get information when filtering by limit and offset greater than the total
              When a GET request is made to "/ed-fi/schools?offset=600&limit=5"
              Then it should respond with 200
@@ -61,6 +62,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-122
+        @relational-backend
         Scenario: 03 Ensure clients can GET information when querying using an offset without providing any limit in the query string
              When a GET request is made to "/ed-fi/schools?offset=4"
              Then it should respond with 200
@@ -86,6 +88,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-123
+        @relational-backend
         Scenario: 04 Ensure clients can GET information when filtering with limits and properties
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=School+5&limit=2"
              Then it should respond with 200
@@ -111,6 +114,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-147
+        @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -137,6 +141,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
+        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -114,7 +114,6 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-147
-        @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -141,7 +140,6 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
-        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -113,7 +113,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                     ]
                   """
 
-        @API-147
+        @API-147 @relational-backend
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -140,6 +140,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '0)'                     |
                   | '1%27'                   |
 
+        @relational-backend
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -12,6 +12,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | 5        | School 5          | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Postsecondary"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Educator Preparation Provider"} ] |
 
         @API-120 @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients can get information when filtering by limit and and a valid offset
              When a GET request is made to "/ed-fi/schools?offset=3&limit=2"
              Then it should respond with 200
@@ -53,6 +54,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
 
         @API-121
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients can get information when filtering by limit and offset greater than the total
              When a GET request is made to "/ed-fi/schools?offset=600&limit=5"
              Then it should respond with 200
@@ -63,6 +65,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
 
         @API-122
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients can GET information when querying using an offset without providing any limit in the query string
              When a GET request is made to "/ed-fi/schools?offset=4"
              Then it should respond with 200
@@ -89,6 +92,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
 
         @API-123
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients can GET information when filtering with limits and properties
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=School+5&limit=2"
              Then it should respond with 200
@@ -114,6 +118,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   """
 
         @API-147 @relational-backend
+        @relational-ci-shard-4
         Scenario Outline: 12 Ensure clients can not GET information when filtering by limit and offset using invalid values
             # Some of these are "SQL Injection" style attacks
              When a GET request is made to "/ed-fi/schools?offset=<value>"
@@ -141,6 +146,7 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | '1%27'                   |
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario Outline: 13 Ensure clients can not GET information when filtering by out of tange limit values
              When a GET request is made to "/ed-fi/schools?offset=0&limit=<value>"
              Then it should respond with 400

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -20,6 +20,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
         @API-124 @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -38,6 +39,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-124 @relational-backend
+        @relational-ci-shard-4
         Scenario: 01.1 Ensure clients can GET information when querying by valid datetime ignoring time
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15T17:30:00.000000Z"
              Then it should respond with 200
@@ -56,6 +58,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-125 @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -75,6 +78,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-126 @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -94,6 +98,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-127 @relational-backend
+        @relational-ci-shard-4
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -103,6 +108,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-128 @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -112,6 +118,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-129 @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 Ensure clients can GET information when querying by string parameter
              When a GET request is made to "/ed-fi/academicWeeks?weekIdentifier=Week+One"
              Then it should respond with 200
@@ -130,6 +137,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-130 @relational-backend
+        @relational-ci-shard-4
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -148,6 +156,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-131 @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Ensure clients can GET information when querying with mixed case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIdentifier=Week+One"
              Then it should respond with 200
@@ -166,6 +175,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-132 @relational-backend
+        @relational-ci-shard-4
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -184,6 +194,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-133 @relational-backend
+        @relational-ci-shard-4
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -240,6 +251,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -249,6 +261,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -271,6 +284,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -304,6 +318,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """
@@ -326,6 +341,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 17 Ensure clients can GET information when querying by value in a document reference
              When a GET request is made to "/ed-fi/academicWeeks?schoolId=2"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -20,7 +20,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
         @API-124
-        @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -57,7 +56,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-125
-        @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -77,7 +75,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-126
-        @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -97,7 +94,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-127
-        @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -107,7 +103,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-128
-        @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -135,7 +130,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-130
-        @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -172,7 +166,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-132
-        @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -191,7 +184,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-133
-        @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -247,7 +239,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -256,7 +247,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -278,7 +268,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
-        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -311,7 +300,6 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
-        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -20,6 +20,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
         @API-124
+        @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -56,6 +57,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-125
+        @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -75,6 +77,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-126
+        @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -94,6 +97,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-127
+        @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -103,6 +107,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-128
+        @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -130,6 +135,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-130
+        @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -166,6 +172,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-132
+        @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -184,6 +191,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   """
 
         @API-133
+        @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -239,6 +247,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -247,6 +256,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
+        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -268,6 +278,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -300,6 +311,7 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
+        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -19,7 +19,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   | studentReference                | assessmentReference                                                                              | administrationDate     | studentAssessmentIdentifier |
                   | { "studentUniqueId": "unique" } | {"assessmentIdentifier": "01774fa3-06f1-47fe-8801-c8b1e65057f2", "namespace": "Assessment.xml" } | "2021-09-28T00:10:00Z" | studentAssessmentIdentifier |
 
-        @API-124
+        @API-124 @relational-backend
         Scenario: 01 Ensure clients can GET information when querying by valid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15"
              Then it should respond with 200
@@ -55,7 +55,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-125
+        @API-125 @relational-backend
         Scenario: 02 Ensure clients can't GET information when querying by invalid date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=099-99-09"
              Then it should respond with 400
@@ -74,7 +74,7 @@ Feature: Query String handling for GET requests for Resource Queries
                    }
                   """
 
-        @API-126
+        @API-126 @relational-backend
         Scenario: 03 Ensure clients can't GET information when querying by a word
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=word"
              Then it should respond with 400
@@ -93,7 +93,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }
                   """
 
-        @API-127
+        @API-127 @relational-backend
         Scenario: 04 Ensure clients can't GET information when querying by wrong begin date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=1970-04-09"
              Then it should respond with 200
@@ -102,7 +102,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-128
+        @API-128 @relational-backend
         Scenario: 05 Ensure clients can't GET information when querying by correct begin date and wrong end date
              When a GET request is made to "/ed-fi/academicWeeks?beginDate=2024-05-15&endDate=2025-06-23"
              Then it should respond with 200
@@ -111,7 +111,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-129
+        @API-129 @relational-backend
         Scenario: 06 Ensure clients can GET information when querying by string parameter
              When a GET request is made to "/ed-fi/academicWeeks?weekIdentifier=Week+One"
              Then it should respond with 200
@@ -129,7 +129,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-130
+        @API-130 @relational-backend
         Scenario: 07 Ensure clients can GET information when querying by integer parameter
              When a GET request is made to "/ed-fi/academicWeeks?totalInstructionalDays=2"
              Then it should respond with 200
@@ -147,7 +147,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-131
+        @API-131 @relational-backend
         Scenario: 08 Ensure clients can GET information when querying with mixed case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIdentifier=Week+One"
              Then it should respond with 200
@@ -165,7 +165,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-132
+        @API-132 @relational-backend
         Scenario: 09 Ensure clients can GET information when querying with lower case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?weekidentifier=Week+One"
              Then it should respond with 200
@@ -183,7 +183,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-133
+        @API-133 @relational-backend
         Scenario: 10 Ensure clients can GET information when querying with upper case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIDENTIFIER=Week+One"
              Then it should respond with 200
@@ -239,6 +239,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 13 Ensure clients get empty array when querying datetime with no time component and no midnight match
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28"
              Then it should respond with 200
@@ -247,6 +248,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
+        @relational-backend
         Scenario: 14 Ensure clients get correct results when querying datetime with time component
              When a GET request is made to "/ed-fi/studentAssessments?administrationDate=2021-09-28T00:10:00Z"
              Then it should respond with 200
@@ -268,6 +270,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   ]
                   """
 
+        @relational-backend
         Scenario: 15 Ensure clients get midnight results when querying without a time component
             Given a POST request is made to "/ed-fi/studentAssessments" with
                   """
@@ -300,6 +303,7 @@ Feature: Query String handling for GET requests for Resource Queries
                     }]
                   """
 
+        @relational-backend
         Scenario: 16 Ensure clients get results when querying boolean with capitalized values
             Given a POST request is made to "/ed-fi/schoolYearTypes" with
                   """
@@ -321,6 +325,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
+        @relational-backend
         Scenario: 17 Ensure clients can GET information when querying by value in a document reference
              When a GET request is made to "/ed-fi/academicWeeks?schoolId=2"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/ResourceQueriesQueryString.feature
@@ -111,7 +111,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   []
                   """
 
-        @API-129 @relational-backend
+        @API-129
         Scenario: 06 Ensure clients can GET information when querying by string parameter
              When a GET request is made to "/ed-fi/academicWeeks?weekIdentifier=Week+One"
              Then it should respond with 200
@@ -147,7 +147,7 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @API-131 @relational-backend
+        @API-131
         Scenario: 08 Ensure clients can GET information when querying with mixed case parameter name
              When a GET request is made to "/ed-fi/academicWeeks?WEEKIdentifier=Week+One"
              Then it should respond with 200
@@ -321,7 +321,6 @@ Feature: Query String handling for GET requests for Resource Queries
                   }]
                   """
 
-        @relational-backend
         Scenario: 17 Ensure clients can GET information when querying by value in a document reference
              When a GET request is made to "/ed-fi/academicWeeks?schoolId=2"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -11,6 +11,7 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @API-136 @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -22,18 +23,21 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-137 @relational-backend
+        @relational-ci-shard-4
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-138 @relational-backend
+        @relational-ci-shard-4
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-140 @relational-backend
+        @relational-ci-shard-4
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -45,18 +49,21 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-141 @relational-backend
+        @relational-ci-shard-4
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-142 @relational-backend
+        @relational-ci-shard-4
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-143 @relational-backend
+        @relational-ci-shard-4
         Scenario: 08 Ensure results can be limited and totalCount matches the actual number of existing records
              When a GET request is made to "/ed-fi/schools?totalCount=true&limit=2"
              Then getting less schools than the total-count

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -11,7 +11,6 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @API-136
-        @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -23,21 +22,18 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-137
-        @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-138
-        @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-140
-        @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -49,14 +45,12 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-141
-        @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-142
-        @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -11,6 +11,7 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @API-136
+        @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -22,18 +23,21 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-137
+        @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-138
+        @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-140
+        @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -45,12 +49,14 @@ Feature: TotalCount Response Header for GET Requests
                   """
 
         @API-141
+        @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
         @API-142
+        @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -10,7 +10,7 @@ Feature: TotalCount Response Header for GET Requests
                   | 255901044 | Grand Bend Middle School                      | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"} ]    | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
                   | 255901045 | UT Austin Extended Campus                     | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Twelfth grade"} ]  | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
-        @API-136
+        @API-136 @relational-backend
         Scenario: 01 Validate totalCount value when there are no matching schools in the Database
              When a GET request is made to "/ed-fi/schools?totalCount=true&nameOfInstitution=does+not+exist"
              Then it should respond with 200
@@ -21,19 +21,19 @@ Feature: TotalCount Response Header for GET Requests
                     }
                   """
 
-        @API-137
+        @API-137 @relational-backend
         Scenario: 02 Validate totalCount is not included when there are no existing schools in the Database and value equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-138
+        @API-138 @relational-backend
         Scenario: 03 Validate totalCount is not included when is not included in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-140
+        @API-140 @relational-backend
         Scenario: 05 Ensure that schools return the total count
              When a GET request is made to "/ed-fi/schools?totalCount=true"
              Then it should respond with 200
@@ -44,19 +44,19 @@ Feature: TotalCount Response Header for GET Requests
                     }
                   """
 
-        @API-141
+        @API-141 @relational-backend
         Scenario: 06 Validate totalCount Header is not included when equals to false
              When a GET request is made to "/ed-fi/schools?totalCount=false"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-142
+        @API-142 @relational-backend
         Scenario: 07 Validate totalCount is not included when it is not present in the URL
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-143
+        @API-143 @relational-backend
         Scenario: 08 Ensure results can be limited and totalCount matches the actual number of existing records
              When a GET request is made to "/ed-fi/schools?totalCount=true&limit=2"
              Then getting less schools than the total-count

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/TotalCountQueryString.feature
@@ -56,7 +56,7 @@ Feature: TotalCount Response Header for GET Requests
              Then it should respond with 200
               And the response headers does not include total-count
 
-        @API-143 @relational-backend
+        @API-143
         Scenario: 08 Ensure results can be limited and totalCount matches the actual number of existing records
              When a GET request is made to "/ed-fi/schools?totalCount=true&limit=2"
              Then getting less schools than the total-count

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -13,7 +13,7 @@ Feature: Resources "Create" Operation validations
 
     Rule: Resources
 
-        @API-152 @POST
+        @API-152 @POST @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -34,7 +34,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-153 @POST
+        @API-153 @POST @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -70,7 +70,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-154 @POST
+        @API-154 @POST @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -102,7 +102,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-155 @POST
+        @API-155 @POST @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -134,7 +134,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-156 @POST
+        @API-156 @POST @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -166,7 +166,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-157 @POST
+        @API-157 @POST @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -179,7 +179,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @API-158 @POST
+        @API-158 @POST @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -194,7 +194,7 @@ Feature: Resources "Create" Operation validations
             # 200 because this is updating the document stored with the scenario above.
              Then it should respond with 200
 
-        @API-159 @POST
+        @API-159 @POST @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -226,7 +226,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-160 @API-233 @POST
+        @API-160 @API-233 @POST @relational-backend
         Scenario: 10 Create a document with an extra property (overpost) (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -254,7 +254,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-161 @POST
+        @API-161 @POST @relational-backend
         Scenario: 11 Create a document with an null optional property (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -280,7 +280,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-162 @POST
+        @API-162 @POST @relational-backend
         Scenario: 12 Post an numeric and boolean fields as strings are coerced (Resource)
             # In this example schoolId is numeric and doNotPublishIndicator are boolean, yet posted in quotes as strings
             # In the GET request you can see they are coerced to their proper types
@@ -350,7 +350,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-163 @POST
+        @API-163 @POST @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -382,7 +382,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-164 @POST
+        @API-164 @POST @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -414,7 +414,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-165 @POST
+        @API-165 @POST @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -449,7 +449,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-166 @POST
+        @API-166 @POST @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -474,7 +474,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 200
 
-        @API-167 @POST
+        @API-167 @POST @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -506,7 +506,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-168 @POST
+        @API-168 @POST @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -535,7 +535,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-169 @POST
+        @API-169 @POST @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -548,7 +548,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201 or 200
 
-        @API-170 @POST
+        @API-170 @POST @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -577,7 +577,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-171 @POST
+        @API-171 @POST @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -606,7 +606,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-172 @APIConventions @POST
+        @API-172 @APIConventions @POST @relational-backend
         Scenario: 24 Verify user can send a POST using extra fields
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -686,7 +686,7 @@ Feature: Resources "Create" Operation validations
                   content-type: application/problem+json
                   """
 
-        @API-174 @APIConventions @POST
+        @API-174 @APIConventions @POST @relational-backend
         Scenario: 26 Validate special characters values during POST action
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -705,7 +705,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-175 @POST
+        @API-175 @POST @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -737,6 +737,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -765,6 +766,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -797,6 +799,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -837,6 +840,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -865,6 +869,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -878,6 +883,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -906,6 +912,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -14,6 +14,7 @@ Feature: Resources "Create" Operation validations
     Rule: Resources
 
         @API-152 @POST
+        @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -35,6 +36,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-153 @POST
+        @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -71,6 +73,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-154 @POST
+        @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -103,6 +106,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-155 @POST
+        @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -135,6 +139,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-156 @POST
+        @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -167,6 +172,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-157 @POST
+        @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -180,6 +186,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @API-158 @POST
+        @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -195,6 +202,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-159 @POST
+        @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -351,6 +359,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-163 @POST
+        @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -383,6 +392,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-164 @POST
+        @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -415,6 +425,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-165 @POST
+        @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -450,6 +461,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-166 @POST
+        @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -475,6 +487,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-167 @POST
+        @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -507,6 +520,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-168 @POST
+        @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -536,6 +550,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-169 @POST
+        @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -549,6 +564,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201 or 200
 
         @API-170 @POST
+        @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -578,6 +594,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-171 @POST
+        @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -706,6 +723,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-175 @POST
+        @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -737,6 +755,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -765,6 +784,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -797,6 +817,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -837,6 +858,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -865,6 +887,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -878,6 +901,7 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
+        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -906,6 +930,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
+        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -14,6 +14,7 @@ Feature: Resources "Create" Operation validations
     Rule: Resources
 
         @API-152 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -35,6 +36,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-153 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -71,6 +73,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-154 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -103,6 +106,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-155 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -135,6 +139,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-156 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -167,6 +172,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-157 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -180,6 +186,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @API-158 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -195,6 +202,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-159 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -227,6 +235,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-160 @API-233 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 Create a document with an extra property (overpost) (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -255,6 +264,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-161 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 Create a document with an null optional property (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -281,6 +291,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-162 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 Post an numeric and boolean fields as strings are coerced (Resource)
             # In this example schoolId is numeric and doNotPublishIndicator are boolean, yet posted in quotes as strings
             # In the GET request you can see they are coerced to their proper types
@@ -351,6 +362,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-163 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -383,6 +395,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-164 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -415,6 +428,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-165 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -475,6 +489,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-167 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -507,6 +522,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-168 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -536,6 +552,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-169 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -549,6 +566,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201 or 200
 
         @API-170 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -578,6 +596,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-171 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -607,6 +626,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-172 @APIConventions @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 24 Verify user can send a POST using extra fields
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -687,6 +707,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-174 @APIConventions @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 26 Validate special characters values during POST action
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -706,6 +727,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-175 @POST @relational-backend
+        @relational-ci-shard-1
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -738,6 +760,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -767,6 +790,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -800,6 +824,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -841,6 +866,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -870,6 +896,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -884,6 +911,7 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -913,6 +941,7 @@ Feature: Resources "Create" Operation validations
                   """
 
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -14,7 +14,6 @@ Feature: Resources "Create" Operation validations
     Rule: Resources
 
         @API-152 @POST
-        @relational-backend
         Scenario: 01 Post an empty request object (Resource)
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -36,7 +35,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-153 @POST
-        @relational-backend
         Scenario: 02 Post using an empty JSON body (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -73,7 +71,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-154 @POST
-        @relational-backend
         Scenario: 03 Create a document with spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -106,7 +103,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-155 @POST
-        @relational-backend
         Scenario: 04 Create a document with leading spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -139,7 +135,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-156 @POST
-        @relational-backend
         Scenario: 05 Create a document with trailing spaces in identity fields (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -172,7 +167,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-157 @POST
-        @relational-backend
         Scenario: 07 Create a document with a required, non-identity, property's value containing leading and trailing white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -186,7 +180,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201
 
         @API-158 @POST
-        @relational-backend
         Scenario: 08 Create a document with optional property's value containing only white spaces (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -202,7 +195,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-159 @POST
-        @relational-backend
         Scenario: 09 Create a document with id property (Resource)
             # The ID used does not need to exist: any ID is invalid here
              When a POST request is made to "/ed-fi/academicWeeks" with
@@ -359,7 +351,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-163 @POST
-        @relational-backend
         Scenario: 13 Post a request with a value that is too short (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -392,7 +383,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-164 @POST
-        @relational-backend
         Scenario: 14 Post a request with a value that is too long (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -425,7 +415,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-165 @POST
-        @relational-backend
         Scenario: 15 Create a document that is missing multiple required properties (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -461,7 +450,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-166 @POST
-        @relational-backend
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -487,7 +475,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 200
 
         @API-167 @POST
-        @relational-backend
         Scenario: 17 Post a request with a duplicated value (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -520,7 +507,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-168 @POST
-        @relational-backend
         Scenario: 18 Create a document with empty value in identity fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -550,7 +536,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-169 @POST
-        @relational-backend
         Scenario: 19 Create a document with leading and trailing spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -564,7 +549,6 @@ Feature: Resources "Create" Operation validations
              Then it should respond with 201 or 200
 
         @API-170 @POST
-        @relational-backend
         Scenario: 20 Create a document with just spaces in required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -594,7 +578,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-171 @POST
-        @relational-backend
         Scenario: 21 Create a document with empty required fields (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -723,7 +706,6 @@ Feature: Resources "Create" Operation validations
                   """
 
         @API-175 @POST
-        @relational-backend
         Scenario: 27 Post an invalid document missing a comma (Resource)
              When a POST request is made to "/ed-fi/academicWeeks" with
                   """
@@ -755,7 +737,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 28 Ensure the location header has correct path when a path base is provided
              When a POST request is made to "/ed-fi/students" with path base "api"
                   """
@@ -784,7 +765,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 29 Ensure prunning of an empty collection
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these descriptors
@@ -817,7 +797,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 30 Insert the same school after deletion
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -858,7 +837,6 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @relational-backend
         Scenario: 31 When posting a resource with decimal overflow
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -887,7 +865,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 32 When posting a resource with decimal as int
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -901,7 +878,6 @@ Feature: Resources "Create" Operation validations
                   """
              Then it should respond with 201
 
-        @relational-backend
         Scenario: 33 When posting a resource with decimal overflow as string
              When a POST request is made to "/ed-fi/staffs" with
                   """
@@ -930,7 +906,6 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @relational-backend
         Scenario: 34 Post and Put a request with slash-formatted dates that get coerced to ISO-8601 format (Resource)
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -226,7 +226,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-160 @API-233 @POST @relational-backend
+        @API-160 @API-233 @POST
         Scenario: 10 Create a document with an extra property (overpost) (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -254,7 +254,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-161 @POST @relational-backend
+        @API-161 @POST
         Scenario: 11 Create a document with an null optional property (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """
@@ -280,7 +280,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-162 @POST @relational-backend
+        @API-162 @POST
         Scenario: 12 Post an numeric and boolean fields as strings are coerced (Resource)
             # In this example schoolId is numeric and doNotPublishIndicator are boolean, yet posted in quotes as strings
             # In the GET request you can see they are coerced to their proper types
@@ -606,7 +606,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-172 @APIConventions @POST @relational-backend
+        @API-172 @APIConventions @POST
         Scenario: 24 Verify user can send a POST using extra fields
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -686,7 +686,7 @@ Feature: Resources "Create" Operation validations
                   content-type: application/problem+json
                   """
 
-        @API-174 @APIConventions @POST @relational-backend
+        @API-174 @APIConventions @POST
         Scenario: 26 Validate special characters values during POST action
              When a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/CreateResourcesValidation.feature
@@ -449,7 +449,7 @@ Feature: Resources "Create" Operation validations
                   }
                   """
 
-        @API-166 @POST @relational-backend
+        @API-166 @POST
         Scenario: 16 Post a new document (Resource)
              When a POST request is made to "/ed-fi/educationContents" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
@@ -4,7 +4,7 @@ Feature: Resources "Delete" Reference Conflict validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-176 @relational-backend
+        @API-176
         Scenario: 01 Verify response when deleting a referenced school
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -33,7 +33,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-177 @relational-backend
+        @API-177
         Scenario: 02 Verify response when deleting a referenced schoolyeartype
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -62,7 +62,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-178 @relational-backend
+        @API-178
         Scenario: 03 Verify response when deleting a referenced student
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -90,4 +90,3 @@ Feature: Resources "Delete" Reference Conflict validations
                         "errors": []
                     }
                   """
-

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
@@ -4,7 +4,7 @@ Feature: Resources "Delete" Reference Conflict validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-176
+        @API-176 @relational-backend
         Scenario: 01 Verify response when deleting a referenced school
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -33,7 +33,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-177
+        @API-177 @relational-backend
         Scenario: 02 Verify response when deleting a referenced schoolyeartype
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -62,7 +62,7 @@ Feature: Resources "Delete" Reference Conflict validations
                     }
                   """
 
-        @API-178
+        @API-178 @relational-backend
         Scenario: 03 Verify response when deleting a referenced student
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/DeleteResourcesReferenceValidation.feature
@@ -5,6 +5,7 @@ Feature: Resources "Delete" Reference Conflict validations
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-176 @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Verify response when deleting a referenced school
             Given the system has these "schools" references
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -34,6 +35,7 @@ Feature: Resources "Delete" Reference Conflict validations
                   """
 
         @API-177 @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Verify response when deleting a referenced schoolyeartype
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |
@@ -63,6 +65,7 @@ Feature: Resources "Delete" Reference Conflict validations
                   """
 
         @API-178 @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Verify response when deleting a referenced student
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
@@ -36,7 +36,7 @@ Feature: Resources "Read" Operation validations
              When a GET request is made to "/ed-fi/schools/{id}"
              Then it should respond with 404
 
-        @API-182
+        @API-182 @relational-backend
         Scenario: 02 Verify response code 200 when trying to get a student with a correct ID
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
@@ -37,6 +37,7 @@ Feature: Resources "Read" Operation validations
              Then it should respond with 404
 
         @API-182 @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Verify response code 200 when trying to get a student with a correct ID
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/ReadResourcesValidation.feature
@@ -36,7 +36,7 @@ Feature: Resources "Read" Operation validations
              When a GET request is made to "/ed-fi/schools/{id}"
              Then it should respond with 404
 
-        @API-182 @relational-backend
+        @API-182
         Scenario: 02 Verify response code 200 when trying to get a student with a correct ID
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -18,6 +18,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-184 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Put an existing document (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -121,6 +122,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-188 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -146,6 +148,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-189 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -168,6 +171,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-190 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -200,6 +204,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-191 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -227,6 +232,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-192 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -254,6 +260,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-193 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -310,6 +317,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-195 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -338,6 +346,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-196 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -371,6 +380,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-197 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -406,6 +416,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-198 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -439,6 +450,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-199 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -483,6 +495,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-200 @PUT @relational-backend
+        @relational-ci-shard-1
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1108,6 +1121,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-221 @IdempotentUpdate @relational-backend
+        @relational-ci-shard-1
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -121,6 +121,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-188 @PUT
+        @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -146,6 +147,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-189 @PUT
+        @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -168,6 +170,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-190 @PUT
+        @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -200,6 +203,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-191 @PUT
+        @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -227,6 +231,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-192 @PUT
+        @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -254,6 +259,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-193 @PUT
+        @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -310,6 +316,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-195 @PUT
+        @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -338,6 +345,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-196 @PUT
+        @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -371,6 +379,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-197 @PUT
+        @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -406,6 +415,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-198 @PUT
+        @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -439,6 +449,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-199 @PUT
+        @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -483,6 +494,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-200 @PUT
+        @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1108,6 +1120,7 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-221 @IdempotentUpdate
+        @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -121,7 +121,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-188 @PUT
-        @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -147,7 +146,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-189 @PUT
-        @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -170,7 +168,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-190 @PUT
-        @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -203,7 +200,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-191 @PUT
-        @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -231,7 +227,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-192 @PUT
-        @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -259,7 +254,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-193 @PUT
-        @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -316,7 +310,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-195 @PUT
-        @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -345,7 +338,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-196 @PUT
-        @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -379,7 +371,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-197 @PUT
-        @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -415,7 +406,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-198 @PUT
-        @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -449,7 +439,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-199 @PUT
-        @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -494,7 +483,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-200 @PUT
-        @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1120,7 +1108,6 @@ Feature: Resources "Update" Operation validations
                   """
 
         @API-221 @IdempotentUpdate
-        @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -17,7 +17,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-184 @PUT
+        @API-184 @PUT @relational-backend
         Scenario: 01 Put an existing document (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -120,7 +120,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-188 @PUT
+        @API-188 @PUT @relational-backend
         Scenario: 05 Update a document with modification of an identity field (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -145,7 +145,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-189 @PUT
+        @API-189 @PUT @relational-backend
         Scenario: 06  Put an empty request object (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -167,7 +167,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-190 @PUT
+        @API-190 @PUT @relational-backend
         Scenario: 07 Put an empty JSON body (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -199,7 +199,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-191 @PUT
+        @API-191 @PUT @relational-backend
         Scenario: 08 Update a document with mismatch between URL and id (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -226,7 +226,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-192 @PUT
+        @API-192 @PUT @relational-backend
         Scenario: 09 Update a document with a blank id (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -253,7 +253,7 @@ Feature: Resources "Update" Operation validations
                    }
                   """
 
-        @API-193 @PUT
+        @API-193 @PUT @relational-backend
         Scenario: 10 Update a document with an invalid id format (Resource)
              # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -309,7 +309,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-195 @PUT
+        @API-195 @PUT @relational-backend
         Scenario: 12 Put an existing document with null optional value (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -337,7 +337,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-196 @PUT
+        @API-196 @PUT @relational-backend
         Scenario: 13 Put an existing document with a string that is too long (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
@@ -370,7 +370,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-197 @PUT
+        @API-197 @PUT @relational-backend
         Scenario: 14 Update a document with a value that is too short (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -405,7 +405,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-198 @PUT
+        @API-198 @PUT @relational-backend
         Scenario: 15 Update a document with a duplicated value (Resource)
              When a PUT request is made to "/ed-fi/educationContents/{id}" with
                   """
@@ -438,7 +438,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-199 @PUT
+        @API-199 @PUT @relational-backend
         Scenario: 16 Verify clients cannot update a resource with a duplicate descriptor
              When a PUT request is made to "/ed-fi/schools/{id}" with
                   """
@@ -482,7 +482,7 @@ Feature: Resources "Update" Operation validations
                     }
                   """
 
-        @API-200 @PUT
+        @API-200 @PUT @relational-backend
         Scenario: 17 Verify clients cannot upadate a resource with a duplicate resource reference
              When a PUT request is made to "/ed-fi/bellschedules/{id}" with
                   """
@@ -1107,7 +1107,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-221 @IdempotentUpdate
+        @API-221 @IdempotentUpdate @relational-backend
         Scenario: 23 Update with identical payload should not make database changes
             # This test verifies that updating a resource with an identical payload doesn't cause any database changes
              When a GET request is made to "/ed-fi/educationContents/{id}"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -17,7 +17,7 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-184 @PUT @relational-backend
+        @API-184 @PUT
         Scenario: 01 Put an existing document (Resource)
             # The id value should be replaced with the resource created in the Background section
              When a PUT request is made to "/ed-fi/educationContents/{id}" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -4,6 +4,7 @@ Feature: ETag validations
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
         @API-260 @relational-backend
+        @relational-ci-shard-1
         Scenario: 01 Ensure that clients can retrieve an ETag in the response header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -28,6 +29,7 @@ Feature: ETag validations
                   }
                   """
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 02 Ensure that clients can pass an IfMatch in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -52,6 +54,7 @@ Feature: ETag validations
                   """
              Then it should respond with 204
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 03 Ensure that clients can pass an IfMatch in the request header and ignore _etag in request body
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -77,6 +80,7 @@ Feature: ETag validations
                   """
              Then it should respond with 204
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 04 Ensure that clients cannot pass a different If-Match in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -114,6 +118,7 @@ Feature: ETag validations
                   }
                   """
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 05 Ensure that clients cannot pass a different ETag in the If-Match header to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """
@@ -140,6 +145,7 @@ Feature: ETag validations
                   }
                   """
         @relational-backend
+        @relational-ci-shard-1
         Scenario: 06 Ensure that clients can pass an ETag to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -3,7 +3,7 @@ Feature: ETag validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-260 @relational-backend
+        @API-260
         Scenario: 01 Ensure that clients can retrieve an ETag in the response header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -27,7 +27,6 @@ Feature: ETag validations
                     "_etag": "{etag}"
                   }
                   """
-        @relational-backend
         Scenario: 02 Ensure that clients can pass an IfMatch in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -51,7 +50,6 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
-        @relational-backend
         Scenario: 03 Ensure that clients can pass an IfMatch in the request header and ignore _etag in request body
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -76,7 +74,6 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
-        @relational-backend
         Scenario: 04 Ensure that clients cannot pass a different If-Match in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -113,7 +110,6 @@ Feature: ETag validations
                       ]
                   }
                   """
-        @relational-backend
         Scenario: 05 Ensure that clients cannot pass a different ETag in the If-Match header to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """
@@ -139,7 +135,6 @@ Feature: ETag validations
                       ]
                   }
                   """
-        @relational-backend
         Scenario: 06 Ensure that clients can pass an ETag to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -3,7 +3,7 @@ Feature: ETag validations
         Background:
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
 
-        @API-260
+        @API-260 @relational-backend
         Scenario: 01 Ensure that clients can retrieve an ETag in the response header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -27,6 +27,7 @@ Feature: ETag validations
                     "_etag": "{etag}"
                   }
                   """
+        @relational-backend
         Scenario: 02 Ensure that clients can pass an IfMatch in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -50,6 +51,7 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
+        @relational-backend
         Scenario: 03 Ensure that clients can pass an IfMatch in the request header and ignore _etag in request body
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -74,6 +76,7 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 204
+        @relational-backend
         Scenario: 04 Ensure that clients cannot pass a different If-Match in the request header
              When a POST request is made to "/ed-fi/students" with
                   """
@@ -110,6 +113,7 @@ Feature: ETag validations
                       ]
                   }
                   """
+        @relational-backend
         Scenario: 05 Ensure that clients cannot pass a different ETag in the If-Match header to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """
@@ -135,6 +139,7 @@ Feature: ETag validations
                       ]
                   }
                   """
+        @relational-backend
         Scenario: 06 Ensure that clients can pass an ETag to delete a resource
             Given a POST request is made to "/ed-fi/students" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
@@ -5,7 +5,6 @@ Feature: SchoolYearType resource
 
     Rule: SchoolYearType resource
 
-        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a schoolYearTypes resource
       # POST request to create a school
              When a POST request is made to "/ed-fi/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
@@ -5,6 +5,7 @@ Feature: SchoolYearType resource
 
     Rule: SchoolYearType resource
 
+        @relational-backend
         Scenario: 01 Ensure clients can create/update/get/delete a schoolYearTypes resource
       # POST request to create a school
              When a POST request is made to "/ed-fi/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/SchoolYearType/SchoolYearType.feature
@@ -6,6 +6,7 @@ Feature: SchoolYearType resource
     Rule: SchoolYearType resource
 
         @relational-backend
+        @relational-ci-shard-4
         Scenario: 01 Ensure clients can create/update/get/delete a schoolYearTypes resource
       # POST request to create a school
              When a POST request is made to "/ed-fi/schoolYearTypes/" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -7,21 +7,25 @@ Feature: OWASP critical attack path protections
                   | 1001     | Security School   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?schoolId=9999' OR 1=1--"
              Then it should respond with 400
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01a SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?OR 1=1--schoolId=9999"
              Then it should respond with 400
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 01b SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?+OR+1%3D1+--schoolId=9999"
              Then it should respond with 400
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 02 SQL injection payload in JSON body numeric field is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -43,6 +47,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 400
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 CSRF style forged browser request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker" and
@@ -65,11 +70,13 @@ Feature: OWASP critical attack path protections
              Then it should respond with 401
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Path traversal attempts are not resolved as files
              When a GET request is made to "/../appsettings.json"
              Then it should respond with 404
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 05 X-Forwarded-Proto spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Proto" value "https" and
@@ -92,6 +99,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 401
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 06 X-Forwarded-Host spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Host" value "trusted.local" and
@@ -117,6 +125,7 @@ Feature: OWASP critical attack path protections
         # so the rejected request actually fails the signature validation before expiry is evaluated.
         # A pure expired-token check would need an issued token to naturally lapse (or a configurable IdP).
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 06a Expired JWT is rejected
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token is expired
@@ -128,6 +137,7 @@ Feature: OWASP critical attack path protections
         # This scenario validates that authentication is enforced on all unauthenticated requests
         # regardless of any Host-like header value — it does NOT verify server-side Host validation.
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 07 Unauthenticated request with Host header is rejected by authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Host" value "trusted.local" and
@@ -150,6 +160,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 401
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 08 Allowed CORS origin receives Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "http://localhost:8082"
              Then it should respond with 200
@@ -161,12 +172,14 @@ Feature: OWASP critical attack path protections
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 09 Disallowed CORS origin does not receive Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker"
              Then it should respond with 200
               And the response header "Access-Control-Allow-Origin" is not present
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 10 Malformed JSON request body is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -198,6 +211,7 @@ Feature: OWASP critical attack path protections
         # Real browser CORS preflights are unauthenticated; the assertion (no allow-origin for
         # disallowed origins) is independent of auth and is still correct here.
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 12 Disallowed CORS preflight does not return allow-origin header
              When an "OPTIONS" request is made to "/ed-fi/schools" with headers
                   | Key                           | Value                |
@@ -209,6 +223,7 @@ Feature: OWASP critical attack path protections
         # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
         # enforced at the routing layer regardless of auth state.
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
@@ -279,6 +294,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 403
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 16a Deleting a referenced student returns conflict
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these "schools"
@@ -294,6 +310,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 409
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 17 CSRF style forged browser cookie request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Cookie" value "sessionid=forged-session-id" and
@@ -316,6 +333,7 @@ Feature: OWASP critical attack path protections
              Then it should respond with 401
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 18 SQL injection payload in string query field is treated as data
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=%27%20OR%20%271%27%3D%271"
              Then it should respond with 200
@@ -325,6 +343,7 @@ Feature: OWASP critical attack path protections
                   """
 
         @relational-backend
+        @relational-ci-shard-3
         Scenario: 19 CSRF style browser form post without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated Form URL Encoded POST request is made to "/ed-fi/schools" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -6,22 +6,18 @@ Feature: OWASP critical attack path protections
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
                   | 1001     | Security School   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
-        @relational-backend
         Scenario: 01 SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?schoolId=9999' OR 1=1--"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 01a SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?OR 1=1--schoolId=9999"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 01b SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?+OR+1%3D1+--schoolId=9999"
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 02 SQL injection payload in JSON body numeric field is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -42,7 +38,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 400
 
-        @relational-backend
         Scenario: 03 CSRF style forged browser request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker" and
@@ -64,12 +59,10 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 04 Path traversal attempts are not resolved as files
              When a GET request is made to "/../appsettings.json"
              Then it should respond with 404
 
-        @relational-backend
         Scenario: 05 X-Forwarded-Proto spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Proto" value "https" and
@@ -91,7 +84,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 06 X-Forwarded-Host spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Host" value "trusted.local" and
@@ -116,7 +108,6 @@ Feature: OWASP critical attack path protections
         # The "token is expired" step overwrites the exp claim but keeps the original signature,
         # so the rejected request actually fails the signature validation before expiry is evaluated.
         # A pure expired-token check would need an issued token to naturally lapse (or a configurable IdP).
-        @relational-backend
         Scenario: 06a Expired JWT is rejected
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token is expired
@@ -127,7 +118,6 @@ Feature: OWASP critical attack path protections
         # Playwright/Chromium silently drops it, so the spoofed value never reaches the server.
         # This scenario validates that authentication is enforced on all unauthenticated requests
         # regardless of any Host-like header value — it does NOT verify server-side Host validation.
-        @relational-backend
         Scenario: 07 Unauthenticated request with Host header is rejected by authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Host" value "trusted.local" and
@@ -149,7 +139,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 08 Allowed CORS origin receives Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "http://localhost:8082"
              Then it should respond with 200
@@ -160,13 +149,11 @@ Feature: OWASP critical attack path protections
                   }
                   """
 
-        @relational-backend
         Scenario: 09 Disallowed CORS origin does not receive Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker"
              Then it should respond with 200
               And the response header "Access-Control-Allow-Origin" is not present
 
-        @relational-backend
         Scenario: 10 Malformed JSON request body is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -197,7 +184,6 @@ Feature: OWASP critical attack path protections
         # Note: WhenAnRequestIsMadeToWithHeaders includes the bearer token from the test context.
         # Real browser CORS preflights are unauthenticated; the assertion (no allow-origin for
         # disallowed origins) is independent of auth and is still correct here.
-        @relational-backend
         Scenario: 12 Disallowed CORS preflight does not return allow-origin header
              When an "OPTIONS" request is made to "/ed-fi/schools" with headers
                   | Key                           | Value                |
@@ -208,7 +194,6 @@ Feature: OWASP critical attack path protections
 
         # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
         # enforced at the routing layer regardless of auth state.
-        @relational-backend
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
@@ -278,7 +263,6 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/studentSchoolAssociations/{BolaStudentSchoolAssociationId}"
              Then it should respond with 403
 
-        @relational-backend
         Scenario: 16a Deleting a referenced student returns conflict
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these "schools"
@@ -293,7 +277,6 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/students/{ReferencedStudentId}"
              Then it should respond with 409
 
-        @relational-backend
         Scenario: 17 CSRF style forged browser cookie request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Cookie" value "sessionid=forged-session-id" and
@@ -315,7 +298,6 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
-        @relational-backend
         Scenario: 18 SQL injection payload in string query field is treated as data
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=%27%20OR%20%271%27%3D%271"
              Then it should respond with 200
@@ -324,7 +306,6 @@ Feature: OWASP critical attack path protections
                   []
                   """
 
-        @relational-backend
         Scenario: 19 CSRF style browser form post without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated Form URL Encoded POST request is made to "/ed-fi/schools" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -6,18 +6,22 @@ Feature: OWASP critical attack path protections
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                   |
                   | 1001     | Security School   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] |
 
+        @relational-backend
         Scenario: 01 SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?schoolId=9999' OR 1=1--"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 01a SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?OR 1=1--schoolId=9999"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 01b SQL injection payload in query string numeric field is rejected
              When a GET request is made to "/ed-fi/schools?+OR+1%3D1+--schoolId=9999"
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 02 SQL injection payload in JSON body numeric field is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -38,6 +42,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 400
 
+        @relational-backend
         Scenario: 03 CSRF style forged browser request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker" and
@@ -59,10 +64,12 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 04 Path traversal attempts are not resolved as files
              When a GET request is made to "/../appsettings.json"
              Then it should respond with 404
 
+        @relational-backend
         Scenario: 05 X-Forwarded-Proto spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Proto" value "https" and
@@ -84,6 +91,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 06 X-Forwarded-Host spoofing does not bypass authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "X-Forwarded-Host" value "trusted.local" and
@@ -108,6 +116,7 @@ Feature: OWASP critical attack path protections
         # The "token is expired" step overwrites the exp claim but keeps the original signature,
         # so the rejected request actually fails the signature validation before expiry is evaluated.
         # A pure expired-token check would need an issued token to naturally lapse (or a configurable IdP).
+        @relational-backend
         Scenario: 06a Expired JWT is rejected
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token is expired
@@ -118,6 +127,7 @@ Feature: OWASP critical attack path protections
         # Playwright/Chromium silently drops it, so the spoofed value never reaches the server.
         # This scenario validates that authentication is enforced on all unauthenticated requests
         # regardless of any Host-like header value — it does NOT verify server-side Host validation.
+        @relational-backend
         Scenario: 07 Unauthenticated request with Host header is rejected by authentication
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Host" value "trusted.local" and
@@ -139,6 +149,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 08 Allowed CORS origin receives Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "http://localhost:8082"
              Then it should respond with 200
@@ -149,11 +160,13 @@ Feature: OWASP critical attack path protections
                   }
                   """
 
+        @relational-backend
         Scenario: 09 Disallowed CORS origin does not receive Access-Control-Allow-Origin
              When a security GET request is made to "/ed-fi/schools" with header "Origin" value "https://malicious.attacker"
              Then it should respond with 200
               And the response header "Access-Control-Allow-Origin" is not present
 
+        @relational-backend
         Scenario: 10 Malformed JSON request body is rejected
              When a POST request is made to "/ed-fi/schools" with
                   """
@@ -184,6 +197,7 @@ Feature: OWASP critical attack path protections
         # Note: WhenAnRequestIsMadeToWithHeaders includes the bearer token from the test context.
         # Real browser CORS preflights are unauthenticated; the assertion (no allow-origin for
         # disallowed origins) is independent of auth and is still correct here.
+        @relational-backend
         Scenario: 12 Disallowed CORS preflight does not return allow-origin header
              When an "OPTIONS" request is made to "/ed-fi/schools" with headers
                   | Key                           | Value                |
@@ -194,6 +208,7 @@ Feature: OWASP critical attack path protections
 
         # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
         # enforced at the routing layer regardless of auth state.
+        @relational-backend
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
@@ -263,6 +278,7 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/studentSchoolAssociations/{BolaStudentSchoolAssociationId}"
              Then it should respond with 403
 
+        @relational-backend
         Scenario: 16a Deleting a referenced student returns conflict
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the system has these "schools"
@@ -277,6 +293,7 @@ Feature: OWASP critical attack path protections
              When a DELETE request is made to "/ed-fi/students/{ReferencedStudentId}"
              Then it should respond with 409
 
+        @relational-backend
         Scenario: 17 CSRF style forged browser cookie request without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated POST request is made to "/ed-fi/schools" with header "Cookie" value "sessionid=forged-session-id" and
@@ -298,6 +315,7 @@ Feature: OWASP critical attack path protections
                   """
              Then it should respond with 401
 
+        @relational-backend
         Scenario: 18 SQL injection payload in string query field is treated as data
              When a GET request is made to "/ed-fi/schools?nameOfInstitution=%27%20OR%20%271%27%3D%271"
              Then it should respond with 200
@@ -306,6 +324,7 @@ Feature: OWASP critical attack path protections
                   []
                   """
 
+        @relational-backend
         Scenario: 19 CSRF style browser form post without bearer token is rejected
             Given there is no Authorization header
              When an unauthenticated Form URL Encoded POST request is made to "/ed-fi/schools" with

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -8,21 +8,25 @@ Feature: JWT Token Introspection
             Given there is no Authorization header
 
     @API-213
+    @relational-backend
     Scenario: Accept root endpoint requests that do not contain a token
       When a GET request is made to "/"
       Then it should respond with 200
 
     @API-214
+    @relational-backend
     Scenario: Accept dependencies endpoint requests that do not contain a token
       When a GET request is made to "/metadata/dependencies"
       Then it should respond with 200
 
     @API-215
+    @relational-backend
     Scenario: Accept OpenAPI specifications endpoint requests that do not contain a token
       When a GET request is made to "/metadata/specifications"
       Then it should respond with 200
 
     @API-216
+    @relational-backend
     Scenario: Accept XSD endpoint requests that do not contain a token
       When a GET request is made to "/metadata/xsd"
       Then it should respond with 200
@@ -31,11 +35,13 @@ Feature: JWT Token Introspection
             Given there is no Authorization header
 
     @API-217
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request that does not contain a token
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 401
 
     @API-218
+    @relational-backend
     Scenario: Reject a Resource endpoint POST request that does not contain a token
       When a POST request is made to "/ed-fi/academicWeeks" with
         """
@@ -52,6 +58,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @API-219
+    @relational-backend
     Scenario: Reject a Resource endpoint PUT request that does not contain a token
       When a PUT request is made to "/ed-fi/academicWeeks/1" with
         """
@@ -68,6 +75,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @API-220
+    @relational-backend
     Scenario: Reject a Resource endpoint DELETE request that does not contain a token
       When a DELETE request is made to "/ed-fi/academicWeeks/1"
       Then it should respond with 401
@@ -75,11 +83,13 @@ Feature: JWT Token Introspection
   Rule: Resource API accepts a valid token
 
     @API-229
+    @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
@@ -87,6 +97,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @DMS-823
+    @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -208,6 +219,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -228,6 +240,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -82,19 +82,20 @@ Feature: JWT Token Introspection
 
   Rule: Resource API accepts a valid token
 
-    @API-229
+    @API-229 @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
+    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 401
 
-    @DMS-823
+    @DMS-823 @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -216,6 +217,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -236,6 +238,7 @@ Feature: JWT Token Introspection
         }
         """
 
+    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -83,13 +83,11 @@ Feature: JWT Token Introspection
   Rule: Resource API accepts a valid token
 
     @API-229
-    @relational-backend
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
-    @relational-backend
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
@@ -97,7 +95,6 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @DMS-823
-    @relational-backend
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -219,7 +216,6 @@ Feature: JWT Token Introspection
         }
         """
 
-    @relational-backend
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -240,7 +236,6 @@ Feature: JWT Token Introspection
         }
         """
 
-    @relational-backend
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/TokenIntrospection.feature
@@ -9,24 +9,28 @@ Feature: JWT Token Introspection
 
     @API-213
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Accept root endpoint requests that do not contain a token
       When a GET request is made to "/"
       Then it should respond with 200
 
     @API-214
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Accept dependencies endpoint requests that do not contain a token
       When a GET request is made to "/metadata/dependencies"
       Then it should respond with 200
 
     @API-215
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Accept OpenAPI specifications endpoint requests that do not contain a token
       When a GET request is made to "/metadata/specifications"
       Then it should respond with 200
 
     @API-216
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Accept XSD endpoint requests that do not contain a token
       When a GET request is made to "/metadata/xsd"
       Then it should respond with 200
@@ -36,12 +40,14 @@ Feature: JWT Token Introspection
 
     @API-217
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Reject a Resource endpoint GET request that does not contain a token
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 401
 
     @API-218
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Reject a Resource endpoint POST request that does not contain a token
       When a POST request is made to "/ed-fi/academicWeeks" with
         """
@@ -59,6 +65,7 @@ Feature: JWT Token Introspection
 
     @API-219
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Reject a Resource endpoint PUT request that does not contain a token
       When a PUT request is made to "/ed-fi/academicWeeks/1" with
         """
@@ -76,6 +83,7 @@ Feature: JWT Token Introspection
 
     @API-220
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Reject a Resource endpoint DELETE request that does not contain a token
       When a DELETE request is made to "/ed-fi/academicWeeks/1"
       Then it should respond with 401
@@ -83,12 +91,14 @@ Feature: JWT Token Introspection
   Rule: Resource API accepts a valid token
 
     @API-229 @relational-backend
+    @relational-ci-shard-3
     Scenario: Accept a Resource endpoint GET request where the token is valid
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       When a GET request is made to "/ed-fi/academicWeeks"
       Then it should respond with 200
 
     @relational-backend
+    @relational-ci-shard-3
     Scenario: Reject a Resource endpoint GET request where the token signature is manipulated
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       And the token signature is manipulated
@@ -96,6 +106,7 @@ Feature: JWT Token Introspection
       Then it should respond with 401
 
     @DMS-823 @relational-backend
+    @relational-ci-shard-3
     Scenario: Verify JWT token contains dmsInstanceIds claim
       Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
       Then the JWT token should contain the dmsInstanceIds claim
@@ -218,6 +229,7 @@ Feature: JWT Token Introspection
         """
 
     @relational-backend
+    @relational-ci-shard-3
     Scenario: 02 Missing token in request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """
@@ -239,6 +251,7 @@ Feature: JWT Token Introspection
         """
 
     @relational-backend
+    @relational-ci-shard-3
     Scenario: 03 Token mismatch between Authorization header and request body returns bad request error
       When a POST request is made to "/oauth/token_info" with
         """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ClaimSetManagementHooks.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ClaimSetManagementHooks.cs
@@ -204,7 +204,10 @@ public class ClaimSetManagementHooks(
                 $"No SystemAdministrator token found, registering new admin client: {clientId}"
             );
             await SystemAdministrator.Register(clientId, clientSecret);
+            return;
         }
+
+        await SystemAdministrator.GetToken();
     }
 
     /// <summary>
@@ -212,7 +215,7 @@ public class ClaimSetManagementHooks(
     /// </summary>
     private async Task ReloadDmsClaimsets()
     {
-        List<KeyValuePair<string, string>> headers = CreateAuthHeaders();
+        List<KeyValuePair<string, string>> headers = await CreateAuthHeaders();
 
         // Increased timeout for CI environments
         var options = new APIRequestContextOptions
@@ -259,7 +262,10 @@ public class ClaimSetManagementHooks(
         };
 
         httpClient.DefaultRequestHeaders.Authorization =
-            new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", SystemAdministrator.Token);
+            new System.Net.Http.Headers.AuthenticationHeaderValue(
+                "Bearer",
+                await SystemAdministrator.GetToken()
+            );
 
         // POST with empty body for reload-claims endpoint
         using StringContent content = new("{}", System.Text.Encoding.UTF8, "application/json");
@@ -279,7 +285,7 @@ public class ClaimSetManagementHooks(
     /// </summary>
     private async Task VerifyDmsCacheState()
     {
-        var headers = CreateAuthHeaders();
+        var headers = await CreateAuthHeaders();
 
         var options = new APIRequestContextOptions
         {
@@ -309,14 +315,10 @@ public class ClaimSetManagementHooks(
     /// <summary>
     /// Creates authorization headers with the system administrator bearer token.
     /// </summary>
-    private static List<KeyValuePair<string, string>> CreateAuthHeaders()
+    private static async Task<List<KeyValuePair<string, string>>> CreateAuthHeaders()
     {
-        List<KeyValuePair<string, string>> headers = [];
-        if (!string.IsNullOrEmpty(SystemAdministrator.Token))
-        {
-            headers.Add(new("Authorization", $"Bearer {SystemAdministrator.Token}"));
-        }
-        return headers;
+        string systemAdministratorToken = await SystemAdministrator.GetToken();
+        return [new("Authorization", $"Bearer {systemAdministratorToken}")];
     }
 
     private async Task<IAPIRequestContext> GetApiRequestContextAsync()

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ProfileSetupHooks.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Hooks/ProfileSetupHooks.cs
@@ -48,7 +48,8 @@ public static class ProfileSetupHooks
         logger.log.Information("===== ProfileSetupHooks: Creating test profiles =====");
 
         // SystemAdministrator should already be registered by SetupHooks (Order = 10000)
-        if (string.IsNullOrEmpty(SystemAdministrator.Token))
+        string systemAdministratorToken = await SystemAdministrator.GetToken();
+        if (string.IsNullOrEmpty(systemAdministratorToken))
         {
             throw new InvalidOperationException(
                 "SystemAdministrator.Token is not available. Ensure SetupHooks.BeforeTestRun runs before ProfileSetupHooks."
@@ -69,7 +70,7 @@ public static class ProfileSetupHooks
                 int profileId = await ProfileAwareAuthorizationProvider.CreateProfile(
                     name,
                     xml,
-                    SystemAdministrator.Token
+                    systemAdministratorToken
                 );
 
                 ProfileTestData.RegisterProfile(name, profileId);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
@@ -94,7 +94,7 @@ public class ProfileStepDefinitions(
             int profileId = await ProfileAwareAuthorizationProvider.CreateProfile(
                 profileName,
                 profileXml,
-                SystemAdministrator.Token
+                await SystemAdministrator.GetToken()
             );
 
             ProfileTestData.RegisterProfile(profileName, profileId);
@@ -209,7 +209,7 @@ public class ProfileStepDefinitions(
             "profiletest@example.com",
             namespacePrefixes,
             educationOrganizationIds,
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             claimSetName,
             profileNames
         );
@@ -345,7 +345,7 @@ public class ProfileStepDefinitions(
             "descriptor@test.com",
             "uri://ed-fi.org, uri://sample.ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "EdFiSandbox"
         );
 
@@ -364,7 +364,7 @@ public class ProfileStepDefinitions(
             "entity@test.com",
             "uri://ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "E2E-NoFurtherAuthRequiredClaimSet"
         );
 
@@ -383,7 +383,7 @@ public class ProfileStepDefinitions(
             "seeddata@test.com",
             "uri://ed-fi.org, uri://sample.ed-fi.org, uri://tpdm.ed-fi.org, uri://homograph.ed-fi.org",
             "",
-            SystemAdministrator.Token,
+            await SystemAdministrator.GetToken(),
             "E2E-NoFurtherAuthRequiredClaimSet"
         );
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -125,9 +125,11 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             string claimSetName = "E2E-NoFurtherAuthRequiredClaimSet"
         )
         {
+            string systemAdministratorToken = await SystemAdministrator.GetToken();
+
             // Clear the DMS claimset cache before setting a new authorization context
             // This ensures test isolation when scenarios have different auth contexts
-            await ClearDmsClaimsetCache();
+            await ClearDmsClaimsetCache(systemAdministratorToken);
 
             await AuthorizationDataProvider.CreateClientCredentials(
                 Guid.NewGuid().ToString(),
@@ -135,7 +137,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 "cmb@example.com",
                 namespacePrefixes,
                 educationOrganizationIds,
-                SystemAdministrator.Token,
+                systemAdministratorToken,
                 claimSetName
             );
 
@@ -144,14 +146,14 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         }
 
         // Helper method to clear the DMS claimset cache
-        private async Task ClearDmsClaimsetCache()
+        private async Task ClearDmsClaimsetCache(string systemAdministratorToken)
         {
             try
             {
                 // Create authorization header - using Bearer token for DMS
                 var headers = new List<KeyValuePair<string, string>>
                 {
-                    new("Authorization", $"Bearer {SystemAdministrator.Token}"),
+                    new("Authorization", $"Bearer {systemAdministratorToken}"),
                 };
 
                 var dmsResponse = await _playwrightContext.ApiRequestContext?.PostAsync(
@@ -914,7 +916,10 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             var content = new StringContent(claimsJson, System.Text.Encoding.UTF8, "application/json");
 
             // Get SystemAdministrator auth header for CMS request
-            httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {SystemAdministrator.Token}");
+            httpClient.DefaultRequestHeaders.Add(
+                "Authorization",
+                $"Bearer {await SystemAdministrator.GetToken()}"
+            );
 
             var response = await httpClient.PostAsync(
                 $"http://localhost:{AppSettings.ConfigServicePort}/config/management/upload-claims",
@@ -946,7 +951,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 {
                     Headers = new Dictionary<string, string>
                     {
-                        { "Authorization", $"Bearer {SystemAdministrator.Token}" },
+                        { "Authorization", $"Bearer {await SystemAdministrator.GetToken()}" },
                     },
                 }
             )!;
@@ -969,7 +974,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                 {
                     Headers = new Dictionary<string, string>
                     {
-                        { "Authorization", $"Bearer {SystemAdministrator.Token}" },
+                        { "Authorization", $"Bearer {await SystemAdministrator.GetToken()}" },
                     },
                 }
             )!;
@@ -984,14 +989,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         [When("a POST request is made to CMS {string}")]
         public async Task WhenAPOSTRequestIsMadeToCMS(string endpoint)
         {
-            // Get system administrator token for CMS API access
-            if (string.IsNullOrEmpty(SystemAdministrator.Token))
-            {
-                await SystemAdministrator.Register(
-                    "SystemAdministratorClient",
-                    SystemAdministrator.DefaultClientSecret
-                );
-            }
+            string systemAdministratorToken = await SystemAdministrator.GetToken();
 
             // Use HttpClient to call CMS management API
             using var httpClient = new HttpClient
@@ -1000,7 +998,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             };
 
             httpClient.DefaultRequestHeaders.Authorization =
-                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", SystemAdministrator.Token);
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", systemAdministratorToken);
 
             // POST with empty body for reload-claims endpoint
             using var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_Build_Dms_E2E_Guardrails.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_Build_Dms_E2E_Guardrails.cs
@@ -156,6 +156,50 @@ public class Given_Build_Dms_E2E_Guardrails
             );
     }
 
+    [Test]
+    public async Task It_accepts_a_relational_filter_combined_with_a_shard_filter()
+    {
+        var result = await RunBuildDmsE2ETest(
+            """
+            USE_RELATIONAL_BACKEND=true
+            RELATIONAL_E2E_DATABASE_NAME=edfi_datamanagementservice_relational
+            """,
+            "Category=@relational-backend&Category=@relational-ci-shard-2"
+        );
+
+        // The script bails out before docker / dotnet are available in this unit context,
+        // so it will not exit 0, but the filter itself must not be rejected by the lane assertion.
+        result.Output.Should().NotContain("Relational E2E environment");
+        result.Output.Should().NotContain("cannot use");
+    }
+
+    [Test]
+    public void It_derives_shard_suffix_from_relational_ci_shard_filter()
+    {
+        var suffixDefinition = ExtractFunctionBody("Get-E2ETestResultSuffix");
+
+        suffixDefinition
+            .Should()
+            .Contain("relational-ci-shard-")
+            .And.Contain("relational-shard-")
+            .And.Contain("ConvertTo-NormalizedTestFilter");
+    }
+
+    private string ExtractFunctionBody(string functionName)
+    {
+        int startIndex = _buildScriptContents.IndexOf($"function {functionName}", StringComparison.Ordinal);
+        startIndex.Should().BeGreaterThan(-1, $"function '{functionName}' must exist in build-dms.ps1");
+
+        int nextFunctionIndex = _buildScriptContents.IndexOf(
+            "\nfunction ",
+            startIndex + 1,
+            StringComparison.Ordinal
+        );
+
+        int endIndex = nextFunctionIndex == -1 ? _buildScriptContents.Length : nextFunctionIndex;
+        return _buildScriptContents.Substring(startIndex, endIndex - startIndex);
+    }
+
     private async Task<BuildScriptResult> RunBuildDmsE2ETest(
         string environmentFileContents,
         string? testFilter = null

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_E2E_Feature_File_Guardrails.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_E2E_Feature_File_Guardrails.cs
@@ -58,6 +58,138 @@ public class Given_E2E_Feature_File_Guardrails
             );
     }
 
+    [Test]
+    public void It_assigns_exactly_one_relational_ci_shard_tag_to_every_relational_backend_scenario()
+    {
+        string[] offendingScenarios = EnumerateScenariosWithTags()
+            .Where(s => s.Tags.Contains("@relational-backend", StringComparer.OrdinalIgnoreCase))
+            .Where(s =>
+                s.Tags.Count(t => t.StartsWith("@relational-ci-shard-", StringComparison.OrdinalIgnoreCase))
+                != 1
+            )
+            .Select(s => $"{s.RelativePath}:{s.LineNumber} ({s.Title})")
+            .ToArray();
+
+        offendingScenarios
+            .Should()
+            .BeEmpty(
+                "each @relational-backend scenario must carry exactly one @relational-ci-shard-N tag so PR CI shards balance and never overlap"
+            );
+    }
+
+    [Test]
+    public void It_never_applies_a_relational_ci_shard_tag_outside_the_relational_lane()
+    {
+        string[] offendingScenarios = EnumerateScenariosWithTags()
+            .Where(s =>
+                s.Tags.Any(t => t.StartsWith("@relational-ci-shard-", StringComparison.OrdinalIgnoreCase))
+            )
+            .Where(s => !s.Tags.Contains("@relational-backend", StringComparer.OrdinalIgnoreCase))
+            .Select(s => $"{s.RelativePath}:{s.LineNumber} ({s.Title})")
+            .ToArray();
+
+        offendingScenarios
+            .Should()
+            .BeEmpty("@relational-ci-shard-N tags belong only to scenarios in the relational lane");
+    }
+
+    [Test]
+    public void It_only_uses_relational_ci_shard_numbers_in_the_supported_range()
+    {
+        string[] offendingTags = EnumerateScenariosWithTags()
+            .SelectMany(s =>
+                s.Tags.Where(t => t.StartsWith("@relational-ci-shard-", StringComparison.OrdinalIgnoreCase))
+                    .Select(t => new
+                    {
+                        s.RelativePath,
+                        s.LineNumber,
+                        Tag = t,
+                    })
+            )
+            .Where(x =>
+            {
+                string suffix = x.Tag.Substring("@relational-ci-shard-".Length);
+                return !int.TryParse(suffix, out int n) || n < 1 || n > 4;
+            })
+            .Select(x => $"{x.RelativePath}:{x.LineNumber} ({x.Tag})")
+            .ToArray();
+
+        offendingTags
+            .Should()
+            .BeEmpty(
+                "shard numbers must be in [1..4]; rebalancing the matrix size is a separate, deliberate change"
+            );
+    }
+
+    /// <summary>
+    /// Enumerates every Scenario / Scenario Outline under the Features tree along with the
+    /// tags that attach to it.
+    /// </summary>
+    /// <remarks>
+    /// SpecFlow / Reqnroll treat comment lines (those starting with a hash, '#') as transparent
+    /// inside a tag block; tags above such a comment still attach to the scenario below it,
+    /// so the backward walk skips blank lines and hash-prefixed lines and only stops at the
+    /// first non-tag, non-comment line.
+    /// </remarks>
+    private IEnumerable<ScenarioRecord> EnumerateScenariosWithTags()
+    {
+        foreach (
+            FileInfo featureFile in _featuresDirectory.EnumerateFiles(
+                "*.feature",
+                SearchOption.AllDirectories
+            )
+        )
+        {
+            string[] lines = File.ReadAllLines(featureFile.FullName);
+            string relativePath = Path.GetRelativePath(_repositoryRoot.FullName, featureFile.FullName);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string trimmed = lines[i].TrimStart();
+                bool isScenario =
+                    trimmed.StartsWith("Scenario:", StringComparison.Ordinal)
+                    || trimmed.StartsWith("Scenario Outline:", StringComparison.Ordinal);
+
+                if (!isScenario)
+                {
+                    continue;
+                }
+
+                var tags = new List<string>();
+                for (int j = i - 1; j >= 0; j--)
+                {
+                    string previous = lines[j].Trim();
+
+                    if (previous.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (previous.StartsWith('#'))
+                    {
+                        continue;
+                    }
+
+                    if (!previous.StartsWith('@'))
+                    {
+                        break;
+                    }
+
+                    tags.AddRange(previous.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries));
+                }
+
+                yield return new ScenarioRecord(relativePath.Replace('\\', '/'), i + 1, trimmed, tags);
+            }
+        }
+    }
+
+    private sealed record ScenarioRecord(
+        string RelativePath,
+        int LineNumber,
+        string Title,
+        IReadOnlyCollection<string> Tags
+    );
+
     private static DirectoryInfo FindRepositoryRoot()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_Relational_Provisioning_Helper.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Unit/Given_Relational_Provisioning_Helper.cs
@@ -54,8 +54,8 @@ public partial class Given_Relational_Provisioning_Helper
         );
 
         result.ExitCode.Should().NotBe(0);
-        result.Output.Should().Contain("must be dedicated");
-        result.Output.Should().Contain("POSTGRES_DB_NAME");
+        result.NormalizedOutput.Should().Contain("must be dedicated");
+        result.NormalizedOutput.Should().Contain("POSTGRES_DB_NAME");
     }
 
     [Test]
@@ -72,7 +72,7 @@ public partial class Given_Relational_Provisioning_Helper
         );
 
         result.ExitCode.Should().NotBe(0);
-        result.Output.Should().Contain("must stay separate from DATABASE_CONNECTION_STRING");
+        result.NormalizedOutput.Should().Contain("must stay separate from DATABASE_CONNECTION_STRING");
     }
 
     [Test]
@@ -88,8 +88,8 @@ public partial class Given_Relational_Provisioning_Helper
         );
 
         result.ExitCode.Should().NotBe(0);
-        result.Output.Should().Contain("reserved PostgreSQL system database");
-        result.Output.Should().Contain("postgres");
+        result.NormalizedOutput.Should().Contain("reserved PostgreSQL system database");
+        result.NormalizedOutput.Should().Contain("postgres");
     }
 
     private async Task<ScriptResult> RunProvisioningHelper(string environmentFileContents)
@@ -119,14 +119,19 @@ public partial class Given_Relational_Provisioning_Helper
                 WorkingDirectory = repositoryRoot.FullName,
             };
 
+            startInfo.Environment["NO_COLOR"] = "1";
+            startInfo.Environment["TERM"] = "dumb";
+
             startInfo.ArgumentList.Add("-NoLogo");
             startInfo.ArgumentList.Add("-NoProfile");
-            startInfo.ArgumentList.Add("-File");
-            startInfo.ArgumentList.Add(scriptPath);
-            startInfo.ArgumentList.Add("-EnvironmentFile");
-            startInfo.ArgumentList.Add(environmentFilePath);
-            startInfo.ArgumentList.Add("-Configuration");
-            startInfo.ArgumentList.Add("Release");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            // -Command prelude: stop on errors, set PlainText rendering, and use NormalView for
+            // errors so ConciseView's pipe-prefix line wrapping does not break substring assertions.
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add(
+                $"$ErrorActionPreference='Stop'; $PSStyle.OutputRendering='PlainText'; $ErrorView='NormalView'; "
+                    + $"& '{scriptPath}' -EnvironmentFile '{environmentFilePath}' -Configuration Release"
+            );
 
             using var process = Process.Start(startInfo);
             process.Should().NotBeNull();
@@ -136,7 +141,8 @@ public partial class Given_Relational_Provisioning_Helper
 
             await process.WaitForExitAsync();
 
-            return new ScriptResult(process.ExitCode, await standardOutputTask + await standardErrorTask);
+            string raw = await standardOutputTask + await standardErrorTask;
+            return new ScriptResult(process.ExitCode, raw, NormalizePowerShellOutput(raw));
         }
         finally
         {
@@ -164,8 +170,22 @@ public partial class Given_Relational_Provisioning_Helper
             );
     }
 
+    private static string NormalizePowerShellOutput(string output)
+    {
+        var withoutAnsi = AnsiEscapeRegex().Replace(output, "");
+        var normalizedLines = withoutAnsi.Replace("\r\n", "\n").Replace('\r', '\n');
+
+        return WhitespaceRegex().Replace(normalizedLines, " ").Trim();
+    }
+
     [GeneratedRegex(@"-U\s+postgres\b", RegexOptions.CultureInvariant)]
     private static partial Regex HardcodedPostgresUserRegex();
 
-    private sealed record ScriptResult(int ExitCode, string Output);
+    [GeneratedRegex(@"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])", RegexOptions.CultureInvariant)]
+    private static partial Regex AnsiEscapeRegex();
+
+    [GeneratedRegex(@"\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex WhitespaceRegex();
+
+    private sealed record ScriptResult(int ExitCode, string Output, string NormalizedOutput);
 }


### PR DESCRIPTION
## Summary

This PR includes the relational E2E migration work plus the DMS-1135 CI sharding/harness changes.

- Adds `@relational-backend` coverage to `404` additional DMS E2E scenarios/scenario outlines.
- Brings the relational E2E lane to `483 / 753` total scenarios/scenario outlines, including the `79` already tagged on `main`.
- Leaves `270` scenarios/scenario outlines outside the relational lane for follow-up migration work.
- Splits the relational E2E lane into a 2x4 PR matrix (`identityprovider x shard`) with stable per-IDP/per-shard artifact, TRX, and log names.
- Adds `relational-e2e-summary` as a lightweight roll-up job so branch protection has one stable required-status name regardless of shard count.
- Hardens `Given_Relational_Provisioning_Helper` against PowerShell host formatting flake by setting `NO_COLOR`, using `PlainText`/`NormalView` in the child process, and normalizing output at the assertion boundary.

Legacy E2E coverage is not reintroduced into the PR build; the PR workflow runs only the relational backend lane.

## Test plan

- [ ] `Run PostgreSQL Relational E2E (keycloak, Shard 1..4)` x 4 matrix jobs all green
- [ ] `Run PostgreSQL Relational E2E (self-contained, Shard 1..4)` x 4 matrix jobs all green
- [ ] `relational-e2e-summary` shows green after all 8 shards pass
- [ ] Per-shard artifacts upload uniquely (`postgresql-<idp>-relational-shard-<n>-test-logs`)
- [ ] Per-shard TRXs upload with unique reporter names
- [ ] `Given_E2E_Feature_File_Guardrails`, `Given_Build_Dms_E2E_Guardrails`, and `Given_Relational_Provisioning_Helper` all green in the unit-tests job