### PR TITLE
[DMS-1091] Formalize auth startup as IDmsStartupTask

### DIFF
--- a/docs/CACHING-STRATEGY.md
+++ b/docs/CACHING-STRATEGY.md
@@ -125,7 +125,7 @@ built-in stampede protection
 
 **Multi-Tenancy Support:** Yes - one cache entry per tenant
 
-**Warm-up:** Loaded on startup via `RetrieveAndCacheClaimSets()` in `Program.cs`
+**Warm-up:** Loaded on startup by `CacheClaimSetsTask` (Order 410), run by `DmsStartupOrchestrator` during the `InitializeAuthMetadata` phase.
 
 **Cache Operations:**
 
@@ -356,10 +356,11 @@ keys for token validation.
 - **RefreshInterval:** 60 minutes (minimum time between forced refreshes)
 - **AutomaticRefreshInterval:** 24 hours (background refresh interval)
 
-**Warm-up:** Loaded on startup via `WarmUpOidcMetadataCache()` in `Program.cs`.
-The startup will fail if OIDC metadata cannot be retrieved from the identity
-provider, ensuring DMS doesn't accept requests until JWT authentication is
-fully functional. When `BypassAuthorization` is enabled, the warm-up is skipped.
+**Warm-up:** Loaded on startup by `WarmUpOidcMetadataTask` (Order 400), run by
+`DmsStartupOrchestrator` during the `InitializeAuthMetadata` phase. The startup
+will fail if OIDC metadata cannot be retrieved from the identity provider,
+ensuring DMS doesn't accept requests until JWT authentication is fully
+functional. When `BypassAuthorization` is enabled, the warm-up is skipped.
 
 **Invalidation Strategy:**
 

--- a/reference/design/backend-redesign/epics/15-plan-compilation/startup-failure-status-surfacing.md
+++ b/reference/design/backend-redesign/epics/15-plan-compilation/startup-failure-status-surfacing.md
@@ -14,7 +14,7 @@ Use a file-backed startup status signal that is written before HTTP route bindin
 Contract:
 
 - `State`: `Starting`, `Completed`, `Failed`, or `Ready`
-- `Phase`: one of `ConfigureServices`, `BuildApplication`, `LoadDmsInstances`, `InitializeDatabase`, `InitializeApiSchemas`, `InitializeBackendMappings`, `WarmUpOidcMetadataCache`, `ConfigureEndpoints`, or `Ready`
+- `Phase`: one of `ConfigureServices`, `BuildApplication`, `LoadDmsInstances`, `InitializeDatabase`, `InitializeApiSchemas`, `InitializeBackendMappings`, `InitializeAuthMetadata`, `ConfigureEndpoints`, or `Ready`
 - `Summary`: short human-readable phase summary
 - `ErrorType` / `ErrorMessage`: populated only for failures
 - `UpdatedAtUtc`: last write timestamp
@@ -36,7 +36,7 @@ This keeps fatal startup semantics unchanged: fatal phases still terminate the p
 3. On success, overwrite the file with `Completed`.
 4. On failure, overwrite the file with `Failed`, then invoke the existing process-exit behavior.
 
-The current startup sequence writes these phase names in order: `ConfigureServices`, `BuildApplication`, `LoadDmsInstances`, `InitializeDatabase`, `InitializeApiSchemas`, `InitializeBackendMappings`, `WarmUpOidcMetadataCache`, `ConfigureEndpoints`, and `Ready`.
+The current startup sequence writes these phase names in order: `ConfigureServices`, `BuildApplication`, `LoadDmsInstances`, `InitializeDatabase`, `InitializeApiSchemas`, `InitializeBackendMappings`, `InitializeAuthMetadata`, `ConfigureEndpoints`, and `Ready`.
 
 Bootstrap phases before the app host exists (`ConfigureServices`, `BuildApplication`) use the same status contract, but rethrow after writing the failure because the process has not yet built the DI graph used by the runtime exit hook. After the host exists, `ConfigureEndpoints` is written immediately before routing and endpoint registration, and `Ready` is written after middleware and endpoint mapping complete successfully.
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/AuthStartupTaskRegistrationTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/AuthStartupTaskRegistrationTests.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Startup;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Serilog;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Startup;
+
+[TestFixture]
+public class AuthStartupTaskRegistrationTests
+{
+    [TestFixture]
+    public class Given_DmsCoreServices_Are_Registered : AuthStartupTaskRegistrationTests
+    {
+        private IServiceCollection _services = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection([]).Build();
+
+            _services = new ServiceCollection();
+            _services.AddDmsDefaultConfiguration(
+                new LoggerConfiguration().CreateLogger(),
+                configuration.GetSection("CircuitBreaker"),
+                configuration.GetSection("DeadlockRetry"),
+                false
+            );
+        }
+
+        [Test]
+        public void It_registers_the_oidc_warm_up_task_as_an_IDmsStartupTask()
+        {
+            _services
+                .Should()
+                .Contain(descriptor =>
+                    descriptor.ServiceType == typeof(IDmsStartupTask)
+                    && descriptor.ImplementationType != null
+                    && descriptor.ImplementationType.Name == "WarmUpOidcMetadataTask"
+                );
+        }
+
+        [Test]
+        public void It_registers_the_cache_claim_sets_task_as_an_IDmsStartupTask()
+        {
+            _services
+                .Should()
+                .Contain(descriptor =>
+                    descriptor.ServiceType == typeof(IDmsStartupTask)
+                    && descriptor.ImplementationType != null
+                    && descriptor.ImplementationType.Name == "CacheClaimSetsTask"
+                );
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/CacheClaimSetsTaskTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/CacheClaimSetsTaskTests.cs
@@ -233,7 +233,8 @@ public class CacheClaimSetsTaskTests
     }
 
     [TestFixture]
-    public class Given_A_Dependency_Throws_OperationCanceledException : CacheClaimSetsTaskTests
+    public class Given_GetAllClaimSets_Throws_OperationCanceledException_With_Uncanceled_Token
+        : CacheClaimSetsTaskTests
     {
         private CacheClaimSetsTask _task = null!;
 
@@ -242,17 +243,52 @@ public class CacheClaimSetsTaskTests
         {
             var claimSetProvider = A.Fake<IClaimSetProvider>();
             A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
-                .ThrowsAsync(new OperationCanceledException("dependency canceled"));
+                .ThrowsAsync(new TaskCanceledException("dependency canceled (e.g. HttpClient timeout)"));
 
             _task = CreateTask(claimSetProvider, A.Fake<IDmsInstanceProvider>(), multiTenancy: false);
         }
 
         [Test]
-        public async Task It_does_not_swallow_the_cancellation()
+        public async Task It_does_not_throw()
         {
             Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
 
-            await act.Should().ThrowAsync<OperationCanceledException>();
+            await act.Should().NotThrowAsync();
+        }
+    }
+
+    [TestFixture]
+    public class Given_LoadTenants_Throws_OperationCanceledException_With_Uncanceled_Token
+        : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+        private IClaimSetProvider _claimSetProvider = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _claimSetProvider = A.Fake<IClaimSetProvider>();
+            var dmsInstanceProvider = A.Fake<IDmsInstanceProvider>();
+            A.CallTo(() => dmsInstanceProvider.LoadTenants())
+                .ThrowsAsync(new TaskCanceledException("dependency canceled (e.g. HttpClient timeout)"));
+
+            _task = CreateTask(_claimSetProvider, dmsInstanceProvider, multiTenancy: true);
+        }
+
+        [Test]
+        public async Task It_does_not_throw()
+        {
+            Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Test]
+        public async Task It_does_not_call_get_all_claim_sets()
+        {
+            await _task.ExecuteAsync(CancellationToken.None);
+
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets(A<string?>._)).MustNotHaveHappened();
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/CacheClaimSetsTaskTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/CacheClaimSetsTaskTests.cs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Startup;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Startup;
+
+[TestFixture]
+public class CacheClaimSetsTaskTests
+{
+    private static AppSettings AppSettingsWith(bool multiTenancy) =>
+        new() { AllowIdentityUpdateOverrides = string.Empty, MultiTenancy = multiTenancy };
+
+    private static CacheClaimSetsTask CreateTask(
+        IClaimSetProvider claimSetProvider,
+        IDmsInstanceProvider dmsInstanceProvider,
+        bool multiTenancy
+    ) =>
+        new(
+            claimSetProvider,
+            dmsInstanceProvider,
+            Options.Create(AppSettingsWith(multiTenancy)),
+            NullLogger<CacheClaimSetsTask>.Instance
+        );
+
+    [TestFixture]
+    public class Given_Default_Construction : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _task = CreateTask(
+                A.Fake<IClaimSetProvider>(),
+                A.Fake<IDmsInstanceProvider>(),
+                multiTenancy: false
+            );
+        }
+
+        [Test]
+        public void It_has_order_410()
+        {
+            _task.Order.Should().Be(410);
+        }
+
+        [Test]
+        public void It_has_expected_name()
+        {
+            _task.Name.Should().Be("Cache Claim Sets");
+        }
+    }
+
+    [TestFixture]
+    public class Given_Single_Tenant_Mode : CacheClaimSetsTaskTests
+    {
+        private IClaimSetProvider _claimSetProvider = null!;
+        private IDmsInstanceProvider _dmsInstanceProvider = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _claimSetProvider = A.Fake<IClaimSetProvider>();
+            _dmsInstanceProvider = A.Fake<IDmsInstanceProvider>();
+
+            var task = CreateTask(_claimSetProvider, _dmsInstanceProvider, multiTenancy: false);
+            await task.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public void It_calls_get_all_claim_sets_once_with_no_tenant()
+        {
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets(null)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void It_does_not_load_tenants()
+        {
+            A.CallTo(() => _dmsInstanceProvider.LoadTenants()).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_Multi_Tenant_Mode_With_Multiple_Tenants : CacheClaimSetsTaskTests
+    {
+        private IClaimSetProvider _claimSetProvider = null!;
+        private IDmsInstanceProvider _dmsInstanceProvider = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _claimSetProvider = A.Fake<IClaimSetProvider>();
+            _dmsInstanceProvider = A.Fake<IDmsInstanceProvider>();
+            A.CallTo(() => _dmsInstanceProvider.LoadTenants())
+                .Returns<IList<string>>(["tenant-a", "tenant-b"]);
+
+            var task = CreateTask(_claimSetProvider, _dmsInstanceProvider, multiTenancy: true);
+            await task.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public void It_loads_tenants_once()
+        {
+            A.CallTo(() => _dmsInstanceProvider.LoadTenants()).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void It_calls_get_all_claim_sets_for_each_tenant_in_order()
+        {
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets("tenant-a"))
+                .MustHaveHappenedOnceExactly()
+                .Then(
+                    A.CallTo(() => _claimSetProvider.GetAllClaimSets("tenant-b"))
+                        .MustHaveHappenedOnceExactly()
+                );
+        }
+
+        [Test]
+        public void It_does_not_call_no_tenant_overload()
+        {
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets(null)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_LoadTenants_Throws : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+        private IClaimSetProvider _claimSetProvider = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _claimSetProvider = A.Fake<IClaimSetProvider>();
+            var dmsInstanceProvider = A.Fake<IDmsInstanceProvider>();
+            A.CallTo(() => dmsInstanceProvider.LoadTenants())
+                .ThrowsAsync(new InvalidOperationException("tenant load failed"));
+
+            _task = CreateTask(_claimSetProvider, dmsInstanceProvider, multiTenancy: true);
+        }
+
+        [Test]
+        public async Task It_does_not_throw()
+        {
+            Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Test]
+        public async Task It_does_not_call_get_all_claim_sets()
+        {
+            await _task.ExecuteAsync(CancellationToken.None);
+
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets(A<string?>._)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_GetAllClaimSets_Throws : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var claimSetProvider = A.Fake<IClaimSetProvider>();
+            A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
+                .ThrowsAsync(new InvalidOperationException("claim set fetch failed"));
+
+            _task = CreateTask(claimSetProvider, A.Fake<IDmsInstanceProvider>(), multiTenancy: false);
+        }
+
+        [Test]
+        public async Task It_does_not_throw()
+        {
+            Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
+        }
+    }
+
+    [TestFixture]
+    public class Given_A_PreCanceled_Token : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+        private IClaimSetProvider _claimSetProvider = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _claimSetProvider = A.Fake<IClaimSetProvider>();
+            _task = CreateTask(_claimSetProvider, A.Fake<IDmsInstanceProvider>(), multiTenancy: false);
+        }
+
+        [Test]
+        public async Task It_propagates_OperationCanceledException()
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            Func<Task> act = async () => await _task.ExecuteAsync(cts.Token);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Test]
+        public async Task It_does_not_call_get_all_claim_sets()
+        {
+            using var cts = new CancellationTokenSource();
+            await cts.CancelAsync();
+
+            try
+            {
+                await _task.ExecuteAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // expected
+            }
+
+            A.CallTo(() => _claimSetProvider.GetAllClaimSets(A<string?>._)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_A_Dependency_Throws_OperationCanceledException : CacheClaimSetsTaskTests
+    {
+        private CacheClaimSetsTask _task = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var claimSetProvider = A.Fake<IClaimSetProvider>();
+            A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
+                .ThrowsAsync(new OperationCanceledException("dependency canceled"));
+
+            _task = CreateTask(claimSetProvider, A.Fake<IDmsInstanceProvider>(), multiTenancy: false);
+        }
+
+        [Test]
+        public async Task It_does_not_swallow_the_cancellation()
+        {
+            Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
+
+            await act.Should().ThrowAsync<OperationCanceledException>();
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/DmsStartupOrchestratorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/DmsStartupOrchestratorTests.cs
@@ -3,9 +3,16 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Security.Model;
 using EdFi.DataManagementService.Core.Startup;
+using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Core.Tests.Unit.Startup;
@@ -308,6 +315,183 @@ public class DmsStartupOrchestratorTests
 
             // Assert - Second task should not have run
             _executionOrder.Should().Equal(100);
+        }
+    }
+
+    private static AppSettings AuthAppSettings(bool bypassAuthorization = false, bool multiTenancy = false) =>
+        new()
+        {
+            AllowIdentityUpdateOverrides = string.Empty,
+            BypassAuthorization = bypassAuthorization,
+            MultiTenancy = multiTenancy,
+        };
+
+    private static WarmUpOidcMetadataTask CreateOidcTask(
+        IConfigurationManager<OpenIdConnectConfiguration> configurationManager,
+        bool bypassAuthorization = false
+    )
+    {
+        var serviceProvider = A.Fake<IServiceProvider>();
+        A.CallTo(() => serviceProvider.GetService(typeof(IConfigurationManager<OpenIdConnectConfiguration>)))
+            .Returns(configurationManager);
+
+        return new WarmUpOidcMetadataTask(
+            serviceProvider,
+            Options.Create(AuthAppSettings(bypassAuthorization: bypassAuthorization)),
+            NullLogger<WarmUpOidcMetadataTask>.Instance
+        );
+    }
+
+    private static CacheClaimSetsTask CreateClaimSetsTask(IClaimSetProvider claimSetProvider) =>
+        new(
+            claimSetProvider,
+            A.Fake<IDmsInstanceProvider>(),
+            Options.Create(AuthAppSettings(multiTenancy: false)),
+            NullLogger<CacheClaimSetsTask>.Instance
+        );
+
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_Both_Auth_Tasks_Are_Registered : DmsStartupOrchestratorTests
+    {
+        private static List<string> _callOrder = null!;
+        private DmsStartupOrchestrator _orchestrator = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _callOrder = [];
+
+            var oidcConfigurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => oidcConfigurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .ReturnsLazily(() =>
+                {
+                    _callOrder.Add("oidc");
+                    return Task.FromResult(
+                        new OpenIdConnectConfiguration { Issuer = "https://issuer.example" }
+                    );
+                });
+
+            var claimSetProvider = A.Fake<IClaimSetProvider>();
+            A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
+                .ReturnsLazily(() =>
+                {
+                    _callOrder.Add("claim-sets");
+                    return Task.FromResult<IList<ClaimSet>>([]);
+                });
+
+            // Intentionally register out of declared order to verify orchestrator sorting.
+            var tasks = new List<IDmsStartupTask>
+            {
+                CreateClaimSetsTask(claimSetProvider),
+                CreateOidcTask(oidcConfigurationManager),
+            };
+
+            _orchestrator = new DmsStartupOrchestrator(tasks, NullLogger<DmsStartupOrchestrator>.Instance);
+        }
+
+        [Test]
+        public async Task It_runs_OIDC_warm_up_before_claim_set_cache()
+        {
+            await _orchestrator.RunAllAsync(CancellationToken.None);
+
+            _callOrder.Should().Equal("oidc", "claim-sets");
+        }
+
+        [Test]
+        public async Task It_runs_both_auth_tasks_when_executed_by_the_auth_order_range()
+        {
+            await _orchestrator.RunByOrderRangeAsync(
+                DmsStartupTaskOrderRanges.AuthInitializationMinimum,
+                DmsStartupTaskOrderRanges.AuthInitializationMaximum,
+                CancellationToken.None
+            );
+
+            _callOrder.Should().Equal("oidc", "claim-sets");
+        }
+    }
+
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_The_OIDC_Warm_Up_Task_Fails : DmsStartupOrchestratorTests
+    {
+        private static List<string> _callOrder = null!;
+        private DmsStartupOrchestrator _orchestrator = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _callOrder = [];
+
+            var oidcConfigurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => oidcConfigurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .ThrowsAsync(new InvalidOperationException("OIDC metadata unavailable"));
+
+            var claimSetProvider = A.Fake<IClaimSetProvider>();
+            A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
+                .Invokes(() => _callOrder.Add("claim-sets"))
+                .ReturnsLazily(() => Task.FromResult<IList<ClaimSet>>([]));
+
+            var tasks = new List<IDmsStartupTask>
+            {
+                CreateOidcTask(oidcConfigurationManager),
+                CreateClaimSetsTask(claimSetProvider),
+            };
+
+            _orchestrator = new DmsStartupOrchestrator(tasks, NullLogger<DmsStartupOrchestrator>.Instance);
+        }
+
+        [Test]
+        public async Task It_aborts_startup_with_a_wrapped_exception()
+        {
+            Func<Task> act = async () => await _orchestrator.RunAllAsync(CancellationToken.None);
+
+            var exception = await act.Should().ThrowAsync<InvalidOperationException>();
+            exception.Which.Message.Should().Contain("Warm Up OIDC Metadata Cache");
+            exception.Which.InnerException.Should().BeOfType<InvalidOperationException>();
+        }
+
+        [Test]
+        public async Task It_does_not_execute_the_claim_set_task()
+        {
+            try
+            {
+                await _orchestrator.RunAllAsync(CancellationToken.None);
+            }
+            catch (InvalidOperationException)
+            {
+                // Expected
+            }
+
+            _callOrder.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_The_Claim_Set_Task_Has_An_Internal_Failure : DmsStartupOrchestratorTests
+    {
+        private DmsStartupOrchestrator _orchestrator = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var claimSetProvider = A.Fake<IClaimSetProvider>();
+            A.CallTo(() => claimSetProvider.GetAllClaimSets(A<string?>._))
+                .ThrowsAsync(new InvalidOperationException("Configuration Service unreachable"));
+
+            _orchestrator = new DmsStartupOrchestrator(
+                [CreateClaimSetsTask(claimSetProvider)],
+                NullLogger<DmsStartupOrchestrator>.Instance
+            );
+        }
+
+        [Test]
+        public async Task It_does_not_bubble_out_of_the_orchestrator()
+        {
+            Func<Task> act = async () => await _orchestrator.RunAllAsync(CancellationToken.None);
+
+            await act.Should().NotThrowAsync();
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/WarmUpOidcMetadataTaskTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Startup/WarmUpOidcMetadataTaskTests.cs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Startup;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Startup;
+
+[TestFixture]
+public class WarmUpOidcMetadataTaskTests
+{
+    private static AppSettings AppSettingsWith(bool bypassAuthorization) =>
+        new() { AllowIdentityUpdateOverrides = string.Empty, BypassAuthorization = bypassAuthorization };
+
+    [TestFixture]
+    public class Given_Default_Construction : WarmUpOidcMetadataTaskTests
+    {
+        private WarmUpOidcMetadataTask _task = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _task = new WarmUpOidcMetadataTask(
+                A.Fake<IServiceProvider>(),
+                Options.Create(AppSettingsWith(bypassAuthorization: false)),
+                NullLogger<WarmUpOidcMetadataTask>.Instance
+            );
+        }
+
+        [Test]
+        public void It_has_order_400()
+        {
+            _task.Order.Should().Be(400);
+        }
+
+        [Test]
+        public void It_has_expected_name()
+        {
+            _task.Name.Should().Be("Warm Up OIDC Metadata Cache");
+        }
+    }
+
+    [TestFixture]
+    public class Given_BypassAuthorization_Is_Enabled : WarmUpOidcMetadataTaskTests
+    {
+        private IServiceProvider _serviceProvider = null!;
+        private WarmUpOidcMetadataTask _task = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _serviceProvider = A.Fake<IServiceProvider>();
+            _task = new WarmUpOidcMetadataTask(
+                _serviceProvider,
+                Options.Create(AppSettingsWith(bypassAuthorization: true)),
+                NullLogger<WarmUpOidcMetadataTask>.Instance
+            );
+
+            await _task.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public void It_does_not_resolve_the_oidc_configuration_manager()
+        {
+            A.CallTo(() =>
+                    _serviceProvider.GetService(typeof(IConfigurationManager<OpenIdConnectConfiguration>))
+                )
+                .MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_Bypass_Disabled_And_Metadata_Succeeds : WarmUpOidcMetadataTaskTests
+    {
+        private IServiceProvider _serviceProvider = null!;
+        private IConfigurationManager<OpenIdConnectConfiguration> _configurationManager = null!;
+        private WarmUpOidcMetadataTask _task = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _configurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => _configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(new OpenIdConnectConfiguration { Issuer = "https://issuer.example" });
+
+            _serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() =>
+                    _serviceProvider.GetService(typeof(IConfigurationManager<OpenIdConnectConfiguration>))
+                )
+                .Returns(_configurationManager);
+
+            _task = new WarmUpOidcMetadataTask(
+                _serviceProvider,
+                Options.Create(AppSettingsWith(bypassAuthorization: false)),
+                NullLogger<WarmUpOidcMetadataTask>.Instance
+            );
+
+            await _task.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Test]
+        public void It_resolves_the_oidc_configuration_manager()
+        {
+            A.CallTo(() =>
+                    _serviceProvider.GetService(typeof(IConfigurationManager<OpenIdConnectConfiguration>))
+                )
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void It_calls_get_configuration_async_exactly_once()
+        {
+            A.CallTo(() => _configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .MustHaveHappenedOnceExactly();
+        }
+    }
+
+    [TestFixture]
+    public class Given_Metadata_Fetch_Fails : WarmUpOidcMetadataTaskTests
+    {
+        private WarmUpOidcMetadataTask _task = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            var configurationManager = A.Fake<IConfigurationManager<OpenIdConnectConfiguration>>();
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .ThrowsAsync(new InvalidOperationException("OIDC metadata unavailable"));
+
+            var serviceProvider = A.Fake<IServiceProvider>();
+            A.CallTo(() =>
+                    serviceProvider.GetService(typeof(IConfigurationManager<OpenIdConnectConfiguration>))
+                )
+                .Returns(configurationManager);
+
+            _task = new WarmUpOidcMetadataTask(
+                serviceProvider,
+                Options.Create(AppSettingsWith(bypassAuthorization: false)),
+                NullLogger<WarmUpOidcMetadataTask>.Instance
+            );
+        }
+
+        [Test]
+        public async Task It_propagates_the_exception()
+        {
+            Func<Task> act = async () => await _task.ExecuteAsync(CancellationToken.None);
+
+            await act.Should()
+                .ThrowAsync<InvalidOperationException>()
+                .WithMessage("OIDC metadata unavailable");
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettings.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettings.cs
@@ -70,4 +70,9 @@ public class AppSettings
     /// mapping selection. When false (default), the existing backend path is used.
     /// </summary>
     public bool UseRelationalBackend { get; set; }
+
+    /// <summary>
+    /// If true, authorization is bypassed and OIDC metadata is not warmed up at startup.
+    /// </summary>
+    public bool BypassAuthorization { get; set; }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -67,6 +67,8 @@ public static class DmsCoreServiceExtensions
             .AddSingleton<IDmsStartupTask, LoadAndBuildEffectiveSchemaTask>()
             .AddSingleton<IDmsStartupTask, BackendMappingInitializationTask>()
             .AddSingleton<IDmsStartupTask, ValidateStartupInstancesTask>()
+            .AddSingleton<IDmsStartupTask, WarmUpOidcMetadataTask>()
+            .AddSingleton<IDmsStartupTask, CacheClaimSetsTask>()
             // Startup components
             .AddSingleton<IApiSchemaInputNormalizer, ApiSchemaInputNormalizer>()
             .AddSingleton<IEffectiveSchemaHashProvider, EffectiveSchemaHashProvider>()

--- a/src/dms/core/EdFi.DataManagementService.Core/Startup/CacheClaimSetsTask.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Startup/CacheClaimSetsTask.cs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Core.Utilities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DataManagementService.Core.Startup;
+
+/// <summary>
+/// Startup task that pre-caches claim set metadata so the first authorized request
+/// does not pay the Configuration Service round-trip. Failures here are logged at
+/// Critical level but never abort startup — DMS availability must not depend on the
+/// Configuration Service being reachable when the host comes up.
+/// </summary>
+internal class CacheClaimSetsTask(
+    IClaimSetProvider claimSetProvider,
+    IDmsInstanceProvider dmsInstanceProvider,
+    IOptions<AppSettings> appSettings,
+    ILogger<CacheClaimSetsTask> logger
+) : IDmsStartupTask
+{
+    private readonly IClaimSetProvider _claimSetProvider = claimSetProvider;
+    private readonly IDmsInstanceProvider _dmsInstanceProvider = dmsInstanceProvider;
+    private readonly AppSettings _appSettings = appSettings.Value;
+    private readonly ILogger _logger = logger;
+
+    /// <inheritdoc />
+    public int Order => 410;
+
+    /// <inheritdoc />
+    public string Name => "Cache Claim Sets";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _logger.LogInformation("Retrieving and caching required claim sets");
+
+        try
+        {
+            if (_appSettings.MultiTenancy)
+            {
+                IList<string> tenants = await _dmsInstanceProvider.LoadTenants();
+
+                foreach (string tenant in tenants)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    _logger.LogInformation(
+                        "Caching claim sets for tenant: {TenantName}",
+                        LoggingSanitizer.SanitizeForLogging(tenant)
+                    );
+
+                    await _claimSetProvider.GetAllClaimSets(tenant);
+                }
+            }
+            else
+            {
+                await _claimSetProvider.GetAllClaimSets();
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Pre-caching claim sets is best-effort; a Configuration Service failure
+            // here must not prevent DMS from starting and serving traffic.
+            _logger.LogCritical(ex, "Retrieving and caching required claim sets failure");
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Startup/CacheClaimSetsTask.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Startup/CacheClaimSetsTask.cs
@@ -65,10 +65,17 @@ internal class CacheClaimSetsTask(
                 await _claimSetProvider.GetAllClaimSets();
             }
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             // Pre-caching claim sets is best-effort; a Configuration Service failure
-            // here must not prevent DMS from starting and serving traffic.
+            // here must not prevent DMS from starting and serving traffic. A dependency
+            // that surfaces OperationCanceledException (for example an HttpClient
+            // timeout as TaskCanceledException) is treated as a fetch failure when our
+            // own startup token has not been canceled.
             _logger.LogCritical(ex, "Retrieving and caching required claim sets failure");
         }
     }

--- a/src/dms/core/EdFi.DataManagementService.Core/Startup/IDmsStartupTask.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Startup/IDmsStartupTask.cs
@@ -10,6 +10,8 @@ public static class DmsStartupTaskOrderRanges
     public const int ApiSchemaInitializationMaximum = 299;
     public const int BackendMappingMinimum = 300;
     public const int BackendMappingMaximum = 399;
+    public const int AuthInitializationMinimum = 400;
+    public const int AuthInitializationMaximum = 499;
 }
 
 /// <summary>
@@ -24,6 +26,7 @@ public interface IDmsStartupTask
     /// - 100-199: Schema loading and validation
     /// - 200-299: Schema processing (normalization, hashing)
     /// - 300-399: Backend mapping initialization and instance validation
+    /// - 400-499: Authentication/authorization metadata caches (OIDC, claim sets)
     /// </summary>
     int Order { get; }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Startup/WarmUpOidcMetadataTask.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Startup/WarmUpOidcMetadataTask.cs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace EdFi.DataManagementService.Core.Startup;
+
+/// <summary>
+/// Startup task that warms up the OIDC discovery/JWKS metadata cache so the first
+/// authenticated request does not pay the discovery round-trip. Resolves the OIDC
+/// configuration manager lazily so a bypass-authorization deployment never touches
+/// authentication services.
+/// </summary>
+internal class WarmUpOidcMetadataTask(
+    IServiceProvider serviceProvider,
+    IOptions<AppSettings> appSettings,
+    ILogger<WarmUpOidcMetadataTask> logger
+) : IDmsStartupTask
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly AppSettings _appSettings = appSettings.Value;
+    private readonly ILogger _logger = logger;
+
+    /// <inheritdoc />
+    public int Order => 400;
+
+    /// <inheritdoc />
+    public string Name => "Warm Up OIDC Metadata Cache";
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        if (_appSettings.BypassAuthorization)
+        {
+            _logger.LogInformation("BypassAuthorization is enabled, skipping OIDC metadata cache warm-up");
+            return;
+        }
+
+        _logger.LogInformation("Warming up OIDC metadata cache");
+
+        var configurationManager = _serviceProvider.GetRequiredService<
+            IConfigurationManager<OpenIdConnectConfiguration>
+        >();
+
+        OpenIdConnectConfiguration config = await configurationManager.GetConfigurationAsync(
+            cancellationToken
+        );
+
+        _logger.LogInformation(
+            "OIDC metadata cache warmed up successfully. Issuer: {Issuer}, SigningKeys: {SigningKeyCount}",
+            config.Issuer,
+            config.SigningKeys.Count
+        );
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/StartupPhaseExecutor.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/StartupPhaseExecutor.cs
@@ -26,7 +26,7 @@ internal static class DmsStartupPhases
     public const string InitializeDatabase = "InitializeDatabase";
     public const string InitializeApiSchemas = "InitializeApiSchemas";
     public const string InitializeBackendMappings = "InitializeBackendMappings";
-    public const string WarmUpOidcMetadataCache = "WarmUpOidcMetadataCache";
+    public const string InitializeAuthMetadata = "InitializeAuthMetadata";
     public const string ConfigureEndpoints = "ConfigureEndpoints";
     public const string Ready = "Ready";
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
@@ -9,7 +9,6 @@ using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Response;
-using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Core.Startup;
 using EdFi.DataManagementService.Core.Utilities;
 using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
@@ -19,8 +18,6 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using AppSettings = EdFi.DataManagementService.Frontend.AspNetCore.Configuration.AppSettings;
 using ResponseCompressionDefaults = Microsoft.AspNetCore.ResponseCompression.ResponseCompressionDefaults;
 
@@ -183,13 +180,12 @@ if (invalidConfigurationException is null)
         "Backend mapping initialization failed. DMS cannot start without compiled backend mappings.",
         () => InitializeBackendMappings(app)
     );
-    await RetrieveAndCacheClaimSets(app);
     await startupPhaseExecutor.RunFatalAsync(
-        DmsStartupPhases.WarmUpOidcMetadataCache,
-        "Retrieving OIDC metadata for the startup cache.",
-        "OIDC metadata cache warm-up completed or was skipped.",
-        "Unable to retrieve OIDC metadata from identity provider. JWT authentication will not function correctly.",
-        () => WarmUpOidcMetadataCache(app),
+        DmsStartupPhases.InitializeAuthMetadata,
+        "Initializing authentication metadata caches (OIDC warm-up and claim sets).",
+        "Authentication metadata initialization completed successfully.",
+        "Authentication metadata initialization failed. JWT authentication will not function correctly.",
+        () => InitializeAuthMetadata(app),
         exitCode: 1
     );
 
@@ -372,42 +368,16 @@ async Task InitializeBackendMappings(WebApplication app)
     app.Logger.LogInformation("Backend mapping initialization completed successfully");
 }
 
-async Task RetrieveAndCacheClaimSets(WebApplication app)
+async Task InitializeAuthMetadata(WebApplication app)
 {
-    app.Logger.LogInformation("Retrieving and caching required claim sets");
-    try
-    {
-        var claimSetProvider = app.Services.GetRequiredService<IClaimSetProvider>();
-        var multiTenancyEnabled = app.Configuration.GetValue<bool>("AppSettings:MultiTenancy");
-
-        if (multiTenancyEnabled)
-        {
-            var dmsInstanceProvider = app.Services.GetRequiredService<IDmsInstanceProvider>();
-            IList<string> tenants = await dmsInstanceProvider.LoadTenants();
-
-            foreach (string tenant in tenants)
-            {
-                app.Logger.LogInformation(
-                    "Caching claim sets for tenant: {TenantName}",
-                    LoggingSanitizer.SanitizeForLogging(tenant)
-                );
-                await claimSetProvider.GetAllClaimSets(tenant);
-            }
-        }
-        else
-        {
-            await claimSetProvider.GetAllClaimSets();
-        }
-    }
-    catch (Exception ex)
-    {
-        // Aim to cache the claim set list during the application's startup
-        // process. However, if caching fails for any reason, we do not prevent
-        // DMS from loading. This approach is intended to optimize the process
-        // of loading claims set list from Configuration service without
-        // impacting the application's availability.
-        app.Logger.LogCritical(ex, "Retrieving and caching required claim sets failure");
-    }
+    app.Logger.LogInformation("Initializing authentication metadata caches at startup");
+    var orchestrator = app.Services.GetRequiredService<DmsStartupOrchestrator>();
+    await orchestrator.RunByOrderRangeAsync(
+        DmsStartupTaskOrderRanges.AuthInitializationMinimum,
+        DmsStartupTaskOrderRanges.AuthInitializationMaximum,
+        CancellationToken.None
+    );
+    app.Logger.LogInformation("Authentication metadata initialization completed successfully");
 }
 
 async Task InitializeDmsInstances(WebApplication app)
@@ -505,25 +475,6 @@ void LogInstanceDetails(WebApplication app, IList<DmsInstance> instances)
             hasConnectionString
         );
     }
-}
-
-async Task WarmUpOidcMetadataCache(WebApplication app)
-{
-    var bypassAuthorizationEnabled = app.Configuration.GetValue<bool>("AppSettings:BypassAuthorization");
-    if (bypassAuthorizationEnabled)
-    {
-        app.Logger.LogInformation("BypassAuthorization is enabled, skipping OIDC metadata cache warm-up");
-        return;
-    }
-
-    app.Logger.LogInformation("Warming up OIDC metadata cache");
-    var configManager = app.Services.GetRequiredService<IConfigurationManager<OpenIdConnectConfiguration>>();
-    var config = await configManager.GetConfigurationAsync(CancellationToken.None);
-    app.Logger.LogInformation(
-        "OIDC metadata cache warmed up successfully. Issuer: {Issuer}, SigningKeys: {SigningKeyCount}",
-        config.Issuer,
-        config.SigningKeys.Count
-    );
 }
 
 void RunBootstrapPhase(


### PR DESCRIPTION
## Summary

- Moves `WarmUpOidcMetadataCache()` and `RetrieveAndCacheClaimSets()` out of `Program.cs` and into the `DmsStartupOrchestrator` as `IDmsStartupTask` implementations, matching the lifecycle prescribed in `reference/design/backend-redesign/design-docs/new-startup-flow.md`.
- New tasks live in `EdFi.DataManagementService.Core/Startup/`:
  - `WarmUpOidcMetadataTask` (Order 400) — warms the OIDC discovery/JWKS metadata cache. Resolves `IConfigurationManager<OpenIdConnectConfiguration>` through `IServiceProvider` lazily, **after** the `BypassAuthorization` short-circuit, so a bypass deployment never touches authentication services. Propagates any metadata fetch failure so the orchestrator aborts startup.
  - `CacheClaimSetsTask` (Order 410) — preserves single- and multi-tenant claim-set pre-caching. Catches `Exception ex when (ex is not OperationCanceledException)` and logs Critical so a Configuration Service outage cannot prevent DMS from serving traffic; cancellation flows through unswallowed.
- Adds `AuthInitializationMinimum=400` / `AuthInitializationMaximum=499` to `DmsStartupTaskOrderRanges`; documents the new range on `IDmsStartupTask.Order`.
- Adds `BypassAuthorization` to `Core.Configuration.AppSettings` so the OIDC task reads it through `IOptions<AppSettings>` instead of via the raw config key.
- Renames `DmsStartupPhases.WarmUpOidcMetadataCache` → `DmsStartupPhases.InitializeAuthMetadata`. `Program.cs` replaces the two standalone helpers with one `RunFatalAsync` wrapping `InitializeAuthMetadata(app)` (which delegates to `orchestrator.RunByOrderRangeAsync(400, 499)`). The OIDC fatal phase keeps `exitCode: 1`.
- Updates `docs/CACHING-STRATEGY.md` and `epics/15-plan-compilation/startup-failure-status-surfacing.md` to reference the new task classes and phase name.

## Test plan

- [x] `dotnet build` clean across Core and Frontend (0 warnings, 0 errors).
- [x] `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit` — 2452/2452 passing (1 pre-existing skip).
- [x] `dotnet test src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit` — 65/65 passing.
- [x] CSharpier formatted via Husky pre-commit hook.
- [x] New tests cover:
  - `WarmUpOidcMetadataTaskTests` (6) — order/name, bypass short-circuit does not resolve the OIDC config manager, success calls `GetConfigurationAsync` once, failure propagates.
  - `CacheClaimSetsTaskTests` (13) — single- and multi-tenant paths, non-OCE failures from `LoadTenants` and `GetAllClaimSets` are swallowed, pre-canceled token and dependency-thrown `OperationCanceledException` both propagate.
  - `DmsStartupOrchestratorTests` — three new orchestration-level fixtures using the real auth task types: OIDC runs before claim-sets, OIDC failure aborts startup and the claim-set task does not run, claim-set internal failure does not bubble out of the orchestrator.
  - `AuthStartupTaskRegistrationTests` (2) — `AddDmsDefaultConfiguration` registers both auth tasks as `IDmsStartupTask`.

Closes DMS-1091.