### PR TITLE
[DMS-1090] Verify NoFurtherAuthorizationRequired strategy no-op contract

### DIFF
--- a/reference/design/backend-redesign/epics/14-authorization/17-no-further-auth-required-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/17-no-further-auth-required-strategy.md
@@ -17,3 +17,10 @@ Implement the `NoFurtherAuthorizationRequired` authorization strategy per:
 - GET-many: No authorization filter is applied — all resources of the requested type are returned (subject to pagination and any non-auth filters).
 - GET-by-id, POST, PUT, DELETE: No authorization check is executed — the operation proceeds as long as the caller is authenticated and has the appropriate claim for the action.
 - When combined with other strategies via AND semantics, `NoFurtherAuthorizationRequired` is a no-op (it does not restrict and does not contribute error hints).
+
+## Composition with relationship strategies
+
+`NoFurtherAuthorizationRequired` GET-many AND-composition is covered at the
+classifier level. CRUD AND-composition is intentionally deferred to DMS-1056,
+where relationship CRUD authorization is implemented and mixed-strategy
+behavior can be tested against the real authorization path.

--- a/reference/design/backend-redesign/epics/14-authorization/17-no-further-auth-required-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/17-no-further-auth-required-strategy.md
@@ -20,7 +20,22 @@ Implement the `NoFurtherAuthorizationRequired` authorization strategy per:
 
 ## Composition with relationship strategies
 
-`NoFurtherAuthorizationRequired` GET-many AND-composition is covered at the
-classifier level. CRUD AND-composition is intentionally deferred to DMS-1056,
-where relationship CRUD authorization is implemented and mixed-strategy
-behavior can be tested against the real authorization path.
+`NoFurtherAuthorizationRequired` AND-composition with relationship strategies
+is covered at the contract level, so the no-op semantics hold across both
+read- and write-side planning regardless of how each surface is wired up later:
+
+- GET-many AND-composition is covered through the classifier and query
+  planning path: the classifier routes `NoFurtherAuthorizationRequired` into a
+  separate no-op bucket so it never contributes a relationship subject, check,
+  or error hint to the read-side query plan.
+- CRUD AND-composition is covered at the planner / proposed-value contract
+  level: `RelationshipAuthorizationPlanner.PlanProposedValues(...)` reuses the
+  same classification, so `NoFurtherAuthorizationRequired` emits no proposed
+  check spec, does not shift the configured-index or relationship-local
+  ordering of sibling relationship strategies, and does not contribute
+  security-configuration failures.
+
+Full end-to-end relational CRUD authorization — wiring the proposed-value
+check specs into the write path, enforcing them at execution time, and
+exercising mixed strategies through E2E flows — remains owned by the
+relationship CRUD authorization work tracked outside DMS-1090.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationPlannerTests.cs
@@ -208,6 +208,90 @@ public class Given_RelationshipAuthorizationPlannerTests
     }
 
     [Test]
+    public void It_should_treat_no_further_authorization_required_as_a_noop_in_proposed_value_planning()
+    {
+        (_, var mappingSet) = Ds52FixtureHelper.BuildAndCompile();
+        var resource = new QualifiedResourceName("Ed-Fi", "CourseOffering");
+        var writePlan = mappingSet.GetWritePlanOrThrow(resource);
+        var rootTablePlan = GetRootTableWritePlan(writePlan);
+        var planner = CreatePlanner();
+
+        var result = planner.PlanProposedValues(
+            mappingSet,
+            resource,
+            CreateConfiguredAuthorizationStrategies(
+                AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnlyInverted
+            ),
+            new RelationalAuthorizationContext([42L], []),
+            writePlan
+        );
+
+        result.Should().BeOfType<RelationshipAuthorizationResult.Authorized>();
+
+        var authorizedResult = (RelationshipAuthorizationResult.Authorized)result;
+
+        authorizedResult.CheckSpecs.Should().HaveCount(2);
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.ConfiguredStrategy.StrategyName)
+            .Should()
+            .Equal(
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnlyInverted
+            );
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.ConfiguredStrategy.RawConfiguredIndex)
+            .Should()
+            .Equal(1, 2);
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.RelationshipLocalOrder)
+            .Should()
+            .Equal(0, 1);
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.Direction)
+            .Should()
+            .Equal(
+                RelationshipAuthorizationHierarchyDirection.Normal,
+                RelationshipAuthorizationHierarchyDirection.Inverted
+            );
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.ValueSource)
+            .Should()
+            .OnlyContain(static valueSource => valueSource == RelationshipAuthorizationValueSource.Proposed);
+        authorizedResult
+            .CheckSpecs.Select(static checkSpec => checkSpec.CheckTarget)
+            .Should()
+            .AllSatisfy(checkTarget =>
+                checkTarget.Should().BeOfType<RelationshipAuthorizationCheckTarget.Proposed>()
+            );
+
+        foreach (var checkSpec in authorizedResult.CheckSpecs)
+        {
+            var proposedTarget = (RelationshipAuthorizationCheckTarget.Proposed)checkSpec.CheckTarget;
+            var subject = checkSpec.Subjects.Single();
+            var expectedBinding = rootTablePlan
+                .ColumnBindings.Select(static (binding, index) => (binding, index))
+                .Single(entry => entry.binding.Column.ColumnName.Equals(subject.Column));
+
+            proposedTarget.RootTable.Should().Be(rootTablePlan.TableModel.Table);
+            proposedTarget
+                .SubjectBindingsInOrder.Should()
+                .ContainSingle()
+                .Which.Should()
+                .BeEquivalentTo(
+                    new RelationshipAuthorizationProposedValueBinding(
+                        subject.Table,
+                        subject.Column,
+                        expectedBinding.index,
+                        subject.Column.Value,
+                        expectedBinding.binding.ParameterName
+                    )
+                );
+        }
+    }
+
+    [Test]
     public void It_should_report_missing_proposed_root_bindings_as_security_configuration_errors()
     {
         (_, var mappingSet) = Ds52FixtureHelper.BuildAndCompile();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/NamedAuthorizationServiceFactoryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/NamedAuthorizationServiceFactoryTests.cs
@@ -63,8 +63,11 @@ public class NamedAuthorizationServiceFactoryTests
             handlerProvider = new NamedAuthorizationServiceFactory();
         }
 
-        [Test]
-        public void Should_Return_NoFurtherAuthorizationRequiredValidator()
+        [TestCase(OperationType.Get)]
+        [TestCase(OperationType.Upsert)]
+        [TestCase(OperationType.Update)]
+        [TestCase(OperationType.Delete)]
+        public async Task Should_Return_NoFurtherAuthorizationRequiredValidator(OperationType operationType)
         {
             var handler =
                 handlerProvider!.GetByName<IAuthorizationValidator>(
@@ -72,14 +75,12 @@ public class NamedAuthorizationServiceFactoryTests
                     serviceProvider!
                 ) as NoFurtherAuthorizationRequiredValidator;
             handler.Should().NotBeNull();
-            var authResult = handler!
-                .ValidateAuthorization(
-                    new DocumentSecurityElements([], [], [], [], []),
-                    [],
-                    [],
-                    OperationType.Get
-                )
-                .Result;
+            var authResult = await handler!.ValidateAuthorization(
+                new DocumentSecurityElements([], [], [], [], []),
+                [],
+                [],
+                operationType
+            );
             authResult.Should().NotBeNull();
             authResult.Should().BeOfType<ResourceAuthorizationResult.Authorized>();
         }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NoFurtherAuthorizationRequired.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NoFurtherAuthorizationRequired.feature
@@ -25,8 +25,8 @@ Feature: NoFurtherAuthorizationRequired strategy is a no-op for relational read 
                   | localEducationAgencyId | nameOfInstitution | stateEducationAgencyReference   | categories                                                                                                               | localEducationAgencyCategoryDescriptor                       |
                   | 201                    | DMS-1090 LEA      | { "stateEducationAgencyId": 2 } | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#District" }] | "uri://ed-fi.org/localEducationAgencyCategoryDescriptor#ABC" |
               And the system has these "schools"
-                  | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        | localEducationAgencyReference    |
-                  | 20101    | DMS-1090 school   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] | { "localEducationAgencyId": 201} |
+                  | _storeResultingIdInVariable | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        | localEducationAgencyReference    |
+                  | SchoolId1                   | 20101    | DMS-1090 school   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] | { "localEducationAgencyId": 201} |
             # Switch to a claim set whose EdOrg id 999 has no overlap with the seeded hierarchy.
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "999"
              When a GET request is made to "/ed-fi/schools"
@@ -50,7 +50,7 @@ Feature: NoFurtherAuthorizationRequired strategy is a no-op for relational read 
                       }
                   ]
                   """
-             When a GET request is made to "/ed-fi/schools/{id}"
+             When a GET request is made to "/ed-fi/schools/{SchoolId1}"
              Then it should respond with 200
 
         @relational-backend

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NoFurtherAuthorizationRequired.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NoFurtherAuthorizationRequired.feature
@@ -1,0 +1,105 @@
+@reset-data-before-scenario
+Feature: NoFurtherAuthorizationRequired strategy is a no-op for relational read and write paths
+
+    Rule: Query and write scenarios use the relational backend authorization lane
+
+        Background:
+            # Seed the descriptors required by the write scenario's POST. The read scenario's
+            # data-seed step (`the system has these "schools"`) does not require descriptors to
+            # be pre-seeded, but a user-issued POST goes through full descriptor validation.
+            Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2, 201"
+              And the system has these descriptors
+                  | descriptorValue                                                                  |
+                  | uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School              |
+                  | uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade                                 |
+
+        @relational-backend
+        @relational-ci-shard-3
+        Scenario: Read paths return resources whose EdOrg context is disjoint from the caller's claim
+            # Seed the SEA/LEA/School hierarchy with a claim set authorized for the target EdOrg context.
+            Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2, 201, 20101"
+              And the system has these "stateEducationAgencies"
+                  | stateEducationAgencyId | nameOfInstitution | categories                                                                                                            |
+                  | 2                      | DMS-1090 SEA      | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#State" }] |
+              And the system has these "localEducationAgencies"
+                  | localEducationAgencyId | nameOfInstitution | stateEducationAgencyReference   | categories                                                                                                               | localEducationAgencyCategoryDescriptor                       |
+                  | 201                    | DMS-1090 LEA      | { "stateEducationAgencyId": 2 } | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#District" }] | "uri://ed-fi.org/localEducationAgencyCategoryDescriptor#ABC" |
+              And the system has these "schools"
+                  | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        | localEducationAgencyReference    |
+                  | 20101    | DMS-1090 school   | [ {"gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade"} ] | [ {"educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School"} ] | { "localEducationAgencyId": 201} |
+            # Switch to a claim set whose EdOrg id 999 has no overlap with the seeded hierarchy.
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "999"
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 200
+              And the response body is
+                  """
+                  [
+                      {
+                          "id": "{id}",
+                          "schoolId": 20101,
+                          "nameOfInstitution": "DMS-1090 school",
+                          "gradeLevels": [
+                              { "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" }
+                          ],
+                          "educationOrganizationCategories": [
+                              { "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School" }
+                          ],
+                          "localEducationAgencyReference": {
+                              "localEducationAgencyId": 201
+                          }
+                      }
+                  ]
+                  """
+             When a GET request is made to "/ed-fi/schools/{id}"
+             Then it should respond with 200
+
+        @relational-backend
+        @relational-ci-shard-3
+        Scenario: Write paths succeed when the caller's claim contains no EdOrgs that cover the target resource
+            # Seed only the SEA/LEA hierarchy with a claim set authorized for the target EdOrg context.
+            Given the claimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" is authorized with educationOrganizationIds "2, 201"
+              And the system has these "stateEducationAgencies"
+                  | stateEducationAgencyId | nameOfInstitution | categories                                                                                                            |
+                  | 2                      | DMS-1090 SEA      | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#State" }] |
+              And the system has these "localEducationAgencies"
+                  | localEducationAgencyId | nameOfInstitution | stateEducationAgencyReference   | categories                                                                                                               | localEducationAgencyCategoryDescriptor                       |
+                  | 201                    | DMS-1090 LEA      | { "stateEducationAgencyId": 2 } | [{ "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#District" }] | "uri://ed-fi.org/localEducationAgencyCategoryDescriptor#ABC" |
+            # Switch to a claim set whose EdOrg id 999 has no overlap with the seeded hierarchy.
+            Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with educationOrganizationIds "999"
+             When a POST request is made to "/ed-fi/schools" with
+                  """
+                  {
+                      "schoolId": 30101,
+                      "nameOfInstitution": "DMS-1090 created school",
+                      "gradeLevels": [
+                          { "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" }
+                      ],
+                      "educationOrganizationCategories": [
+                          { "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School" }
+                      ],
+                      "localEducationAgencyReference": {
+                          "localEducationAgencyId": 201
+                      }
+                  }
+                  """
+             Then it should respond with 201
+             When a PUT request is made to "/ed-fi/schools/{id}" with
+                  """
+                  {
+                      "id": "{id}",
+                      "schoolId": 30101,
+                      "nameOfInstitution": "DMS-1090 updated school",
+                      "gradeLevels": [
+                          { "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Tenth Grade" }
+                      ],
+                      "educationOrganizationCategories": [
+                          { "educationOrganizationCategoryDescriptor": "uri://tpdm.ed-fi.org/EducationOrganizationCategoryDescriptor#School" }
+                      ],
+                      "localEducationAgencyReference": {
+                          "localEducationAgencyId": 201
+                      }
+                  }
+                  """
+             Then it should respond with 204
+             When a DELETE request is made to "/ed-fi/schools/{id}"
+             Then it should respond with 204


### PR DESCRIPTION
## Summary

DMS-1090 is a verification/closure story for the `NoFurtherAuthorizationRequired` authorization strategy. The runtime no-op already lives across `NoFurtherAuthorizationRequiredValidator`, `NoFurtherAuthorizationRequiredFiltersProvider`, and `RelationalGetManyAuthorizationStrategyClassifier`. This PR adds the missing coverage and resolves the CRUD AND-composition boundary at the planner contract level instead of deferring it to DMS-1056.

**Zero production-code changes.** Five commits, five touched paths:

- Classifier unit test for the standalone "only `NoFurtherAuthorizationRequired` present" case (returns `NoAuthorizationRequired`).
- Validator unit test parameterized across all `OperationType` values (Get, Upsert, Update, Delete) using `[TestCase]` + async/await.
- New E2E feature `NoFurtherAuthorizationRequired.feature` with two scenarios on the relational backend:
  - **Read paths**: seed SEA/LEA/school under EdOrg `2/201/20101` with the EdOrgsOnly setup claim set, switch to `E2E-NoFurtherAuthRequiredClaimSet` with disjoint EdOrg `999`, assert GET-many returns the seeded school and GET-by-id succeeds.
  - **Write paths**: seed SEA/LEA only, switch to `E2E-NoFurtherAuthRequiredClaimSet` with EdOrg `999`, assert POST creates school `30101`, PUT updates it, DELETE removes it.
- Planner unit test (`RelationshipAuthorizationPlannerTests.cs`) proving `NoFurtherAuthorizationRequired` is a no-op in `RelationshipAuthorizationPlanner.PlanProposedValues` when mixed with `RelationshipsWithEdOrgsOnly` + `RelationshipsWithEdOrgsOnlyInverted` on a real `CourseOffering` write plan: `Authorized` result, exactly two proposed-value check specs (NFAR contributes none), `RawConfiguredIndex` preserved at `(1, 2)`, relationship-local order `(0, 1)`, directions Normal/Inverted, and each proposed target bound back to the correct root-table `ColumnBindings` entry.
- Story-doc update in `17-no-further-auth-required-strategy.md` replacing the prior CRUD AND-composition deferral note with language that distinguishes GET-many composition (classifier / query-planning path), CRUD composition (planner / proposed-value contract level — covered by this PR), and full E2E relational CRUD enforcement (still owned outside DMS-1090).

The explicit success codes on every E2E step are the no-403 assertion. A Background under the Rule seeds the descriptors required by the user-issued POST.

## Test plan

- [x] `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/...` — 1406 passed
- [x] `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/...` — 2429 passed
- [x] `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/...` — 906 passed (includes new planner test)
- [x] New E2E feature — 4 passed (2 scenarios × 2 backends) on fresh local dms-local stack
- [x] CSharpier formatting clean
- [x] No `.feature.cs` generated files staged
