### PR TITLE
[DMS-1135] FIX: Self-contain SuperclassReferenceValidation Scenario 06

### DIFF
--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/References/SuperclassReferenceValidation.feature
@@ -166,6 +166,9 @@ Feature: SuperclassReferenceValidation of Creation, Update and Deletion of resou
             Given the system has these "localEducationAgencies" references
                   | localEducationAgencyId | nameOfInstitution           | localEducationAgencyCategoryDescriptor                                              | categories                                                                                                                            |
                   | 333                    | Other Education Agency Test | uri://ed-fi.org/LocalEducationAgencyCategoryDescriptor#Other local education agency | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#Local Education Agency"}] |
+              And the system has these "Schools"
+                  | schoolId | nameOfInstitution | localEducationAgencyReference  | educationOrganizationCategories                                                                                       | gradeLevels                                                                     |
+                  | 200      | School Test 99    | {"localEducationAgencyId":333} | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"}] | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"}] |
               And the system has these "programs"
                   | programName          | programTypeDescriptor                              | educationOrganizationReference  | programId |
                   | Career and Technical | "uri://ed-fi.org/ProgramTypeDescriptor#Billingual" | {"educationOrganizationId":333} | "111"     |


### PR DESCRIPTION
## Summary

The two scheduled CI workflows that ran 2026-05-16 (`Scheduled Build` and `Scheduled pre Image Tests`) both fail on a single legacy E2E test:

`SuperclassReferenceValidation.feature` → `06 Ensure clients cannot delete and existing Education Organization that is referenced to a Program`.

This is a test-correctness issue, not a production bug. The production response is now actually correct; the test was relying on hidden cross-scenario state.

## Root cause

Scenario 06 deletes LEA 333 and asserts the 409 lists dependents `"Program, School"`. Its own `Given` block only sets up `Program 111 → LEA 333`, so on its own it can only produce `"Program"`. The `"School"` part was incidental leakage from `@API-107` (Scenario 04, *"update a school to reference an existing local education agency"*), which PUTs `School 200 → LEA 333` and leaves that row in the database for subsequent scenarios in the same lane.

#964 (`[DMS-1135] Parallelize relational E2E lane and harden harness`) tagged Scenarios 01–05 of this feature with `@relational-backend` / `@relational-ci-shard-4` but **left Scenario 06 untagged**. The legacy lane runs `Category!=@relational-backend`, so on the May 16 run Scenario 06 executed in isolation for the first time:

| Run | Legacy lane total tests | Scenario 06 |
|---|---|---|
| 2026-05-09 (passed) | 686 | passes — Scenario 04 ran first |
| 2026-05-16 (failed) | 234 | fails — Scenario 04 now runs in the relational lane |

DMS container log for the failing DELETE (`/data/ed-fi/localEducationAgencies/48deb32e-7167-f5b0-a1a1-a8094c6a8edd`) shows the legacy backend correctly returns just `Program` — no School row references LEA 333 in this lane anymore.

Both lanes (self-contained and keycloak), both workflows (`Scheduled Build` and `Scheduled pre Image Tests`), single failing test. Same root cause.

## Fix

Add an inline `And the system has these "Schools"` Given step to Scenario 06 that posts `School 200 → LEA 333`. Scenario 06 now owns the precondition it asserts against and is independent of sibling-scenario execution order.

`.feature.cs` is gitignored and regenerates on build.

## Test plan

- [ ] Manual run of `Scheduled Build` workflow on this branch — both matrix lanes (`self-contained`, `keycloak`) should pass legacy E2E, including Scenario 06.
- [ ] Manual run of `Scheduled pre Image Tests` workflow on this branch — same expectation.
- [ ] On-PR checks pass.

[DMS-1135]: https://edfi.atlassian.net/browse/DMS-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ