### PR TITLE
[DMS-1150] Bootstrap-mode schema and claims workspace staging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,8 @@
 * text eol=lf
 
 *.sh eol=lf
+ApiSchema*.json text eol=lf
+*-claimset.json text eol=lf
 
 ## SOURCE CODE
 *.bat  text eol=crlf

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -93,6 +93,28 @@ jobs:
     with:
       config-file-path: ./.github/workflows/bidi-config.json
 
+  run-bootstrap-pester-tests:
+    name: Run Bootstrap Pester Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout the Repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Pester
+        run: Install-Module Pester -RequiredVersion 5.7.1 -Scope CurrentUser -Force
+
+      - name: Run Bootstrap Pester Tests
+        run: |
+          $result = Invoke-Pester -Path eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1 -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+              throw "$($result.FailedCount) bootstrap Pester test(s) failed."
+          }
+
   run-unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ BenchmarkDotNet.Artifacts/
 project.lock.json
 project.fragment.lock.json
 artifacts/
+eng/docker-compose/.bootstrap/
 
 # ASP.NET Scaffolding
 ScaffoldingReadMe.txt

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -672,37 +672,37 @@ function Start-DockerEnvironment {
     Invoke-Execute {
         try {
             Push-Location "$PSScriptRoot/eng/docker-compose"
-            ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -d -v
-            ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -d -v
+            ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -d -v -RemoveBootstrap
+            ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -d -v -RemoveBootstrap
         }
         finally {
             Pop-Location
         }
     }
-        Invoke-Execute {
-            try {
-                Push-Location "$PSScriptRoot/eng/docker-compose"
-                if ($UsePublishedImage) {
-                    if ($LoadSeedData) {
-                    ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -AddExtensionSecurityMetadata -LoadSeedData -IdentityProvider $IdentityProvider
-                    }
-                    else {
-                    ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -AddExtensionSecurityMetadata -IdentityProvider $IdentityProvider
-                    }
+    Invoke-Execute {
+        try {
+            Push-Location "$PSScriptRoot/eng/docker-compose"
+            if ($UsePublishedImage) {
+                if ($LoadSeedData) {
+                    ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -LoadSeedData -IdentityProvider $IdentityProvider -AddExtensionSecurityMetadata
                 }
                 else {
-                    if ($LoadSeedData) {
-                    ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -AddExtensionSecurityMetadata -LoadSeedData -IdentityProvider $IdentityProvider
-                    }
-                    else {
-                    ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -AddExtensionSecurityMetadata -IdentityProvider $IdentityProvider
-                    }
+                    ./start-published-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -AddExtensionSecurityMetadata
                 }
             }
-            finally {
-                Pop-Location
+            else {
+                if ($LoadSeedData) {
+                    ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -LoadSeedData -IdentityProvider $IdentityProvider -AddExtensionSecurityMetadata
+                }
+                else {
+                    ./start-local-dms.ps1 -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -AddExtensionSecurityMetadata
+                }
             }
         }
+        finally {
+            Pop-Location
+        }
+    }
 }
 
 function Initialize-RelationalE2EDatabase {

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -65,8 +65,8 @@ also append `-v`. Examples:
 # Start everything
 ./start-local-dms.ps1
 
-# Start everything for E2E testing
-./start-local-dms.ps1 -EnvironmentFile ./.env.e2e
+# Start everything for E2E testing (DLL-backed schema packages)
+../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
 
 # Stop the services, keeping volumes
 ./start-local-dms.ps1 -d
@@ -82,10 +82,12 @@ provisioned and DMS must observe the provisioned `dms.EffectiveSchema` before
 it can serve requests. Because `provision-relational-e2e-database.ps1`
 provisions inside the running `dms-postgresql` container, the sequence is:
 
-1. Start the Docker environment so PostgreSQL is up:
+1. Start the Docker environment so PostgreSQL is up. The E2E setup wrapper uses
+   the DLL-backed `SCHEMA_PACKAGES` schema path until Story 04 adds runtime
+   loose-file content loading:
 
    ```pwsh
-   ./start-local-dms.ps1 -EnvironmentFile ./.env.e2e.relational
+   ../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1 -EnvironmentFile ./.env.e2e.relational
    ```
 
 2. Run the provisioning script:
@@ -114,8 +116,8 @@ If you want to use Keycloak as the identity provider, pass the `-IdentityProvide
 # Start everything (Self-Contained/OpenIddict mode)
 ./start-local-dms.ps1 -IdentityProvider self-contained
 
-# Start everything for E2E testing (Self-Contained/OpenIddict mode)
-./start-local-dms.ps1 -IdentityProvider self-contained -EnvironmentFile ./.env.e2e
+# Start everything for E2E testing (Self-Contained/OpenIddict mode, DLL-backed schema by default)
+../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
 
 # Stop the services, keeping volumes (Self-Contained/OpenIddict mode)
 ./start-local-dms.ps1 -d
@@ -179,21 +181,59 @@ USE_API_SCHEMA_PATH and API_SCHEMA_PATH environment variables.
 ]'
 ```
 
-You can also automatically include extension-specific metadata in the
-authorization hierarchy to enable authorization for your extension resources. To
-do this:
+For bootstrap-managed schema and extension security metadata, stage the inputs
+before starting Docker:
 
-1. Author your security claims hierarchy JSON file. See `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets`
-for examples. Files must follow the pattern: `{number}-{description}-claimset.json` and will be processed in order.
-
-2. Place it in a directory mounted as a Docker volume named `app/additional-claims` for CMS to see at runtime. The default behavior of the docker compose
-scripts is to mount `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets`.
-
-3. Use the `-AddExtensionSecurityMetadata` parameter to configure CMS to read claimsets from `app/additional-claims`:
+> **Requirement — `dms-schema` tool:** `prepare-dms-schema.ps1` needs the
+> in-repo `dms-schema` CLI published as a native executable. Build it once
+> before running the prepare command (the publish step is safe to re-run after
+> branch switches).
 
 ```pwsh
-./start-local-dms.ps1 -AddExtensionSecurityMetadata
+# 1. Publish the dms-schema tool (required on a clean checkout)
+$schemaToolProject = "../../src/dms/clis/EdFi.DataManagementService.SchemaTools/EdFi.DataManagementService.SchemaTools.csproj"
+$schemaToolOutput  = ".bootstrap/tools/dms-schema"
+dotnet publish $schemaToolProject -c Release -p:UseAppHost=true -o $schemaToolOutput
+
+# 2. Point to the platform-appropriate executable
+$schemaToolExe = if ($IsWindows) { "$schemaToolOutput/dms-schema.exe" } else { "$schemaToolOutput/dms-schema" }
+
+# 3. Stage schema and claims, then start DMS
+./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+./prepare-dms-claims.ps1 -ClaimsDirectoryPath <directory-with-tpdm-claimset-fragment>
+./start-local-dms.ps1
 ```
+
+`prepare-dms-claims.ps1` stages `*-claimset.json` fragments into
+`.bootstrap/claims`, and the Config Service reads that workspace at
+`/app/additional-claims` when a bootstrap manifest is present. The staged
+`.bootstrap/ApiSchema` workspace is also produced for `dms-schema hash`
+and downstream consumption, but DMS Docker startup still loads schemas
+from the DLL-backed `SCHEMA_PACKAGES` packages — runtime reads of the
+staged ApiSchema workspace land in Story 04.
+
+The full in-repo `EdFi.DataStandard52.ApiSchema` directory includes TPDM. Story
+00 automatically maps only Sample and Homograph extension claim fragments, so
+the full in-repo schema requires `-ClaimsDirectoryPath` with a TPDM
+`*-claimset.json` fragment. For a schema set containing only core, Sample, and
+Homograph, the claims command can be run without `-ClaimsDirectoryPath`.
+
+The DMS E2E setup wrappers stay on the prior DLL-backed `SCHEMA_PACKAGES` flow
+because the DMS runtime ContentProvider does not yet load loose JSON content
+(Story 04). The wrappers should move to the staged `.bootstrap/ApiSchema` and
+`.bootstrap/claims` workspaces when Story 04 lands.
+
+If `prepare-dms-schema.ps1` or `prepare-dms-claims.ps1` fail with a
+fingerprint-mismatch teardown-guidance error after a branch switch or input
+change, recover by running `./start-local-dms.ps1 -d -v -RemoveBootstrap`
+(which removes the local `.bootstrap/` workspace) or the matching E2E
+`teardown-local-dms.ps1` script, then rerun the prepare commands.
+
+> **Note on `-RemoveBootstrap`:** By default, `./start-local-dms.ps1 -d -v`
+> and `./start-published-dms.ps1 -d -v` do **not** delete the `.bootstrap/`
+> workspace on teardown. Pass `-RemoveBootstrap` explicitly when you want the
+> workspace wiped (e.g. after a branch switch). The E2E teardown wrappers
+> always remove it unconditionally.
 
 ## Default URLs
 

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -205,12 +205,13 @@ $schemaToolExe = if ($IsWindows) { "$schemaToolOutput/dms-schema.exe" } else { "
 ```
 
 `prepare-dms-claims.ps1` stages `*-claimset.json` fragments into
-`.bootstrap/claims`, and the Config Service reads that workspace at
-`/app/additional-claims` when a bootstrap manifest is present. The staged
-`.bootstrap/ApiSchema` workspace is also produced for `dms-schema hash`
-and downstream consumption, but DMS Docker startup still loads schemas
-from the DLL-backed `SCHEMA_PACKAGES` packages — runtime reads of the
-staged ApiSchema workspace land in Story 04.
+`.bootstrap/claims`. Story 00 validates the prepared manifest but does
+not point the Config Service at `.bootstrap/claims` during startup because
+DMS Docker startup still uses the non-staged schema path. When a bootstrap
+manifest is present, startup disables `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH`
+so the container falls back to its built-in DLL-backed schema assemblies.
+Runtime reads of `.bootstrap/ApiSchema` and matching staged claims activation
+land together in Story 04.
 
 The full in-repo `EdFi.DataStandard52.ApiSchema` directory includes TPDM. Story
 00 automatically maps only Sample and Homograph extension claim fragments, so

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -1,0 +1,493 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Set-StrictMode -Version Latest
+
+$script:DockerComposeRoot = $PSScriptRoot
+$script:RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $script:DockerComposeRoot "../.."))
+$script:BootstrapRoot = Join-Path $script:DockerComposeRoot ".bootstrap"
+$script:BootstrapManifestPath = Join-Path $script:BootstrapRoot "bootstrap-manifest.json"
+$script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$script:WorkspaceMismatchMessage = "Existing staged bootstrap workspace differs from requested inputs, manifest state is incomplete, or files were manually edited (partial prior state). Stop the local stack and remove eng/docker-compose/.bootstrap before retrying. For local Docker, run: pwsh eng/docker-compose/start-local-dms.ps1 -d -v -RemoveBootstrap. E2E teardown wrappers also remove the bootstrap workspace."
+
+function Get-BootstrapRepoRoot {
+    return $script:RepoRoot
+}
+
+function Get-BootstrapRoot {
+    return $script:BootstrapRoot
+}
+
+function Get-BootstrapWorkspaceMismatchMessage {
+    param(
+        [string]
+        $Reason
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+        return $script:WorkspaceMismatchMessage.Replace(
+            "Stop the local stack",
+            "Diverging field: $(Format-LogSafeText $Reason). Stop the local stack"
+        )
+    }
+
+    return $script:WorkspaceMismatchMessage
+}
+
+function Format-LogSafeText {
+    param(
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return ""
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrEmpty($text)) {
+        return ""
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    foreach ($character in $text.ToCharArray()) {
+        if ([char]::IsLetterOrDigit($character) -or
+            $character -eq " " -or
+            $character -eq "_" -or
+            $character -eq "-" -or
+            $character -eq "." -or
+            $character -eq ":" -or
+            $character -eq "/") {
+            $null = $builder.Append($character)
+        }
+    }
+
+    return $builder.ToString()
+}
+
+function New-BootstrapManifest {
+    return @{
+        version = 1
+    }
+}
+
+function Read-BootstrapManifest {
+    param(
+        [string]
+        $Path = $script:BootstrapManifestPath
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $null
+    }
+
+    try {
+        $manifest = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+    } catch {
+        throw "Bootstrap manifest '$(Format-LogSafeText $Path)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    if ($manifest -isnot [System.Collections.IDictionary]) {
+        throw "Bootstrap manifest '$(Format-LogSafeText $Path)' must contain a JSON object."
+    }
+
+    if (-not $manifest.ContainsKey("version") -or $null -eq $manifest["version"]) {
+        $manifest["version"] = 1
+        return $manifest
+    }
+
+    try {
+        $manifestVersion = [int]$manifest["version"]
+    } catch {
+        throw "Bootstrap manifest '$(Format-LogSafeText $Path)' has malformed version: $(Format-LogSafeText ($manifest["version"]))"
+    }
+
+    if ($manifestVersion -gt 1) {
+        throw "Bootstrap manifest version unsupported: $(Format-LogSafeText $manifestVersion). This checkout supports version 1."
+    }
+
+    if ($manifestVersion -lt 1) {
+        throw "Bootstrap manifest '$(Format-LogSafeText $Path)' has malformed version: $(Format-LogSafeText $manifestVersion)"
+    }
+
+    $manifest["version"] = $manifestVersion
+    return $manifest
+}
+
+function Write-BootstrapJson {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory)]
+        $Value
+    )
+
+    $directory = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($directory)) {
+        New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    }
+
+    $json = $Value | ConvertTo-Json -Depth 100
+    [System.IO.File]::WriteAllText($Path, "$json`n", $script:Utf8NoBom)
+}
+
+function Write-BootstrapManifest {
+    param(
+        [Parameter(Mandatory)]
+        $Manifest,
+
+        [string]
+        $Path = $script:BootstrapManifestPath
+    )
+
+    $orderedManifest = [ordered]@{
+        version = 1
+    }
+
+    foreach ($sectionName in @("schema", "claims", "seed")) {
+        if ($Manifest.ContainsKey($sectionName)) {
+            $orderedManifest[$sectionName] = $Manifest[$sectionName]
+        }
+    }
+
+    Write-BootstrapJson -Path $Path -Value $orderedManifest
+}
+
+function Set-BootstrapManifestSection {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet("schema", "claims", "seed")]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory)]
+        $Value,
+
+        [string]
+        $Path = $script:BootstrapManifestPath
+    )
+
+    $manifest = Read-BootstrapManifest -Path $Path
+    if ($null -eq $manifest) {
+        $manifest = New-BootstrapManifest
+    }
+
+    $manifest[$Name] = $Value
+    Write-BootstrapManifest -Manifest $manifest -Path $Path
+}
+
+function Get-BootstrapRelativePath {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [string]
+        $BasePath = $script:BootstrapRoot
+    )
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    $fullBasePath = [System.IO.Path]::GetFullPath($BasePath)
+    return [System.IO.Path]::GetRelativePath($fullBasePath, $fullPath).Replace("\", "/")
+}
+
+function Resolve-BootstrapPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $RelativePath
+    )
+
+    return [System.IO.Path]::GetFullPath((Join-Path $script:BootstrapRoot $RelativePath))
+}
+
+function Resolve-BootstrapWorkspaceRelativePath {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $RelativePath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ManifestField
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RelativePath)) {
+        throw "Bootstrap manifest field '$(Format-LogSafeText $ManifestField)' must not be empty."
+    }
+
+    $normalizedPath = $RelativePath.Replace("\", "/")
+    if ([System.IO.Path]::IsPathRooted($RelativePath) -or $normalizedPath.StartsWith("/")) {
+        throw "Bootstrap manifest field '$(Format-LogSafeText $ManifestField)' must be relative to the bootstrap workspace: $(Format-LogSafeText $RelativePath)"
+    }
+
+    $pathSegments = @($normalizedPath -split "/")
+    if ($pathSegments | Where-Object { [string]::IsNullOrWhiteSpace($_) -or $_ -eq "." -or $_ -eq ".." }) {
+        throw "Bootstrap manifest field '$(Format-LogSafeText $ManifestField)' must not contain empty, current, or parent path segments: $(Format-LogSafeText $RelativePath)"
+    }
+
+    return $normalizedPath
+}
+
+function Get-BootstrapFingerprintBytes {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    $extension = [System.IO.Path]::GetExtension($Path)
+    $isTextFile = $extension.Equals(".json", [System.StringComparison]::OrdinalIgnoreCase) -or
+                  $extension.Equals(".xsd", [System.StringComparison]::OrdinalIgnoreCase)
+
+    if ($isTextFile) {
+        $text = [System.IO.File]::ReadAllText($Path)
+        $normalizedText = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+        return [System.Text.Encoding]::UTF8.GetBytes($normalizedText)
+    }
+
+    return [System.IO.File]::ReadAllBytes($Path)
+}
+
+function Get-BootstrapWorkspaceFingerprint {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [string[]]
+        $ExcludeRelativePath = @()
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Workspace path does not exist: $(Format-LogSafeText $Path)"
+    }
+
+    $excludeSet = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($relativePath in $ExcludeRelativePath) {
+        $null = $excludeSet.Add($relativePath.Replace("\", "/"))
+    }
+
+    $entries = @(
+        Get-ChildItem -LiteralPath $Path -File -Recurse | ForEach-Object {
+            $relativePath = Get-BootstrapRelativePath -Path $_.FullName -BasePath $Path
+            if (-not $excludeSet.Contains($relativePath)) {
+                [pscustomobject]@{
+                    RelativePath = $relativePath
+                    FullName = $_.FullName
+                }
+            }
+        }
+    )
+
+    $sortedEntries = @($entries | Sort-Object -Property RelativePath)
+    $incrementalHash = [System.Security.Cryptography.IncrementalHash]::CreateHash(
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256
+    )
+    [byte[]] $separator = 0
+
+    foreach ($entry in $sortedEntries) {
+        $relativePathBytes = [System.Text.Encoding]::UTF8.GetBytes($entry.RelativePath)
+        $incrementalHash.AppendData($relativePathBytes)
+        $incrementalHash.AppendData($separator)
+        $incrementalHash.AppendData((Get-BootstrapFingerprintBytes -Path $entry.FullName))
+        $incrementalHash.AppendData($separator)
+    }
+
+    return [System.Convert]::ToHexString($incrementalHash.GetHashAndReset()).ToLowerInvariant()
+}
+
+function Read-RequiredJsonBoolean {
+    param(
+        [Parameter(Mandatory)]
+        $Hashtable,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Key,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ArtifactContext
+    )
+
+    if ($Hashtable -isnot [System.Collections.IDictionary] -or -not $Hashtable.Contains($Key)) {
+        throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+    }
+
+    $value = $Hashtable[$Key]
+    if ($value -is [bool]) {
+        return $value
+    }
+
+    throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+}
+
+function Set-BootstrapStartupEnvironment {
+    param(
+        [switch]
+        $SkipArtifactValidation
+    )
+
+    if (-not (Test-Path -LiteralPath $script:BootstrapManifestPath)) {
+        return $false
+    }
+
+    $manifest = Read-BootstrapManifest
+    if ($null -eq $manifest -or -not $manifest.ContainsKey("schema")) {
+        throw "Bootstrap manifest is missing the schema section. Run prepare-dms-schema.ps1 before starting services."
+    }
+
+    $schemaSection = $manifest["schema"]
+    if ($schemaSection -isnot [System.Collections.IDictionary]) {
+        throw "Bootstrap manifest schema section must be a JSON object."
+    }
+    $schemaMode = $schemaSection["mode"]
+    if ($schemaMode -ne "ApiSchemaPath") {
+        throw "Bootstrap schema mode '$(Format-LogSafeText $schemaMode)' is not supported in Story 00; only 'ApiSchemaPath' is accepted."
+    }
+    if (-not $schemaSection.ContainsKey("apiSchemaManifestPath") -or [string]::IsNullOrWhiteSpace($schemaSection["apiSchemaManifestPath"])) {
+        throw "Bootstrap manifest field 'schema.apiSchemaManifestPath' must not be empty."
+    }
+    $apiSchemaManifestRelativePath = Resolve-BootstrapWorkspaceRelativePath `
+        -RelativePath $schemaSection["apiSchemaManifestPath"] `
+        -ManifestField "schema.apiSchemaManifestPath"
+    $apiSchemaManifestPath = Resolve-BootstrapPath -RelativePath $apiSchemaManifestRelativePath
+
+    $apiSchemaPath = Join-Path $script:BootstrapRoot "ApiSchema"
+    if (-not $SkipArtifactValidation -and -not (Test-Path -LiteralPath $apiSchemaPath)) {
+        throw "Bootstrap ApiSchema workspace is missing: $(Format-LogSafeText $apiSchemaPath)"
+    }
+
+    if (-not $SkipArtifactValidation -and -not (Test-Path -LiteralPath $apiSchemaManifestPath -PathType Leaf)) {
+        throw "Bootstrap ApiSchema manifest is missing: $(Format-LogSafeText $apiSchemaManifestPath)"
+    }
+
+    # NOTE (Story 04): Flipping DMS into staged-workspace runtime loading (USE_API_SCHEMA_PATH=true,
+    # API_SCHEMA_PATH=/app/ApiSchema, clearing SCHEMA_PACKAGES, and mounting .bootstrap/ApiSchema via
+    # bootstrap-dms.yml) is deferred to Story 04. ContentProvider still expects *.ApiSchema.dll assemblies,
+    # so activating that path here would cause discovery/XSD content fetches to fail in bootstrap mode.
+    # Story 00 validates the manifest and wires CMS claims loading only; Story 04 owns the DMS runtime flip.
+
+    if (-not $manifest.ContainsKey("claims")) {
+        if (-not $SkipArtifactValidation) {
+            throw "Bootstrap manifest is missing the claims section. Run prepare-dms-claims.ps1 before starting services."
+        }
+
+        # Clear any stale claims env vars inherited from a prior run so teardown does not carry them forward.
+        $env:DMS_CONFIG_CLAIMS_SOURCE = ""
+        $env:DMS_CONFIG_CLAIMS_DIRECTORY = ""
+        $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+        return $true
+    }
+
+    $claimsSection = $manifest["claims"]
+    if ($claimsSection -isnot [System.Collections.IDictionary]) {
+        throw "Bootstrap manifest claims section must be a JSON object."
+    }
+    $claimsMode = $claimsSection["mode"]
+    if ($claimsMode -notin @("Embedded", "Hybrid")) {
+        throw "Bootstrap manifest field 'claims.mode' must be Embedded or Hybrid: $(Format-LogSafeText $claimsMode)"
+    }
+
+    if (-not $claimsSection.ContainsKey("directory") -or [string]::IsNullOrWhiteSpace($claimsSection["directory"])) {
+        throw "Bootstrap manifest field 'claims.directory' must not be empty."
+    }
+    $claimsDirectory = $claimsSection["directory"]
+    $claimsDirectory = Resolve-BootstrapWorkspaceRelativePath `
+        -RelativePath $claimsDirectory `
+        -ManifestField "claims.directory"
+
+    $claimsPath = Resolve-BootstrapPath -RelativePath $claimsDirectory
+    if (-not $SkipArtifactValidation -and -not (Test-Path -LiteralPath $claimsPath)) {
+        throw "Bootstrap claims workspace is missing: $(Format-LogSafeText $claimsPath)"
+    }
+
+    if (-not $manifest.ContainsKey("seed")) {
+        throw "Bootstrap manifest is missing the seed section. Run prepare-dms-claims.ps1 before starting services."
+    }
+
+    $seedSection = $manifest["seed"]
+    if ($seedSection -isnot [System.Collections.IDictionary]) {
+        throw "Bootstrap manifest seed section must be a JSON object."
+    }
+
+    if (-not $seedSection.ContainsKey("extensionNamespacePrefixes")) {
+        throw "Bootstrap manifest seed section is missing 'extensionNamespacePrefixes'."
+    }
+
+    $extensionNamespacePrefixes = $seedSection["extensionNamespacePrefixes"]
+    if ($null -ne $extensionNamespacePrefixes -and $extensionNamespacePrefixes -isnot [System.Collections.IList]) {
+        throw "Bootstrap manifest seed.extensionNamespacePrefixes must be a JSON array."
+    }
+
+    foreach ($extensionNamespacePrefix in @($extensionNamespacePrefixes)) {
+        if ($extensionNamespacePrefix -isnot [string]) {
+            throw "Bootstrap manifest seed.extensionNamespacePrefixes must contain only strings."
+        }
+    }
+
+    $env:DMS_CONFIG_CLAIMS_SOURCE = $claimsMode
+    $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = [System.IO.Path]::GetFullPath((Join-Path $script:DockerComposeRoot ".bootstrap/$claimsDirectory"))
+
+    return $true
+}
+
+$script:BootstrapEnvVarNames = @(
+    "DMS_CONFIG_CLAIMS_SOURCE",
+    "DMS_CONFIG_CLAIMS_DIRECTORY",
+    "DMS_CONFIG_CLAIMS_MOUNT_SOURCE"
+)
+
+function Get-BootstrapEnvSnapshot {
+    $snapshot = @{}
+    foreach ($name in $script:BootstrapEnvVarNames) {
+        $snapshot[$name] = [System.Environment]::GetEnvironmentVariable($name)
+    }
+    return $snapshot
+}
+
+function Restore-BootstrapEnvSnapshot {
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]
+        $Snapshot
+    )
+
+    foreach ($name in $script:BootstrapEnvVarNames) {
+        if ($Snapshot.ContainsKey($name)) {
+            $value = $Snapshot[$name]
+            if ($null -eq $value) {
+                [System.Environment]::SetEnvironmentVariable($name, $null)
+            } else {
+                [System.Environment]::SetEnvironmentVariable($name, $value)
+            }
+        } else {
+            [System.Environment]::SetEnvironmentVariable($name, $null)
+        }
+    }
+}
+
+Export-ModuleMember -Function `
+    Get-BootstrapRepoRoot, `
+    Get-BootstrapRoot, `
+    Get-BootstrapWorkspaceMismatchMessage, `
+    Format-LogSafeText, `
+    New-BootstrapManifest, `
+    Read-BootstrapManifest, `
+    Read-RequiredJsonBoolean, `
+    Write-BootstrapJson, `
+    Write-BootstrapManifest, `
+    Set-BootstrapManifestSection, `
+    Get-BootstrapRelativePath, `
+    Resolve-BootstrapWorkspaceRelativePath, `
+    Resolve-BootstrapPath, `
+    Get-BootstrapFingerprintBytes, `
+    Get-BootstrapWorkspaceFingerprint, `
+    Set-BootstrapStartupEnvironment, `
+    Get-BootstrapEnvSnapshot, `
+    Restore-BootstrapEnvSnapshot

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -13,14 +13,26 @@ $script:Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
 $script:WorkspaceMismatchMessage = "Existing staged bootstrap workspace differs from requested inputs, manifest state is incomplete, or files were manually edited (partial prior state). Stop the local stack and remove eng/docker-compose/.bootstrap before retrying. For local Docker, run: pwsh eng/docker-compose/start-local-dms.ps1 -d -v -RemoveBootstrap. E2E teardown wrappers also remove the bootstrap workspace."
 
 function Get-BootstrapRepoRoot {
+    <#
+    .SYNOPSIS
+    Repo root resolved from this module's location.
+    #>
     return $script:RepoRoot
 }
 
 function Get-BootstrapRoot {
+    <#
+    .SYNOPSIS
+    Absolute path to eng/docker-compose/.bootstrap (staged workspace root).
+    #>
     return $script:BootstrapRoot
 }
 
 function Get-BootstrapWorkspaceMismatchMessage {
+    <#
+    .SYNOPSIS
+    Formats the standard "staged workspace mismatch" error message, optionally including a diverging-field reason.
+    #>
     param(
         [string]
         $Reason
@@ -37,6 +49,10 @@ function Get-BootstrapWorkspaceMismatchMessage {
 }
 
 function Format-LogSafeText {
+    <#
+    .SYNOPSIS
+    Sanitizes a value for safe inclusion in log output (whitelist of letters, digits, and safe punctuation).
+    #>
     param(
         $Value
     )
@@ -67,12 +83,22 @@ function Format-LogSafeText {
 }
 
 function New-BootstrapManifest {
+    <#
+    .SYNOPSIS
+    Returns a fresh in-memory bootstrap manifest hashtable seeded with the supported schema version.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; the bootstrap scripts do not expose -WhatIf end to end, so a partial ShouldProcess opt-in would just enable silent no-ops.')]
+    param()
     return @{
         version = 1
     }
 }
 
 function Read-BootstrapManifest {
+    <#
+    .SYNOPSIS
+    Reads and validates the on-disk bootstrap manifest; returns $null when the file does not exist.
+    #>
     param(
         [string]
         $Path = $script:BootstrapManifestPath
@@ -116,6 +142,10 @@ function Read-BootstrapManifest {
 }
 
 function Write-BootstrapJson {
+    <#
+    .SYNOPSIS
+    Writes a JSON payload to disk using UTF-8 (no BOM) with a trailing newline, creating parent directories as needed.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -135,6 +165,10 @@ function Write-BootstrapJson {
 }
 
 function Write-BootstrapManifest {
+    <#
+    .SYNOPSIS
+    Persists a bootstrap manifest hashtable to disk with sections in canonical order.
+    #>
     param(
         [Parameter(Mandatory)]
         $Manifest,
@@ -157,6 +191,11 @@ function Write-BootstrapManifest {
 }
 
 function Set-BootstrapManifestSection {
+    <#
+    .SYNOPSIS
+    Replaces a named section (schema, claims, or seed) in the bootstrap manifest on disk.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; the bootstrap scripts do not expose -WhatIf end to end, so a partial ShouldProcess opt-in would just enable silent no-ops.')]
     param(
         [Parameter(Mandatory)]
         [ValidateSet("schema", "claims", "seed")]
@@ -180,6 +219,10 @@ function Set-BootstrapManifestSection {
 }
 
 function Get-BootstrapRelativePath {
+    <#
+    .SYNOPSIS
+    Returns a forward-slash-normalized path relative to BasePath.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -195,6 +238,10 @@ function Get-BootstrapRelativePath {
 }
 
 function Resolve-BootstrapPath {
+    <#
+    .SYNOPSIS
+    Resolves a manifest-relative path against the bootstrap workspace root into an absolute path.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -205,6 +252,10 @@ function Resolve-BootstrapPath {
 }
 
 function Resolve-BootstrapWorkspaceRelativePath {
+    <#
+    .SYNOPSIS
+    Validates a manifest field's relative path and returns it normalized; throws if the path escapes the workspace.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -232,7 +283,11 @@ function Resolve-BootstrapWorkspaceRelativePath {
     return $normalizedPath
 }
 
-function Get-BootstrapFingerprintBytes {
+function Get-BootstrapFingerprintByte {
+    <#
+    .SYNOPSIS
+    Reads a workspace file as a byte sequence (input to the workspace fingerprint hash).
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -253,6 +308,10 @@ function Get-BootstrapFingerprintBytes {
 }
 
 function Get-BootstrapWorkspaceFingerprint {
+    <#
+    .SYNOPSIS
+    Computes a deterministic SHA-256 fingerprint over a directory's file contents and relative paths.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]
@@ -293,7 +352,7 @@ function Get-BootstrapWorkspaceFingerprint {
         $relativePathBytes = [System.Text.Encoding]::UTF8.GetBytes($entry.RelativePath)
         $incrementalHash.AppendData($relativePathBytes)
         $incrementalHash.AppendData($separator)
-        $incrementalHash.AppendData((Get-BootstrapFingerprintBytes -Path $entry.FullName))
+        $incrementalHash.AppendData((Get-BootstrapFingerprintByte -Path $entry.FullName))
         $incrementalHash.AppendData($separator)
     }
 
@@ -301,6 +360,10 @@ function Get-BootstrapWorkspaceFingerprint {
 }
 
 function Read-RequiredJsonBoolean {
+    <#
+    .SYNOPSIS
+    Reads a required boolean field from a JSON hashtable; throws if missing or malformed.
+    #>
     param(
         [Parameter(Mandatory)]
         $Hashtable,
@@ -327,6 +390,11 @@ function Read-RequiredJsonBoolean {
 }
 
 function Set-BootstrapStartupEnvironment {
+    <#
+    .SYNOPSIS
+    Validates the on-disk bootstrap manifest for startup; returns $true when a manifest is present. DMS schema path and staged CMS claims activation are deferred to Story 04.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; the bootstrap scripts do not expose -WhatIf end to end, so a partial ShouldProcess opt-in would just enable silent no-ops.')]
     param(
         [switch]
         $SkipArtifactValidation
@@ -345,9 +413,9 @@ function Set-BootstrapStartupEnvironment {
     if ($schemaSection -isnot [System.Collections.IDictionary]) {
         throw "Bootstrap manifest schema section must be a JSON object."
     }
-    $schemaMode = $schemaSection["mode"]
-    if ($schemaMode -ne "ApiSchemaPath") {
-        throw "Bootstrap schema mode '$(Format-LogSafeText $schemaMode)' is not supported in Story 00; only 'ApiSchemaPath' is accepted."
+    $schemaSelectionMode = $schemaSection["selectionMode"]
+    if ($schemaSelectionMode -ne "ApiSchemaPath") {
+        throw "Bootstrap schema selectionMode '$(Format-LogSafeText $schemaSelectionMode)' is not supported in Story 00; only 'ApiSchemaPath' is accepted."
     }
     if (-not $schemaSection.ContainsKey("apiSchemaManifestPath") -or [string]::IsNullOrWhiteSpace($schemaSection["apiSchemaManifestPath"])) {
         throw "Bootstrap manifest field 'schema.apiSchemaManifestPath' must not be empty."
@@ -366,20 +434,26 @@ function Set-BootstrapStartupEnvironment {
         throw "Bootstrap ApiSchema manifest is missing: $(Format-LogSafeText $apiSchemaManifestPath)"
     }
 
-    # NOTE (Story 04): Flipping DMS into staged-workspace runtime loading (USE_API_SCHEMA_PATH=true,
-    # API_SCHEMA_PATH=/app/ApiSchema, clearing SCHEMA_PACKAGES, and mounting .bootstrap/ApiSchema via
-    # bootstrap-dms.yml) is deferred to Story 04. ContentProvider still expects *.ApiSchema.dll assemblies,
-    # so activating that path here would cause discovery/XSD content fetches to fail in bootstrap mode.
-    # Story 00 validates the manifest and wires CMS claims loading only; Story 04 owns the DMS runtime flip.
+    # NOTE (Story 04): Flipping DMS into staged-workspace runtime loading
+    # (USE_API_SCHEMA_PATH=true, API_SCHEMA_PATH=/app/ApiSchema, clearing SCHEMA_PACKAGES, and
+    # mounting .bootstrap/ApiSchema via bootstrap-dms.yml) is deferred to Story 04. ContentProvider
+    # still expects *.ApiSchema.dll assemblies, so activating that path here would cause
+    # discovery/XSD content fetches to fail in bootstrap mode.
+    #
+    # Story 00 validates the prepared manifest but does not activate the staged DMS schema workspace
+    # or staged CMS claims workspace at startup. Keep runtime vars blank in the process environment so
+    # `docker compose --env-file .env` cannot leak Story-04-shaped values into the DMS/CMS containers.
+    # Compose treats `${VAR:-default}` as "use default when VAR is empty."
+    $env:USE_API_SCHEMA_PATH = ""
+    $env:API_SCHEMA_PATH = ""
 
     if (-not $manifest.ContainsKey("claims")) {
         if (-not $SkipArtifactValidation) {
             throw "Bootstrap manifest is missing the claims section. Run prepare-dms-claims.ps1 before starting services."
         }
 
-        # Clear any stale claims env vars inherited from a prior run so teardown does not carry them forward.
-        $env:DMS_CONFIG_CLAIMS_SOURCE = ""
-        $env:DMS_CONFIG_CLAIMS_DIRECTORY = ""
+        # Keep any caller/env-file claims source settings intact for the current non-staged runtime path,
+        # but prevent a stale process value from mounting staged .bootstrap/claims in Story 00.
         $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
         return $true
     }
@@ -430,9 +504,10 @@ function Set-BootstrapStartupEnvironment {
         }
     }
 
-    $env:DMS_CONFIG_CLAIMS_SOURCE = $claimsMode
-    $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = [System.IO.Path]::GetFullPath((Join-Path $script:DockerComposeRoot ".bootstrap/$claimsDirectory"))
+    # Do not point CMS at staged .bootstrap/claims until DMS also reads the matching staged schema
+    # workspace. Leave ClaimsSource/ClaimsDirectory to the env-file or AddExtensionSecurityMetadata
+    # fallback so the current non-staged Hybrid claims path keeps working.
+    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
 
     return $true
 }
@@ -440,10 +515,16 @@ function Set-BootstrapStartupEnvironment {
 $script:BootstrapEnvVarNames = @(
     "DMS_CONFIG_CLAIMS_SOURCE",
     "DMS_CONFIG_CLAIMS_DIRECTORY",
-    "DMS_CONFIG_CLAIMS_MOUNT_SOURCE"
+    "DMS_CONFIG_CLAIMS_MOUNT_SOURCE",
+    "USE_API_SCHEMA_PATH",
+    "API_SCHEMA_PATH"
 )
 
 function Get-BootstrapEnvSnapshot {
+    <#
+    .SYNOPSIS
+    Captures current values of the bootstrap-managed environment variables for later restoration.
+    #>
     $snapshot = @{}
     foreach ($name in $script:BootstrapEnvVarNames) {
         $snapshot[$name] = [System.Environment]::GetEnvironmentVariable($name)
@@ -452,6 +533,10 @@ function Get-BootstrapEnvSnapshot {
 }
 
 function Restore-BootstrapEnvSnapshot {
+    <#
+    .SYNOPSIS
+    Restores bootstrap-managed environment variables from a prior snapshot.
+    #>
     param(
         [Parameter(Mandatory)]
         [hashtable]
@@ -472,6 +557,74 @@ function Restore-BootstrapEnvSnapshot {
     }
 }
 
+function Invoke-BootstrapStartupConfiguration {
+    <#
+    .SYNOPSIS
+    Shared startup helper for start-local-dms.ps1 / start-published-dms.ps1: validates the bootstrap manifest (teardown-tolerant), and applies the transitional non-bootstrap Hybrid claims fallback. The caller owns the env snapshot so that Restore/Pop run cleanly even when this helper throws.
+    #>
+    param(
+        [switch]
+        $IsTeardown,
+
+        [switch]
+        $AddExtensionSecurityMetadata
+    )
+
+    try {
+        $bootstrapMode = Set-BootstrapStartupEnvironment -SkipArtifactValidation:$IsTeardown
+    } catch {
+        if ($IsTeardown) {
+            Write-Warning "Bootstrap manifest could not be loaded during teardown; continuing anyway. $(Format-LogSafeText ($_.Exception.Message))"
+            $bootstrapMode = $false
+        } else {
+            throw
+        }
+    }
+
+    if ($bootstrapMode) {
+        Write-Output "Bootstrap manifest detected and validated. Staged schema and claims runtime startup remains deferred to Story 04; current bootstrap-present startup falls back to built-in DLL-backed schema assemblies."
+        if ($AddExtensionSecurityMetadata) {
+            # DLL-backed mode: activate Hybrid claims so extension claimset fragments
+            # are loaded from /app/additional-claims (already mounted by the Config Service compose file).
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+            Write-Output "Extension Security Metadata: Hybrid claims mode enabled (DLL-backed startup; staged bootstrap claims remain inactive)."
+        }
+    } elseif ($AddExtensionSecurityMetadata) {
+        # DLL-backed mode: activate Hybrid claims so extension claimset fragments
+        # are loaded from /app/additional-claims (already mounted by the Config Service compose file).
+        $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
+        $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+        $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+        Write-Output "Extension Security Metadata: Hybrid claims mode enabled (DLL-backed startup)."
+    }
+}
+
+function Remove-BootstrapWorkspaceIfRequested {
+    <#
+    .SYNOPSIS
+    Removes the staged .bootstrap workspace when -RemoveBootstrap is requested (paired with teardown).
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; the bootstrap scripts do not expose -WhatIf end to end, so a partial ShouldProcess opt-in would just enable silent no-ops.')]
+    param(
+        [switch]
+        $RemoveBootstrap
+    )
+
+    if (-not $RemoveBootstrap) {
+        return
+    }
+
+    $bootstrapDir = Get-BootstrapRoot
+    if (Test-Path -LiteralPath $bootstrapDir) {
+        Write-Output "Removing bootstrap workspace at $(Format-LogSafeText $bootstrapDir)"
+        # Remove-Item is non-terminating by default; promote to a terminating error so a failed
+        # cleanup cannot leave a stale manifest behind for the next start to pick up.
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force -ErrorAction Stop
+    }
+}
+
 Export-ModuleMember -Function `
     Get-BootstrapRepoRoot, `
     Get-BootstrapRoot, `
@@ -486,8 +639,10 @@ Export-ModuleMember -Function `
     Get-BootstrapRelativePath, `
     Resolve-BootstrapWorkspaceRelativePath, `
     Resolve-BootstrapPath, `
-    Get-BootstrapFingerprintBytes, `
+    Get-BootstrapFingerprintByte, `
     Get-BootstrapWorkspaceFingerprint, `
     Set-BootstrapStartupEnvironment, `
     Get-BootstrapEnvSnapshot, `
-    Restore-BootstrapEnvSnapshot
+    Restore-BootstrapEnvSnapshot, `
+    Invoke-BootstrapStartupConfiguration, `
+    Remove-BootstrapWorkspaceIfRequested

--- a/eng/docker-compose/local-config.yml
+++ b/eng/docker-compose/local-config.yml
@@ -44,7 +44,7 @@ services:
     ports:
       - "127.0.0.1:${DMS_CONFIG_ASPNETCORE_HTTP_PORTS:-8081}:${DMS_CONFIG_ASPNETCORE_HTTP_PORTS:-8081}"
     volumes:
-      - ../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets:/app/additional-claims
+      - ${DMS_CONFIG_CLAIMS_MOUNT_SOURCE:-../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets}:/app/additional-claims:ro
     networks:
       - dms
     restart: unless-stopped

--- a/eng/docker-compose/local-dms.yml
+++ b/eng/docker-compose/local-dms.yml
@@ -53,7 +53,7 @@ services:
       CacheSettings__DmsInstanceCacheRefreshEnabled: ${DMS_INSTANCE_CACHE_REFRESH_ENABLED:-true}
       AppSettings__DomainsExcludedFromOpenApi: ${DOMAINS_EXCLUDED_FROM_OPEN_API:-}
       AppSettings__RouteQualifierSegments: ${ROUTE_QUALIFIER_SEGMENTS:-}
-      SCHEMA_PACKAGES: ${SCHEMA_PACKAGES}
+      SCHEMA_PACKAGES: ${SCHEMA_PACKAGES:-}
       # JWT Authentication
       JwtAuthentication__Authority: ${DMS_JWT_AUTHORITY:-http://dms-keycloak:8080/realms/edfi}
       JwtAuthentication__Audience: ${DMS_JWT_AUDIENCE:-account}
@@ -66,8 +66,6 @@ services:
       JwtAuthentication__AutomaticRefreshIntervalHours: ${DMS_JWT_AUTOMATIC_REFRESH_INTERVAL_HOURS:-24}
     ports:
       - "127.0.0.1:${DMS_HTTP_PORTS}:${DMS_HTTP_PORTS}"
-    volumes:
-      - ../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets:/app/additional-claims
     networks:
       - dms
     restart: unless-stopped

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -1,0 +1,510 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[CmdletBinding()]
+param(
+    [string]
+    $ClaimsDirectoryPath
+)
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+
+$knownExtensionClaims = @{
+    "Sample" = @{
+        FragmentFileName = "004-sample-extension-claimset.json"
+        NamespacePrefix = "uri://sample.ed-fi.org"
+    }
+    "Homograph" = @{
+        FragmentFileName = "005-homograph-extension-claimset.json"
+    }
+}
+
+$baselineFragmentFileNames = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@(
+        "001-namespace-claimset.json",
+        "002-nofurtherauth-claimset.json",
+        "003-edorgsonly-claimset.json"
+    ),
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+
+function Read-JsonHashtable {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ArtifactName
+    )
+
+    try {
+        return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+    } catch {
+        throw "$(Format-LogSafeText $ArtifactName) '$(Format-LogSafeText $Path)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+    }
+}
+
+function Get-ValueOrNull {
+    param(
+        $Hashtable,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Key
+    )
+
+    if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Contains($Key)) {
+        return $Hashtable[$Key]
+    }
+
+    return $null
+}
+
+function Add-EffectiveClaimSetName {
+    param(
+        [System.Collections.Generic.HashSet[string]]
+        $ClaimSetNames,
+
+        [string]
+        $Name
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($Name)) {
+        $null = $ClaimSetNames.Add($Name)
+    }
+}
+
+function Test-TruthyJsonValue {
+    param(
+        $Value,
+
+        [string]
+        $Path
+    )
+
+    if ($null -eq $Value) {
+        return $false
+    }
+
+    if ($Value -is [bool]) {
+        return $Value
+    }
+
+    try {
+        return [System.Convert]::ToBoolean($Value)
+    } catch {
+        throw "Claimset fragment '$(Format-LogSafeText $Path)' has malformed boolean for 'isParent'."
+    }
+}
+
+function Get-EffectiveClaimSetNames {
+    $repoRoot = Get-BootstrapRepoRoot
+    $claimsPath = Join-Path $repoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json"
+    $claims = Read-JsonHashtable -Path $claimsPath -ArtifactName "Embedded claims"
+    $claimSetNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    # Embedded Claims.json declares effective claim sets in the top-level claimSets[*].claimSetName list.
+    # Nested claimsHierarchy[*].claimSets[*].name entries are attachments to those claim sets, not definitions.
+    foreach ($claimSet in @((Get-ValueOrNull -Hashtable $claims -Key "claimSets"))) {
+        if ($claimSet -is [System.Collections.IDictionary]) {
+            Add-EffectiveClaimSetName `
+                -ClaimSetNames $claimSetNames `
+                -Name (Get-ValueOrNull -Hashtable $claimSet -Key "claimSetName")
+        }
+    }
+
+    return $claimSetNames
+}
+
+function Add-FragmentInput {
+    param(
+        [System.Collections.Generic.Dictionary[string, string]]
+        $TargetSources,
+
+        [System.Collections.ArrayList]
+        $Fragments,
+
+        [Parameter(Mandatory)]
+        [string]
+        $SourcePath
+    )
+
+    $fileName = [System.IO.Path]::GetFileName($SourcePath)
+    if ($TargetSources.ContainsKey($fileName)) {
+        throw "Claimset fragment filename collision for '$(Format-LogSafeText $fileName)' from '$(Format-LogSafeText $SourcePath)' and '$(Format-LogSafeText ($TargetSources[$fileName]))'."
+    }
+
+    $TargetSources[$fileName] = $SourcePath
+    $null = $Fragments.Add(
+        [pscustomobject]@{
+            SourcePath = $SourcePath
+            FileName = $fileName
+        }
+    )
+}
+
+function Get-UserFragmentFiles {
+    param(
+        [string]
+        $Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return @()
+    }
+
+    $fullPath = [System.IO.Path]::GetFullPath($Path)
+    if (-not (Test-Path -LiteralPath $fullPath -PathType Container)) {
+        if (Test-Path -LiteralPath $fullPath -PathType Leaf) {
+            throw "ClaimsDirectoryPath must be a directory: $(Format-LogSafeText $fullPath)"
+        }
+
+        throw "ClaimsDirectoryPath directory was not found: $(Format-LogSafeText $fullPath)"
+    }
+
+    $directory = Get-Item -LiteralPath $fullPath
+
+    $claimsetFiles = @(
+        Get-ChildItem -LiteralPath $directory.FullName -File -Filter "*-claimset.json" |
+            Sort-Object -Property FullName
+    )
+
+    $reservedFiles = @($claimsetFiles | Where-Object { $baselineFragmentFileNames.Contains($_.Name) })
+    if ($reservedFiles.Count -gt 0) {
+        $reservedFileNames = @($reservedFiles | ForEach-Object { $_.Name }) -join ", "
+        throw "ClaimsDirectoryPath '$(Format-LogSafeText ($directory.FullName))' contains reserved baseline fragment filename(s): $(Format-LogSafeText $reservedFileNames). Baseline fragment names are reserved."
+    }
+
+    $files = @($claimsetFiles | ForEach-Object { $_.FullName })
+    if ($files.Count -eq 0) {
+        throw "ClaimsDirectoryPath '$(Format-LogSafeText ($directory.FullName))' does not contain any non-baseline *-claimset.json files."
+    }
+
+    return $files
+}
+
+function Add-ExpectedVerificationCheck {
+    param(
+        [System.Collections.Generic.HashSet[string]]
+        $Seen,
+
+        [System.Collections.ArrayList]
+        $Checks,
+
+        [string]
+        $ClaimSetName,
+
+        [string]
+        $ResourceClaim,
+
+        [string]
+        $Action
+    )
+
+    if ([string]::IsNullOrWhiteSpace($ClaimSetName) -or
+        [string]::IsNullOrWhiteSpace($ResourceClaim) -or
+        [string]::IsNullOrWhiteSpace($Action)) {
+        return
+    }
+
+    $key = "$ClaimSetName|$ResourceClaim|$Action"
+    if ($Seen.Add($key)) {
+        $null = $Checks.Add(
+            [ordered]@{
+                claimSetName = $ClaimSetName
+                resourceClaim = $ResourceClaim
+                action = $Action
+            }
+        )
+    }
+}
+
+function Assert-FragmentValidAndExtractChecks {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path,
+
+        [System.Collections.Generic.HashSet[string]]
+        $EffectiveClaimSetNames,
+
+        [System.Collections.Generic.HashSet[string]]
+        $SeenChecks,
+
+        [System.Collections.ArrayList]
+        $ExpectedVerificationChecks
+    )
+
+    $fragment = Read-JsonHashtable -Path $Path -ArtifactName "Claimset fragment"
+    $fragmentName = Get-ValueOrNull -Hashtable $fragment -Key "name"
+
+    $resourceClaims = Get-ValueOrNull -Hashtable $fragment -Key "resourceClaims"
+    if ($null -eq $resourceClaims -or @($resourceClaims).Count -eq 0) {
+        throw "Claimset fragment '$(Format-LogSafeText $Path)' does not contain resourceClaims."
+    }
+
+    $usesTopLevelNameAsClaimSet = $false
+    $implicitVerificationChecks = [System.Collections.ArrayList]::new()
+    foreach ($resourceClaim in @($resourceClaims)) {
+        if ($resourceClaim -isnot [System.Collections.IDictionary]) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' has a resourceClaims entry that is not a JSON object."
+        }
+
+        $resourceClaimName = Get-ValueOrNull -Hashtable $resourceClaim -Key "name"
+        if ([string]::IsNullOrWhiteSpace($resourceClaimName)) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' has a resourceClaims entry missing 'name'."
+        }
+
+        $isParent = Test-TruthyJsonValue `
+            -Value (Get-ValueOrNull -Hashtable $resourceClaim -Key "isParent") `
+            -Path $Path
+        $claimSets = Get-ValueOrNull -Hashtable $resourceClaim -Key "claimSets"
+        $usesImplicitClaimSetName = -not $isParent -and ($null -eq $claimSets -or @($claimSets).Count -eq 0)
+
+        if ($usesImplicitClaimSetName) {
+            $usesTopLevelNameAsClaimSet = $true
+        }
+
+        foreach ($claimSet in @($claimSets)) {
+            if ($null -eq $claimSet) {
+                continue
+            }
+
+            $claimSetName = Get-ValueOrNull -Hashtable $claimSet -Key "name"
+            if ([string]::IsNullOrWhiteSpace($claimSetName)) {
+                throw "Claimset fragment '$(Format-LogSafeText $Path)' has a claimSets entry missing 'name'."
+            }
+
+            if (-not $EffectiveClaimSetNames.Contains($claimSetName)) {
+                throw "Claimset fragment '$(Format-LogSafeText $Path)' references unknown effective claim set '$(Format-LogSafeText $claimSetName)'."
+            }
+
+            foreach ($action in @((Get-ValueOrNull -Hashtable $claimSet -Key "actions"))) {
+                if ($null -eq $action) {
+                    continue
+                }
+
+                $actionName = Get-ValueOrNull -Hashtable $action -Key "name"
+                if ([string]::IsNullOrWhiteSpace($actionName)) {
+                    throw "Claimset fragment '$(Format-LogSafeText $Path)' has a claimSets actions entry missing 'name'."
+                }
+
+                Add-ExpectedVerificationCheck `
+                    -Seen $SeenChecks `
+                    -Checks $ExpectedVerificationChecks `
+                    -ClaimSetName $claimSetName `
+                    -ResourceClaim $resourceClaimName `
+                    -Action $actionName
+            }
+        }
+
+        if ($usesImplicitClaimSetName) {
+            foreach ($action in @((Get-ValueOrNull -Hashtable $resourceClaim -Key "authorizationStrategyOverridesForCRUD"))) {
+                $actionName = Get-ValueOrNull -Hashtable $action -Key "actionName"
+                if ([string]::IsNullOrWhiteSpace($actionName)) {
+                    throw "Claimset fragment '$(Format-LogSafeText $Path)' has an authorizationStrategyOverridesForCRUD entry missing 'actionName'."
+                }
+
+                $null = $implicitVerificationChecks.Add(
+                    [pscustomobject]@{
+                        ResourceClaim = $resourceClaimName
+                        Action = $actionName
+                    }
+                )
+            }
+        }
+    }
+
+    if ($usesTopLevelNameAsClaimSet) {
+        if ([string]::IsNullOrWhiteSpace($fragmentName)) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' is missing top-level name required by non-parent resource claims."
+        }
+
+        if (-not $EffectiveClaimSetNames.Contains($fragmentName)) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' uses unknown effective claim set '$(Format-LogSafeText $fragmentName)'."
+        }
+
+        foreach ($implicitVerificationCheck in $implicitVerificationChecks) {
+            Add-ExpectedVerificationCheck `
+                -Seen $SeenChecks `
+                -Checks $ExpectedVerificationChecks `
+                -ClaimSetName $fragmentName `
+                -ResourceClaim $implicitVerificationCheck.ResourceClaim `
+                -Action $implicitVerificationCheck.Action
+        }
+    }
+}
+
+$bootstrapRoot = Get-BootstrapRoot
+$rootManifest = Read-BootstrapManifest
+if ($null -eq $rootManifest -or -not $rootManifest.ContainsKey("schema")) {
+    throw "Bootstrap manifest is missing the schema section. Run prepare-dms-schema.ps1 before prepare-dms-claims.ps1."
+}
+
+$apiSchemaManifestPath = Join-Path $bootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+if (-not (Test-Path -LiteralPath $apiSchemaManifestPath)) {
+    throw "Staged ApiSchema manifest was not found: $(Format-LogSafeText $apiSchemaManifestPath)"
+}
+
+$apiSchemaManifest = Read-JsonHashtable -Path $apiSchemaManifestPath -ArtifactName "ApiSchema manifest"
+$projectsValue = Get-ValueOrNull -Hashtable $apiSchemaManifest -Key "projects"
+if ($null -eq $projectsValue) {
+    throw "Bootstrap ApiSchema manifest is missing 'projects': $(Format-LogSafeText $apiSchemaManifestPath)"
+}
+if ($apiSchemaManifest["projects"] -isnot [System.Collections.IList]) {
+    throw "ApiSchema manifest projects must be a JSON array: $(Format-LogSafeText $apiSchemaManifestPath)"
+}
+$projects = @($projectsValue)
+$extensionProjects = @(
+    $projects |
+        Where-Object {
+            if ($_ -isnot [System.Collections.IDictionary]) {
+                throw "Bootstrap ApiSchema manifest project entry is not a JSON object."
+            }
+            Read-RequiredJsonBoolean `
+                -Hashtable $_ `
+                -Key "isExtensionProject" `
+                -ArtifactContext "Manifest project entry"
+        }
+)
+
+$repoRoot = Get-BootstrapRepoRoot
+$shippedClaimsDirectory = Join-Path $repoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets"
+$targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+$fragments = [System.Collections.ArrayList]::new()
+$namespacePrefixes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$unmappedExtensionNames = [System.Collections.ArrayList]::new()
+
+foreach ($extensionProject in $extensionProjects) {
+    $projectName = Get-ValueOrNull -Hashtable $extensionProject -Key "projectName"
+    if ([string]::IsNullOrWhiteSpace($projectName)) {
+        throw "Bootstrap ApiSchema manifest project entry is missing 'projectName'."
+    }
+
+    if ($knownExtensionClaims.ContainsKey($projectName)) {
+        $knownExtension = $knownExtensionClaims[$projectName]
+        if ($knownExtension.ContainsKey("FragmentFileName")) {
+            $fragmentPath = Join-Path $shippedClaimsDirectory $knownExtension["FragmentFileName"]
+            if (-not (Test-Path -LiteralPath $fragmentPath -PathType Leaf)) {
+                throw "Shipped claimset fragment was not found for extension '$(Format-LogSafeText $projectName)': $(Format-LogSafeText $fragmentPath)"
+            }
+
+            Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $fragmentPath
+        }
+
+        if ($knownExtension.ContainsKey("NamespacePrefix")) {
+            $null = $namespacePrefixes.Add($knownExtension["NamespacePrefix"])
+        }
+    } else {
+        $null = $unmappedExtensionNames.Add($projectName)
+    }
+}
+
+$userFragmentFiles = @(Get-UserFragmentFiles -Path $ClaimsDirectoryPath)
+if ($unmappedExtensionNames.Count -gt 0 -and $userFragmentFiles.Count -eq 0) {
+    throw "ClaimsDirectoryPath is required for unmapped extension project(s): $(Format-LogSafeText ($unmappedExtensionNames -join ', '))."
+}
+
+foreach ($userFragmentFile in $userFragmentFiles) {
+    Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $userFragmentFile
+}
+
+$effectiveClaimSetNames = Get-EffectiveClaimSetNames
+$expectedVerificationChecks = [System.Collections.ArrayList]::new()
+$seenChecks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+# Keep the core baseline probe even in Embedded mode; startup readiness owns verifying
+# that CMS applied the embedded base claims before checking staged extension entries.
+Add-ExpectedVerificationCheck `
+    -Seen $seenChecks `
+    -Checks $expectedVerificationChecks `
+    -ClaimSetName "EdFiSandbox" `
+    -ResourceClaim "http://ed-fi.org/identity/claims/domains/edFiTypes" `
+    -Action "Read"
+
+foreach ($fragment in $fragments) {
+    Assert-FragmentValidAndExtractChecks `
+        -Path $fragment.SourcePath `
+        -EffectiveClaimSetNames $effectiveClaimSetNames `
+        -SeenChecks $seenChecks `
+        -ExpectedVerificationChecks $expectedVerificationChecks
+}
+
+$temporaryRoot = Join-Path (Join-Path $bootstrapRoot ".tmp") "claims-$([Guid]::NewGuid().ToString('N'))"
+$finalWorkspace = Join-Path $bootstrapRoot "claims"
+$temporaryMoved = $false
+
+try {
+    New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
+
+    foreach ($fragment in $fragments) {
+        Copy-Item -LiteralPath $fragment.SourcePath -Destination (Join-Path $temporaryRoot $fragment.FileName)
+    }
+
+    $fingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
+    $claimsMode = if ($fragments.Count -eq 0) { "Embedded" } else { "Hybrid" }
+    $claimsSection = [ordered]@{
+        mode = $claimsMode
+        directory = "claims"
+        fingerprint = $fingerprint
+        expectedVerificationChecks = @($expectedVerificationChecks)
+    }
+    $seedSection = [ordered]@{
+        extensionNamespacePrefixes = @($namespacePrefixes | Sort-Object)
+    }
+
+    if (Test-Path -LiteralPath $finalWorkspace) {
+        if (-not $rootManifest.ContainsKey("claims")) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest claims section missing")
+        }
+
+        $existingClaimsSection = $rootManifest["claims"]
+        if ($existingClaimsSection -isnot [System.Collections.IDictionary]) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest claims section malformed")
+        }
+        if ($existingClaimsSection["fingerprint"] -ne $fingerprint) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "claims fingerprint mismatch")
+        }
+
+        $existingFingerprint = Get-BootstrapWorkspaceFingerprint -Path $finalWorkspace
+        if ($existingFingerprint -ne $fingerprint) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "staged claims content drift")
+        }
+
+        if (-not $rootManifest.ContainsKey("seed")) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest seed section missing")
+        }
+
+        $existingSeedSection = $rootManifest["seed"]
+        if ($existingSeedSection -isnot [System.Collections.IDictionary]) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest seed section malformed")
+        }
+
+        $existingPrefixes = @(@($existingSeedSection["extensionNamespacePrefixes"]) | ForEach-Object { [string]$_ } | Sort-Object)
+        $intendedPrefixes = @($seedSection["extensionNamespacePrefixes"] | ForEach-Object { [string]$_ } | Sort-Object)
+        if ((($existingPrefixes -join "`n") -ne ($intendedPrefixes -join "`n"))) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "seed extensionNamespacePrefixes mismatch")
+        }
+    } else {
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace
+        $temporaryMoved = $true
+    }
+
+    Set-BootstrapManifestSection -Name "claims" -Value $claimsSection
+    Set-BootstrapManifestSection -Name "seed" -Value $seedSection
+
+    Write-Output "Prepared claims workspace at $(Format-LogSafeText $finalWorkspace)"
+    Write-Output "Claims mode: $claimsMode"
+} finally {
+    if (-not $temporaryMoved -and (Test-Path -LiteralPath $temporaryRoot)) {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+    }
+}

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -103,7 +103,7 @@ function Test-TruthyJsonValue {
     }
 }
 
-function Get-EffectiveClaimSetNames {
+function Get-EffectiveClaimSetName {
     $repoRoot = Get-BootstrapRepoRoot
     $claimsPath = Join-Path $repoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json"
     $claims = Read-JsonHashtable -Path $claimsPath -ArtifactName "Embedded claims"
@@ -149,7 +149,7 @@ function Add-FragmentInput {
     )
 }
 
-function Get-UserFragmentFiles {
+function Get-UserFragmentFile {
     param(
         [string]
         $Path
@@ -225,7 +225,7 @@ function Add-ExpectedVerificationCheck {
     }
 }
 
-function Assert-FragmentValidAndExtractChecks {
+function Assert-FragmentValidAndExtractCheck {
     param(
         [Parameter(Mandatory)]
         [string]
@@ -264,9 +264,14 @@ function Assert-FragmentValidAndExtractChecks {
         $isParent = Test-TruthyJsonValue `
             -Value (Get-ValueOrNull -Hashtable $resourceClaim -Key "isParent") `
             -Path $Path
-        $claimSets = Get-ValueOrNull -Hashtable $resourceClaim -Key "claimSets"
-        $usesImplicitClaimSetName = -not $isParent -and ($null -eq $claimSets -or @($claimSets).Count -eq 0)
 
+        $claimSets = Get-ValueOrNull -Hashtable $resourceClaim -Key "claimSets"
+        $claimSetsCount = if ($null -eq $claimSets) { 0 } else { @($claimSets).Count }
+        if (-not $isParent -and $claimSetsCount -gt 0) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' has a non-parent resourceClaims entry with claimSets. CMS composes non-parent claims from the fragment top-level name and authorizationStrategyOverridesForCRUD; move the actions there or make the resource claim a parent."
+        }
+
+        $usesImplicitClaimSetName = -not $isParent -and $claimSetsCount -eq 0
         if ($usesImplicitClaimSetName) {
             $usesTopLevelNameAsClaimSet = $true
         }
@@ -408,7 +413,7 @@ foreach ($extensionProject in $extensionProjects) {
     }
 }
 
-$userFragmentFiles = @(Get-UserFragmentFiles -Path $ClaimsDirectoryPath)
+$userFragmentFiles = @(Get-UserFragmentFile -Path $ClaimsDirectoryPath)
 if ($unmappedExtensionNames.Count -gt 0 -and $userFragmentFiles.Count -eq 0) {
     throw "ClaimsDirectoryPath is required for unmapped extension project(s): $(Format-LogSafeText ($unmappedExtensionNames -join ', '))."
 }
@@ -417,7 +422,7 @@ foreach ($userFragmentFile in $userFragmentFiles) {
     Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $userFragmentFile
 }
 
-$effectiveClaimSetNames = Get-EffectiveClaimSetNames
+$effectiveClaimSetNames = Get-EffectiveClaimSetName
 $expectedVerificationChecks = [System.Collections.ArrayList]::new()
 $seenChecks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 # Keep the core baseline probe even in Embedded mode; startup readiness owns verifying
@@ -430,7 +435,7 @@ Add-ExpectedVerificationCheck `
     -Action "Read"
 
 foreach ($fragment in $fragments) {
-    Assert-FragmentValidAndExtractChecks `
+    Assert-FragmentValidAndExtractCheck `
         -Path $fragment.SourcePath `
         -EffectiveClaimSetNames $effectiveClaimSetNames `
         -SeenChecks $seenChecks `

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -60,7 +60,9 @@ function Get-ValueOrNull {
     )
 
     if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Contains($Key)) {
-        return $Hashtable[$Key]
+        # Wrap with the unary comma so PowerShell does not flatten single-element arrays into
+        # scalars on function return — callers rely on the original shape for IList checks.
+        return ,$Hashtable[$Key]
     }
 
     return $null
@@ -96,11 +98,7 @@ function Test-TruthyJsonValue {
         return $Value
     }
 
-    try {
-        return [System.Convert]::ToBoolean($Value)
-    } catch {
-        throw "Claimset fragment '$(Format-LogSafeText $Path)' has malformed boolean for 'isParent'."
-    }
+    throw "Claimset fragment '$(Format-LogSafeText $Path)' has malformed boolean for 'isParent'."
 }
 
 function Get-EffectiveClaimSetName {
@@ -171,7 +169,7 @@ function Get-UserFragmentFile {
     $directory = Get-Item -LiteralPath $fullPath
 
     $claimsetFiles = @(
-        Get-ChildItem -LiteralPath $directory.FullName -File -Filter "*-claimset.json" |
+        Get-ChildItem -LiteralPath $directory.FullName -File -Filter "*-claimset.json" -Recurse |
             Sort-Object -Property FullName
     )
 
@@ -245,7 +243,13 @@ function Assert-FragmentValidAndExtractCheck {
     $fragmentName = Get-ValueOrNull -Hashtable $fragment -Key "name"
 
     $resourceClaims = Get-ValueOrNull -Hashtable $fragment -Key "resourceClaims"
-    if ($null -eq $resourceClaims -or @($resourceClaims).Count -eq 0) {
+    if ($null -eq $resourceClaims) {
+        throw "Claimset fragment '$(Format-LogSafeText $Path)' does not contain resourceClaims."
+    }
+    if ($resourceClaims -isnot [System.Collections.IList]) {
+        throw "Claimset fragment '$(Format-LogSafeText $Path)' has a resourceClaims value that is not a JSON array."
+    }
+    if (@($resourceClaims).Count -eq 0) {
         throw "Claimset fragment '$(Format-LogSafeText $Path)' does not contain resourceClaims."
     }
 
@@ -266,6 +270,9 @@ function Assert-FragmentValidAndExtractCheck {
             -Path $Path
 
         $claimSets = Get-ValueOrNull -Hashtable $resourceClaim -Key "claimSets"
+        if ($null -ne $claimSets -and $claimSets -isnot [System.Collections.IList]) {
+            throw "Claimset fragment '$(Format-LogSafeText $Path)' has a claimSets value that is not a JSON array."
+        }
         $claimSetsCount = if ($null -eq $claimSets) { 0 } else { @($claimSets).Count }
         if (-not $isParent -and $claimSetsCount -gt 0) {
             throw "Claimset fragment '$(Format-LogSafeText $Path)' has a non-parent resourceClaims entry with claimSets. CMS composes non-parent claims from the fragment top-level name and authorizationStrategyOverridesForCRUD; move the actions there or make the resource claim a parent."
@@ -290,7 +297,11 @@ function Assert-FragmentValidAndExtractCheck {
                 throw "Claimset fragment '$(Format-LogSafeText $Path)' references unknown effective claim set '$(Format-LogSafeText $claimSetName)'."
             }
 
-            foreach ($action in @((Get-ValueOrNull -Hashtable $claimSet -Key "actions"))) {
+            $actions = Get-ValueOrNull -Hashtable $claimSet -Key "actions"
+            if ($null -ne $actions -and $actions -isnot [System.Collections.IList]) {
+                throw "Claimset fragment '$(Format-LogSafeText $Path)' has a claimSets actions value that is not a JSON array."
+            }
+            foreach ($action in @($actions)) {
                 if ($null -eq $action) {
                     continue
                 }
@@ -310,7 +321,11 @@ function Assert-FragmentValidAndExtractCheck {
         }
 
         if ($usesImplicitClaimSetName) {
-            foreach ($action in @((Get-ValueOrNull -Hashtable $resourceClaim -Key "authorizationStrategyOverridesForCRUD"))) {
+            $overrideActions = Get-ValueOrNull -Hashtable $resourceClaim -Key "authorizationStrategyOverridesForCRUD"
+            if ($null -ne $overrideActions -and $overrideActions -isnot [System.Collections.IList]) {
+                throw "Claimset fragment '$(Format-LogSafeText $Path)' has an authorizationStrategyOverridesForCRUD value that is not a JSON array."
+            }
+            foreach ($action in @($overrideActions)) {
                 $actionName = Get-ValueOrNull -Hashtable $action -Key "actionName"
                 if ([string]::IsNullOrWhiteSpace($actionName)) {
                     throw "Claimset fragment '$(Format-LogSafeText $Path)' has an authorizationStrategyOverridesForCRUD entry missing 'actionName'."
@@ -450,7 +465,7 @@ try {
     New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
 
     foreach ($fragment in $fragments) {
-        Copy-Item -LiteralPath $fragment.SourcePath -Destination (Join-Path $temporaryRoot $fragment.FileName)
+        Copy-Item -LiteralPath $fragment.SourcePath -Destination (Join-Path $temporaryRoot $fragment.FileName) -ErrorAction Stop
     }
 
     $fingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
@@ -498,8 +513,12 @@ try {
             throw (Get-BootstrapWorkspaceMismatchMessage -Reason "seed extensionNamespacePrefixes mismatch")
         }
     } else {
+        if ($rootManifest.ContainsKey("claims") -or $rootManifest.ContainsKey("seed")) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest has stale claims/seed sections but claims workspace is missing")
+        }
+
         New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
-        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace
+        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace -ErrorAction Stop
         $temporaryMoved = $true
     }
 

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -1,0 +1,513 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[CmdletBinding()]
+param(
+    [string]
+    $ApiSchemaPath,
+
+    [string[]]
+    $Extensions,
+
+    [string]
+    $SchemaToolPath = $env:DMS_SCHEMA_TOOL_PATH
+)
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+
+$story06Message = "Package-backed standard schema selection is deferred until Story 06. For Story 00, supply -ApiSchemaPath pointing to a filesystem ApiSchema directory."
+
+if ($PSBoundParameters.ContainsKey("Extensions")) {
+    throw $story06Message
+}
+
+if (-not $PSBoundParameters.ContainsKey("ApiSchemaPath") -or [string]::IsNullOrWhiteSpace($ApiSchemaPath)) {
+    throw $story06Message
+}
+
+function Get-DotNetFrameworkVersion {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+    )
+
+    if ($Name -match "^net(?<Major>\d+)(?:\.(?<Minor>\d+))?") {
+        $minor = if ([string]::IsNullOrWhiteSpace($matches["Minor"])) { 0 } else { [int]$matches["Minor"] }
+        return [version]::new([int]$matches["Major"], $minor)
+    }
+
+    return [version]::new(0, 0)
+}
+
+function Get-DmsSchemaToolCandidateDirectories {
+    $repoRoot = Get-BootstrapRepoRoot
+    $toolBinRoot = Join-Path $repoRoot "src/dms/clis/EdFi.DataManagementService.SchemaTools/bin"
+    $frameworkDirectories = [System.Collections.ArrayList]::new()
+
+    foreach ($configuration in @("Debug", "Release")) {
+        $configurationRoot = Join-Path $toolBinRoot $configuration
+        if (-not (Test-Path -LiteralPath $configurationRoot -PathType Container)) {
+            continue
+        }
+
+        foreach ($frameworkDirectory in Get-ChildItem -LiteralPath $configurationRoot -Directory -Filter "net*") {
+            if ($frameworkDirectory.Name -notmatch "^net\d") {
+                continue
+            }
+
+            $null = $frameworkDirectories.Add(
+                [pscustomobject]@{
+                    Directory = $frameworkDirectory.FullName
+                    FrameworkVersion = Get-DotNetFrameworkVersion -Name $frameworkDirectory.Name
+                    ConfigurationPriority = if ($configuration -eq "Debug") { 0 } else { 1 }
+                }
+            )
+        }
+    }
+
+    return @(
+        $frameworkDirectories |
+            Sort-Object `
+                -Property @{ Expression = { $_.FrameworkVersion }; Descending = $true },
+                    @{ Expression = { $_.ConfigurationPriority }; Ascending = $true } |
+            ForEach-Object { $_.Directory }
+    )
+}
+
+function Resolve-DmsSchemaTool {
+    param(
+        [string]
+        $RequestedPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        $fullPath = [System.IO.Path]::GetFullPath($RequestedPath)
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            throw "The configured dms-schema executable was not found: $(Format-LogSafeText $fullPath)"
+        }
+
+        return $fullPath
+    }
+
+    $candidateNames = if ($IsWindows) {
+        @("dms-schema.exe", "dms-schema")
+    } else {
+        @("dms-schema")
+    }
+
+    foreach ($candidateDirectory in Get-DmsSchemaToolCandidateDirectories) {
+        foreach ($candidateName in $candidateNames) {
+            $candidate = Join-Path $candidateDirectory $candidateName
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return $candidate
+            }
+        }
+    }
+
+    $pathCommand = Get-Command "dms-schema" -ErrorAction SilentlyContinue
+    if ($null -ne $pathCommand) {
+        if ($env:DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK -ne "true") {
+            throw "In-repo dms-schema tool not found. Build src/dms/clis/EdFi.DataManagementService.SchemaTools, set DMS_SCHEMA_TOOL_PATH, or set DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK=true to opt in to PATH fallback."
+        }
+
+        Write-Warning "Falling back to PATH-resolved dms-schema executable: $(Format-LogSafeText ($pathCommand.Source))"
+        return $pathCommand.Source
+    }
+
+    throw "Unable to resolve the dms-schema executable. Build src/dms/clis/EdFi.DataManagementService.SchemaTools or set DMS_SCHEMA_TOOL_PATH."
+}
+
+function Invoke-DmsSchemaHash {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ToolPath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $CoreSchemaPath,
+
+        [string[]]
+        $ExtensionSchemaPath = @()
+    )
+
+    $arguments = @("hash", $CoreSchemaPath) + $ExtensionSchemaPath
+    $output = if ($ToolPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+        & pwsh -NoLogo -NoProfile -File $ToolPath @arguments 2>&1
+    } else {
+        & $ToolPath @arguments 2>&1
+    }
+
+    $exitCode = $LASTEXITCODE
+    $outputText = ($output | Out-String).Trim()
+
+    if ($exitCode -ne 0) {
+        throw "dms-schema hash failed with exit code $exitCode. $(Format-LogSafeText $outputText)"
+    }
+
+    if ($outputText -notmatch "(?m)^Effective schema hash:\s*([a-fA-F0-9]{64})\s*$") {
+        throw "dms-schema hash completed but did not report an Effective schema hash. $(Format-LogSafeText $outputText)"
+    }
+
+    return $matches[1].ToLowerInvariant()
+}
+
+function Get-ProjectDirectoryName {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ProjectName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ProjectEndpointName
+    )
+
+    $candidate = if ([string]::IsNullOrWhiteSpace($ProjectName)) {
+        $ProjectEndpointName
+    } else {
+        $ProjectName
+    }
+
+    $normalized = [System.Text.RegularExpressions.Regex]::Replace($candidate.Trim(), "[^A-Za-z0-9._-]", "-")
+    $normalized = [System.Text.RegularExpressions.Regex]::Replace($normalized, "-+", "-").Trim(".-")
+
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        throw "ApiSchema project '$(Format-LogSafeText $ProjectName)' has no usable normalized project directory name."
+    }
+
+    return $normalized
+}
+
+function Read-ApiSchemaIdentity {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    try {
+        $schema = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+    } catch {
+        throw "ApiSchema file '$(Format-LogSafeText $Path)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    if (-not $schema.ContainsKey("projectSchema")) {
+        throw "ApiSchema file '$(Format-LogSafeText $Path)' is missing projectSchema."
+    }
+
+    $projectSchema = $schema["projectSchema"]
+    $projectName = $projectSchema["projectName"]
+    $projectEndpointName = $projectSchema["projectEndpointName"]
+
+    if ([string]::IsNullOrWhiteSpace($projectName)) {
+        throw "ApiSchema file '$(Format-LogSafeText $Path)' is missing projectSchema.projectName."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($projectEndpointName)) {
+        throw "ApiSchema file '$(Format-LogSafeText $Path)' is missing projectSchema.projectEndpointName."
+    }
+
+    $isExtensionProject = Read-RequiredJsonBoolean `
+        -Hashtable $projectSchema `
+        -Key "isExtensionProject" `
+        -ArtifactContext ("ApiSchema project schema in '" + (Format-LogSafeText $Path) + "'")
+
+    $projectDirectoryName = Get-ProjectDirectoryName `
+        -ProjectName $projectName `
+        -ProjectEndpointName $projectEndpointName
+
+    return [pscustomobject]@{
+        SourcePath = [System.IO.Path]::GetFullPath($Path)
+        SourceDirectory = [System.IO.Path]::GetDirectoryName([System.IO.Path]::GetFullPath($Path))
+        ProjectName = $projectName
+        ProjectEndpointName = $projectEndpointName
+        IsExtensionProject = $isExtensionProject
+        ProjectDirectoryName = $projectDirectoryName
+    }
+}
+
+function Find-ApiSchemaFiles {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Path
+    )
+
+    function Test-CanonicalApiSchemaFileName {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Name
+        )
+
+        return $Name -ieq "ApiSchema.json" -or $Name -imatch "^ApiSchema(?:-[A-Za-z0-9][A-Za-z0-9._-]*-EXTENSION|-EXTENSION)\.json$"
+    }
+
+    try {
+        $resolvedPath = Resolve-Path -LiteralPath $Path -ErrorAction Stop
+    } catch {
+        throw "ApiSchemaPath was not found: $(Format-LogSafeText $Path). $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    $item = Get-Item -LiteralPath $resolvedPath
+
+    if (-not $item.PSIsContainer) {
+        throw "ApiSchemaPath must be a directory: $(Format-LogSafeText ($item.FullName))"
+    }
+
+    $apiSchemaLikeFiles = @(
+        Get-ChildItem -LiteralPath $item.FullName -File -Filter "ApiSchema*.json" |
+            Sort-Object -Property FullName
+    )
+
+    $rejectedFiles = @($apiSchemaLikeFiles | Where-Object { -not (Test-CanonicalApiSchemaFileName -Name $_.Name) })
+    if ($rejectedFiles.Count -gt 0) {
+        throw "ApiSchemaPath contains unsupported ApiSchema-like file name: $(Format-LogSafeText ($rejectedFiles[0].FullName)). Files must be named ApiSchema.json, ApiSchema-EXTENSION.json, or ApiSchema-<Name>-EXTENSION.json."
+    }
+
+    $schemaFiles = @($apiSchemaLikeFiles | ForEach-Object { $_.FullName })
+    if ($schemaFiles.Count -eq 0) {
+        throw "No canonical ApiSchema JSON files were found under '$(Format-LogSafeText ($item.FullName))'."
+    }
+
+    return $schemaFiles
+}
+
+function Add-CopyOperation {
+    param(
+        [System.Collections.Generic.Dictionary[string, string]]
+        $TargetSources,
+
+        [System.Collections.ArrayList]
+        $CopyOperations,
+
+        [Parameter(Mandatory)]
+        [string]
+        $SourcePath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $RelativeTargetPath
+    )
+
+    $normalizedRelativeTargetPath = $RelativeTargetPath.Replace("\", "/")
+    if ($TargetSources.ContainsKey($normalizedRelativeTargetPath)) {
+        throw "Normalized path collision for '$(Format-LogSafeText $normalizedRelativeTargetPath)' from '$(Format-LogSafeText $SourcePath)' and '$(Format-LogSafeText ($TargetSources[$normalizedRelativeTargetPath]))'."
+    }
+
+    $TargetSources[$normalizedRelativeTargetPath] = $SourcePath
+    $null = $CopyOperations.Add(
+        [pscustomobject]@{
+            SourcePath = $SourcePath
+            RelativeTargetPath = $normalizedRelativeTargetPath
+        }
+    )
+}
+
+function Add-ProjectContentOperations {
+    param(
+        [Parameter(Mandatory)]
+        $Project,
+
+        [System.Collections.Generic.Dictionary[string, string]]
+        $TargetSources,
+
+        [System.Collections.ArrayList]
+        $CopyOperations
+    )
+
+    $contentRoot = "content/$($Project.ProjectDirectoryName)"
+    $discoverySpecSourcePath = Join-Path $Project.SourceDirectory "discovery-spec.json"
+    $discoverySpecRelativePath = $null
+    if (Test-Path -LiteralPath $discoverySpecSourcePath -PathType Leaf) {
+        $discoverySpecRelativePath = "$contentRoot/discovery-spec.json"
+        Add-CopyOperation `
+            -TargetSources $TargetSources `
+            -CopyOperations $CopyOperations `
+            -SourcePath $discoverySpecSourcePath `
+            -RelativeTargetPath $discoverySpecRelativePath
+    }
+
+    $xsdSourceDirectory = Join-Path $Project.SourceDirectory "xsd"
+    if (-not (Test-Path -LiteralPath $xsdSourceDirectory -PathType Container)) {
+        $xsdSourceDirectory = Join-Path $Project.SourceDirectory "XSD"
+    }
+
+    $xsdDirectoryRelativePath = $null
+    if (Test-Path -LiteralPath $xsdSourceDirectory -PathType Container) {
+        $xsdDirectoryRelativePath = "$contentRoot/xsd"
+        foreach ($xsdFile in Get-ChildItem -LiteralPath $xsdSourceDirectory -File -Recurse | Sort-Object -Property FullName) {
+            $sourceRelativePath = Get-BootstrapRelativePath -Path $xsdFile.FullName -BasePath $xsdSourceDirectory
+            Add-CopyOperation `
+                -TargetSources $TargetSources `
+                -CopyOperations $CopyOperations `
+                -SourcePath $xsdFile.FullName `
+                -RelativeTargetPath "$xsdDirectoryRelativePath/$sourceRelativePath"
+        }
+    }
+
+    return [pscustomobject]@{
+        DiscoverySpecPath = $discoverySpecRelativePath
+        XsdDirectory = $xsdDirectoryRelativePath
+    }
+}
+
+$schemaSourceFiles = Find-ApiSchemaFiles -Path $ApiSchemaPath
+$schemaProjects = @($schemaSourceFiles | ForEach-Object { Read-ApiSchemaIdentity -Path $_ })
+
+$coreProjects = @($schemaProjects | Where-Object { -not $_.IsExtensionProject })
+if ($coreProjects.Count -ne 1) {
+    throw "ApiSchemaPath must stage exactly one core schema. Found $($coreProjects.Count)."
+}
+
+$extensionProjects = @(
+    $schemaProjects |
+        Where-Object { $_.IsExtensionProject } |
+        Sort-Object -Property @{ Expression = { $_.ProjectEndpointName.ToLowerInvariant() } }, SourcePath
+)
+
+$orderedProjects = @($coreProjects[0]) + $extensionProjects
+$sourceDirectoryGroups = $schemaProjects | Group-Object -Property SourceDirectory -AsHashTable
+
+$targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase
+)
+$copyOperations = [System.Collections.ArrayList]::new()
+$manifestProjects = [System.Collections.ArrayList]::new()
+
+foreach ($project in $orderedProjects) {
+    $schemaRelativePath = "schemas/$($project.ProjectDirectoryName)/ApiSchema.json"
+    Add-CopyOperation `
+        -TargetSources $targetSources `
+        -CopyOperations $copyOperations `
+        -SourcePath $project.SourcePath `
+        -RelativeTargetPath $schemaRelativePath
+
+    $contentPaths = [pscustomobject]@{
+        DiscoverySpecPath = $null
+        XsdDirectory = $null
+    }
+
+    $sourceDirectoryGroup = @($sourceDirectoryGroups[$project.SourceDirectory])
+    if ($sourceDirectoryGroup.Count -gt 1 -and ($sourceDirectoryGroup | Where-Object { -not $_.IsExtensionProject }).Count -eq 0) {
+        throw "Ambiguous schema-adjacent content ownership: source directory '$(Format-LogSafeText $project.SourceDirectory)' contains multiple extension schemas and no core schema. Move each extension into its own directory."
+    }
+    $projectOwnsSharedContent = $sourceDirectoryGroup.Count -eq 1 -or -not $project.IsExtensionProject
+    if ($projectOwnsSharedContent) {
+        $contentPaths = Add-ProjectContentOperations `
+            -Project $project `
+            -TargetSources $targetSources `
+            -CopyOperations $copyOperations
+    }
+
+    $manifestProject = [ordered]@{
+        projectName = $project.ProjectName
+        projectEndpointName = $project.ProjectEndpointName
+        isExtensionProject = $project.IsExtensionProject
+        schemaPath = $schemaRelativePath
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($contentPaths.DiscoverySpecPath)) {
+        $manifestProject["discoverySpecPath"] = $contentPaths.DiscoverySpecPath
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($contentPaths.XsdDirectory)) {
+        $manifestProject["xsdDirectory"] = $contentPaths.XsdDirectory
+    }
+
+    $null = $manifestProjects.Add($manifestProject)
+}
+
+$bootstrapRoot = Get-BootstrapRoot
+$temporaryRoot = Join-Path (Join-Path $bootstrapRoot ".tmp") "ApiSchema-$([Guid]::NewGuid().ToString('N'))"
+$finalWorkspace = Join-Path $bootstrapRoot "ApiSchema"
+$temporaryMoved = $false
+
+try {
+    New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
+
+    foreach ($copyOperation in $copyOperations) {
+        $targetPath = Join-Path $temporaryRoot $copyOperation.RelativeTargetPath
+        New-Item -ItemType Directory -Path (Split-Path -Parent $targetPath) -Force | Out-Null
+        Copy-Item -LiteralPath $copyOperation.SourcePath -Destination $targetPath
+    }
+
+    $apiSchemaManifest = [ordered]@{
+        version = 1
+        projects = @($manifestProjects)
+    }
+    $apiSchemaManifestPath = Join-Path $temporaryRoot "bootstrap-api-schema-manifest.json"
+    Write-BootstrapJson -Path $apiSchemaManifestPath -Value $apiSchemaManifest
+
+    $coreStagedSchemaPath = Join-Path $temporaryRoot $manifestProjects[0]["schemaPath"]
+    $extensionStagedSchemaPaths = @(
+        $manifestProjects |
+            Where-Object { $_["isExtensionProject"] } |
+            ForEach-Object { Join-Path $temporaryRoot $_["schemaPath"] }
+    )
+
+    $schemaTool = Resolve-DmsSchemaTool -RequestedPath $SchemaToolPath
+    $effectiveSchemaHash = Invoke-DmsSchemaHash `
+        -ToolPath $schemaTool `
+        -CoreSchemaPath $coreStagedSchemaPath `
+        -ExtensionSchemaPath $extensionStagedSchemaPaths
+
+    $workspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
+    $schemaSection = [ordered]@{
+        mode = "ApiSchemaPath"
+        selectedExtensions = @($extensionProjects | ForEach-Object { $_.ProjectEndpointName.ToLowerInvariant() })
+        effectiveSchemaHash = $effectiveSchemaHash
+        workspaceFingerprint = $workspaceFingerprint
+        apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
+    }
+
+    $rootManifest = Read-BootstrapManifest
+    if ($null -eq $rootManifest) {
+        $rootManifest = New-BootstrapManifest
+    }
+    if (Test-Path -LiteralPath $finalWorkspace) {
+        if (-not $rootManifest.ContainsKey("schema")) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section missing")
+        }
+
+        $existingSchemaSection = $rootManifest["schema"]
+        if ($existingSchemaSection -isnot [System.Collections.IDictionary]) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section malformed")
+        }
+        if ($existingSchemaSection["effectiveSchemaHash"] -ne $effectiveSchemaHash) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "effective schema hash mismatch")
+        }
+
+        if ($existingSchemaSection["workspaceFingerprint"] -ne $workspaceFingerprint) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "workspace fingerprint mismatch")
+        }
+
+        $existingFingerprint = Get-BootstrapWorkspaceFingerprint -Path $finalWorkspace
+        if ($existingFingerprint -ne $workspaceFingerprint) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "staged content drift")
+        }
+    } else {
+        if ($rootManifest.ContainsKey("claims") -or $rootManifest.ContainsKey("seed")) {
+            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest has stale claims/seed sections but ApiSchema workspace is missing")
+        }
+
+        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace
+        $temporaryMoved = $true
+    }
+
+    Set-BootstrapManifestSection -Name "schema" -Value $schemaSection
+
+    Write-Output "Prepared ApiSchema workspace at $(Format-LogSafeText $finalWorkspace)"
+    Write-Output "Effective schema hash: $effectiveSchemaHash"
+} finally {
+    if (-not $temporaryMoved -and (Test-Path -LiteralPath $temporaryRoot)) {
+        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+    }
+}

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -431,7 +431,7 @@ try {
     foreach ($copyOperation in $copyOperations) {
         $targetPath = Join-Path $temporaryRoot $copyOperation.RelativeTargetPath
         New-Item -ItemType Directory -Path (Split-Path -Parent $targetPath) -Force | Out-Null
-        Copy-Item -LiteralPath $copyOperation.SourcePath -Destination $targetPath
+        Copy-Item -LiteralPath $copyOperation.SourcePath -Destination $targetPath -ErrorAction Stop
     }
 
     $apiSchemaManifest = [ordered]@{
@@ -494,7 +494,7 @@ try {
         }
 
         New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
-        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace
+        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace -ErrorAction Stop
         $temporaryMoved = $true
     }
 

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -44,7 +44,7 @@ function Get-DotNetFrameworkVersion {
     return [version]::new(0, 0)
 }
 
-function Get-DmsSchemaToolCandidateDirectories {
+function Get-DmsSchemaToolCandidateDirectory {
     $repoRoot = Get-BootstrapRepoRoot
     $toolBinRoot = Join-Path $repoRoot "src/dms/clis/EdFi.DataManagementService.SchemaTools/bin"
     $frameworkDirectories = [System.Collections.ArrayList]::new()
@@ -100,7 +100,7 @@ function Resolve-DmsSchemaTool {
         @("dms-schema")
     }
 
-    foreach ($candidateDirectory in Get-DmsSchemaToolCandidateDirectories) {
+    foreach ($candidateDirectory in Get-DmsSchemaToolCandidateDirectory) {
         foreach ($candidateName in $candidateNames) {
             $candidate = Join-Path $candidateDirectory $candidateName
             if (Test-Path -LiteralPath $candidate -PathType Leaf) {
@@ -232,22 +232,12 @@ function Read-ApiSchemaIdentity {
     }
 }
 
-function Find-ApiSchemaFiles {
+function Find-ApiSchemaFile {
     param(
         [Parameter(Mandatory)]
         [string]
         $Path
     )
-
-    function Test-CanonicalApiSchemaFileName {
-        param(
-            [Parameter(Mandatory)]
-            [string]
-            $Name
-        )
-
-        return $Name -ieq "ApiSchema.json" -or $Name -imatch "^ApiSchema(?:-[A-Za-z0-9][A-Za-z0-9._-]*-EXTENSION|-EXTENSION)\.json$"
-    }
 
     try {
         $resolvedPath = Resolve-Path -LiteralPath $Path -ErrorAction Stop
@@ -261,19 +251,14 @@ function Find-ApiSchemaFiles {
         throw "ApiSchemaPath must be a directory: $(Format-LogSafeText ($item.FullName))"
     }
 
-    $apiSchemaLikeFiles = @(
-        Get-ChildItem -LiteralPath $item.FullName -File -Filter "ApiSchema*.json" |
-            Sort-Object -Property FullName
+    $schemaFiles = @(
+        Get-ChildItem -LiteralPath $item.FullName -File -Filter "ApiSchema*.json" -Recurse |
+            Sort-Object -Property FullName |
+            ForEach-Object { $_.FullName }
     )
 
-    $rejectedFiles = @($apiSchemaLikeFiles | Where-Object { -not (Test-CanonicalApiSchemaFileName -Name $_.Name) })
-    if ($rejectedFiles.Count -gt 0) {
-        throw "ApiSchemaPath contains unsupported ApiSchema-like file name: $(Format-LogSafeText ($rejectedFiles[0].FullName)). Files must be named ApiSchema.json, ApiSchema-EXTENSION.json, or ApiSchema-<Name>-EXTENSION.json."
-    }
-
-    $schemaFiles = @($apiSchemaLikeFiles | ForEach-Object { $_.FullName })
     if ($schemaFiles.Count -eq 0) {
-        throw "No canonical ApiSchema JSON files were found under '$(Format-LogSafeText ($item.FullName))'."
+        throw "No ApiSchema*.json files were found under '$(Format-LogSafeText ($item.FullName))'."
     }
 
     return $schemaFiles
@@ -310,7 +295,7 @@ function Add-CopyOperation {
     )
 }
 
-function Add-ProjectContentOperations {
+function Add-ProjectContentOperation {
     param(
         [Parameter(Mandatory)]
         $Project,
@@ -358,7 +343,7 @@ function Add-ProjectContentOperations {
     }
 }
 
-$schemaSourceFiles = Find-ApiSchemaFiles -Path $ApiSchemaPath
+$schemaSourceFiles = Find-ApiSchemaFile -Path $ApiSchemaPath
 $schemaProjects = @($schemaSourceFiles | ForEach-Object { Read-ApiSchemaIdentity -Path $_ })
 
 $coreProjects = @($schemaProjects | Where-Object { -not $_.IsExtensionProject })
@@ -380,6 +365,7 @@ $targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
 )
 $copyOperations = [System.Collections.ArrayList]::new()
 $manifestProjects = [System.Collections.ArrayList]::new()
+$contentBySourceDirectory = @{}
 
 foreach ($project in $orderedProjects) {
     $schemaRelativePath = "schemas/$($project.ProjectDirectoryName)/ApiSchema.json"
@@ -389,22 +375,32 @@ foreach ($project in $orderedProjects) {
         -SourcePath $project.SourcePath `
         -RelativeTargetPath $schemaRelativePath
 
-    $contentPaths = [pscustomobject]@{
-        DiscoverySpecPath = $null
-        XsdDirectory = $null
-    }
+    if (-not $contentBySourceDirectory.ContainsKey($project.SourceDirectory)) {
+        # When two or more projects share a source directory AND that directory carries
+        # schema-adjacent content (discovery-spec.json or xsd/), the core schema owns the staged
+        # content path that every project in the group references. Extension-only groups have no
+        # unambiguous owner in that case — fail fast and tell the caller to put each extension in
+        # its own directory (or add a sibling core schema). When no schema-adjacent content exists
+        # in the directory, there is nothing to disambiguate, so multiple extensions in the same
+        # directory are accepted (typical of recursive ApiSchema*.json discovery layouts).
+        $sourceDirectoryGroup = @($sourceDirectoryGroups[$project.SourceDirectory])
+        $coreInGroup = @($sourceDirectoryGroup | Where-Object { -not $_.IsExtensionProject })
+        if ($sourceDirectoryGroup.Count -gt 1 -and $coreInGroup.Count -eq 0) {
+            $hasSchemaAdjacentContent =
+                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "discovery-spec.json") -PathType Leaf) -or
+                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "xsd") -PathType Container) -or
+                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "XSD") -PathType Container)
+            if ($hasSchemaAdjacentContent) {
+                throw "Ambiguous schema-adjacent content ownership: source directory '$(Format-LogSafeText $project.SourceDirectory)' contains multiple extension schemas and no core schema. Move each extension into its own directory."
+            }
+        }
 
-    $sourceDirectoryGroup = @($sourceDirectoryGroups[$project.SourceDirectory])
-    if ($sourceDirectoryGroup.Count -gt 1 -and ($sourceDirectoryGroup | Where-Object { -not $_.IsExtensionProject }).Count -eq 0) {
-        throw "Ambiguous schema-adjacent content ownership: source directory '$(Format-LogSafeText $project.SourceDirectory)' contains multiple extension schemas and no core schema. Move each extension into its own directory."
-    }
-    $projectOwnsSharedContent = $sourceDirectoryGroup.Count -eq 1 -or -not $project.IsExtensionProject
-    if ($projectOwnsSharedContent) {
-        $contentPaths = Add-ProjectContentOperations `
+        $contentBySourceDirectory[$project.SourceDirectory] = Add-ProjectContentOperation `
             -Project $project `
             -TargetSources $targetSources `
             -CopyOperations $copyOperations
     }
+    $contentPaths = $contentBySourceDirectory[$project.SourceDirectory]
 
     $manifestProject = [ordered]@{
         projectName = $project.ProjectName
@@ -460,7 +456,7 @@ try {
 
     $workspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
     $schemaSection = [ordered]@{
-        mode = "ApiSchemaPath"
+        selectionMode = "ApiSchemaPath"
         selectedExtensions = @($extensionProjects | ForEach-Object { $_.ProjectEndpointName.ToLowerInvariant() })
         effectiveSchemaHash = $effectiveSchemaHash
         workspaceFingerprint = $workspaceFingerprint

--- a/eng/docker-compose/published-config.yml
+++ b/eng/docker-compose/published-config.yml
@@ -41,7 +41,7 @@ services:
     ports:
       - '127.0.0.1:${DMS_CONFIG_ASPNETCORE_HTTP_PORTS:-8081}:${DMS_CONFIG_ASPNETCORE_HTTP_PORTS:-8081}'
     volumes:
-      - ../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets:/app/additional-claims
+      - ${DMS_CONFIG_CLAIMS_MOUNT_SOURCE:-../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets}:/app/additional-claims:ro
     networks:
       - dms
     restart: unless-stopped

--- a/eng/docker-compose/published-dms.yml
+++ b/eng/docker-compose/published-dms.yml
@@ -50,7 +50,7 @@ services:
       CacheSettings__DmsInstanceCacheRefreshEnabled: ${DMS_INSTANCE_CACHE_REFRESH_ENABLED:-true}
       AppSettings__DomainsExcludedFromOpenApi: ${DOMAINS_EXCLUDED_FROM_OPEN_API:-}
       AppSettings__RouteQualifierSegments: ${ROUTE_QUALIFIER_SEGMENTS:-}
-      SCHEMA_PACKAGES: ${SCHEMA_PACKAGES}
+      SCHEMA_PACKAGES: ${SCHEMA_PACKAGES:-}
       # JWT Authentication
       JwtAuthentication__Authority: ${DMS_JWT_AUTHORITY:-}
       JwtAuthentication__Audience: ${DMS_JWT_AUDIENCE:-}
@@ -63,8 +63,6 @@ services:
       JwtAuthentication__AutomaticRefreshIntervalHours: ${DMS_JWT_AUTOMATIC_REFRESH_INTERVAL_HOURS:-24}
     ports:
       - '127.0.0.1:${DMS_HTTP_PORTS}:${DMS_HTTP_PORTS}'
-    volumes:
-      - ../../src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets:/app/additional-claims
     networks:
       - dms
     restart: unless-stopped

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -68,7 +68,6 @@ param (
 )
 
 Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
-$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 $originalLocation = Get-Location
 if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
     if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
@@ -81,31 +80,10 @@ if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
     }
 }
-try {
+$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 Push-Location $PSScriptRoot
 try {
-    $bootstrapMode = Set-BootstrapStartupEnvironment -SkipArtifactValidation:$d
-}
-catch {
-    if ($d) {
-        Write-Warning "Bootstrap manifest could not be loaded during teardown; continuing anyway. $(Format-LogSafeText ($_.Exception.Message))"
-        $bootstrapMode = $false
-    }
-    else {
-        throw
-    }
-}
-if ($bootstrapMode) {
-    Write-Output "Bootstrap manifest detected. Configured staged claims startup inputs. Schema runtime loading still uses DLL-backed schema packages (Story 04 enables runtime reads of the staged workspace)."
-}
-elseif ($AddExtensionSecurityMetadata) {
-    # Non-bootstrap (DLL-backed) mode: activate Hybrid claims so extension claimset fragments
-    # are loaded from /app/additional-claims (already mounted by local-config.yml).
-    $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
-    $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
-    Write-Output "Extension Security Metadata: Hybrid claims mode enabled (non-bootstrap DLL-backed startup)."
-}
+Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadata:$AddExtensionSecurityMetadata
 
 # Identity provider configuration
 Import-Module ./env-utility.psm1 -Force
@@ -167,13 +145,7 @@ if ($d) {
         Write-Output "Shutting down with volume delete"
         docker compose $files --env-file $EnvironmentFile -p dms-local down -v
 
-        if ($RemoveBootstrap) {
-            $bootstrapDir = Get-BootstrapRoot
-            if (Test-Path -LiteralPath $bootstrapDir) {
-                Write-Output "Removing bootstrap workspace at $(Format-LogSafeText $bootstrapDir)"
-                Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
-            }
-        }
+        Remove-BootstrapWorkspaceIfRequested -RemoveBootstrap:$RemoveBootstrap
     }
     else {
         Write-Output "Shutting down"
@@ -341,5 +313,5 @@ else {
 }
 } finally {
     Restore-BootstrapEnvSnapshot -Snapshot $bootstrapEnvSnapshot
-    Set-Location $originalLocation
+    Pop-Location
 }

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -36,10 +36,6 @@ param (
     [Switch]
     $LoadSeedData,
 
-    # Add extension security metadata
-    [Switch]
-    $AddExtensionSecurityMetadata,
-
     # Add smoke test credentials
     [Switch]
     $AddSmokeTestCredentials,
@@ -55,47 +51,90 @@ param (
 
     # School year range for multi-instance setup (format: StartYear-EndYear, e.g., "2022-2026")
     [string]
-    $SchoolYearRange = ""
+    $SchoolYearRange = "",
+
+    # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
+    # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
+    [Switch]
+    $RemoveBootstrap,
+
+    # Transitional non-bootstrap helper: when no bootstrap manifest is present (DLL-backed startup),
+    # passing this switch sets DMS_CONFIG_CLAIMS_SOURCE=Hybrid and DMS_CONFIG_CLAIMS_DIRECTORY=/app/additional-claims
+    # so that extension claimset fragments (e.g. Sample, Homograph) are loaded from the AdditionalClaimsets
+    # directory that is already mounted at /app/additional-claims by local-config.yml.
+    # This flag is intentionally kept until Story 04 moves E2E runtime loading onto the staged bootstrap workspace.
+    [Switch]
+    $AddExtensionSecurityMetadata
 )
 
-
-# Configure environment variables for new claimset loading approach
-if($AddExtensionSecurityMetadata)
-{
-    # Set environment variables for hybrid claimset loading
-    $env:DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING = "true"
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
+$originalLocation = Get-Location
+if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
+    if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
+        # Caller supplied an explicit relative path — resolve against the caller's CWD.
+        $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $originalLocation.Path $EnvironmentFile))
+    }
+    else {
+        # Default value — resolve against the script directory so that invoking the
+        # script from any CWD (e.g. the repo root) still finds eng/docker-compose/.env.
+        $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
+    }
+}
+try {
+Push-Location $PSScriptRoot
+try {
+    $bootstrapMode = Set-BootstrapStartupEnvironment -SkipArtifactValidation:$d
+}
+catch {
+    if ($d) {
+        Write-Warning "Bootstrap manifest could not be loaded during teardown; continuing anyway. $(Format-LogSafeText ($_.Exception.Message))"
+        $bootstrapMode = $false
+    }
+    else {
+        throw
+    }
+}
+if ($bootstrapMode) {
+    Write-Output "Bootstrap manifest detected. Configured staged claims startup inputs. Schema runtime loading still uses DLL-backed schema packages (Story 04 enables runtime reads of the staged workspace)."
+}
+elseif ($AddExtensionSecurityMetadata) {
+    # Non-bootstrap (DLL-backed) mode: activate Hybrid claims so extension claimset fragments
+    # are loaded from /app/additional-claims (already mounted by local-config.yml).
     $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
     $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-    Write-Output "Configured environment variables for file-based extension claimset loading"
+    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+    Write-Output "Extension Security Metadata: Hybrid claims mode enabled (non-bootstrap DLL-backed startup)."
 }
-    # Identity provider configuration
-    Import-Module ./env-utility.psm1 -Force
-    $envValues = ReadValuesFromEnvFile $EnvironmentFile
-    $env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
-    Write-Output "Identity Provider $IdentityProvider"
-    if($IdentityProvider -eq "keycloak")
-    {
-        $env:OAUTH_TOKEN_ENDPOINT = $envValues.KEYCLOAK_OAUTH_TOKEN_ENDPOINT
-        $env:DMS_JWT_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
-        $env:DMS_JWT_METADATA_ADDRESS = $envValues.KEYCLOAK_DMS_JWT_METADATA_ADDRESS
-        $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
-    }
-    elseif ($IdentityProvider -eq "self-contained") {
-        $env:OAUTH_TOKEN_ENDPOINT = $envValues.SELF_CONTAINED_OAUTH_TOKEN_ENDPOINT
-        $env:DMS_JWT_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
-        $env:DMS_JWT_METADATA_ADDRESS = $envValues.SELF_CONTAINED_DMS_JWT_METADATA_ADDRESS
-        $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+
+# Identity provider configuration
+Import-Module ./env-utility.psm1 -Force
+$envValues = ReadValuesFromEnvFile $EnvironmentFile
+$env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
+Write-Output "Identity Provider $IdentityProvider"
+if($IdentityProvider -eq "keycloak")
+{
+    $env:OAUTH_TOKEN_ENDPOINT = $envValues.KEYCLOAK_OAUTH_TOKEN_ENDPOINT
+    $env:DMS_JWT_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
+    $env:DMS_JWT_METADATA_ADDRESS = $envValues.KEYCLOAK_DMS_JWT_METADATA_ADDRESS
+    $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
+}
+elseif ($IdentityProvider -eq "self-contained") {
+    $env:OAUTH_TOKEN_ENDPOINT = $envValues.SELF_CONTAINED_OAUTH_TOKEN_ENDPOINT
+    $env:DMS_JWT_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+    $env:DMS_JWT_METADATA_ADDRESS = $envValues.SELF_CONTAINED_DMS_JWT_METADATA_ADDRESS
+    $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+}
+
+if (-not $d) {
+    if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
+        throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
     }
 
-    if (-not $d) {
-        if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
-            throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
-        }
-
-        if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange) -and $envValues.DMS_CONFIG_MULTI_TENANCY -eq "true" -and -not $envValues.CONFIG_SERVICE_TENANT) {
-            throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true (the Configuration Service requires the Tenant header)."
-        }
+    if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange) -and $envValues.DMS_CONFIG_MULTI_TENANCY -eq "true" -and -not $envValues.CONFIG_SERVICE_TENANT) {
+        throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true (the Configuration Service requires the Tenant header)."
     }
+}
 $files = @(
     "-f",
     "postgresql.yml",
@@ -116,7 +155,7 @@ if ($EnableKafkaUI) {
 
 # Include configuration service if enabled or if using self-contained identity provider
 if ($EnableConfig -or $IdentityProvider -eq "self-contained") {
-  $files += @("-f", "local-config.yml")
+    $files += @("-f", "local-config.yml")
 }
 
 if ($EnableSwaggerUI) {
@@ -127,6 +166,14 @@ if ($d) {
     if ($v) {
         Write-Output "Shutting down with volume delete"
         docker compose $files --env-file $EnvironmentFile -p dms-local down -v
+
+        if ($RemoveBootstrap) {
+            $bootstrapDir = Get-BootstrapRoot
+            if (Test-Path -LiteralPath $bootstrapDir) {
+                Write-Output "Removing bootstrap workspace at $(Format-LogSafeText $bootstrapDir)"
+                Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+            }
+        }
     }
     else {
         Write-Output "Shutting down"
@@ -291,5 +338,8 @@ else {
     }
 
     Start-Sleep 20
-
+}
+} finally {
+    Restore-BootstrapEnvSnapshot -Snapshot $bootstrapEnvSnapshot
+    Set-Location $originalLocation
 }

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -32,10 +32,6 @@ param (
     [Switch]
     $LoadSeedData,
 
-    # Add extension security metadata
-    [Switch]
-    $AddExtensionSecurityMetadata,
-
     # Add smoke test credentials
     [Switch]
     $AddSmokeTestCredentials,
@@ -51,48 +47,90 @@ param (
 
     # School year range for multi-instance setup (format: StartYear-EndYear, e.g., "2022-2026")
     [string]
-    $SchoolYearRange = ""
+    $SchoolYearRange = "",
+
+    # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
+    # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
+    [Switch]
+    $RemoveBootstrap,
+
+    # Transitional non-bootstrap helper: when no bootstrap manifest is present (DLL-backed startup),
+    # passing this switch sets DMS_CONFIG_CLAIMS_SOURCE=Hybrid and DMS_CONFIG_CLAIMS_DIRECTORY=/app/additional-claims
+    # so that extension claimset fragments (e.g. Sample, Homograph) are loaded from the AdditionalClaimsets
+    # directory that is already mounted at /app/additional-claims by published-config.yml.
+    # This flag is intentionally kept until Story 04 moves E2E runtime loading onto the staged bootstrap workspace.
+    [Switch]
+    $AddExtensionSecurityMetadata
 )
 
-
-# Configure environment variables for new claimset loading approach
-if($AddExtensionSecurityMetadata)
-{
-    # Set environment variables for hybrid claimset loading
-    $env:DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING = "true"
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
+$originalLocation = Get-Location
+if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
+    if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
+        # Caller supplied an explicit relative path — resolve against the caller's CWD.
+        $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $originalLocation.Path $EnvironmentFile))
+    }
+    else {
+        # Default value — resolve against the script directory so that invoking the
+        # script from any CWD (e.g. the repo root) still finds eng/docker-compose/.env.
+        $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
+    }
+}
+try {
+Push-Location $PSScriptRoot
+try {
+    $bootstrapMode = Set-BootstrapStartupEnvironment -SkipArtifactValidation:$d
+}
+catch {
+    if ($d) {
+        Write-Warning "Bootstrap manifest could not be loaded during teardown; continuing anyway. $(Format-LogSafeText ($_.Exception.Message))"
+        $bootstrapMode = $false
+    }
+    else {
+        throw
+    }
+}
+if ($bootstrapMode) {
+    Write-Output "Bootstrap manifest detected. Configured staged claims startup inputs. Schema runtime loading still uses DLL-backed schema packages (Story 04 enables runtime reads of the staged workspace)."
+}
+elseif ($AddExtensionSecurityMetadata) {
+    # Non-bootstrap (DLL-backed) mode: activate Hybrid claims so extension claimset fragments
+    # are loaded from /app/additional-claims (already mounted by published-config.yml).
     $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
     $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-    Write-Output "Configured environment variables for file-based extension claimset loading"
+    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+    Write-Output "Extension Security Metadata: Hybrid claims mode enabled (non-bootstrap DLL-backed startup)."
 }
 
-    # Identity provider configuration
-    Import-Module ./env-utility.psm1 -Force
-    $envValues = ReadValuesFromEnvFile $EnvironmentFile
-    $env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
-    Write-Output "Identity Provider $IdentityProvider"
-    if($IdentityProvider -eq "keycloak")
-    {
-        $env:OAUTH_TOKEN_ENDPOINT = $envValues.KEYCLOAK_OAUTH_TOKEN_ENDPOINT
-        $env:DMS_JWT_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
-        $env:DMS_JWT_METADATA_ADDRESS = $envValues.KEYCLOAK_DMS_JWT_METADATA_ADDRESS
-        $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
-    }
-    elseif ($IdentityProvider -eq "self-contained") {
-        $env:OAUTH_TOKEN_ENDPOINT = $envValues.SELF_CONTAINED_OAUTH_TOKEN_ENDPOINT
-        $env:DMS_JWT_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
-        $env:DMS_JWT_METADATA_ADDRESS = $envValues.SELF_CONTAINED_DMS_JWT_METADATA_ADDRESS
-        $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+# Identity provider configuration
+Import-Module ./env-utility.psm1 -Force
+$envValues = ReadValuesFromEnvFile $EnvironmentFile
+$env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
+Write-Output "Identity Provider $IdentityProvider"
+if($IdentityProvider -eq "keycloak")
+{
+    $env:OAUTH_TOKEN_ENDPOINT = $envValues.KEYCLOAK_OAUTH_TOKEN_ENDPOINT
+    $env:DMS_JWT_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
+    $env:DMS_JWT_METADATA_ADDRESS = $envValues.KEYCLOAK_DMS_JWT_METADATA_ADDRESS
+    $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.KEYCLOAK_DMS_JWT_AUTHORITY
+}
+elseif ($IdentityProvider -eq "self-contained") {
+    $env:OAUTH_TOKEN_ENDPOINT = $envValues.SELF_CONTAINED_OAUTH_TOKEN_ENDPOINT
+    $env:DMS_JWT_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+    $env:DMS_JWT_METADATA_ADDRESS = $envValues.SELF_CONTAINED_DMS_JWT_METADATA_ADDRESS
+    $env:DMS_CONFIG_IDENTITY_AUTHORITY = $envValues.SELF_CONTAINED_DMS_JWT_AUTHORITY
+}
+
+if (-not $d) {
+    if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
+        throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
     }
 
-    if (-not $d) {
-        if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
-            throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
-        }
-
-        if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange) -and $envValues.DMS_CONFIG_MULTI_TENANCY -eq "true" -and -not $envValues.CONFIG_SERVICE_TENANT) {
-            throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true (the Configuration Service requires the Tenant header)."
-        }
+    if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange) -and $envValues.DMS_CONFIG_MULTI_TENANCY -eq "true" -and -not $envValues.CONFIG_SERVICE_TENANT) {
+        throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true (the Configuration Service requires the Tenant header)."
     }
+}
 $files = @(
     "-f",
     "postgresql.yml",
@@ -124,6 +162,14 @@ if ($d) {
     if ($v) {
         Write-Output "Shutting down with volume delete"
         docker compose $files --env-file $EnvironmentFile -p dms-published down -v
+
+        if ($RemoveBootstrap) {
+            $bootstrapDir = Get-BootstrapRoot
+            if (Test-Path -LiteralPath $bootstrapDir) {
+                Write-Output "Removing bootstrap workspace at $(Format-LogSafeText $bootstrapDir)"
+                Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+            }
+        }
     }
     else {
         Write-Output "Shutting down"
@@ -135,7 +181,7 @@ else {
     if (! $existingNetwork) {
         docker network create dms
     }
-	  if($IdentityProvider -eq "keycloak")
+    if($IdentityProvider -eq "keycloak")
     {
         Write-Output "Starting Keycloak first..."
         docker compose $files --env-file $EnvironmentFile -p dms-published up -d keycloak
@@ -281,4 +327,8 @@ else {
     }
 
     Start-Sleep 20
+}
+} finally {
+    Restore-BootstrapEnvSnapshot -Snapshot $bootstrapEnvSnapshot
+    Set-Location $originalLocation
 }

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -64,7 +64,6 @@ param (
 )
 
 Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
-$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 $originalLocation = Get-Location
 if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
     if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
@@ -77,31 +76,10 @@ if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
     }
 }
-try {
+$bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 Push-Location $PSScriptRoot
 try {
-    $bootstrapMode = Set-BootstrapStartupEnvironment -SkipArtifactValidation:$d
-}
-catch {
-    if ($d) {
-        Write-Warning "Bootstrap manifest could not be loaded during teardown; continuing anyway. $(Format-LogSafeText ($_.Exception.Message))"
-        $bootstrapMode = $false
-    }
-    else {
-        throw
-    }
-}
-if ($bootstrapMode) {
-    Write-Output "Bootstrap manifest detected. Configured staged claims startup inputs. Schema runtime loading still uses DLL-backed schema packages (Story 04 enables runtime reads of the staged workspace)."
-}
-elseif ($AddExtensionSecurityMetadata) {
-    # Non-bootstrap (DLL-backed) mode: activate Hybrid claims so extension claimset fragments
-    # are loaded from /app/additional-claims (already mounted by published-config.yml).
-    $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
-    $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-    $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
-    Write-Output "Extension Security Metadata: Hybrid claims mode enabled (non-bootstrap DLL-backed startup)."
-}
+Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadata:$AddExtensionSecurityMetadata
 
 # Identity provider configuration
 Import-Module ./env-utility.psm1 -Force
@@ -163,13 +141,7 @@ if ($d) {
         Write-Output "Shutting down with volume delete"
         docker compose $files --env-file $EnvironmentFile -p dms-published down -v
 
-        if ($RemoveBootstrap) {
-            $bootstrapDir = Get-BootstrapRoot
-            if (Test-Path -LiteralPath $bootstrapDir) {
-                Write-Output "Removing bootstrap workspace at $(Format-LogSafeText $bootstrapDir)"
-                Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
-            }
-        }
+        Remove-BootstrapWorkspaceIfRequested -RemoveBootstrap:$RemoveBootstrap
     }
     else {
         Write-Output "Shutting down"
@@ -330,5 +302,5 @@ else {
 }
 } finally {
     Restore-BootstrapEnvSnapshot -Snapshot $bootstrapEnvSnapshot
-    Set-Location $originalLocation
+    Pop-Location
 }

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -628,6 +628,140 @@ exit $ExitCode
             { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
                 Should -Throw -ExpectedMessage "*missing 'name'*"
         }
+
+        It "discovers caller fragments recursively to match CMS ClaimsFragmentComposer" {
+            # CMS scans -ClaimsDirectoryPath with SearchOption.AllDirectories. Bootstrap input
+            # discovery must match so nested fragments are staged (and nested duplicates rejected).
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "nested-claims"
+            $nestedDir = Join-Path $claimsDir "subdir"
+            New-ExplicitClaimsetFragment -Path (Join-Path $nestedDir "010-tpdm-claimset.json")
+
+            Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir
+
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims/010-tpdm-claimset.json") |
+                Should -BeTrue
+        }
+
+        It "detects nested filename collisions across subdirectories" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "nested-collision"
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "a/010-tpdm-claimset.json")
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "b/010-tpdm-claimset.json")
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*filename collision*"
+        }
+
+        It "rejects a non-boolean isParent value because CMS deserializes IsParent as a strict bool" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "string-isparent"
+            $fragment = [ordered]@{
+                name = "EdFiSandbox"
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = "true"
+                        name = "http://example.org/identity/claims/widget"
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $claimsDir "010-string-isparent-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*malformed boolean for 'isParent'*"
+        }
+
+        It "rejects a resourceClaims value that is a single object instead of an array" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "scalar-resourceclaims"
+            $fragment = [ordered]@{
+                name = "EdFiSandbox"
+                resourceClaims = [ordered]@{
+                    isParent = $false
+                    name = "http://example.org/identity/claims/widget"
+                }
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $claimsDir "010-scalar-resourceclaims-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*resourceClaims value that is not a JSON array*"
+        }
+
+        It "rejects a claimSets value that is a single object instead of an array" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "scalar-claimsets"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                        name = "http://example.org/identity/claims/domains/explicitParent"
+                        claimSets = [ordered]@{
+                            name = "EdFiSandbox"
+                            actions = @(
+                                [ordered]@{
+                                    name = "Read"
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $claimsDir "010-scalar-claimsets-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*claimSets value that is not a JSON array*"
+        }
+
+        It "rejects an actions value that is a single object instead of an array" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "scalar-actions"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                        name = "http://example.org/identity/claims/domains/explicitParent"
+                        claimSets = @(
+                            [ordered]@{
+                                name = "EdFiSandbox"
+                                actions = [ordered]@{
+                                    name = "Read"
+                                }
+                            }
+                        )
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $claimsDir "010-scalar-actions-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*claimSets actions value that is not a JSON array*"
+        }
+
+        It "fails fast when manifest has stale claims/seed sections but claims workspace is missing" {
+            # Symmetric to the prepare-dms-schema.ps1 guard: a partial prior state (manifest
+            # records claims/seed but .bootstrap/claims was removed) must not silently rewrite
+            # the manifest sections; teardown is the required remediation.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "stale-claims-input"
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
+            Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir
+
+            $stagedClaims = Join-Path $script:repo.BootstrapRoot "claims"
+            Remove-Item -LiteralPath $stagedClaims -Recurse -Force
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*stale claims/seed sections*"
+
+            Test-Path -LiteralPath $stagedClaims | Should -BeFalse
+        }
     }
 
     Context "startup handoff" {

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -1,0 +1,680 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Describe "Story 00 bootstrap" {
+    BeforeAll {
+        $script:sourceRepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:sourceDockerComposeRoot = Join-Path $script:sourceRepoRoot "eng/docker-compose"
+        $script:hashA = "0000000000000000000000000000000000000000000000000000000000000001"
+        $script:hashB = "0000000000000000000000000000000000000000000000000000000000000002"
+        # Story 04 boundary: USE_API_SCHEMA_PATH, API_SCHEMA_PATH, SCHEMA_PACKAGES,
+        # DMS_API_SCHEMA_MOUNT_SOURCE are NOT set by Set-BootstrapStartupEnvironment (Story 04 owns
+        # that flip). They are included here for isolation only so that incidental env state from
+        # the host environment does not bleed into assertion tests that expect those vars to be absent.
+        $script:bootstrapEnvVars = @(
+            "USE_API_SCHEMA_PATH",
+            "API_SCHEMA_PATH",
+            "SCHEMA_PACKAGES",
+            "DMS_API_SCHEMA_MOUNT_SOURCE",
+            "DMS_CONFIG_CLAIMS_SOURCE",
+            "DMS_CONFIG_CLAIMS_DIRECTORY",
+            "DMS_CONFIG_CLAIMS_MOUNT_SOURCE"
+        )
+
+    function script:New-TestDirectory {
+        $path = Join-Path ([System.IO.Path]::GetTempPath()) "dms-story00-$([Guid]::NewGuid().ToString('N'))"
+        New-Item -ItemType Directory -Path $path -Force | Out-Null
+        return $path
+    }
+
+    function script:New-IsolatedBootstrapRepo {
+        $repoRoot = New-TestDirectory
+        $dockerComposeRoot = Join-Path $repoRoot "eng/docker-compose"
+        New-Item -ItemType Directory -Path $dockerComposeRoot -Force | Out-Null
+
+        foreach ($fileName in @("bootstrap-manifest.psm1", "prepare-dms-schema.ps1", "prepare-dms-claims.ps1")) {
+            Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot $fileName) -Destination $dockerComposeRoot
+        }
+
+        $claimsSourceRoot = Join-Path $script:sourceRepoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend"
+        $claimsTargetRoot = Join-Path $repoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend"
+        New-Item -ItemType Directory -Path $claimsTargetRoot -Force | Out-Null
+        Copy-Item -LiteralPath (Join-Path $claimsSourceRoot "Claims") -Destination $claimsTargetRoot -Recurse
+        Copy-Item -LiteralPath (Join-Path $claimsSourceRoot "Deploy") -Destination $claimsTargetRoot -Recurse
+
+        return [pscustomobject]@{
+            RepoRoot = $repoRoot
+            DockerComposeRoot = $dockerComposeRoot
+            BootstrapRoot = Join-Path $dockerComposeRoot ".bootstrap"
+            PrepareSchemaScript = Join-Path $dockerComposeRoot "prepare-dms-schema.ps1"
+            PrepareClaimsScript = Join-Path $dockerComposeRoot "prepare-dms-claims.ps1"
+            ManifestModule = Join-Path $dockerComposeRoot "bootstrap-manifest.psm1"
+        }
+    }
+
+    function script:New-FakeSchemaTool {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Directory,
+
+            [string]
+            $Hash = $script:hashA,
+
+            [int]
+            $ExitCode = 0
+        )
+
+        $path = Join-Path $Directory "fake-dms-schema.ps1"
+        @"
+param([Parameter(ValueFromRemainingArguments = `$true)][string[]] `$Arguments)
+Write-Output "Effective schema hash: $Hash"
+exit $ExitCode
+"@ | Set-Content -LiteralPath $path -Encoding utf8
+        return $path
+    }
+
+    function script:New-ApiSchemaFile {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ProjectName,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ProjectEndpointName,
+
+            [bool]
+            $IsExtensionProject
+        )
+
+        $schema = [ordered]@{
+            apiSchemaVersion = "1.0.0"
+            projectSchema = [ordered]@{
+                projectName = $ProjectName
+                projectEndpointName = $ProjectEndpointName
+                isExtensionProject = $IsExtensionProject
+                resourceSchemas = [ordered]@{}
+                openApiBaseDocuments = [ordered]@{
+                    resources = [ordered]@{
+                        openapi = "3.0.1"
+                    }
+                }
+            }
+        }
+
+        New-Item -ItemType Directory -Path (Split-Path -Parent $Path) -Force | Out-Null
+        $schema | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+
+    function script:New-ApiSchemaSet {
+        param(
+            [string[]]
+            $Extensions = @()
+        )
+
+        $schemaDir = Join-Path $script:repo.RepoRoot "schema"
+        New-ApiSchemaFile `
+            -Path (Join-Path $schemaDir "ApiSchema.json") `
+            -ProjectName "Ed-Fi" `
+            -ProjectEndpointName "ed-fi" `
+            -IsExtensionProject $false
+
+        foreach ($extension in $Extensions) {
+            New-ApiSchemaFile `
+                -Path (Join-Path $schemaDir "ApiSchema-$extension-EXTENSION.json") `
+                -ProjectName $extension `
+                -ProjectEndpointName $extension.ToLowerInvariant() `
+                -IsExtensionProject $true
+        }
+
+        return $schemaDir
+    }
+
+    function script:Invoke-PrepareSchema {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $ApiSchemaPath,
+
+            [string]
+            $Hash = $script:hashA,
+
+            [int]
+            $ToolExitCode = 0
+        )
+
+        $tool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $Hash -ExitCode $ToolExitCode
+        & $script:repo.PrepareSchemaScript -ApiSchemaPath $ApiSchemaPath -SchemaToolPath $tool | Out-Null
+    }
+
+    function script:Invoke-PrepareClaims {
+        param(
+            [string]
+            $ClaimsDirectoryPath
+        )
+
+        if ([string]::IsNullOrWhiteSpace($ClaimsDirectoryPath)) {
+            & $script:repo.PrepareClaimsScript | Out-Null
+            return
+        }
+
+        & $script:repo.PrepareClaimsScript -ClaimsDirectoryPath $ClaimsDirectoryPath | Out-Null
+    }
+
+    function script:Get-RootManifest {
+        return Get-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") -Raw |
+            ConvertFrom-Json
+    }
+
+    function script:New-ExplicitClaimsetFragment {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [string]
+            $ClaimSetName = "EdFiSandbox",
+
+            [string]
+            $ResourceClaim = "http://example.org/identity/claims/widget",
+
+            [string]
+            $Action = "Read"
+        )
+
+        $fragment = [ordered]@{
+            name = "ExtensionClaims"
+            resourceClaims = @(
+                [ordered]@{
+                    isParent = $false
+                    name = $ResourceClaim
+                    claimSets = @(
+                        [ordered]@{
+                            name = $ClaimSetName
+                            actions = @(
+                                [ordered]@{
+                                    name = $Action
+                                }
+                            )
+                        }
+                    )
+                }
+            )
+        }
+
+        New-Item -ItemType Directory -Path (Split-Path -Parent $Path) -Force | Out-Null
+        $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
+    }
+    }
+
+    BeforeEach {
+        $script:envSnapshot = @{}
+        foreach ($name in $script:bootstrapEnvVars) {
+            $script:envSnapshot[$name] = [System.Environment]::GetEnvironmentVariable($name)
+        }
+
+        $script:repo = New-IsolatedBootstrapRepo
+    }
+
+    AfterEach {
+        foreach ($name in $script:bootstrapEnvVars) {
+            [System.Environment]::SetEnvironmentVariable($name, $script:envSnapshot[$name])
+        }
+
+        if ($null -ne $script:repo -and (Test-Path -LiteralPath $script:repo.RepoRoot)) {
+            Remove-Item -LiteralPath $script:repo.RepoRoot -Recurse -Force
+        }
+    }
+
+    Context "schema staging" {
+        It "rejects missing ApiSchemaPath and Story 06 schema parameters" {
+            { & $script:repo.PrepareSchemaScript } |
+                Should -Throw -ExpectedMessage "*Story 06*"
+
+            { & $script:repo.PrepareSchemaScript -Extensions sample } |
+                Should -Throw -ExpectedMessage "*Story 06*"
+        }
+
+        It "stages core plus extension schemas and records the Story 00 manifest contract" {
+            $schemaDir = New-ApiSchemaSet -Extensions @("Sample")
+
+            Invoke-PrepareSchema -ApiSchemaPath $schemaDir
+            $manifest = Get-RootManifest
+
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") |
+                Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Sample/ApiSchema.json") |
+                Should -BeTrue
+            $manifest.schema.mode | Should -Be "ApiSchemaPath"
+            $manifest.schema.selectedExtensions | Should -Contain "sample"
+            $manifest.schema.effectiveSchemaHash | Should -Be $script:hashA
+            $manifest.schema.apiSchemaManifestPath | Should -Be "ApiSchema/bootstrap-api-schema-manifest.json"
+        }
+
+        It "copies optional schema-adjacent runtime content and preserves schema JSON payloads" {
+            $schemaDir = New-ApiSchemaSet
+            "discovery" | Set-Content -LiteralPath (Join-Path $schemaDir "discovery-spec.json") -Encoding utf8
+            New-Item -ItemType Directory -Path (Join-Path $schemaDir "xsd") -Force | Out-Null
+            "<xs:schema />" | Set-Content -LiteralPath (Join-Path $schemaDir "xsd/Ed-Fi-Core.xsd") -Encoding utf8
+
+            Invoke-PrepareSchema -ApiSchemaPath $schemaDir
+            $apiSchemaManifest = Get-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json") -Raw |
+                ConvertFrom-Json
+            $stagedCore = Get-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") -Raw |
+                ConvertFrom-Json
+
+            $apiSchemaManifest.projects[0].discoverySpecPath | Should -Be "content/Ed-Fi/discovery-spec.json"
+            $apiSchemaManifest.projects[0].xsdDirectory | Should -Be "content/Ed-Fi/xsd"
+            $stagedCore.projectSchema.openApiBaseDocuments.resources.openapi | Should -Be "3.0.1"
+        }
+
+        It "detects normalized-path collisions before finalizing a workspace" {
+            $schemaDir = Join-Path $script:repo.RepoRoot "schema"
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema.json") -ProjectName "Ed-Fi" -ProjectEndpointName "ed-fi" -IsExtensionProject $false
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema-SameA-EXTENSION.json") -ProjectName "Same!" -ProjectEndpointName "same-a" -IsExtensionProject $true
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema-SameB-EXTENSION.json") -ProjectName "Same?" -ProjectEndpointName "same-b" -IsExtensionProject $true
+
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir } |
+                Should -Throw -ExpectedMessage "*Normalized path collision*"
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                Should -BeFalse
+        }
+
+        It "reuses identical workspaces and rejects changed schema selections" {
+            $schemaDir = New-ApiSchemaSet -Extensions @("Sample")
+
+            Invoke-PrepareSchema -ApiSchemaPath $schemaDir
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir } |
+                Should -Not -Throw
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir -Hash $script:hashB } |
+                Should -Throw -ExpectedMessage "*effective schema hash mismatch*"
+        }
+
+        It "fails when dms-schema hashing fails" {
+            $schemaDir = New-ApiSchemaSet
+
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir -ToolExitCode 1 } |
+                Should -Throw -ExpectedMessage "*dms-schema hash failed*"
+        }
+
+        It "fails fast when manifest has stale claims/seed sections but ApiSchema workspace is missing" {
+            $schemaDir = New-ApiSchemaSet
+
+            # Seed the manifest with stale claims and seed sections but no schema section
+            # and no .bootstrap/ApiSchema directory present (partial prior state)
+            $staleManifest = [ordered]@{
+                version = 1
+                claims = [ordered]@{
+                    mode = "Embedded"
+                    directory = "claims"
+                }
+                seed = [ordered]@{
+                    extensionNamespacePrefixes = @()
+                }
+            }
+            $bootstrapRoot = Join-Path $script:repo.DockerComposeRoot ".bootstrap"
+            New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+            $staleManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $bootstrapRoot "bootstrap-manifest.json") -Encoding utf8
+
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir } |
+                Should -Throw -ExpectedMessage "*stale claims/seed sections*"
+
+            # No ApiSchema workspace should have been created
+            Test-Path -LiteralPath (Join-Path $bootstrapRoot "ApiSchema") |
+                Should -BeFalse
+
+            # The manifest must not have been modified: claims/seed still present, no schema section added
+            $manifestAfter = Get-Content -LiteralPath (Join-Path $bootstrapRoot "bootstrap-manifest.json") -Raw |
+                ConvertFrom-Json
+            $manifestAfter.claims | Should -Not -BeNullOrEmpty
+            $manifestAfter.seed | Should -Not -BeNullOrEmpty
+            $manifestAfter.schema | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "claims staging" {
+        It "writes Embedded claims mode for core-only schema" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet)
+
+            Invoke-PrepareClaims
+            $manifest = Get-RootManifest
+
+            $manifest.claims.mode | Should -Be "Embedded"
+            @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File).Count |
+                Should -Be 0
+        }
+
+        It "auto-stages Sample and Homograph fragments without staging baseline fragments" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample", "Homograph"))
+
+            Invoke-PrepareClaims
+            $manifest = Get-RootManifest
+            $claimFiles = @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File | ForEach-Object Name)
+
+            $manifest.claims.mode | Should -Be "Hybrid"
+            $claimFiles | Should -Contain "004-sample-extension-claimset.json"
+            $claimFiles | Should -Contain "005-homograph-extension-claimset.json"
+            $claimFiles | Should -Not -Contain "001-namespace-claimset.json"
+            $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://sample.ed-fi.org"
+        }
+
+        It "requires caller-supplied claims for unmapped extensions such as TPDM" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+
+            { Invoke-PrepareClaims } |
+                Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*TPDM*"
+        }
+
+        It "stages caller fragments and records expected verification checks" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
+
+            Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir
+            $manifest = Get-RootManifest
+
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims/010-tpdm-claimset.json") |
+                Should -BeTrue
+            $check = @($manifest.claims.expectedVerificationChecks |
+                Where-Object { $_.resourceClaim -eq "http://example.org/identity/claims/widget" })[0]
+            $check.claimSetName | Should -Be "EdFiSandbox"
+            $check.action | Should -Be "Read"
+        }
+
+        It "rejects malformed, duplicate, or unknown claim fragments" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+
+            $badJsonDir = Join-Path $script:repo.RepoRoot "bad-json"
+            New-Item -ItemType Directory -Path $badJsonDir -Force | Out-Null
+            "{" | Set-Content -LiteralPath (Join-Path $badJsonDir "010-bad-claimset.json") -Encoding utf8
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $badJsonDir } |
+                Should -Throw -ExpectedMessage "*malformed JSON*"
+
+            $unknownDir = Join-Path $script:repo.RepoRoot "unknown"
+            New-ExplicitClaimsetFragment -Path (Join-Path $unknownDir "010-unknown-claimset.json") -ClaimSetName "NotAClaimSet"
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $unknownDir } |
+                Should -Throw -ExpectedMessage "*unknown effective claim set*"
+        }
+
+        It "accepts parent-only fragments without a top-level claim-set name" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "parent-only"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                        name = "http://example.org/identity/claims/domain"
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Not -Throw
+        }
+
+        It "requires a top-level name for implicit non-parent claim-set use" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "implicit"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $false
+                        name = "http://example.org/identity/claims/implicit"
+                        authorizationStrategyOverridesForCRUD = @(
+                            [ordered]@{
+                                actionName = "Read"
+                            }
+                        )
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-implicit-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*missing top-level name*"
+        }
+
+        It "reuses identical claims workspaces and rejects changed fragment sets" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
+
+            Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Not -Throw
+
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "011-extra-claimset.json")
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*claims fingerprint mismatch*"
+        }
+
+        It "rejects a fragment whose resourceClaims contains a non-object entry" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "bad-resource-claims"
+            $fragment = [ordered]@{
+                name = "EdFiSandbox"
+                resourceClaims = @("not-an-object")
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-bad-resource-claims-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*not a JSON object*"
+        }
+
+        It "rejects a parent resourceClaim missing 'name'" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "parent-missing-name"
+            $fragment = [ordered]@{
+                name = "FragLabel"
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-missing-name-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*missing 'name'*"
+        }
+
+        It "rejects an implicit non-parent resourceClaim missing 'name'" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "implicit-missing-name"
+            $fragment = [ordered]@{
+                name = "FragLabel"
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $false
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-implicit-missing-name-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*missing 'name'*"
+        }
+    }
+
+    Context "startup handoff" {
+        It "sets Config Service claim inputs from the bootstrap manifest but does not flip DMS into staged-workspace loading (Story 04 boundary)" {
+            # Story 04 boundary: with a valid bootstrap manifest present, Set-BootstrapStartupEnvironment
+            # returns $true and sets CMS claims env vars, but does NOT set USE_API_SCHEMA_PATH or
+            # API_SCHEMA_PATH because ContentProvider still expects *.ApiSchema.dll assemblies. The
+            # runtime DMS flip belongs to Story 04.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample"))
+            Invoke-PrepareClaims
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            Set-BootstrapStartupEnvironment | Should -BeTrue
+
+            # DMS runtime schema loading env vars must NOT be set by Set-BootstrapStartupEnvironment
+            # (Story 04 owns flipping DMS into the staged workspace path)
+            $env:USE_API_SCHEMA_PATH | Should -BeNullOrEmpty
+            $env:API_SCHEMA_PATH | Should -BeNullOrEmpty
+            $env:SCHEMA_PACKAGES | Should -BeNullOrEmpty
+            $env:DMS_API_SCHEMA_MOUNT_SOURCE | Should -BeNullOrEmpty
+
+            # CMS claims env vars ARE set by Set-BootstrapStartupEnvironment (in scope for Story 00)
+            $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
+            [System.IO.Path]::IsPathRooted($env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE) | Should -BeTrue
+        }
+
+        It "keeps bootstrap mounts out of the default DMS service and routes claims through Config Service" {
+            # bootstrap-dms.yml is removed in Story 00 (Story 04 will re-introduce runtime DMS wiring).
+            # local-dms.yml and published-dms.yml must not carry additional-claims or ApiSchema mounts;
+            # those belong to the Config Service and the Story 04 bootstrap compose surface respectively.
+            $localDms = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "local-dms.yml") -Raw
+            $publishedDms = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "published-dms.yml") -Raw
+            $localConfig = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "local-config.yml") -Raw
+
+            $localDms | Should -Not -Match "/app/additional-claims"
+            $publishedDms | Should -Not -Match "/app/additional-claims"
+            $localDms | Should -Not -Match "/app/ApiSchema:ro"
+            $localConfig | Should -Match "DMS_CONFIG_CLAIMS_MOUNT_SOURCE"
+
+            # bootstrap-dms.yml must not exist until Story 04 re-enables the runtime DMS bootstrap path
+            Test-Path -LiteralPath (Join-Path $script:sourceDockerComposeRoot "bootstrap-dms.yml") | Should -BeFalse
+        }
+
+        It "retains AddExtensionSecurityMetadata as a transitional non-bootstrap hybrid claims path" {
+            # The -AddExtensionSecurityMetadata switch is kept in the startup wrappers and build script
+            # as a transitional helper for DLL-backed (non-bootstrap) E2E until Story 04 moves runtime
+            # loading onto the staged bootstrap workspace. It must be present in all three files.
+            foreach ($path in @(
+                (Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1"),
+                (Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1"),
+                (Join-Path $script:sourceRepoRoot "build-dms.ps1")
+            )) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $content | Should -Match "AddExtensionSecurityMetadata"
+            }
+        }
+
+        It "sets Hybrid claims env vars when AddExtensionSecurityMetadata is passed without a bootstrap manifest" {
+            # Simulate non-bootstrap (no manifest) mode: load the module from an isolated repo that
+            # has no .bootstrap directory, then directly call Set-BootstrapStartupEnvironment.
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            # Confirm that without a manifest, Set-BootstrapStartupEnvironment returns false.
+            $bootstrapMode = Set-BootstrapStartupEnvironment
+            $bootstrapMode | Should -BeFalse
+
+            # Simulate the non-bootstrap Hybrid path that start-local-dms.ps1 applies when
+            # -AddExtensionSecurityMetadata is passed and $bootstrapMode is $false.
+            if (-not $bootstrapMode) {
+                $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
+                $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+            }
+
+            $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
+        }
+
+        It "clears DMS_CONFIG_CLAIMS_MOUNT_SOURCE when AddExtensionSecurityMetadata is passed without a bootstrap manifest" {
+            # Pre-set a stale ambient value that a prior bootstrap session might have left behind.
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = "/some/stale/path"
+
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            $bootstrapMode = Set-BootstrapStartupEnvironment
+            $bootstrapMode | Should -BeFalse
+
+            # Simulate the non-bootstrap Hybrid path that start-local-dms.ps1 applies when
+            # -AddExtensionSecurityMetadata is passed and $bootstrapMode is $false.
+            if (-not $bootstrapMode) {
+                $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
+                $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+                $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
+            }
+
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -BeNullOrEmpty
+        }
+
+        It "restores bootstrap environment variables through the snapshot helper" {
+            # The snapshot/restore set now covers only CMS claims vars (Story 04 boundary: DMS runtime
+            # schema vars USE_API_SCHEMA_PATH, API_SCHEMA_PATH, SCHEMA_PACKAGES, DMS_API_SCHEMA_MOUNT_SOURCE
+            # are not managed by the bootstrap manifest snapshot because Set-BootstrapStartupEnvironment
+            # does not set them until Story 04).
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "existing"
+            [System.Environment]::SetEnvironmentVariable("DMS_CONFIG_CLAIMS_DIRECTORY", $null)
+            $snapshot = Get-BootstrapEnvSnapshot
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "mutated"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+
+            Restore-BootstrapEnvSnapshot -Snapshot $snapshot
+
+            $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "existing"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "E2E wrappers" {
+        It "keeps E2E setup on the DLL-backed schema path until Story 04" {
+            foreach ($path in @(
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"),
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1")
+            )) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $content | Should -Not -Match "UseBootstrapWorkspace"
+                $content | Should -Not -Match "prepare-dms-schema"
+                $content | Should -Not -Match "prepare-dms-claims"
+                $content | Should -Match "DLL-backed schema"
+            }
+        }
+
+        It "passes AddExtensionSecurityMetadata in E2E setup scripts to enable Hybrid claims for extension schemas" {
+            # Confirm that both E2E setup wrappers pass -AddExtensionSecurityMetadata to start-local-dms.ps1
+            # so extension claimset fragments (e.g. Sample, Homograph) are loaded in non-bootstrap mode.
+            foreach ($path in @(
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"),
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1")
+            )) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $content | Should -Match "AddExtensionSecurityMetadata"
+            }
+        }
+
+        It "build-dms.ps1 teardown invocations include -RemoveBootstrap to wipe stale bootstrap workspace" {
+            # Confirm that both teardown invocations in Start-DockerEnvironment pass -RemoveBootstrap so
+            # a manually-staged .bootstrap/ from a developer session cannot hijack the subsequent E2E start.
+            $buildScript = Get-Content -LiteralPath (Join-Path $script:sourceRepoRoot "build-dms.ps1") -Raw
+            $buildScript | Should -Match "start-local-dms\.ps1.*-d.*-v.*-RemoveBootstrap"
+            $buildScript | Should -Match "start-published-dms\.ps1.*-d.*-v.*-RemoveBootstrap"
+        }
+
+        It "E2E setup wrappers contain defensive .bootstrap removal step before DLL-backed startup" {
+            # Confirm that both E2E setup wrappers defensively remove .bootstrap/ before invoking
+            # start-local-dms.ps1 so a stale bootstrap workspace cannot hijack the DLL-backed run
+            # even when a developer skips teardown between sessions.
+            foreach ($path in @(
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"),
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1")
+            )) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $content | Should -Match "Remove-Item -LiteralPath"
+                $content | Should -Match "\.bootstrap"
+            }
+        }
+    }
+}

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -154,7 +154,7 @@ exit $ExitCode
         & $script:repo.PrepareSchemaScript -ApiSchemaPath $ApiSchemaPath -SchemaToolPath $tool | Out-Null
     }
 
-    function script:Invoke-PrepareClaims {
+    function script:Invoke-PrepareClaim {
         param(
             [string]
             $ClaimsDirectoryPath
@@ -190,19 +190,14 @@ exit $ExitCode
         )
 
         $fragment = [ordered]@{
-            name = "ExtensionClaims"
+            name = $ClaimSetName
             resourceClaims = @(
                 [ordered]@{
                     isParent = $false
                     name = $ResourceClaim
-                    claimSets = @(
+                    authorizationStrategyOverridesForCRUD = @(
                         [ordered]@{
-                            name = $ClaimSetName
-                            actions = @(
-                                [ordered]@{
-                                    name = $Action
-                                }
-                            )
+                            actionName = $Action
                         }
                     )
                 }
@@ -252,7 +247,7 @@ exit $ExitCode
                 Should -BeTrue
             Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Sample/ApiSchema.json") |
                 Should -BeTrue
-            $manifest.schema.mode | Should -Be "ApiSchemaPath"
+            $manifest.schema.selectionMode | Should -Be "ApiSchemaPath"
             $manifest.schema.selectedExtensions | Should -Contain "sample"
             $manifest.schema.effectiveSchemaHash | Should -Be $script:hashA
             $manifest.schema.apiSchemaManifestPath | Should -Be "ApiSchema/bootstrap-api-schema-manifest.json"
@@ -295,6 +290,65 @@ exit $ExitCode
                 Should -Not -Throw
             { Invoke-PrepareSchema -ApiSchemaPath $schemaDir -Hash $script:hashB } |
                 Should -Throw -ExpectedMessage "*effective schema hash mismatch*"
+        }
+
+        It "accepts ApiSchema*.json files without the -EXTENSION suffix and discovers them recursively" {
+            $schemaDir = Join-Path $script:repo.RepoRoot "schema"
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema.json") -ProjectName "Ed-Fi" -ProjectEndpointName "ed-fi" -IsExtensionProject $false
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "nested/ApiSchema-Sample.json") -ProjectName "Sample" -ProjectEndpointName "sample" -IsExtensionProject $true
+
+            Invoke-PrepareSchema -ApiSchemaPath $schemaDir
+            $manifest = Get-RootManifest
+
+            $manifest.schema.selectedExtensions | Should -Contain "sample"
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Sample/ApiSchema.json") | Should -BeTrue
+        }
+
+        It "rejects ambiguous schema-adjacent content ownership when extensions share a directory with discovery/xsd content" {
+            $schemaDir = Join-Path $script:repo.RepoRoot "schema"
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema.json") -ProjectName "Ed-Fi" -ProjectEndpointName "ed-fi" -IsExtensionProject $false
+            $sharedDir = Join-Path $schemaDir "shared"
+            New-ApiSchemaFile -Path (Join-Path $sharedDir "ApiSchema-First.json") -ProjectName "First" -ProjectEndpointName "first" -IsExtensionProject $true
+            New-ApiSchemaFile -Path (Join-Path $sharedDir "ApiSchema-Second.json") -ProjectName "Second" -ProjectEndpointName "second" -IsExtensionProject $true
+            # Schema-adjacent content in the shared dir is what makes ownership ambiguous.
+            "discovery" | Set-Content -LiteralPath (Join-Path $sharedDir "discovery-spec.json") -Encoding utf8
+
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir } |
+                Should -Throw -ExpectedMessage "*Ambiguous schema-adjacent content ownership*"
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") | Should -BeFalse
+        }
+
+        It "accepts multiple extensions sharing a directory without a core schema when no schema-adjacent content is present" {
+            $schemaDir = Join-Path $script:repo.RepoRoot "schema"
+            New-ApiSchemaFile -Path (Join-Path $schemaDir "ApiSchema.json") -ProjectName "Ed-Fi" -ProjectEndpointName "ed-fi" -IsExtensionProject $false
+            $sharedDir = Join-Path $schemaDir "shared"
+            New-ApiSchemaFile -Path (Join-Path $sharedDir "ApiSchema-First.json") -ProjectName "First" -ProjectEndpointName "first" -IsExtensionProject $true
+            New-ApiSchemaFile -Path (Join-Path $sharedDir "ApiSchema-Second.json") -ProjectName "Second" -ProjectEndpointName "second" -IsExtensionProject $true
+
+            { Invoke-PrepareSchema -ApiSchemaPath $schemaDir } | Should -Not -Throw
+            $manifest = Get-RootManifest
+            $manifest.schema.selectedExtensions | Should -Contain "first"
+            $manifest.schema.selectedExtensions | Should -Contain "second"
+        }
+
+        It "shares discovery-spec and xsd content across all projects in a single source directory" {
+            $schemaDir = New-ApiSchemaSet -Extensions @("Sample", "Homograph")
+            "discovery" | Set-Content -LiteralPath (Join-Path $schemaDir "discovery-spec.json") -Encoding utf8
+            New-Item -ItemType Directory -Path (Join-Path $schemaDir "xsd") -Force | Out-Null
+            "<xs:schema />" | Set-Content -LiteralPath (Join-Path $schemaDir "xsd/Ed-Fi-Core.xsd") -Encoding utf8
+
+            Invoke-PrepareSchema -ApiSchemaPath $schemaDir
+            $apiSchemaManifest = Get-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json") -Raw |
+                ConvertFrom-Json
+
+            # Every project in the shared directory references the same staged content paths.
+            $sharedDiscovery = $apiSchemaManifest.projects[0].discoverySpecPath
+            $sharedXsd = $apiSchemaManifest.projects[0].xsdDirectory
+            $sharedDiscovery | Should -Not -BeNullOrEmpty
+            foreach ($project in $apiSchemaManifest.projects) {
+                $project.discoverySpecPath | Should -Be $sharedDiscovery
+                $project.xsdDirectory | Should -Be $sharedXsd
+            }
         }
 
         It "fails when dms-schema hashing fails" {
@@ -344,7 +398,7 @@ exit $ExitCode
         It "writes Embedded claims mode for core-only schema" {
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet)
 
-            Invoke-PrepareClaims
+            Invoke-PrepareClaim
             $manifest = Get-RootManifest
 
             $manifest.claims.mode | Should -Be "Embedded"
@@ -355,7 +409,7 @@ exit $ExitCode
         It "auto-stages Sample and Homograph fragments without staging baseline fragments" {
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample", "Homograph"))
 
-            Invoke-PrepareClaims
+            Invoke-PrepareClaim
             $manifest = Get-RootManifest
             $claimFiles = @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File | ForEach-Object Name)
 
@@ -369,24 +423,87 @@ exit $ExitCode
         It "requires caller-supplied claims for unmapped extensions such as TPDM" {
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
 
-            { Invoke-PrepareClaims } |
+            { Invoke-PrepareClaim } |
                 Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*TPDM*"
         }
 
-        It "stages caller fragments and records expected verification checks" {
+        It "stages caller fragments and records expected verification checks with the fragment's raw resource name" {
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
             $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
 
-            Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir
+            Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir
             $manifest = Get-RootManifest
 
             Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims/010-tpdm-claimset.json") |
                 Should -BeTrue
+            # Story 00 records the fragment's resource name verbatim. CMS (or a future shared
+            # composer helper) owns matching it against the composed hierarchy at startup.
             $check = @($manifest.claims.expectedVerificationChecks |
                 Where-Object { $_.resourceClaim -eq "http://example.org/identity/claims/widget" })[0]
             $check.claimSetName | Should -Be "EdFiSandbox"
             $check.action | Should -Be "Read"
+        }
+
+        It "records explicit parent claimSets readiness checks structurally" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "parent-explicit"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                        name = "http://example.org/identity/claims/domains/explicitParent"
+                        claimSets = @(
+                            [ordered]@{
+                                name = "EdFiSandbox"
+                                actions = @(
+                                    [ordered]@{
+                                        name = "Read"
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-explicit-claimset.json") -Encoding utf8
+
+            Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir
+            $manifest = Get-RootManifest
+
+            $check = @($manifest.claims.expectedVerificationChecks |
+                Where-Object { $_.resourceClaim -eq "http://example.org/identity/claims/domains/explicitParent" })[0]
+            $check.claimSetName | Should -Be "EdFiSandbox"
+            $check.action | Should -Be "Read"
+        }
+
+        It "rejects explicit claimSets on non-parent resource claims because CMS does not compose them" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "non-parent-explicit"
+            $fragment = [ordered]@{
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $false
+                        name = "http://example.org/identity/claims/widgets"
+                        claimSets = @(
+                            [ordered]@{
+                                name = "EdFiSandbox"
+                                actions = @(
+                                    [ordered]@{
+                                        name = "Read"
+                                    }
+                                )
+                            }
+                        )
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-non-parent-explicit-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*non-parent resourceClaims entry with claimSets*"
         }
 
         It "rejects malformed, duplicate, or unknown claim fragments" {
@@ -395,12 +512,12 @@ exit $ExitCode
             $badJsonDir = Join-Path $script:repo.RepoRoot "bad-json"
             New-Item -ItemType Directory -Path $badJsonDir -Force | Out-Null
             "{" | Set-Content -LiteralPath (Join-Path $badJsonDir "010-bad-claimset.json") -Encoding utf8
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $badJsonDir } |
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $badJsonDir } |
                 Should -Throw -ExpectedMessage "*malformed JSON*"
 
             $unknownDir = Join-Path $script:repo.RepoRoot "unknown"
             New-ExplicitClaimsetFragment -Path (Join-Path $unknownDir "010-unknown-claimset.json") -ClaimSetName "NotAClaimSet"
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $unknownDir } |
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $unknownDir } |
                 Should -Throw -ExpectedMessage "*unknown effective claim set*"
         }
 
@@ -418,8 +535,57 @@ exit $ExitCode
             New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
             $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-claimset.json") -Encoding utf8
 
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
                 Should -Not -Throw
+        }
+
+        It "reuses identical claims workspaces and rejects changed fragment sets" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
+            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
+
+            Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Not -Throw
+
+            # Use a distinct resource URI so this assertion exercises the fingerprint-mismatch path.
+            New-ExplicitClaimsetFragment `
+                -Path (Join-Path $claimsDir "011-extra-claimset.json") `
+                -ResourceClaim "http://example.org/identity/claims/anotherWidget"
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*claims fingerprint mismatch*"
+        }
+
+        It "rejects a fragment whose resourceClaims contains a non-object entry" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "bad-resource-claims"
+            $fragment = [ordered]@{
+                name = "EdFiSandbox"
+                resourceClaims = @("not-an-object")
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-bad-resource-claims-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*not a JSON object*"
+        }
+
+        It "rejects a parent resourceClaim missing 'name'" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            $claimsDir = Join-Path $script:repo.RepoRoot "parent-missing-name"
+            $fragment = [ordered]@{
+                name = "FragLabel"
+                resourceClaims = @(
+                    [ordered]@{
+                        isParent = $true
+                    }
+                )
+            }
+            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
+            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-missing-name-claimset.json") -Encoding utf8
+
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
+                Should -Throw -ExpectedMessage "*missing 'name'*"
         }
 
         It "requires a top-level name for implicit non-parent claim-set use" {
@@ -441,54 +607,8 @@ exit $ExitCode
             New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
             $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-implicit-claimset.json") -Encoding utf8
 
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
                 Should -Throw -ExpectedMessage "*missing top-level name*"
-        }
-
-        It "reuses identical claims workspaces and rejects changed fragment sets" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
-            $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
-            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
-
-            Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
-                Should -Not -Throw
-
-            New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "011-extra-claimset.json")
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
-                Should -Throw -ExpectedMessage "*claims fingerprint mismatch*"
-        }
-
-        It "rejects a fragment whose resourceClaims contains a non-object entry" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
-            $claimsDir = Join-Path $script:repo.RepoRoot "bad-resource-claims"
-            $fragment = [ordered]@{
-                name = "EdFiSandbox"
-                resourceClaims = @("not-an-object")
-            }
-            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
-            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-bad-resource-claims-claimset.json") -Encoding utf8
-
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
-                Should -Throw -ExpectedMessage "*not a JSON object*"
-        }
-
-        It "rejects a parent resourceClaim missing 'name'" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
-            $claimsDir = Join-Path $script:repo.RepoRoot "parent-missing-name"
-            $fragment = [ordered]@{
-                name = "FragLabel"
-                resourceClaims = @(
-                    [ordered]@{
-                        isParent = $true
-                    }
-                )
-            }
-            New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
-            $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-parent-missing-name-claimset.json") -Encoding utf8
-
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
-                Should -Throw -ExpectedMessage "*missing 'name'*"
         }
 
         It "rejects an implicit non-parent resourceClaim missing 'name'" {
@@ -505,41 +625,114 @@ exit $ExitCode
             New-Item -ItemType Directory -Path $claimsDir -Force | Out-Null
             $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath (Join-Path $claimsDir "010-implicit-missing-name-claimset.json") -Encoding utf8
 
-            { Invoke-PrepareClaims -ClaimsDirectoryPath $claimsDir } |
+            { Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir } |
                 Should -Throw -ExpectedMessage "*missing 'name'*"
         }
     }
 
     Context "startup handoff" {
-        It "sets Config Service claim inputs from the bootstrap manifest but does not flip DMS into staged-workspace loading (Story 04 boundary)" {
+        It "validates the bootstrap manifest without activating staged DMS schema or staged CMS claims startup" {
             # Story 04 boundary: with a valid bootstrap manifest present, Set-BootstrapStartupEnvironment
-            # returns $true and sets CMS claims env vars, but does NOT set USE_API_SCHEMA_PATH or
-            # API_SCHEMA_PATH because ContentProvider still expects *.ApiSchema.dll assemblies. The
-            # runtime DMS flip belongs to Story 04.
+            # returns $true but does not activate either side of the staged runtime pair. DMS falls
+            # back to its built-in DLL-backed schemas, so CMS must not be pointed at staged .bootstrap/claims.
+            # The existing claims source/directory are left intact for the non-staged path.
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample"))
-            Invoke-PrepareClaims
+            Invoke-PrepareClaim
             Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
             Import-Module $script:repo.ManifestModule -Force
 
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = "/some/stale/path"
+            $env:SCHEMA_PACKAGES = "ambient-packages"
+
             Set-BootstrapStartupEnvironment | Should -BeTrue
 
-            # DMS runtime schema loading env vars must NOT be set by Set-BootstrapStartupEnvironment
-            # (Story 04 owns flipping DMS into the staged workspace path)
             $env:USE_API_SCHEMA_PATH | Should -BeNullOrEmpty
             $env:API_SCHEMA_PATH | Should -BeNullOrEmpty
-            $env:SCHEMA_PACKAGES | Should -BeNullOrEmpty
+            $env:SCHEMA_PACKAGES | Should -Be "ambient-packages"
             $env:DMS_API_SCHEMA_MOUNT_SOURCE | Should -BeNullOrEmpty
 
-            # CMS claims env vars ARE set by Set-BootstrapStartupEnvironment (in scope for Story 00)
             $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
             $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
-            [System.IO.Path]::IsPathRooted($env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE) | Should -BeTrue
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -BeNullOrEmpty
         }
 
-        It "keeps bootstrap mounts out of the default DMS service and routes claims through Config Service" {
+        It "explicitly blanks process-env schema vars in bootstrap mode so docker compose --env-file cannot leak UseApiSchemaPath" {
+            # The repo .env / .env.example / .env.e2e set USE_API_SCHEMA_PATH=true and
+            # API_SCHEMA_PATH=/app/ApiSchema for the eventual Story 04 end state. Until Story 04
+            # ships ContentProvider's loose-JSON path, the bootstrap helper must override those
+            # values in the process environment so compose's ${VAR:-default} falls back to
+            # UseApiSchemaPath=false + empty ApiSchemaPath, keeping DMS on built-in DLL-backed assemblies.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample"))
+            Invoke-PrepareClaim
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            $env:USE_API_SCHEMA_PATH = "true"
+            $env:API_SCHEMA_PATH = "/app/ApiSchema"
+
+            Set-BootstrapStartupEnvironment | Should -BeTrue
+
+            $env:USE_API_SCHEMA_PATH | Should -BeNullOrEmpty
+            $env:API_SCHEMA_PATH | Should -BeNullOrEmpty
+        }
+
+        It "clears stale process-env claims mount source in bootstrap mode until staged runtime startup is enabled" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample"))
+            Invoke-PrepareClaim
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            # Simulate process env populated by an outer caller. Source/directory remain caller-owned
+            # for DLL-backed startup, while mount source is cleared to avoid staged .bootstrap/claims.
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "Embedded"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY = ""
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = "/some/stale/path"
+
+            Set-BootstrapStartupEnvironment | Should -BeTrue
+
+            $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Embedded"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -BeNullOrEmpty
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -BeNullOrEmpty
+        }
+
+        It "keeps AddExtensionSecurityMetadata working when a bootstrap manifest exists but staged runtime startup is deferred" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample"))
+            Invoke-PrepareClaim
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            $env:DMS_CONFIG_CLAIMS_SOURCE = "Embedded"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY = ""
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = "/some/stale/path"
+
+            Invoke-BootstrapStartupConfiguration -AddExtensionSecurityMetadata
+
+            $env:USE_API_SCHEMA_PATH | Should -BeNullOrEmpty
+            $env:API_SCHEMA_PATH | Should -BeNullOrEmpty
+            $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
+            $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
+            $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -BeNullOrEmpty
+        }
+
+        It "Invoke-BootstrapStartupConfiguration does not depend on a return value so callers can snapshot env independently" {
+            # Reviewer concern: if the helper threw before assigning $bootstrapStartup, the caller's
+            # finally would null-bind on $bootstrapStartup.EnvSnapshot and skip Pop-Location. The
+            # helper now returns nothing; callers capture Get-BootstrapEnvSnapshot themselves before
+            # Push-Location, so Restore + Pop always run cleanly.
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            $result = Invoke-BootstrapStartupConfiguration -IsTeardown -AddExtensionSecurityMetadata:$false
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "keeps bootstrap mounts out of the default DMS service and leaves Config Service mount source optional" {
             # bootstrap-dms.yml is removed in Story 00 (Story 04 will re-introduce runtime DMS wiring).
-            # local-dms.yml and published-dms.yml must not carry additional-claims or ApiSchema mounts;
-            # those belong to the Config Service and the Story 04 bootstrap compose surface respectively.
+            # local-dms.yml and published-dms.yml must not carry additional-claims or ApiSchema mounts.
+            # Config Service keeps the mount-source env hook for the non-bootstrap transition path and
+            # the future Story 04 staged claims activation.
             $localDms = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "local-dms.yml") -Raw
             $publishedDms = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "published-dms.yml") -Raw
             $localConfig = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "local-config.yml") -Raw
@@ -568,21 +761,10 @@ exit $ExitCode
         }
 
         It "sets Hybrid claims env vars when AddExtensionSecurityMetadata is passed without a bootstrap manifest" {
-            # Simulate non-bootstrap (no manifest) mode: load the module from an isolated repo that
-            # has no .bootstrap directory, then directly call Set-BootstrapStartupEnvironment.
             Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
             Import-Module $script:repo.ManifestModule -Force
 
-            # Confirm that without a manifest, Set-BootstrapStartupEnvironment returns false.
-            $bootstrapMode = Set-BootstrapStartupEnvironment
-            $bootstrapMode | Should -BeFalse
-
-            # Simulate the non-bootstrap Hybrid path that start-local-dms.ps1 applies when
-            # -AddExtensionSecurityMetadata is passed and $bootstrapMode is $false.
-            if (-not $bootstrapMode) {
-                $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
-                $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-            }
+            Invoke-BootstrapStartupConfiguration -AddExtensionSecurityMetadata
 
             $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
             $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
@@ -595,37 +777,47 @@ exit $ExitCode
             Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
             Import-Module $script:repo.ManifestModule -Force
 
-            $bootstrapMode = Set-BootstrapStartupEnvironment
-            $bootstrapMode | Should -BeFalse
-
-            # Simulate the non-bootstrap Hybrid path that start-local-dms.ps1 applies when
-            # -AddExtensionSecurityMetadata is passed and $bootstrapMode is $false.
-            if (-not $bootstrapMode) {
-                $env:DMS_CONFIG_CLAIMS_SOURCE = "Hybrid"
-                $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
-                $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE = ""
-            }
+            Invoke-BootstrapStartupConfiguration -AddExtensionSecurityMetadata
 
             $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -BeNullOrEmpty
         }
 
+        It "leaves non-bootstrap schema env vars untouched when AddExtensionSecurityMetadata is passed" {
+            # .env.e2e uses USE_API_SCHEMA_PATH=true plus SCHEMA_PACKAGES to load Sample/Homograph
+            # schema packages. The transitional non-bootstrap helper only enables Hybrid claims.
+            $env:USE_API_SCHEMA_PATH = "true"
+            $env:API_SCHEMA_PATH = "/app/ApiSchema"
+
+            Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+            Import-Module $script:repo.ManifestModule -Force
+
+            Invoke-BootstrapStartupConfiguration -AddExtensionSecurityMetadata
+
+            $env:USE_API_SCHEMA_PATH | Should -Be "true"
+            $env:API_SCHEMA_PATH | Should -Be "/app/ApiSchema"
+        }
+
         It "restores bootstrap environment variables through the snapshot helper" {
-            # The snapshot/restore set now covers only CMS claims vars (Story 04 boundary: DMS runtime
-            # schema vars USE_API_SCHEMA_PATH, API_SCHEMA_PATH, SCHEMA_PACKAGES, DMS_API_SCHEMA_MOUNT_SOURCE
-            # are not managed by the bootstrap manifest snapshot because Set-BootstrapStartupEnvironment
-            # does not set them until Story 04).
+            # Snapshot/restore covers the process env vars this helper blanks or mutates while preserving
+            # the Story 04 boundary: SCHEMA_PACKAGES and DMS_API_SCHEMA_MOUNT_SOURCE are not managed here.
             Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
             Import-Module $script:repo.ManifestModule -Force
             $env:DMS_CONFIG_CLAIMS_SOURCE = "existing"
             [System.Environment]::SetEnvironmentVariable("DMS_CONFIG_CLAIMS_DIRECTORY", $null)
+            $env:USE_API_SCHEMA_PATH = "true"
+            [System.Environment]::SetEnvironmentVariable("API_SCHEMA_PATH", $null)
             $snapshot = Get-BootstrapEnvSnapshot
             $env:DMS_CONFIG_CLAIMS_SOURCE = "mutated"
             $env:DMS_CONFIG_CLAIMS_DIRECTORY = "/app/additional-claims"
+            $env:USE_API_SCHEMA_PATH = ""
+            $env:API_SCHEMA_PATH = "/app/ApiSchema"
 
             Restore-BootstrapEnvSnapshot -Snapshot $snapshot
 
             $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "existing"
             $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -BeNullOrEmpty
+            $env:USE_API_SCHEMA_PATH | Should -Be "true"
+            $env:API_SCHEMA_PATH | Should -BeNullOrEmpty
         }
     }
 

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -531,8 +531,9 @@ prepare-dms-schema.ps1
 > content fetch failures. Story 00 stages the workspace and validates the manifest; Story 04 owns the
 > `ContentProvider` update that makes the staged JSON workspace the authoritative runtime source,
 > re-introduces `bootstrap-dms.yml`, and wires `Set-BootstrapStartupEnvironment` to emit the
-> `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` env vars. Until Story 04 lands, Docker-hosted DMS continues to
-> use DLL-backed schema loading (`SCHEMA_PACKAGES` or embedded assembly fallback).
+> `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` env vars. Until Story 04 lands, bootstrap-present Docker startup
+> blanks those env vars and falls back to the built-in DLL-backed schema assemblies. Non-bootstrap local
+> startup can still use the existing `SCHEMA_PACKAGES` downloader path.
 
 This reuses the existing host-side pattern already present in `eng/preflight-dms-schema-compile.ps1`: the
 host materializes concrete schema files first, then downstream steps operate on those staged files rather
@@ -777,11 +778,13 @@ The authoritative phase order and ownership rules live only in
 [`command-boundaries.md`](command-boundaries.md), especially Sections 3.2, 3.3, and 4. This section records
 the security-specific acceptance context:
 
-- `prepare-dms-claims.ps1` derives and stages the claims inputs before the Config Service starts.
-- `start-local-dms.ps1` consumes the bootstrap manifest claims section and treats Config Service readiness
-  as both service health and claims-ready verification for the staged inputs.
-- A missing claimset for an extension resource causes authorization failures during API-based seed loading,
-  so seed delivery never proceeds until the claims-ready gate has passed.
+- `prepare-dms-claims.ps1` derives and stages the claims inputs before staged runtime startup.
+- Story 00 `start-local-dms.ps1` validates the bootstrap manifest when present but does not consume the
+  staged claims section at startup until Story 04 can also point DMS at the matching staged ApiSchema
+  workspace.
+- After staged runtime startup is enabled, a missing claimset for an extension resource causes authorization
+  failures during API-based seed loading, so seed delivery never proceeds until the claims-ready gate has
+  passed.
 - Because the current CMS startup path only initial-loads claims into empty tables, changing the selected
   security inputs against a populated `edfi_config` database is outside the supported rerun surface for
   DMS-916. Bootstrap requires teardown rather than trying to replace claims in place.
@@ -790,19 +793,22 @@ For expert-mode bootstraps, `prepare-dms-claims.ps1` still derives the base clai
 schema and available claims inputs. If the staged schema selection requires additional non-core security
 metadata, `-ClaimsDirectoryPath` is required. Bootstrap stages the combined validated set into one workspace
 directory and records the
-effective CMS startup inputs in the root bootstrap manifest under `.bootstrap`. Those
+prepared CMS startup inputs in the root bootstrap manifest under `.bootstrap`. Those
 fragments may extend resource-claim nodes, but they may only attach actions to effective claim set
 references that already exist in embedded `Claims.json`. Bootstrap validates the same effective reference
-set defined in `command-boundaries.md`: explicit `resourceClaims[].claimSets[].name` values, plus the
-top-level fragment `name` only when CMS composition uses it as an implicit claim set name for a non-parent
-resource claim.
+set defined in `command-boundaries.md`: parent `resourceClaims[].claimSets[].name` values, plus the
+top-level fragment `name` when CMS composition uses it as an implicit claim set name for a non-parent
+resource claim. Non-parent explicit `claimSets` are rejected because CMS composes non-parent grants from
+the top-level fragment name and `authorizationStrategyOverridesForCRUD`.
 
 ### 4.5 Claims-Loading Approach: Safe Path vs. Legacy Flag
 
 The bootstrap design uses the claims section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json` to
 carry the effective Config Service claims inputs for the run, including the equivalent of Hybrid vs Embedded
-startup mode and the relative staged claims workspace when Hybrid mode is active. This is the intended path for
-every schema-selection flow, with `-ClaimsDirectoryPath` acting only as an additive input.
+startup mode and the relative staged claims workspace when Hybrid mode is active. Story 00 records and
+validates those inputs; Story 04 activates them at startup when DMS also reads the matching staged schema
+workspace. This is the intended path for every schema-selection flow, with `-ClaimsDirectoryPath` acting only
+as an additive input.
 For expert `-ApiSchemaPath` flows that need additional non-core security metadata, that additive input is
 required because bootstrap does not infer security fragments for arbitrary resources.
 
@@ -811,11 +817,13 @@ required because bootstrap does not infer security fragments for arbitrary resou
 All three schema-selection modes are explicitly designed to operate without this flag:
 
 - **Mode 1 (core only)**: the bootstrap manifest claims section resolves to Embedded mode - no extra flag needed.
-- **Mode 2 (named extensions)**: the bootstrap manifest claims section resolves to Hybrid mode and points at
-  the staged claims workspace containing only the selected claimset files - no extra flag needed.
-- **Mode 3 (expert `-ApiSchemaPath`)**: claims loading is automatic from the staged schema and available
+- **Mode 2 (named extensions)**: the bootstrap manifest claims section resolves to Hybrid mode and, after
+  Story 04 activates staged runtime startup, points at the staged claims workspace containing only the
+  selected claimset files - no extra flag needed.
+- **Mode 3 (expert `-ApiSchemaPath`)**: claims staging is automatic from the staged schema and available
   claims inputs. When the staged schema set contains extension resources with matching fragments, the same
-  bootstrap manifest mechanism stages the matching base fragments and selects Hybrid mode automatically.
+  bootstrap manifest mechanism stages the matching base fragments and selects Hybrid mode automatically for
+  the future staged runtime startup path.
   Additional non-core claim fragments use `-ClaimsDirectoryPath` and that same mechanism. The
   dangerously-enable flag is **not** required in expert mode either.
 - `DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING` is **not set** in any of the three modes above.
@@ -1533,10 +1541,11 @@ start.
 6. If any specified extension artifact cannot be resolved, the owning phase exits with a clear error before
    starting any containers.
 
-The staged claims directory must remain in place while Docker containers are running because it is
-bind-mounted into the container at `/app/additional-claims`. For v1, bootstrap uses a stable repo-local
-workspace under `eng/docker-compose/.bootstrap/claims` rather than per-run temp directories plus a state
-file. On same-checkout reruns, bootstrap compares the intended claims set to the existing workspace.
+Once Story 04 activates staged claims startup, the staged claims directory must remain in place while Docker
+containers are running because it is bind-mounted into the container at `/app/additional-claims`. For v1,
+bootstrap uses a stable repo-local workspace under `eng/docker-compose/.bootstrap/claims` rather than per-run
+temp directories plus a state file. On same-checkout reruns, bootstrap compares the intended claims set to
+the existing workspace.
 Identical contents are reused as-is; a different intended set requires teardown because the current CMS
 startup path only initial-loads claims into empty tables and does not replace a populated claims document in
 place. Teardown removes the entire `eng/docker-compose/.bootstrap/` workspace.
@@ -1847,7 +1856,7 @@ Bootstrap-DMS: Starting...
 [prepare-dms-claims]                                       (0.2s)
   Hybrid mode: 1 security fragment(s) staged
 [start-local-dms -InfraOnly]                              (13.7s)
-  Infrastructure and Config Service are claims-ready
+  Infrastructure and Config Service are health-ready
 [configure-local-dms-instance]                             (1.4s)
 [smoke-test credentials]                                   (0.7s)
   Smoke credentials created for selected target instance(s)
@@ -2531,8 +2540,8 @@ the same provider explicitly, for example
 When `-InfraOnly` is used **without** `-DmsBaseUrl`, `start-local-dms.ps1` itself performs only:
 
 1. Docker infrastructure startup without the DMS container.
-2. Config Service readiness checks. In DMS-916 this means `/health` is green and bootstrap has verified
-   that CMS applied the staged claims content as defined in `command-boundaries.md`.
+2. Config Service readiness checks. Story 00 requires `/health` to be green; staged claims readiness moves
+   with the Story 04 staged-schema runtime activation defined in `command-boundaries.md`.
 3. Exit after the infrastructure phase is ready.
 
 The broader IDE preparation flow then continues through separate phase commands or the thin wrapper:
@@ -2551,8 +2560,8 @@ from the earlier stopped invocation.
 When `-DmsBaseUrl` is provided alongside wrapper `-InfraOnly`, the same pre-DMS phases still complete first:
 
 1. Start Docker infrastructure (PostgreSQL, Kafka, Config Service) but not the DMS container.
-2. Wait for Config Service readiness. In DMS-916 this means `/health` is green and bootstrap has verified
-   that CMS applied the staged claims content as defined in `command-boundaries.md`.
+2. Wait for Config Service readiness. Story 00 requires `/health` to be green; staged claims readiness moves
+   with the Story 04 staged-schema runtime activation defined in `command-boundaries.md`.
 3. Run `configure-local-dms-instance.ps1` to create or confirm the target DMS instances, validate or report
    the fixed dev-only `CMSReadOnlyAccess` client created by local identity setup, and optionally create
    smoke-test credentials.

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -523,6 +523,17 @@ prepare-dms-schema.ps1
 > `-ApiSchemaPath` loading can be implemented and retained independently of package publication. Story 00
 > implements that direct filesystem path only; package-backed Modes 1 and 2 belong to Story 06.
 
+> **Implementation note (Story 04 boundary):** The "Docker-hosted DMS" branch of the diagram above —
+> `bind-mount .bootstrap/ApiSchema/ → /app/ApiSchema`, `set USE_API_SCHEMA_PATH=true`,
+> `set API_SCHEMA_PATH=/app/ApiSchema`, clear `SCHEMA_PACKAGES`, and the companion `bootstrap-dms.yml`
+> Docker Compose override — is **not activated by Story 00**. `ContentProvider` still discovers schema from
+> `*.ApiSchema.dll` assemblies; pointing it at a JSON-only staged workspace would cause discovery and XSD
+> content fetch failures. Story 00 stages the workspace and validates the manifest; Story 04 owns the
+> `ContentProvider` update that makes the staged JSON workspace the authoritative runtime source,
+> re-introduces `bootstrap-dms.yml`, and wires `Set-BootstrapStartupEnvironment` to emit the
+> `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` env vars. Until Story 04 lands, Docker-hosted DMS continues to
+> use DLL-backed schema loading (`SCHEMA_PACKAGES` or embedded assembly fallback).
+
 This reuses the existing host-side pattern already present in `eng/preflight-dms-schema-compile.ps1`: the
 host materializes concrete schema files first, then downstream steps operate on those staged files rather
 than re-resolving packages or inferring schema shape from container-only environment variables.
@@ -681,6 +692,11 @@ in `prepare-dms-schema.ps1`, security fragment metadata
 in `prepare-dms-claims.ps1`, and optional seed package metadata in `load-dms-seed-data.ps1`. Built-in seed
 loading participates only when the seed phase has a concrete built-in seed package for the selected
 extension.
+
+Story 00's v1 direct-filesystem claims lookup is intentionally narrow. It maps only extension projects that
+have current shipped security fragments in the repo, such as Sample and Homograph. TPDM and any other direct
+filesystem extension outside that lookup are treated as unmapped: bootstrap requires `-ClaimsDirectoryPath`
+for caller-supplied fragments and does not silently substitute `sample`, `homograph`, or any default mapping.
 
 The bootstrap logic is:
 

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -336,7 +336,9 @@ are not themselves the hashed artifact. Package-backed selection is a later inpu
 must converge on the same filesystem workspace. Direct `-ApiSchemaPath` loading remains a supported
 bootstrap path after asset-only packages replace DLL-backed package distribution.
 
-The staged ApiSchema workspace is the runtime schema/content contract for the run. DMS runtime reads
+The staged ApiSchema workspace is the end-state runtime schema/content contract for the run after Story 04
+activates file-based runtime loading. Story 00 prepares and validates this workspace but does not make it the
+Docker runtime source of truth. In the Story 04 path, DMS runtime reads
 `eng/docker-compose/.bootstrap/ApiSchema/` and applies the same normalization rules to that staged file set:
 
 - exactly one normalized schema file must have `projectSchema.isExtensionProject=false`; that file is the core

--- a/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
@@ -148,7 +148,8 @@ state. DMS compose services do not consume claimset fragment files, so `local-dm
 | **Must NOT do** | Resolve or validate ApiSchema files; inspect or write the staged-schema or staged-claims workspace; provision databases; enable the legacy `NEED_DATABASE_SETUP` / `EdFi.DataManagementService.Backend.Installer.dll` startup provisioning path; configure DMS instances; create smoke-test or seed-loading CMS application credentials; load seed data; accept schema or claims parameters |
 
 **Boundary note:** `-InfraOnly` and `-DmsBaseUrl` are Docker-layer controls - they decide whether a DMS
-container starts or an already-provisioned IDE-hosted DMS endpoint is health-checked. Story 00 keeps staged
+container starts or an already-provisioned IDE-hosted DMS endpoint is health-checked. Story 00 makes staged
+schema/security the prepared bootstrap contract, not the Docker runtime source of truth. It keeps staged
 schema and staged claims startup inactive as a pair, because activating only CMS claims while DMS remains
 DLL-backed can produce mismatched authorization metadata. Story 04 owns the claims-ready gate for staged
 bootstrap startup, including any CMS load/composition result or authorization metadata verification. `-DmsBaseUrl`

--- a/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
@@ -46,7 +46,7 @@ environment configuration.
 |---|---|
 | **Preconditions** | Story 00: filesystem ApiSchema source available directly through `-ApiSchemaPath`. Story 06: NuGet feed reachable for asset-only package materialization. No Docker services required. |
 | **Inputs** | Story 00: `-ApiSchemaPath <path>` (direct filesystem ApiSchema source). Story 06: `-Extensions <name>` (0..N, package-backed extension names), mutually exclusive with `-ApiSchemaPath`. |
-| **Outputs** | Staged workspace `eng/docker-compose/.bootstrap/ApiSchema/` containing normalized schema JSON files, optional schema-adjacent static content, and `bootstrap-api-schema-manifest.json`; the staged workspace itself is the downstream schema and runtime-asset contract consumed by later phases and DMS runtime |
+| **Outputs** | Staged workspace `eng/docker-compose/.bootstrap/ApiSchema/` containing normalized schema JSON files, optional schema-adjacent static content, and `bootstrap-api-schema-manifest.json`; the staged workspace itself is the downstream schema and runtime-asset contract consumed by later phases and by DMS runtime after Story 04 enables staged workspace loading |
 | **Side effects** | Writes staged workspace; computes expected `EffectiveSchemaHash` via `dms-schema hash`; records manifest-relative paths for schema and optional static content in `bootstrap-api-schema-manifest.json`; writes the schema section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json` with schema-selection mode, selected extensions, the effective schema hash, an ApiSchema workspace fingerprint, and the relative ApiSchema manifest path |
 | **Failure conditions** | Story 00: missing `-ApiSchemaPath`; `-Extensions` supplied before Story 06 behavior is implemented; normalized-path collision; staged workspace exists with different content; `dms-schema hash` exits non-zero; fewer or more than 1 core schema present after staging. Story 06 adds: extension package/artifact resolution failure; `-Extensions` and `-ApiSchemaPath` both supplied; NuGet feed unreachable for package-backed materialization; selected package is missing the required asset-only ApiSchema payload; selected package contains only DLL-backed ApiSchema resources after the asset-only package switch-over. |
 | **Must NOT do** | Start or depend on Docker services; modify `.env` or Docker Compose variables; perform DDL work; contact the Config Service; accept claims-related parameters |
@@ -74,7 +74,7 @@ content-loading story.
 
 ### 3.2 `prepare-dms-claims.ps1` — Claims and Security Staging
 
-**Primary concern:** Stage `*-claimset.json` fragments into the workspace that the Config Service reads on startup.
+**Primary concern:** Stage `*-claimset.json` fragments into the workspace that the Config Service will read when staged runtime startup is enabled.
 
 | Item | Detail |
 |---|---|
@@ -88,11 +88,14 @@ content-loading story.
 **Mode-to-security contract (precise):** This command always stages the automatic base claims set identified by the schema section of the bootstrap manifest from `prepare-dms-schema.ps1`. If the staged schema set is core only, the bootstrap manifest claims mode may stay in Embedded mode. If the staged schema set includes extension resources with matching security fragments, this command stages those fragments automatically and records Hybrid mode. If the staged schema set needs additional non-core security fragments from `-ApiSchemaPath`, `-ClaimsDirectoryPath` is required and its validated fragments are staged alongside any automatic base fragments. Bootstrap validates the supplied fragments structurally, but does not prove that they authorize every custom resource.
 
 **Claim-set-reference validation contract:** This command validates only the claim set names that CMS
-composition will use as effective authorization attachments: every explicit
-`resourceClaims[].claimSets[].name`, plus the fragment top-level `name` only for non-parent resource
-claims that rely on it as the implicit claim set name. A fragment top-level `name` that is only a
-fragment/group label for explicit parent-claim attachments is not by itself a claim set reference and
-must not be rejected merely because it is absent from embedded `Claims.json`.
+composition will use as effective authorization attachments: explicit
+`resourceClaims[].claimSets[].name` entries on parent resource claims, plus the fragment top-level `name`
+for non-parent resource claims that rely on it as the implicit claim set name. Non-parent
+`resourceClaims[].claimSets[]` entries are rejected because the CMS composer does not use that shape for
+non-parent grants; those fragments must use `authorizationStrategyOverridesForCRUD` with an effective
+top-level fragment `name`. A fragment top-level `name` that is only a fragment/group label for explicit
+parent-claim attachments is not by itself a claim set reference and must not be rejected merely because it
+is absent from embedded `Claims.json`.
 
 **Bootstrap manifest handoff contract:** `eng/docker-compose/.bootstrap/bootstrap-manifest.json` is the only
 persisted compatibility and handoff state between bootstrap phases. The ApiSchema manifest under
@@ -127,7 +130,7 @@ are derived from the repo root plus the manifest's relative directories; they ar
 state. DMS compose services do not consume claimset fragment files, so `local-dms.yml` and
 `published-dms.yml` must not mount `/app/additional-claims`; DMS reads authorization metadata from CMS.
 
-**Boundary note:** Claim-fragment validation here is structural only: JSON shape, duplicate filenames, effective claim-set-name references, and mechanical extraction of the expected verification entries. This phase does not inspect attachment overlap, reject duplicate `(resource claim, claim set name)` pairs, or perform semantic composition reasoning; CMS startup remains the authoritative composition gate. Built-in seed-package advertisement is owned by Story 02 / `load-dms-seed-data.ps1`; this phase only stages and validates the claims inputs that later seed delivery depends on. The bootstrap manifest is not a cross-invocation resume mechanism, mutable workflow checkpoint, or second control plane.
+**Boundary note:** Claim-fragment validation here is structural only: JSON shape, duplicate filenames, effective claim-set-name references, rejection of CMS-ignored non-parent explicit `claimSets`, and mechanical extraction of the expected verification entries. This phase does not inspect attachment overlap, reject duplicate `(resource claim, claim set name)` pairs, or perform semantic composition reasoning; CMS startup remains the authoritative composition gate. Built-in seed-package advertisement is owned by Story 02 / `load-dms-seed-data.ps1`; this phase only stages and validates the claims inputs that later seed delivery depends on. The bootstrap manifest is not a cross-invocation resume mechanism, mutable workflow checkpoint, or second control plane.
 
 ---
 
@@ -137,24 +140,19 @@ state. DMS compose services do not consume claimset fragment files, so `local-dm
 
 | Item | Detail |
 |---|---|
-| **Preconditions** | Staged claims workspace (`eng/docker-compose/.bootstrap/claims/`) and bootstrap manifest claims section present when CMS is included (normal flow). When invoked with `-DmsBaseUrl`, `configure-local-dms-instance.ps1` and `provision-dms-schema.ps1` have already completed for the selected target set. |
+| **Preconditions** | Current Story 00 startup may validate a bootstrap manifest when present, but staged claims startup is not activated until Story 04 enables DMS staged-schema runtime loading. When invoked with `-DmsBaseUrl`, `configure-local-dms-instance.ps1` and `provision-dms-schema.ps1` have already completed for the selected target set. |
 | **Inputs** | `-InfraOnly` (exclude DMS container from Docker startup); `-DmsBaseUrl <url>` (post-provision health endpoint of IDE-hosted DMS; valid only with `-InfraOnly` and only at the DMS-start/health-wait point after schema provisioning); `-EnvironmentFile <path>` (select Docker Compose env file and shared local settings); `-Rebuild` / `-r`; `-IdentityProvider`; `-EnableConfig` (legacy compat, not a meaningful opt-out in the normative flow); `-EnableKafkaUI`; `-EnableSwaggerUI`; teardown flags `-d`/`-v` |
-| **Outputs** | Running Docker services; provider-specific local identity clients including `CMSReadOnlyAccess`; claims-ready Config Service; healthy DMS container (non-`-InfraOnly` path) or confirmed healthy IDE-hosted DMS endpoint (post-provision `-DmsBaseUrl` path) |
-| **Side effects** | Docker Compose up/down; runs provider-specific local identity setup, including the fixed `CMSReadOnlyAccess` read-only client; reads the bootstrap manifest claims section and applies it to Config Service startup through `local-config.yml` claims env vars and the Config Service `/app/additional-claims` bind mount; calls `setup-openiddict.ps1 -InitDb` after PostgreSQL health; calls `setup-openiddict.ps1 -InsertData` after Config Service readiness (self-contained path); after `/health` is green, verifies CMS applied the staged claims content using a CMS load/composition result when available, otherwise by probing `/authorizationMetadata?claimSetName=<name>` for the recorded claims-verification checks and requiring each expected resource claim URI/action to be present; polls `$DmsBaseUrl/health` with timeout only during the post-provision DMS-start/health-wait invocation |
-| **Failure conditions** | Docker compose start failure; health-wait timeout for any service; Config Service claims composition/load result is failed, incomplete, or unavailable without successful authorization metadata fallback; authorization metadata fallback returns non-200 or omits the core baseline check or any expected `(claim set name, resource claim URI, action)` entry from the bootstrap manifest claims section; `-DmsBaseUrl` supplied before the selected instances and target databases are ready; `-DmsBaseUrl` health-wait timeout |
+| **Outputs** | Running Docker services; provider-specific local identity clients including `CMSReadOnlyAccess`; healthy Config Service; healthy DMS container (non-`-InfraOnly` path) or confirmed healthy IDE-hosted DMS endpoint (post-provision `-DmsBaseUrl` path) |
+| **Side effects** | Docker Compose up/down; runs provider-specific local identity setup, including the fixed `CMSReadOnlyAccess` read-only client; validates the bootstrap manifest when present but does not apply manifest-selected staged claims to Config Service startup until Story 04 can also point DMS at the matching staged ApiSchema workspace; calls `setup-openiddict.ps1 -InitDb` after PostgreSQL health; calls `setup-openiddict.ps1 -InsertData` after Config Service readiness (self-contained path); polls `$DmsBaseUrl/health` with timeout only during the post-provision DMS-start/health-wait invocation |
+| **Failure conditions** | Docker compose start failure; health-wait timeout for any service; malformed or incomplete bootstrap manifest when present; `-DmsBaseUrl` supplied before the selected instances and target databases are ready; `-DmsBaseUrl` health-wait timeout |
 | **Must NOT do** | Resolve or validate ApiSchema files; inspect or write the staged-schema or staged-claims workspace; provision databases; enable the legacy `NEED_DATABASE_SETUP` / `EdFi.DataManagementService.Backend.Installer.dll` startup provisioning path; configure DMS instances; create smoke-test or seed-loading CMS application credentials; load seed data; accept schema or claims parameters |
 
 **Boundary note:** `-InfraOnly` and `-DmsBaseUrl` are Docker-layer controls - they decide whether a DMS
-container starts or an already-provisioned IDE-hosted DMS endpoint is health-checked. Config Service
-readiness in the first infrastructure invocation is the claims-ready gate for later phases: `/health`
-must be green, and bootstrap must prove that CMS applied the staged claims content. A CMS
-load/composition result is the preferred proof. If that result is not available, the fallback is
-manifest-driven authorization metadata verification: query `/authorizationMetadata?claimSetName=<name>`
-for the recorded checks, require the core baseline check to pass, and require every staged fragment entry
-to contain the expected resource claim URI and action for its claim set. Merely finding `EdFiSandbox`, or
-finding a claim set name without the staged resource/action entries, is not claims-ready. This phase
-consumes the claims section of the bootstrap manifest produced earlier; it does not re-derive claims policy
-from schema or fragment contents. `-DmsBaseUrl` is never a shortcut around instance creation or schema
+container starts or an already-provisioned IDE-hosted DMS endpoint is health-checked. Story 00 keeps staged
+schema and staged claims startup inactive as a pair, because activating only CMS claims while DMS remains
+DLL-backed can produce mismatched authorization metadata. Story 04 owns the claims-ready gate for staged
+bootstrap startup, including any CMS load/composition result or authorization metadata verification. `-DmsBaseUrl`
+is never a shortcut around instance creation or schema
 provisioning: the wrapper must hold that value until after `configure-local-dms-instance.ps1` and
 `provision-dms-schema.ps1` have completed, and manual phase flows must invoke the external health wait in
 the same post-provision position. Once DMS health is confirmed, any later step is owned by wrapper

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -57,12 +57,12 @@ packaging to publish asset-only ApiSchema NuGet packages is Story 05; that packa
 Story 06 package-backed standard-mode slice but does not replace or deprecate direct filesystem loading.
 
 **Mode-to-security summary (normative for Story 00):** The effective staged schema set from `-ApiSchemaPath`
-is the single source of truth for the staged ApiSchema files and for the matching base staged claimset
-fragments available for the run through the Story 00 v1 mapped-extension lookup. If `-ApiSchemaPath` stages
-unmapped non-core schemas that need additional security metadata, `-ClaimsDirectoryPath` is required for
-caller-supplied fragments. No later phase re-derives or replaces that security selection. Story 06
-package-backed `-Extensions` mode must feed the same root bootstrap manifest schema contract and
-claims-staging contract rather than introducing a second path.
+is the single source of truth inside the prepared workspace for the staged ApiSchema files and for the
+matching base staged claimset fragments available for the run through the Story 00 v1 mapped-extension lookup.
+If `-ApiSchemaPath` stages unmapped non-core schemas that need additional security metadata,
+`-ClaimsDirectoryPath` is required for caller-supplied fragments. No later phase re-derives or replaces that
+security selection. Story 06 package-backed `-Extensions` mode must feed the same root bootstrap manifest
+schema contract and claims-staging contract rather than introducing a second path.
 
 ## Acceptance Criteria
 
@@ -75,6 +75,10 @@ claims-staging contract rather than introducing a second path.
 - The staged ApiSchema workspace contains `bootstrap-api-schema-manifest.json` with deterministic
   manifest-relative paths for each selected project's normalized schema file and optional static content. This
   ApiSchema manifest is a runtime asset index only.
+- Story 00 makes staged schema/security the prepared bootstrap contract, not the Docker runtime source of
+  truth. Startup may validate the root bootstrap manifest, but DMS continues using DLL-backed schema
+  assemblies and CMS continues using the non-staged claims path until Story 04 switches both runtime inputs
+  together.
 - `prepare-dms-schema.ps1` writes the schema section of
   `eng/docker-compose/.bootstrap/bootstrap-manifest.json` with schema selection mode (`ApiSchemaPath`),
   selected extension names, expected `EffectiveSchemaHash`, an ApiSchema workspace fingerprint, and the
@@ -226,7 +230,9 @@ claims-staging contract rather than introducing a second path.
    `-AddExtensionSecurityMetadata` compatibility path, but clears `DMS_CONFIG_CLAIMS_MOUNT_SOURCE` so CMS
    cannot mount staged `.bootstrap/claims` for a different staged schema set. Story 04 owns flipping DMS and
    CMS over to the staged workspaces together (re-introducing `bootstrap-dms.yml` and the corresponding
-   env-var wiring in `Set-BootstrapStartupEnvironment`).
+   env-var wiring in `Set-BootstrapStartupEnvironment`). Activating `.bootstrap/claims` without also
+   activating `.bootstrap/ApiSchema` is explicitly prohibited in Story 00 because it can create a
+   schema/security metadata mismatch.
 5. Implement additive security-fragment staging in `prepare-dms-claims.ps1`: stage fragments into one
    bootstrap workspace, with duplicate-filename detection, malformed-JSON validation, unknown effective
    claim-set-reference validation, and updates to the root bootstrap manifest claims section that record the
@@ -282,6 +288,8 @@ claims-staging contract rather than introducing a second path.
 - Flipping Config Service startup to read the staged `.bootstrap/claims` workspace for bootstrap mode; that
   must happen with the Story 04 DMS staged-schema runtime switch so schema and authorization metadata remain
   aligned.
+- Treating the prepared Story 00 schema/security workspace as the Docker runtime source of truth. Story 00
+  records and validates the prepared contract; Story 04 makes that contract runtime-authoritative.
 
 ## Design References
 
@@ -319,3 +327,15 @@ Single high-severity finding; accepted with the "clear `.bootstrap/` before star
 - **FB8 (High, VALID):** `start-local-dms.ps1` checks the bootstrap manifest first and only applies `-AddExtensionSecurityMetadata` in the `elseif`. A stale `.bootstrap/` workspace (core-only, partial, or with a different extension selection) overrides the DLL-backed E2E/build path: CMS reads `.bootstrap/claims` while runtime loads DLL schemas, producing mismatched authorization or a fail-fast on a missing claims/seed section. `build-dms.ps1`'s teardown doesn't pass `-RemoveBootstrap`, and the E2E setup wrappers assume the caller ran teardown first. Fix: add `-RemoveBootstrap` to `build-dms.ps1`'s teardown calls, and add a defensive `.bootstrap/` removal step at the top of both E2E setup wrappers. Add Pester coverage that asserts the cleanup contracts.
 
 No round-3 findings dismissed.
+
+### 2026-05-20 — External PR review round 4 (DMS-1150 / branch)
+
+Five findings; one high accepted as a Story 04 boundary, four mediums accepted:
+
+- **FB9 (High, ACCEPTED AS STORY 04 BOUNDARY):** Reviewer flagged `Set-BootstrapStartupEnvironment` blanking `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` (bootstrap-manifest.psm1:447) and `DMS_CONFIG_CLAIMS_MOUNT_SOURCE` (:510) as leaving startup on DLL-backed schemas and non-staged claims after both prepare scripts run. That observation is correct for Story 00: staged schema/security is the prepared bootstrap contract, not the Docker runtime source of truth. Runtime activation is deferred because `ContentProvider` still loads `*.ApiSchema.dll`, and activating staged CMS claims without staged DMS schema can create mismatched authorization metadata. Story 04 owns flipping DMS and CMS over to the staged workspaces together. The blanking remains as the defensive guard against `.env`-leaked Story-04 values.
+- **FB10 (Medium, VALID):** `prepare-dms-claims.ps1` recreated `.bootstrap/claims` when the workspace was missing without checking for stale manifest `claims`/`seed` sections, then overwrote those sections, bypassing the teardown-guidance fail-fast required by Task #9. Mirror the schema-phase guard (FB3) so partial prior state fails fast with the workspace-mismatch message.
+- **FB11 (Medium, VALID):** Claimset discovery in `prepare-dms-claims.ps1:Get-UserFragmentFile` read only the top level of `-ClaimsDirectoryPath`. CMS `ClaimsFragmentComposer.DiscoverFragmentFiles` uses `SearchOption.AllDirectories`, so nested valid fragments were silently dropped and nested filename collisions were missed. Add `-Recurse` so bootstrap input discovery matches CMS runtime discovery; the existing filename-collision guard then catches nested duplicates after flattening.
+- **FB12 (Medium, VALID):** `Test-TruthyJsonValue` coerced non-bool `isParent` via `[System.Convert]::ToBoolean`, and `resourceClaims`/`claimSets`/`actions` accepted singleton non-arrays through `@(...)` coercion. CMS deserializes `IsParent` as a strict `bool` and the three array fields as `List<T>` with no lenient `JsonSerializerOptions`, so malformed fragments passed bootstrap and failed later at CMS startup. Tighten each to strict shape. Extend the same strict-array guard to `authorizationStrategyOverridesForCRUD` for consistency. (Fixing the IList check also required `Get-ValueOrNull` to wrap returns with the unary comma so PowerShell's function-output unwrapping does not flatten single-element arrays to scalars.)
+- **FB13 (Medium, VALID):** `Copy-Item`/`Move-Item` at `prepare-dms-schema.ps1:431,:497` and `prepare-dms-claims.ps1:452,:502` are non-terminating cmdlets, and neither script sets `$ErrorActionPreference = 'Stop'`. A failed staging copy/move could still allow the manifest write that follows, producing a manifest pointing at an incomplete workspace. Add `-ErrorAction Stop` to the four staging calls.
+
+No round-4 findings dismissed. FB9 is accepted as an intentional Story 04 runtime-activation boundary.

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -114,14 +114,16 @@ claims-staging contract rather than introducing a second path.
   rewriting a directory that may still be bind-mounted into CMS or attempting in-place replacement of
   populated CMS claims data.
 - Claim-fragment validation in bootstrap is structural only: staged fragments must be
-  parseable, must target effective claim set references that already exist in embedded `Claims.json`, and
-  must not collide by filename in the staged workspace. The precise reference rule matches
-  `command-boundaries.md`: every explicit `resourceClaims[].claimSets[].name` is validated, and the
-  fragment top-level `name` is validated only when CMS composition uses it as the implicit claim set name
-  for a non-parent resource claim. A top-level fragment/group label for explicit parent-claim attachments is
-  not itself rejected merely because it is absent from embedded `Claims.json`. Bootstrap does not check
-  attachment overlap or perform semantic composition reasoning; CMS startup is the authoritative composition
-  gate for those outcomes.
+  parseable, must target effective claim set references that already exist in embedded `Claims.json`, must
+  not use explicit `resourceClaims[].claimSets[]` on non-parent claims because CMS composes those through the
+  fragment top-level `name` plus `authorizationStrategyOverridesForCRUD`, and must not collide by filename
+  in the staged workspace. The precise reference rule matches `command-boundaries.md`: explicit
+  `resourceClaims[].claimSets[].name` entries are valid only for parent resource claims, and the fragment
+  top-level `name` is validated when CMS composition uses it as the implicit claim set name for a non-parent
+  resource claim. A top-level fragment/group label for explicit parent-claim attachments is not itself
+  rejected merely because it is absent from embedded `Claims.json`. Bootstrap does not check attachment
+  overlap or perform semantic composition reasoning; CMS startup is the authoritative composition gate for
+  those outcomes.
 - Extension-derived and developer-supplied claimset fragments are staged into one workspace directory with
   fail-fast validation for:
   - missing directory,
@@ -136,14 +138,12 @@ claims-staging contract rather than introducing a second path.
   seed support and does not author or require `SeedLoader` attachments on fragments that lack them — Story
   02 owns built-in seed-package advertisement and the `SeedLoader` coverage requirement enforced at seed
   delivery.
-- CMS consumes the staged claims workspace through the Config Service `/app/additional-claims` mount target.
-  In bootstrap mode, the host source for that mount is the manifest-selected
-  `eng/docker-compose/.bootstrap/claims/` workspace, not the repo
-  `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/` directory. The claims
-  section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json` is the source of truth for the CMS claims
-  mode, relative claims directory, claims fingerprint, and expected claims-verification checks.
-  `start-local-dms.ps1` translates that manifest section into the `local-config.yml` environment and
-  bind-mount inputs used for the run.
+- CMS will consume the staged claims workspace through the Config Service `/app/additional-claims` mount target
+  when Story 04 enables staged runtime startup. Story 00 records the manifest-selected
+  `eng/docker-compose/.bootstrap/claims/` workspace, claims mode, claims fingerprint, and expected
+  claims-verification checks, but `start-local-dms.ps1` does not translate that manifest section into
+  `local-config.yml` environment and bind-mount inputs until DMS also reads the matching staged ApiSchema
+  workspace.
 - `prepare-dms-claims.ps1` updates `eng/docker-compose/.bootstrap/bootstrap-manifest.json` after claims
   staging succeeds. The claims section records only the effective claims startup inputs and fingerprints; the
   seed section records only extension namespace prefixes. The root manifest must not contain built-in
@@ -211,25 +211,37 @@ claims-staging contract rather than introducing a second path.
    stage/validate claim fragments in this phase.
 4. Define the bootstrap-dms compose surface and runtime env wiring (mount `.bootstrap/ApiSchema` →
    `/app/ApiSchema`, set `USE_API_SCHEMA_PATH=true`, set `API_SCHEMA_PATH=/app/ApiSchema`, clear
-   `SCHEMA_PACKAGES`) **in design only**. Story 00 does not enable the runtime DMS bootstrap startup path
-   because `ContentProvider` still expects `*.ApiSchema.dll` assemblies; enabling it now would cause
-   discovery/XSD content fetches to fail in bootstrap mode. Story 04 owns flipping DMS over to the
-   staged workspace at runtime (re-introducing `bootstrap-dms.yml` and the corresponding env-var wiring
-   in `Set-BootstrapStartupEnvironment`).
+   `SCHEMA_PACKAGES`) **in design only** — see the Mode 3 flow in
+   [`bootstrap-design.md`](../../design-docs/bootstrap/bootstrap-design.md) for the end-state diagram
+   Story 04 implements. Story 00 does not enable that runtime DMS bootstrap startup path because
+   `ContentProvider` still expects `*.ApiSchema.dll` assemblies; enabling it now would cause
+   discovery/XSD content fetches to fail in bootstrap mode. To keep the deferral robust against
+   `.env`-leaked values (the repo `.env` / `.env.example` / `.env.e2e` currently set
+   `USE_API_SCHEMA_PATH=true` / `API_SCHEMA_PATH=/app/ApiSchema` for the eventual Story 04 end state),
+   `Set-BootstrapStartupEnvironment` explicitly blanks `USE_API_SCHEMA_PATH` and `API_SCHEMA_PATH` in
+   the process environment when a bootstrap manifest is present. Compose then falls back to
+   `${VAR:-false}` / empty path, so the DMS container does not execute the `SCHEMA_PACKAGES` downloader and
+   uses its built-in DLL-backed schema assemblies. Because DMS is still on that non-staged path here, Story
+   00 leaves `DMS_CONFIG_CLAIMS_SOURCE` and `DMS_CONFIG_CLAIMS_DIRECTORY` to the env file or
+   `-AddExtensionSecurityMetadata` compatibility path, but clears `DMS_CONFIG_CLAIMS_MOUNT_SOURCE` so CMS
+   cannot mount staged `.bootstrap/claims` for a different staged schema set. Story 04 owns flipping DMS and
+   CMS over to the staged workspaces together (re-introducing `bootstrap-dms.yml` and the corresponding
+   env-var wiring in `Set-BootstrapStartupEnvironment`).
 5. Implement additive security-fragment staging in `prepare-dms-claims.ps1`: stage fragments into one
    bootstrap workspace, with duplicate-filename detection, malformed-JSON validation, unknown effective
    claim-set-reference validation, and updates to the root bootstrap manifest claims section that record the
-   Embedded versus Hybrid mode, the relative staged claims workspace CMS must read through the Config Service
-   `/app/additional-claims` mount, the claims fingerprint, and expected verification checks.
-   `start-local-dms.ps1` consumes that manifest section and applies it through `local-config.yml` startup
-   inputs. Also write the root bootstrap manifest seed section from extension namespace-prefix metadata so
-   seed delivery can consume prepared schema/security context without accepting schema or claims parameters.
+   Embedded versus Hybrid mode, the relative staged claims workspace CMS will read through the Config Service
+   `/app/additional-claims` mount once Story 04 enables staged runtime startup, the claims fingerprint, and
+   expected verification checks. `start-local-dms.ps1` validates that manifest section in Story 00 but does
+   not apply it to Config Service startup until DMS also reads the matching staged ApiSchema workspace.
+   Also write the root bootstrap manifest seed section from extension namespace-prefix metadata so seed
+   delivery can consume prepared schema/security context without accepting schema or claims parameters.
    Bootstrap validation stays structural; CMS remains the authority for final composition outcomes.
 6. Remove the redundant DMS-service `/app/additional-claims` bind mounts from `local-dms.yml` and
-   `published-dms.yml`. Update the Config Service `/app/additional-claims` mounts in `local-config.yml` and
-   `published-config.yml` so bootstrap mode sources the manifest-selected `.bootstrap/claims` workspace rather
-   than the repo `AdditionalClaimsets/` directory; DMS reads claimsets from CMS authorization metadata, not
-   from fragment files mounted into the DMS container.
+   `published-dms.yml`. Keep the Config Service `/app/additional-claims` mount source configurable through
+   `DMS_CONFIG_CLAIMS_MOUNT_SOURCE`, but do not set that variable from the bootstrap manifest in Story 00;
+   staged claims startup must move with the Story 04 DMS staged-schema runtime switch. DMS reads claimsets
+   from CMS authorization metadata, not from fragment files mounted into the DMS container.
 7. Ensure operator-facing validation messages report missing schema, security, or seed artifacts as artifact
    resolution/configuration failures.
 8. Remove bootstrap-surface dependence on `DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING` and
@@ -249,8 +261,8 @@ claims-staging contract rather than introducing a second path.
    resources ahead of runtime.
 12. Add focused tests for the Story 00 staging contracts: schema workspace normalization and collision
     detection, schema and claims rerun fingerprint mismatch handling, selected-extension manifest identity,
-    automatic extension-fragment filtering, known namespace-prefix handoff, Config Service mount source
-    selection for `.bootstrap/claims`, and structural claim-fragment validation failures.
+    automatic extension-fragment filtering, known namespace-prefix handoff, Story 00 deferral of the staged
+    Config Service claims mount source to Story 04, and structural claim-fragment validation failures.
 
 ## Out of Scope
 
@@ -267,6 +279,9 @@ claims-staging contract rather than introducing a second path.
   Story 00 stages the workspace and validates the manifest, but `bootstrap-dms.yml` and the
   `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` env-var wiring in `Set-BootstrapStartupEnvironment` are not
   activated until Story 04 updates `ContentProvider` to read staged JSON instead of `*.ApiSchema.dll`.
+- Flipping Config Service startup to read the staged `.bootstrap/claims` workspace for bootstrap mode; that
+  must happen with the Story 04 DMS staged-schema runtime switch so schema and authorization metadata remain
+  aligned.
 
 ## Design References
 
@@ -278,7 +293,7 @@ claims-staging contract rather than introducing a second path.
 
 ### 2026-05-15 — External PR review (DMS-1150 / branch)
 
-Reviewer reported four findings; all four resolved as actionable. Fix tasks recorded in `docs/tasks.md`:
+Reviewer reported four findings; all four resolved as actionable:
 
 - **FB1 (High, VALID):** Removing `-AddExtensionSecurityMetadata` from E2E wrappers (`tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1`, `tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1`) and `build-dms.ps1` regresses extension claims loading for any startup that does not first run the bootstrap commands. `.env.e2e` still loads Sample/Homograph schema packages, but `DMS_CONFIG_CLAIMS_SOURCE` falls back to `Embedded`. Restore the non-bootstrap hybrid claims path until E2E moves onto the staged bootstrap path in Story 04.
 - **FB2 (Medium, VALID — escalated from PARTIAL):** `Set-BootstrapStartupEnvironment` (`bootstrap-manifest.psm1`) flips DMS into `USE_API_SCHEMA_PATH=true` and `bootstrap-dms.yml` mounts `.bootstrap/ApiSchema`, but the existing `ContentProvider` only loads `*.ApiSchema.dll`. Story 00 should stop short of changing runtime DMS loading; remove or gate the bootstrap-mode startup wiring and re-enable it in Story 04 when ContentProvider reads the staged workspace. Update Task #4 wording to match.
@@ -289,7 +304,7 @@ No findings dismissed.
 
 ### 2026-05-15 — External PR review round 2 (DMS-1150 / branch)
 
-Three follow-up findings; all three accepted. Fix tasks recorded in `docs/tasks.md` (FB5-FB7):
+Three follow-up findings; all three accepted:
 
 - **FB5 (Medium, VALID):** `Assert-FragmentValidAndExtractChecks` only requires `resourceClaims[].name` inside the explicit `claimSets` loop. Parent claims and implicit non-parent claims bypass the check, so a fragment can stage with a nameless entry and later cause CMS to deref `resourceClaim.Name!`. Hoist the check to the top of the loop and add Pester cases.
 - **FB6 (Low/Medium, VALID):** The non-bootstrap `-AddExtensionSecurityMetadata` Hybrid branch sets `DMS_CONFIG_CLAIMS_SOURCE`/`DMS_CONFIG_CLAIMS_DIRECTORY` but leaves `DMS_CONFIG_CLAIMS_MOUNT_SOURCE` untouched. `local-config.yml` honors that env var, so a stale ambient value mounts the wrong directory. Clear it to empty in both `start-local-dms.ps1` and `start-published-dms.ps1`, with a Pester guard.
@@ -299,7 +314,7 @@ No round-2 findings dismissed.
 
 ### 2026-05-15 — External PR review round 3 (DMS-1150 / branch)
 
-Single high-severity finding; accepted with the "clear `.bootstrap/` before start" remediation (not the alternative `-NoBootstrap` opt-out switch). Fix task recorded in `docs/tasks.md` as **FB8**:
+Single high-severity finding; accepted with the "clear `.bootstrap/` before start" remediation (not the alternative `-NoBootstrap` opt-out switch):
 
 - **FB8 (High, VALID):** `start-local-dms.ps1` checks the bootstrap manifest first and only applies `-AddExtensionSecurityMetadata` in the `elseif`. A stale `.bootstrap/` workspace (core-only, partial, or with a different extension selection) overrides the DLL-backed E2E/build path: CMS reads `.bootstrap/claims` while runtime loads DLL schemas, producing mismatched authorization or a fail-fast on a missing claims/seed section. `build-dms.ps1`'s teardown doesn't pass `-RemoveBootstrap`, and the E2E setup wrappers assume the caller ran teardown first. Fix: add `-RemoveBootstrap` to `build-dms.ps1`'s teardown calls, and add a defensive `.bootstrap/` removal step at the top of both E2E setup wrappers. Add Pester coverage that asserts the cleanup contracts.
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -10,11 +10,11 @@ jira_url: https://edfi.atlassian.net/browse/DMS-1150
 Implement the first schema and security input slice for developer bootstrap over the stable direct filesystem
 contract. This slice covers:
 
-- direct filesystem schema bootstrap through `-ApiSchemaPath` for core-only, core plus extensions, and custom
-  schema/security/seed inputs,
+- direct filesystem schema bootstrap through `-ApiSchemaPath` for core-only, core plus known mapped
+  extensions, and unmapped custom schema/security/seed inputs,
 - additive security staging through `-ClaimsDirectoryPath`,
-- staging base security fragments available for the selected schema set when those schemas are already present
-  in the direct filesystem input.
+- staging base security fragments for the selected schema set when those schemas are already present in the
+  direct filesystem input and are mapped by the Story 00 v1 claims lookup.
 
 This story intentionally does not implement package-backed standard selection through omitted `-Extensions`
 or named `-Extensions`. Those modes remain in the main bootstrap design as the target day-to-day developer
@@ -26,12 +26,12 @@ developer-supplied `*-claimset.json` fragments into one workspace directory. The
 materialized once into the normalized file-based ApiSchema asset container at
 `eng/docker-compose/.bootstrap/ApiSchema/`. Direct filesystem ApiSchema loading through `-ApiSchemaPath` is
 the stable core contract. Later package-backed selection is an input-materialization path that must produce
-the same workspace. The schema JSON files in that workspace must drive all three schema consumers for the
-run:
+the same workspace. The schema JSON files in that workspace are the stable target source for all schema
+consumers, but Story 00 activates only the staging, hashing, and manifest handoff path:
 
 - `dms-schema hash`,
-- Docker-hosted DMS startup,
-- IDE-hosted DMS startup.
+- downstream schema provisioning input,
+- future Docker-hosted and IDE-hosted DMS startup after Story 04 updates runtime content loading.
 
 The same workspace also carries optional schema-adjacent static content and
 `bootstrap-api-schema-manifest.json` as defined in [`../../design-docs/bootstrap/apischema-container.md`](../../design-docs/bootstrap/apischema-container.md).
@@ -40,9 +40,10 @@ That manifest indexes normalized schema and content paths, but it is not a secon
 Bootstrap must not invent a second schema fingerprint or a second schema-resolution path.
 In this story, the selected schema set drives the DDL target, the hash-validation path, and the exact
 physical schema footprint for the run. A direct filesystem input containing only the core schema yields only
-core tables. Core plus an extension such as Sample yields the tables required by that
-combined schema set. A database provisioned for a different extension selection is incompatible existing
-state for this story's bootstrap run.
+core tables. Core plus a known mapped extension such as Sample yields the tables required by that combined
+schema set. Unmapped extension schemas, including TPDM when supplied through direct filesystem input, are not
+silently substituted by Sample, Homograph, or any default mapping. A database provisioned for a different
+extension selection is incompatible existing state for this story's bootstrap run.
 
 Within the composable bootstrap design, schema selection and asset-container staging are owned exclusively by the
 `prepare-dms-schema.ps1` phase command (see `command-boundaries.md` Section 3.1). Claims and security staging are
@@ -57,10 +58,11 @@ Story 06 package-backed standard-mode slice but does not replace or deprecate di
 
 **Mode-to-security summary (normative for Story 00):** The effective staged schema set from `-ApiSchemaPath`
 is the single source of truth for the staged ApiSchema files and for the matching base staged claimset
-fragments available for the run. If `-ApiSchemaPath` stages schemas that need additional security metadata,
-`-ClaimsDirectoryPath` is required for caller-supplied fragments. No later phase re-derives or replaces that
-security selection. Story 06 package-backed `-Extensions` mode must feed the same root bootstrap manifest
-schema contract and claims-staging contract rather than introducing a second path.
+fragments available for the run through the Story 00 v1 mapped-extension lookup. If `-ApiSchemaPath` stages
+unmapped non-core schemas that need additional security metadata, `-ClaimsDirectoryPath` is required for
+caller-supplied fragments. No later phase re-derives or replaces that security selection. Story 06
+package-backed `-Extensions` mode must feed the same root bootstrap manifest schema contract and
+claims-staging contract rather than introducing a second path.
 
 ## Acceptance Criteria
 
@@ -76,9 +78,25 @@ schema contract and claims-staging contract rather than introducing a second pat
 - `prepare-dms-schema.ps1` writes the schema section of
   `eng/docker-compose/.bootstrap/bootstrap-manifest.json` with schema selection mode (`ApiSchemaPath`),
   selected extension names, expected `EffectiveSchemaHash`, an ApiSchema workspace fingerprint, and the
-  relative ApiSchema manifest path. Extension namespace prefixes are recorded later in the seed section by
-  claims staging.
+  relative ApiSchema manifest path. In this story, selected extension names are the schema
+  `projectEndpointName` values from non-core staged `ApiSchema*.json` files, normalized for manifest
+  comparison as lower-case short names such as `sample` and `homograph`. Claims staging may still use
+  `projectName` for its v1 shipped-fragment lookup. Extension namespace prefixes are recorded later in the
+  seed section by claims staging.
 - Bootstrap detects normalized-path collisions before finalizing the staged ApiSchema workspace.
+- Same-checkout reruns reuse the existing staged ApiSchema workspace only when the intended schema set is
+  identical (matching `EffectiveSchemaHash` and workspace fingerprint). If the intended schema inputs
+  differ, `prepare-dms-schema.ps1` fails fast with teardown guidance rather than rewriting a workspace that
+  may still be bind-mounted into a running DMS container. This mirrors the claims-workspace rerun
+  protection and matches `command-boundaries.md` §3.1 ("staged workspace exists with different content").
+- Workspace normalization in `prepare-dms-schema.ps1` is path/container normalization only: it produces the
+  deterministic `schemas/<project>/ApiSchema.json` and `content/<project>/...` layout described in
+  `apischema-container.md` without rewriting the JSON payloads. Runtime-only payloads such as
+  `projectSchema.openApiBaseDocuments`, `resourceSchemas[*].openApiFragments`, and
+  `abstractResources[*].openApiFragment` remain in the staged files so the Story 04 Docker-hosted and
+  IDE-hosted DMS startup path can read complete schema content. Hash-time stripping (see
+  `Core/Startup/ApiSchemaInputNormalizer.cs`) is an in-memory transform applied while computing
+  `EffectiveSchemaHash` and must not be written back to the staged workspace.
 - Package-backed selection, asset-only NuGet package extraction, package rejection for DLL-only packages,
   no-argument core-only convenience, and named `-Extensions` convenience are not Story 00 acceptance
   criteria; they are Story 06 acceptance criteria.
@@ -112,9 +130,16 @@ schema contract and claims-staging contract rather than introducing a second pat
   - filename collisions,
   - unknown effective claim set references in staged fragments.
 - Every bootstrap-managed extension fragment preserves ordinary developer access by attaching `EdFiSandbox`
-  permissions for the extension resources it contributes. Extension entries that advertise built-in seed
-  packages must additionally attach the required `SeedLoader` permissions for those extension seed resources.
-- CMS consumes that staged workspace through the Config Service `/app/additional-claims` mount. The claims
+  permissions for the extension resources it contributes. Story 00 stages each shipped fragment as-is; if a
+  shipped fragment already attaches `SeedLoader` permissions for its extension seed resources, those
+  attachments pass through staging unchanged. Story 00 does not decide which extensions advertise built-in
+  seed support and does not author or require `SeedLoader` attachments on fragments that lack them — Story
+  02 owns built-in seed-package advertisement and the `SeedLoader` coverage requirement enforced at seed
+  delivery.
+- CMS consumes the staged claims workspace through the Config Service `/app/additional-claims` mount target.
+  In bootstrap mode, the host source for that mount is the manifest-selected
+  `eng/docker-compose/.bootstrap/claims/` workspace, not the repo
+  `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/` directory. The claims
   section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json` is the source of truth for the CMS claims
   mode, relative claims directory, claims fingerprint, and expected claims-verification checks.
   `start-local-dms.ps1` translates that manifest section into the `local-config.yml` environment and
@@ -137,6 +162,24 @@ schema contract and claims-staging contract rather than introducing a second pat
 - CMS claims mode is driven from the staged inputs:
   - Embedded mode for core-only bootstrap,
   - Hybrid mode when one or more staged fragments exist.
+- Automatic extension-fragment selection in `prepare-dms-claims.ps1` is deterministic and explicit. The
+  command holds a short in-script lookup keyed by extension project identity from the staged schema set
+  (`projectName` from each non-core `ApiSchema*.json`) that maps to the exact shipped fragment filename
+  under `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/` (for v1:
+  `Sample` → `004-sample-extension-claimset.json`, `Homograph` → `005-homograph-extension-claimset.json`).
+  The same lookup records any built-in extension seed namespace prefix known to the DMS-916 bootstrap
+  contract; v1 records `Sample` → `uri://sample.ed-fi.org`. Entries without a known built-in seed namespace
+  prefix write no prefix to the root bootstrap manifest, and bootstrap must not infer prefixes from arbitrary
+  direct filesystem schema content.
+  Core-baseline fragments (`001-namespace-claimset.json`, `002-nofurtherauth-claimset.json`,
+  `003-edorgsonly-claimset.json`) remain part of embedded `Claims.json` loading and are never staged into
+  the additive workspace. Staged extensions whose `projectName` is not in the lookup are treated as
+  unmapped: `-ClaimsDirectoryPath` is required and the caller-supplied fragments are the only security
+  inputs for those projects. The lookup is a v1 implementation detail of the claims phase, not a separate
+  catalog artifact in the repo.
+- TPDM is not part of the Story 00 v1 mapped security-fragment surface. If TPDM appears in a direct
+  filesystem ApiSchema input, bootstrap treats it as unmapped and requires caller-supplied security fragments
+  through `-ClaimsDirectoryPath`; it is not silently replaced by `sample`, `homograph`, or any default.
 
 ## Tasks
 
@@ -151,7 +194,9 @@ schema contract and claims-staging contract rather than introducing a second pat
    uses schema identity fields from the direct filesystem input, and `prepare-dms-claims.ps1` uses
    security-fragment fields. `load-dms-seed-data.ps1` owns the separate seed catalog lookup when seed delivery
    runs. `EdFiSandbox` coverage is required for every bootstrap-managed extension fragment and `SeedLoader`
-   coverage is required only where a built-in seed package is advertised.
+   coverage is required only where a built-in seed package is advertised. Story 00's v1 mapped security
+   lookup covers Sample and Homograph only; TPDM and any other direct filesystem extension not in the lookup
+   are treated as unmapped and require `-ClaimsDirectoryPath`.
 3. Implement direct filesystem schema-materialization logic in `prepare-dms-schema.ps1`: normalize
    `-ApiSchemaPath` inputs into the staged workspace, normalize one core schema plus zero or more extension
    schemas into the staged ApiSchema asset workspace, copy optional schema-adjacent static content into
@@ -164,8 +209,13 @@ schema contract and claims-staging contract rather than introducing a second pat
    contract for the run; the computed hash remains metadata for logging or comparison. Do not resolve NuGet
    packages, stage DLLs as a package bridge, perform assembly-resource extraction as the target contract, or
    stage/validate claim fragments in this phase.
-4. Update compose/startup behavior so bootstrap mode mounts `.bootstrap/ApiSchema` to `/app/ApiSchema`,
-   sets `USE_API_SCHEMA_PATH=true`, sets `API_SCHEMA_PATH=/app/ApiSchema`, and clears `SCHEMA_PACKAGES`.
+4. Define the bootstrap-dms compose surface and runtime env wiring (mount `.bootstrap/ApiSchema` →
+   `/app/ApiSchema`, set `USE_API_SCHEMA_PATH=true`, set `API_SCHEMA_PATH=/app/ApiSchema`, clear
+   `SCHEMA_PACKAGES`) **in design only**. Story 00 does not enable the runtime DMS bootstrap startup path
+   because `ContentProvider` still expects `*.ApiSchema.dll` assemblies; enabling it now would cause
+   discovery/XSD content fetches to fail in bootstrap mode. Story 04 owns flipping DMS over to the
+   staged workspace at runtime (re-introducing `bootstrap-dms.yml` and the corresponding env-var wiring
+   in `Set-BootstrapStartupEnvironment`).
 5. Implement additive security-fragment staging in `prepare-dms-claims.ps1`: stage fragments into one
    bootstrap workspace, with duplicate-filename detection, malformed-JSON validation, unknown effective
    claim-set-reference validation, and updates to the root bootstrap manifest claims section that record the
@@ -176,9 +226,10 @@ schema contract and claims-staging contract rather than introducing a second pat
    seed delivery can consume prepared schema/security context without accepting schema or claims parameters.
    Bootstrap validation stays structural; CMS remains the authority for final composition outcomes.
 6. Remove the redundant DMS-service `/app/additional-claims` bind mounts from `local-dms.yml` and
-   `published-dms.yml`. Keep the Config Service mounts in `local-config.yml` and `published-config.yml`;
-   DMS reads claimsets from CMS authorization metadata, not from fragment files mounted into the DMS
-   container.
+   `published-dms.yml`. Update the Config Service `/app/additional-claims` mounts in `local-config.yml` and
+   `published-config.yml` so bootstrap mode sources the manifest-selected `.bootstrap/claims` workspace rather
+   than the repo `AdditionalClaimsets/` directory; DMS reads claimsets from CMS authorization metadata, not
+   from fragment files mounted into the DMS container.
 7. Ensure operator-facing validation messages report missing schema, security, or seed artifacts as artifact
    resolution/configuration failures.
 8. Remove bootstrap-surface dependence on `DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING` and
@@ -196,6 +247,10 @@ schema contract and claims-staging contract rather than introducing a second pat
    normalization, requires `-ClaimsDirectoryPath` when additional non-core security metadata is needed, and validates fragment
    structure, but bootstrap does not certify complete authorization coverage for arbitrary custom non-core
    resources ahead of runtime.
+12. Add focused tests for the Story 00 staging contracts: schema workspace normalization and collision
+    detection, schema and claims rerun fingerprint mismatch handling, selected-extension manifest identity,
+    automatic extension-fragment filtering, known namespace-prefix handoff, Config Service mount source
+    selection for `.bootstrap/claims`, and structural claim-fragment validation failures.
 
 ## Out of Scope
 
@@ -208,9 +263,44 @@ schema contract and claims-staging contract rather than introducing a second pat
   to Story 06 after Story 05 publishes asset-only packages.
 - Updating DMS runtime `ContentProvider` behavior; that belongs to Story 04.
 - Updating MetaEd packaging to produce asset-only ApiSchema packages; that belongs to Story 05.
+- Flipping DMS Docker startup to read the staged ApiSchema workspace at runtime; that belongs to Story 04.
+  Story 00 stages the workspace and validates the manifest, but `bootstrap-dms.yml` and the
+  `USE_API_SCHEMA_PATH`/`API_SCHEMA_PATH` env-var wiring in `Set-BootstrapStartupEnvironment` are not
+  activated until Story 04 updates `ContentProvider` to read staged JSON instead of `*.ApiSchema.dll`.
 
 ## Design References
 
 - [`../../design-docs/bootstrap/bootstrap-design.md`](../../design-docs/bootstrap/bootstrap-design.md), Sections 3, 4, 8, 9.3, and 11
 - [`../../design-docs/bootstrap/apischema-container.md`](../../design-docs/bootstrap/apischema-container.md)
 - [`../../design-docs/bootstrap/command-boundaries.md`](../../design-docs/bootstrap/command-boundaries.md), Section 3.1 (`prepare-dms-schema.ps1`) and Section 3.2 (`prepare-dms-claims.ps1`)
+
+## Feedback Review Log
+
+### 2026-05-15 — External PR review (DMS-1150 / branch)
+
+Reviewer reported four findings; all four resolved as actionable. Fix tasks recorded in `docs/tasks.md`:
+
+- **FB1 (High, VALID):** Removing `-AddExtensionSecurityMetadata` from E2E wrappers (`tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1`, `tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1`) and `build-dms.ps1` regresses extension claims loading for any startup that does not first run the bootstrap commands. `.env.e2e` still loads Sample/Homograph schema packages, but `DMS_CONFIG_CLAIMS_SOURCE` falls back to `Embedded`. Restore the non-bootstrap hybrid claims path until E2E moves onto the staged bootstrap path in Story 04.
+- **FB2 (Medium, VALID — escalated from PARTIAL):** `Set-BootstrapStartupEnvironment` (`bootstrap-manifest.psm1`) flips DMS into `USE_API_SCHEMA_PATH=true` and `bootstrap-dms.yml` mounts `.bootstrap/ApiSchema`, but the existing `ContentProvider` only loads `*.ApiSchema.dll`. Story 00 should stop short of changing runtime DMS loading; remove or gate the bootstrap-mode startup wiring and re-enable it in Story 04 when ContentProvider reads the staged workspace. Update Task #4 wording to match.
+- **FB3 (Medium, VALID):** `prepare-dms-schema.ps1` rebuilds a missing `.bootstrap/ApiSchema` workspace even when the manifest still contains stale `claims`/`seed` sections. Fail fast on this partial state, mirroring the workspace-mismatch path.
+- **FB4 (Low/Medium, VALID):** `Assert-FragmentValidAndExtractChecks` silently accepts `resourceClaims` entries that are not objects. Add an `is [IDictionary]` guard and a Pester test.
+
+No findings dismissed.
+
+### 2026-05-15 — External PR review round 2 (DMS-1150 / branch)
+
+Three follow-up findings; all three accepted. Fix tasks recorded in `docs/tasks.md` (FB5-FB7):
+
+- **FB5 (Medium, VALID):** `Assert-FragmentValidAndExtractChecks` only requires `resourceClaims[].name` inside the explicit `claimSets` loop. Parent claims and implicit non-parent claims bypass the check, so a fragment can stage with a nameless entry and later cause CMS to deref `resourceClaim.Name!`. Hoist the check to the top of the loop and add Pester cases.
+- **FB6 (Low/Medium, VALID):** The non-bootstrap `-AddExtensionSecurityMetadata` Hybrid branch sets `DMS_CONFIG_CLAIMS_SOURCE`/`DMS_CONFIG_CLAIMS_DIRECTORY` but leaves `DMS_CONFIG_CLAIMS_MOUNT_SOURCE` untouched. `local-config.yml` honors that env var, so a stale ambient value mounts the wrong directory. Clear it to empty in both `start-local-dms.ps1` and `start-published-dms.ps1`, with a Pester guard.
+- **FB7 (Low, VALID):** `eng/docker-compose/README.md:207-213` still describes the deleted `bootstrap-dms.yml` and the `.bootstrap/ApiSchema` runtime mount. Rewrite that paragraph so only `.bootstrap/claims` is described as active in Story 00; DMS schema runtime stays on DLL-backed packages until Story 04.
+
+No round-2 findings dismissed.
+
+### 2026-05-15 — External PR review round 3 (DMS-1150 / branch)
+
+Single high-severity finding; accepted with the "clear `.bootstrap/` before start" remediation (not the alternative `-NoBootstrap` opt-out switch). Fix task recorded in `docs/tasks.md` as **FB8**:
+
+- **FB8 (High, VALID):** `start-local-dms.ps1` checks the bootstrap manifest first and only applies `-AddExtensionSecurityMetadata` in the `elseif`. A stale `.bootstrap/` workspace (core-only, partial, or with a different extension selection) overrides the DLL-backed E2E/build path: CMS reads `.bootstrap/claims` while runtime loads DLL schemas, producing mismatched authorization or a fail-fast on a missing claims/seed section. `build-dms.ps1`'s teardown doesn't pass `-RemoveBootstrap`, and the E2E setup wrappers assume the caller ran teardown first. Fix: add `-RemoveBootstrap` to `build-dms.ps1`'s teardown calls, and add a defensive `.bootstrap/` removal step at the top of both E2E setup wrappers. Add Pester coverage that asserts the cleanup contracts.
+
+No round-3 findings dismissed.

--- a/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
@@ -20,10 +20,12 @@ metadata/specification and XSD endpoints read manifest-relative files from that 
 generate DLLs from loose files and does not extract content from assembly resources for the DMS-916 bootstrap
 path.
 
-This story depends on the normalized filesystem workspace and ApiSchema asset manifest contract, not on
-asset-only package publication. It can be implemented in parallel with the MetaEd package switch-over because
-package-backed inputs in Story 06 and direct `-ApiSchemaPath` inputs from Story 00 both
-materialize to the same workspace before runtime starts.
+This story depends on the normalized filesystem workspace, staged claims workspace, and root bootstrap
+manifest contract produced by Story 00, not on asset-only package publication. Story 00 deliberately leaves
+those prepared inputs inactive at Docker runtime; this story is where `.bootstrap/ApiSchema` and
+`.bootstrap/claims` become runtime-authoritative together. It can be implemented in parallel with the MetaEd
+package switch-over because package-backed inputs in Story 06 and direct `-ApiSchemaPath` inputs from Story 00
+both materialize to the same workspace before runtime starts.
 
 ## Acceptance Criteria
 
@@ -43,6 +45,9 @@ materialize to the same workspace before runtime starts.
   - Docker: `AppSettings:UseApiSchemaPath=true`, `AppSettings:ApiSchemaPath=/app/ApiSchema`,
   - IDE: `AppSettings:UseApiSchemaPath=true`,
     `AppSettings:ApiSchemaPath=<repo-root>/eng/docker-compose/.bootstrap/ApiSchema`.
+- Docker bootstrap startup activates staged DMS schema and staged CMS claims as one boundary:
+  `.bootstrap/ApiSchema` is mounted/read by DMS, and `.bootstrap/claims` is mounted/read by Config Service for
+  the same root bootstrap manifest.
 - Existing non-bootstrap behavior may keep a compatibility path for assembly-bundled content when
   `UseApiSchemaPath=false`, but that path is not the DMS-916 bootstrap contract.
 - Unit or integration coverage proves that metadata/specification JSON and XSD endpoints work from a

--- a/reference/design/backend-redesign/epics/16-bootstrap/EPIC.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/EPIC.md
@@ -52,9 +52,11 @@ packaging, and package-backed standard schema selection.
 - Story 03 reuses the parameter surfaces and mechanisms delivered by the other slices where applicable, but
   it is not a blanket prerequisite chain for every Story 03 task. Treat the main design and each companion
   story as the authority for the specific dependency of a given implementation task.
-- Story 04 depends on Story 00's normalized ApiSchema workspace and ApiSchema asset manifest contract. It removes the DMS
-  runtime bootstrap-path dependency on `*.ApiSchema.dll` assemblies for metadata/specification JSON and XSD
-  content. It does not depend on published asset-only packages.
+- Story 04 depends on Story 00's normalized ApiSchema workspace, staged claims workspace, ApiSchema asset
+  manifest, and root bootstrap manifest contracts. Story 00 prepares and validates those inputs; Story 04 makes
+  them runtime-authoritative together by removing the DMS runtime bootstrap-path dependency on
+  `*.ApiSchema.dll` assemblies and activating the matching staged Config Service claims path. It does not
+  depend on published asset-only packages.
 - Story 05 is a cross-repo MetaEd package-production switch-over. It enables Story 06 package-backed
   standard mode against published packages, but it is not a prerequisite for direct filesystem
   ApiSchema loading. Story 00, Story 04, and Story 05 can proceed in parallel because all three meet at the

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -12,11 +12,12 @@ instance. See the steps below.
 
 ### Testing locally with docker compose
 
-From the `eng` directory:
+From the repository root:
 
-- If you have stale volumes with old data run `./start-local-dms.ps1 -d -v` to
-  stop services and delete volumes
-- Run `./start-local-dms.ps1 -EnvironmentFile ./.env.e2e`
+- If you have stale volumes with old data run
+  `pwsh eng/docker-compose/start-local-dms.ps1 -d -v` to stop services and
+  delete volumes
+- Run `pwsh src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1`
 - You must have the following hosts entry to run kafka tests: `127.0.0.1 dms-kafka1`
 
 ### Testing locally with API in debug mode

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -10,6 +10,12 @@
     This script is a convenience wrapper that runs start-local-dms.ps1 with the standard
     E2E testing configuration. It is the companion to teardown-local-dms.ps1.
 
+    Extension schema packages (Sample, Homograph) are loaded via DLL-backed SCHEMA_PACKAGES.
+    The -AddExtensionSecurityMetadata switch activates Hybrid claims mode so extension
+    claimset fragments are loaded from the AdditionalClaimsets directory mounted at
+    /app/additional-claims. This is the non-bootstrap transitional path until Story 04
+    moves E2E runtime loading onto the staged bootstrap workspace.
+
     The script runs:
     ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile <selected env file> -r -AddExtensionSecurityMetadata
 #>
@@ -56,6 +62,12 @@ $dockerComposeDir = Join-Path $PSScriptRoot "../../../../eng/docker-compose"
 try {
     Set-Location $dockerComposeDir
 
+    $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
+    if (Test-Path -LiteralPath $bootstrapDir) {
+        Write-Host "Removing stale .bootstrap workspace before DLL-backed E2E startup..." -ForegroundColor Yellow
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+    }
+
     Write-Host "Starting DMS environment with E2E configuration..." -ForegroundColor Green
     Write-Host "Configuration:" -ForegroundColor Yellow
     Write-Host "  - Search Engine UI: Enabled" -ForegroundColor Gray
@@ -64,6 +76,8 @@ try {
     Write-Host "  - Force Rebuild: Yes" -ForegroundColor Gray
     Write-Host "  - Extension Security Metadata: Yes" -ForegroundColor Gray
     Write-Host ""
+
+    Write-Host "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04." -ForegroundColor Yellow
 
     # Run the start script with E2E configuration
     ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile $EnvironmentFile -r -AddExtensionSecurityMetadata

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -64,8 +64,13 @@ try {
 
     $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
     if (Test-Path -LiteralPath $bootstrapDir) {
-        Write-Host "Removing stale .bootstrap workspace before DLL-backed E2E startup..." -ForegroundColor Yellow
-        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+        Write-Output "Removing stale .bootstrap workspace before DLL-backed E2E startup..."
+        # Fail fast on cleanup errors: a stale manifest left here would trigger bootstrap mode
+        # on the next start-local-dms.ps1 invocation and silently divert the E2E run.
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force -ErrorAction Stop
+        if (Test-Path -LiteralPath $bootstrapDir) {
+            throw "Failed to remove stale .bootstrap workspace at '$bootstrapDir'. Resolve any file locks or permissions before re-running setup."
+        }
     }
 
     Write-Host "Starting DMS environment with E2E configuration..." -ForegroundColor Green
@@ -74,10 +79,10 @@ try {
     Write-Host "  - Configuration Service: Enabled" -ForegroundColor Gray
     Write-Host "  - Environment File: $EnvironmentFile" -ForegroundColor Gray
     Write-Host "  - Force Rebuild: Yes" -ForegroundColor Gray
-    Write-Host "  - Extension Security Metadata: Yes" -ForegroundColor Gray
+    Write-Output "  - Extension Security Metadata: Yes"
     Write-Host ""
 
-    Write-Host "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04." -ForegroundColor Yellow
+    Write-Output "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04."
 
     # Run the start script with E2E configuration
     ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile $EnvironmentFile -r -AddExtensionSecurityMetadata

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/teardown-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/teardown-local-dms.ps1
@@ -395,6 +395,14 @@ try {
         Write-Host "✓ Network removed" -ForegroundColor Green
     }
     
+    # Remove bootstrap workspace so subsequent setup runs do not trip fingerprint-mismatch fail-fast.
+    $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
+    if (Test-Path -LiteralPath $bootstrapDir) {
+        Write-Host "`nRemoving bootstrap workspace at $bootstrapDir..." -ForegroundColor Yellow
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+        Write-Host "✓ Bootstrap workspace removed" -ForegroundColor Green
+    }
+
     if ($verificationFailed) {
         Write-Host "`nTeardown completed with warnings!" -ForegroundColor Yellow
         Write-Host "Some resources may need manual cleanup." -ForegroundColor Yellow
@@ -404,7 +412,7 @@ try {
         Write-Host "`nTeardown complete!" -ForegroundColor Green
         Write-Host "All resources have been successfully removed." -ForegroundColor Green
     }
-    
+
     Write-Host "To setup this environment again, run: ./setup-local-dms.ps1" -ForegroundColor Cyan
 }
 finally {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/teardown-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/teardown-local-dms.ps1
@@ -398,9 +398,9 @@ try {
     # Remove bootstrap workspace so subsequent setup runs do not trip fingerprint-mismatch fail-fast.
     $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
     if (Test-Path -LiteralPath $bootstrapDir) {
-        Write-Host "`nRemoving bootstrap workspace at $bootstrapDir..." -ForegroundColor Yellow
-        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
-        Write-Host "✓ Bootstrap workspace removed" -ForegroundColor Green
+        Write-Output "`nRemoving bootstrap workspace at $bootstrapDir..."
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force -ErrorAction Stop
+        Write-Output "✓ Bootstrap workspace removed"
     }
 
     if ($verificationFailed) {

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -64,8 +64,13 @@ try {
 
     $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
     if (Test-Path -LiteralPath $bootstrapDir) {
-        Write-Host "Removing stale .bootstrap workspace before DLL-backed E2E startup..." -ForegroundColor Yellow
-        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+        Write-Output "Removing stale .bootstrap workspace before DLL-backed E2E startup..."
+        # Fail fast on cleanup errors: a stale manifest left here would trigger bootstrap mode
+        # on the next start-local-dms.ps1 invocation and silently divert the E2E run.
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force -ErrorAction Stop
+        if (Test-Path -LiteralPath $bootstrapDir) {
+            throw "Failed to remove stale .bootstrap workspace at '$bootstrapDir'. Resolve any file locks or permissions before re-running setup."
+        }
     }
 
     Write-Host "Starting DMS environment with Instance Management E2E configuration..." -ForegroundColor Green
@@ -76,12 +81,12 @@ try {
     Write-Host "  - Force Rebuild: $(if ($SkipDockerBuild) { "No" } else { "Yes" })" -ForegroundColor Gray
     Write-Host "  - Route Qualifiers: districtId, schoolYear" -ForegroundColor Cyan
     Write-Host "  - Identity Provider: self-contained" -ForegroundColor Gray
-    Write-Host "  - Extension Security Metadata: Yes" -ForegroundColor Gray
+    Write-Output "  - Extension Security Metadata: Yes"
     Write-Host ""
     Write-Host "NOTE: Tenant, instance, and Kafka infrastructure will be created by tests" -ForegroundColor Yellow
     Write-Host ""
 
-    Write-Host "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04." -ForegroundColor Yellow
+    Write-Output "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04."
 
     # Run the start script - NO instance creation
     if ($SkipDockerBuild) {

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -10,8 +10,14 @@
     This script starts the Docker stack and creates the 3 test databases.
     Tenant, instance, and Kafka infrastructure creation is handled by the tests themselves.
 
+    Extension schema packages (Sample, Homograph) are loaded via DLL-backed SCHEMA_PACKAGES.
+    The -AddExtensionSecurityMetadata switch activates Hybrid claims mode so extension
+    claimset fragments are loaded from the AdditionalClaimsets directory mounted at
+    /app/additional-claims. This is the non-bootstrap transitional path until Story 04
+    moves E2E runtime loading onto the staged bootstrap workspace.
+
     The script runs:
-    ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -AddExtensionSecurityMetadata -IdentityProvider self-contained -NoDmsInstance
+    ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
 #>
 
 [CmdletBinding()]
@@ -56,25 +62,33 @@ $dockerComposeDir = Join-Path $PSScriptRoot "../../../../eng/docker-compose"
 try {
     Set-Location $dockerComposeDir
 
+    $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
+    if (Test-Path -LiteralPath $bootstrapDir) {
+        Write-Host "Removing stale .bootstrap workspace before DLL-backed E2E startup..." -ForegroundColor Yellow
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+    }
+
     Write-Host "Starting DMS environment with Instance Management E2E configuration..." -ForegroundColor Green
     Write-Host "Configuration:" -ForegroundColor Yellow
     Write-Host "  - Kafka UI: Enabled" -ForegroundColor Gray
     Write-Host "  - Configuration Service: Enabled" -ForegroundColor Gray
     Write-Host "  - Environment File: ./.env.routeContext.e2e" -ForegroundColor Gray
     Write-Host "  - Force Rebuild: $(if ($SkipDockerBuild) { "No" } else { "Yes" })" -ForegroundColor Gray
-    Write-Host "  - Extension Security Metadata: Yes" -ForegroundColor Gray
     Write-Host "  - Route Qualifiers: districtId, schoolYear" -ForegroundColor Cyan
     Write-Host "  - Identity Provider: self-contained" -ForegroundColor Gray
+    Write-Host "  - Extension Security Metadata: Yes" -ForegroundColor Gray
     Write-Host ""
     Write-Host "NOTE: Tenant, instance, and Kafka infrastructure will be created by tests" -ForegroundColor Yellow
     Write-Host ""
 
+    Write-Host "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04." -ForegroundColor Yellow
+
     # Run the start script - NO instance creation
     if ($SkipDockerBuild) {
-        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -AddExtensionSecurityMetadata -IdentityProvider self-contained -NoDmsInstance
+        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
     }
     else {
-        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -AddExtensionSecurityMetadata -IdentityProvider self-contained -NoDmsInstance
+        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/teardown-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/teardown-local-dms.ps1
@@ -396,6 +396,14 @@ try {
         Write-Host "✓ Network removed" -ForegroundColor Green
     }
 
+    # Remove bootstrap workspace so subsequent setup runs do not trip fingerprint-mismatch fail-fast.
+    $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
+    if (Test-Path -LiteralPath $bootstrapDir) {
+        Write-Host "`nRemoving bootstrap workspace at $bootstrapDir..." -ForegroundColor Yellow
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
+        Write-Host "✓ Bootstrap workspace removed" -ForegroundColor Green
+    }
+
     if ($verificationFailed) {
         Write-Host "`nTeardown completed with warnings!" -ForegroundColor Yellow
         Write-Host "Some resources may need manual cleanup." -ForegroundColor Yellow

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/teardown-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/teardown-local-dms.ps1
@@ -399,9 +399,9 @@ try {
     # Remove bootstrap workspace so subsequent setup runs do not trip fingerprint-mismatch fail-fast.
     $bootstrapDir = Join-Path $dockerComposeDir ".bootstrap"
     if (Test-Path -LiteralPath $bootstrapDir) {
-        Write-Host "`nRemoving bootstrap workspace at $bootstrapDir..." -ForegroundColor Yellow
-        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force
-        Write-Host "✓ Bootstrap workspace removed" -ForegroundColor Green
+        Write-Output "`nRemoving bootstrap workspace at $bootstrapDir..."
+        Remove-Item -LiteralPath $bootstrapDir -Recurse -Force -ErrorAction Stop
+        Write-Output "✓ Bootstrap workspace removed"
     }
 
     if ($verificationFailed) {


### PR DESCRIPTION
## Summary

Implements Story 00 of the DMS-916 bootstrap epic (`epics/16-bootstrap/00-schema-and-security-selection.md`): prepare-phase commands that stage ApiSchema and claims workspaces under `eng/docker-compose/.bootstrap/` and write the schema/claims manifest sections used by later bootstrap phases.

- `prepare-dms-schema.ps1` stages a normalized `.bootstrap/ApiSchema/schemas/<project>/ApiSchema.json` layout from caller-supplied `-ApiSchemaPath`, computes `EffectiveSchemaHash` via the existing `dms-schema` tool, records optional schema-adjacent content in `bootstrap-api-schema-manifest.json`, and rejects same-checkout reruns when the intended schema set differs from the staged workspace.
- `prepare-dms-claims.ps1` writes `Embedded` mode for core-only and `Hybrid` mode when fragments are staged, auto-selects shipped `Sample` / `Homograph` claimset fragments based on staged extension `projectName`, requires `-ClaimsDirectoryPath` for unmapped extensions, structurally validates staged fragments, and records seed namespace-prefix metadata.
- `bootstrap-manifest.psm1` centralizes manifest read/write plus startup validation. Story 00 validates a prepared manifest but does not activate staged DMS schema loading or staged CMS claims loading; when a bootstrap manifest is present it blanks `USE_API_SCHEMA_PATH` / `API_SCHEMA_PATH` so current startup falls back to built-in DLL-backed schema assemblies. Story 04 will flip DMS and CMS to the staged workspaces together.
- `local-config.yml` / `published-config.yml` keep the Config Service `/app/additional-claims` mount source configurable while defaulting to the repo `AdditionalClaimsets` directory. Redundant DMS-service `/app/additional-claims` mounts are removed because claimsets reach DMS through CMS authorization metadata, not file mounts.
- `-AddExtensionSecurityMetadata` remains as a transitional non-bootstrap Hybrid claims path for DLL-backed E2E/build runs until Story 04 moves runtime loading onto the staged bootstrap workspace.
- E2E setup/teardown wrappers and `build-dms.ps1` remove stale `.bootstrap/` workspaces so DLL-backed runs cannot be hijacked by prior bootstrap staging.
- Adds a Pester suite under `eng/docker-compose/tests/` and a `run-bootstrap-pester-tests` CI job.

## Test plan

- [x] Local `Invoke-Pester -Path eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1 -Output Detailed` (39 tests)
- [x] Local `git diff --check`
- [ ] `run-bootstrap-pester-tests` CI job green
- [ ] Existing on-PR checks green
- [ ] Local smoke: `start-local-dms.ps1 -EnableConfig -AddExtensionSecurityMetadata` still starts cleanly on the legacy DLL-backed schema path
- [ ] `build-dms.ps1 E2ETest` still bootstraps the local stack with no stale `.bootstrap/` remnants

[DMS-1150]: https://edfi.atlassian.net/browse/DMS-1150
