### PR TITLE
[DMS-1081] Align Vendors POST response contract

### DIFF
--- a/eng/Dms-Management.psm1
+++ b/eng/Dms-Management.psm1
@@ -375,6 +375,7 @@ function Add-Vendor {
     $webResponse = Invoke-WebRequest @webRequestParams
     $location = $webResponse.Headers['Location']
     if ($location -is [array]) { $location = $location[0] }
+    if (-not $location) { throw "CMS Add-Vendor response missing Location header" }
     return [long]($location -split '/')[-1]
 }
 

--- a/eng/Dms-Management.psm1
+++ b/eng/Dms-Management.psm1
@@ -320,7 +320,7 @@ function Get-CmsToken {
         The Keycloak bearer token for authorization (mandatory).
 
     .OUTPUTS
-        [string] Returns the vendor ID of the newly created or updated vendor.
+        [long] Returns the vendor ID of the newly created or updated vendor.
 
     .EXAMPLE
         # Create or update a vendor

--- a/eng/Dms-Management.psm1
+++ b/eng/Dms-Management.psm1
@@ -362,18 +362,20 @@ function Add-Vendor {
         $headers["Tenant"] = $Tenant
     }
 
-    $invokeParams = @{
-        BaseUrl      = $CmsUrl
-        RelativeUrl  = "v2/vendors"
-        Method       = "Post"
-        ContentType  = "application/json"
-        Body         = ConvertTo-Json -InputObject $vendorData -Depth 10
-        Headers      = $headers
+    $fullUri = "$($CmsUrl.TrimEnd('/'))/v2/vendors"
+
+    $webRequestParams = @{
+        Uri         = $fullUri
+        Method      = "Post"
+        ContentType = "application/json"
+        Body        = ConvertTo-Json -InputObject $vendorData -Depth 10
+        Headers     = $headers
     }
 
-    $response = Invoke-Api @invokeParams
-
-    return $response.id
+    $webResponse = Invoke-WebRequest @webRequestParams
+    $location = $webResponse.Headers['Location']
+    if ($location -is [array]) { $location = $location[0] }
+    return [long]($location -split '/')[-1]
 }
 
 <#

--- a/getting-started.http
+++ b/getting-started.http
@@ -78,7 +78,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/getting-started.http
+++ b/getting-started.http
@@ -75,7 +75,7 @@ Authorization: bearer {{configToken}}
 ### Read the newly-created Vendor ID from the Location header
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/getting-started.http
+++ b/getting-started.http
@@ -72,8 +72,17 @@ Authorization: bearer {{configToken}}
 # these below), and in some cases they restrict which records your client can
 # access ("namespace-based authorization").
 
-### Read the newly-created Vendor ID from the response body
-@vendorId={{createVendor.response.body.id}}
+### Read the newly-created Vendor ID from the Location header
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### Create a DMS instance
 # @name createDmsInstance

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/VendorRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/VendorRepository.cs
@@ -35,8 +35,8 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories
             try
             {
                 long id = 0;
-                bool isNewVendor;
-                // Check for existing vendor by Company (natural key), update if found
+                bool isNewVendor = false;
+                // Check for existing vendor by Company (and TenantId if multi-tenancy is enabled)
                 var sql =
                     $"SELECT Id FROM dmscs.Vendor WHERE Company = @Company AND {TenantContext.TenantWhereClause()}";
 
@@ -70,7 +70,6 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories
                     sql = "DELETE FROM dmscs.VendorNamespacePrefix WHERE VendorId = @VendorId";
                     await connection.ExecuteAsync(sql, new { VendorId = existingVendorId.Value });
                     id = existingVendorId.Value;
-                    isNewVendor = false;
                 }
                 else
                 {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/VendorRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/VendorRepository.cs
@@ -35,8 +35,8 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories
             try
             {
                 long id = 0;
-                bool isNewVendor = false;
-                // Check for existing vendor by Company (and TenantId if multi-tenancy is enabled)
+                bool isNewVendor;
+                // Check for existing vendor by Company (natural key), update if found
                 var sql =
                     $"SELECT Id FROM dmscs.Vendor WHERE Company = @Company AND {TenantContext.TenantWhereClause()}";
 
@@ -70,6 +70,7 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories
                     sql = "DELETE FROM dmscs.VendorNamespacePrefix WHERE VendorId = @VendorId";
                     await connection.ExecuteAsync(sql, new { VendorId = existingVendorId.Value });
                     id = existingVendorId.Value;
+                    isNewVendor = false;
                 }
                 else
                 {

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IVendorRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IVendorRepository.cs
@@ -22,10 +22,10 @@ public interface IVendorRepository
 public record VendorInsertResult
 {
     /// <summary>
-    /// Successful insert or update.
+    /// Successful vendor insert or update (upsert by natural key).
     /// </summary>
-    /// <param name="Id">The Id of the inserted or updated record.</param>
-    /// <param name="IsNewVendor">Flag indicating whether it's a new vendor.</param>
+    /// <param name="Id">The Id of the inserted or updated vendor.</param>
+    /// <param name="IsNewVendor">True if the vendor was newly inserted; false if an existing vendor was updated.</param>
     public record Success(long Id, bool IsNewVendor) : VendorInsertResult();
 
     /// <summary>

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthorizationTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthorizationTests.cs
@@ -190,7 +190,7 @@ public class AuthorizationTests
         public void SetUp()
         {
             A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
-                .Returns(new VendorInsertResult.Success(1, IsNewVendor: true));
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: false));
 
             A.CallTo(() => _vendorRepository.QueryVendor(A<VendorQuery>.Ignored))
                 .Returns(

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthorizationTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/AuthorizationTests.cs
@@ -93,7 +93,7 @@ public class AuthorizationTests
         public void SetUp()
         {
             A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
-                .Returns(new VendorInsertResult.Success(1, true));
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: true));
 
             A.CallTo(() => _vendorRepository.QueryVendor(A<VendorQuery>.Ignored))
                 .Returns(
@@ -190,7 +190,7 @@ public class AuthorizationTests
         public void SetUp()
         {
             A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
-                .Returns(new VendorInsertResult.Success(1, false));
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: true));
 
             A.CallTo(() => _vendorRepository.QueryVendor(A<VendorQuery>.Ignored))
                 .Returns(

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -460,7 +460,7 @@ public class ApplicationModuleTests
         public void SetUp()
         {
             A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
-                .Returns(new VendorInsertResult.Success(1, true));
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: true));
 
             A.CallTo(() => _applicationRepository.GetApplication(A<long>.Ignored))
                 .Returns(new ApplicationGetResult.FailureNotFound());

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
@@ -323,6 +323,61 @@ public class MetadataModuleTests
             .BeTrue("ApplicationResponse.enabled should be of type boolean in OpenAPI schema");
     }
 
+    [Test]
+    public async Task OpenApi_Vendor_Post_Response_Documents_Location_Header()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/openapi/v1.json");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = System.Text.Json.JsonDocument.Parse(json);
+        var pathMap = doc
+            .RootElement.GetProperty("paths")
+            .EnumerateObject()
+            .ToDictionary(p => p.Name.TrimEnd('/').ToLowerInvariant(), p => p.Value);
+
+        pathMap.Should().ContainKey("/v2/vendors", "path /v2/vendors should exist in OpenAPI spec");
+        var pathItem = pathMap["/v2/vendors"];
+
+        pathItem.TryGetProperty("post", out var postOp).Should().BeTrue("POST /v2/vendors should exist");
+        var responses = postOp.GetProperty("responses");
+
+        responses
+            .TryGetProperty("201", out _)
+            .Should()
+            .BeTrue("POST /v2/vendors should define a 201 response for new resources");
+
+        responses
+            .TryGetProperty("200", out _)
+            .Should()
+            .BeTrue("POST /v2/vendors should define a 200 response for updated resources");
+
+        foreach (var code in new[] { "201", "200" })
+        {
+            responses.TryGetProperty(code, out var codeResponse).Should().BeTrue();
+            codeResponse
+                .TryGetProperty("headers", out var headers)
+                .Should()
+                .BeTrue($"{code} response should define headers");
+            headers
+                .TryGetProperty("Location", out var locationHeader)
+                .Should()
+                .BeTrue($"{code} response headers should include Location");
+            locationHeader.GetProperty("required").GetBoolean().Should().BeTrue();
+            locationHeader.GetProperty("schema").GetProperty("type").GetString().Should().Be("string");
+            locationHeader.GetProperty("schema").GetProperty("format").GetString().Should().Be("uri");
+            locationHeader.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
+        }
+    }
+
     private static bool TypeIncludes(System.Text.Json.JsonElement type, string expectedType)
     {
         return type.ValueKind switch

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/MetadataModuleTests.cs
@@ -375,6 +375,10 @@ public class MetadataModuleTests
             locationHeader.GetProperty("schema").GetProperty("type").GetString().Should().Be("string");
             locationHeader.GetProperty("schema").GetProperty("format").GetString().Should().Be("uri");
             locationHeader.GetProperty("description").GetString().Should().NotBeNullOrWhiteSpace();
+            codeResponse
+                .TryGetProperty("content", out _)
+                .Should()
+                .BeFalse($"{code} response body should be empty per CMS-GAP-009");
         }
     }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
@@ -220,7 +220,7 @@ public class VendorModuleTests
         }
 
         [Test]
-        public async Task Should_return_bad_request_with_Company_key()
+        public async Task Should_return_bad_request_with_Name_field_key()
         {
             using var client = SetUpClient();
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
@@ -77,7 +77,7 @@ public class VendorModuleTests
         public void SetUp()
         {
             A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
-                .Returns(new VendorInsertResult.Success(1, true));
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: true));
 
             A.CallTo(() => _vendorRepository.QueryVendor(A<VendorQuery>.Ignored))
                 .Returns(
@@ -159,11 +159,93 @@ public class VendorModuleTests
 
             //Assert
             addResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            addResponse.Headers.Location!.IsAbsoluteUri.Should().BeTrue();
             addResponse.Headers.Location!.ToString().Should().EndWith("/v2/vendors/1");
+            var addBody = await addResponse.Content.ReadAsStringAsync();
+            addBody.Should().BeEmpty();
             getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             getByIdResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             updateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
             deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        }
+    }
+
+    [TestFixture]
+    public class UpsertTests : VendorModuleTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
+                .Returns(new VendorInsertResult.Success(1, IsNewVendor: false));
+        }
+
+        [Test]
+        public async Task Should_return_200_with_location_when_vendor_already_exists()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync(
+                "/v2/vendors",
+                new StringContent(
+                    """
+                    {
+                      "company": "Existing Company",
+                      "contactName": "Test",
+                      "contactEmailAddress": "test@gmail.com",
+                      "namespacePrefixes": "Test"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.Headers.Location!.IsAbsoluteUri.Should().BeTrue();
+            response.Headers.Location!.ToString().Should().EndWith("/v2/vendors/1");
+            var body = await response.Content.ReadAsStringAsync();
+            body.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    public class FailureDuplicateCompanyNameTests : VendorModuleTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            A.CallTo(() => _vendorRepository.InsertVendor(A<VendorInsertCommand>.Ignored))
+                .Returns(new VendorInsertResult.FailureDuplicateCompanyName());
+        }
+
+        [Test]
+        public async Task Should_return_bad_request_with_Company_key()
+        {
+            using var client = SetUpClient();
+
+            var response = await client.PostAsync(
+                "/v2/vendors",
+                new StringContent(
+                    """
+                    {
+                      "company": "Existing Company",
+                      "contactName": "Test",
+                      "contactEmailAddress": "test@gmail.com",
+                      "namespacePrefixes": "Test"
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            var doc = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+            doc!["validationErrors"]!
+                ["Company"]
+                .Should()
+                .NotBeNull("field key must be 'Company', not 'Name'");
         }
     }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
@@ -243,9 +243,9 @@ public class VendorModuleTests
             response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             var doc = JsonNode.Parse(await response.Content.ReadAsStringAsync());
             doc!["validationErrors"]!
-                ["Company"]
+                ["Name"]
                 .Should()
-                .NotBeNull("field key must be 'Company', not 'Name'");
+                .NotBeNull("field key must be 'Name' per existing contract");
         }
     }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/EdFi.DmsConfigurationService.Frontend.AspNetCore.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="FluentValidation.AspNetCore" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+        <PackageReference Include="Microsoft.OpenApi" />
         <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
         <PackageReference Include="Microsoft.IdentityModel.Protocols" />
         <PackageReference Include="Serilog" />

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
@@ -33,13 +33,6 @@ public class VendorModule : IEndpointModule
                         return Task.CompletedTask;
                     }
 
-                    var locationHeader = new OpenApiHeader
-                    {
-                        Description = "The absolute URL of the vendor resource.",
-                        Required = true,
-                        Schema = new OpenApiSchema { Type = JsonSchemaType.String, Format = "uri" },
-                    };
-
                     foreach (var code in new[] { "201", "200" })
                     {
                         if (
@@ -48,7 +41,12 @@ public class VendorModule : IEndpointModule
                         )
                         {
                             response.Headers ??= new Dictionary<string, IOpenApiHeader>();
-                            response.Headers["Location"] = locationHeader;
+                            response.Headers["Location"] = new OpenApiHeader
+                            {
+                                Description = "The absolute URL of the vendor resource.",
+                                Required = true,
+                                Schema = new OpenApiSchema { Type = JsonSchemaType.String, Format = "uri" },
+                            };
                         }
                     }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
@@ -96,7 +96,7 @@ public class VendorModule : IEndpointModule
                 FailureResponse.ForDataValidation(
                     [
                         new ValidationFailure(
-                            "Company",
+                            "Name",
                             "A vendor name already exists in the database. Please enter a unique name."
                         ),
                     ],

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/VendorModule.cs
@@ -13,6 +13,7 @@ using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure.Authorizat
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Models;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.OpenApi;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
 
@@ -20,7 +21,40 @@ public class VendorModule : IEndpointModule
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapSecuredPost("/v2/vendors/", InsertVendor);
+        endpoints
+            .MapSecuredPost("/v2/vendors/", InsertVendor)
+            .Produces(201)
+            .Produces(200)
+            .AddOpenApiOperationTransformer(
+                (operation, context, ct) =>
+                {
+                    if (operation.Responses is null)
+                    {
+                        return Task.CompletedTask;
+                    }
+
+                    var locationHeader = new OpenApiHeader
+                    {
+                        Description = "The absolute URL of the vendor resource.",
+                        Required = true,
+                        Schema = new OpenApiSchema { Type = JsonSchemaType.String, Format = "uri" },
+                    };
+
+                    foreach (var code in new[] { "201", "200" })
+                    {
+                        if (
+                            operation.Responses.TryGetValue(code, out var iResponse)
+                            && iResponse is OpenApiResponse response
+                        )
+                        {
+                            response.Headers ??= new Dictionary<string, IOpenApiHeader>();
+                            response.Headers["Location"] = locationHeader;
+                        }
+                    }
+
+                    return Task.CompletedTask;
+                }
+            );
         endpoints.MapSecuredGet("/v2/vendors/", GetAll);
         endpoints.MapSecuredGet($"/v2/vendors/{{id}}", GetById);
         endpoints.MapSecuredPut($"/v2/vendors/{{id}}", Update);
@@ -41,30 +75,28 @@ public class VendorModule : IEndpointModule
         var insertResult = await repository.InsertVendor(entity);
 
         var request = httpContext.Request;
+        var locationUrl =
+            $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path.Value?.TrimEnd('/')}/";
+
+        if (insertResult is VendorInsertResult.Success success)
+        {
+            var resourceUrl = $"{locationUrl}{success.Id}";
+            if (success.IsNewVendor)
+            {
+                return Results.Created(resourceUrl, null);
+            }
+
+            httpContext.Response.Headers.Location = resourceUrl;
+            return Results.Ok();
+        }
+
         return insertResult switch
         {
-            VendorInsertResult.Success success when success.IsNewVendor => Results.Created(
-                $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path.Value?.TrimEnd('/')}/{success.Id}",
-                new
-                {
-                    Id = success.Id,
-                    Status = 201,
-                    Title = $"New Vendor {entity.Company} has been created successfully.",
-                }
-            ),
-            VendorInsertResult.Success success when !success.IsNewVendor => Results.Ok(
-                new
-                {
-                    Id = success.Id,
-                    Status = 200,
-                    Title = $"Vendor {entity.Company} has been updated successfully.",
-                }
-            ),
             VendorInsertResult.FailureDuplicateCompanyName => Results.Json(
                 FailureResponse.ForDataValidation(
                     [
                         new ValidationFailure(
-                            "Name",
+                            "Company",
                             "A vendor name already exists in the database. Please enter a unique name."
                         ),
                     ],

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
@@ -57,6 +57,7 @@ Feature: Vendors endpoints
                         "location": "/v2/vendors/{vendorId}"
                     }
                   """
+              And the response body is empty
               And the record can be retrieved with a GET request
                   """
                   {
@@ -370,6 +371,7 @@ Feature: Vendors endpoints
                         "location": "config/v2/vendors/{vendorId}"
                     }
                   """
+              And the response body is empty
               And the record can be retrieved with a GET request
                   """
                   {
@@ -382,3 +384,32 @@ Feature: Vendors endpoints
                   """
 
 
+        Scenario: 18 POST with an existing company name returns 200 and updates the vendor
+             When a POST request is made to "/v2/vendors" with
+                  """
+                   {
+                       "company": "Upsert Co",
+                       "contactName": "Initial Contact",
+                       "contactEmailAddress": "initial@example.com",
+                       "namespacePrefixes": "Test"
+                   }
+                  """
+             Then it should respond with 201
+              And the response body is empty
+             When a POST request is made to "/v2/vendors" with
+                  """
+                   {
+                       "company": "Upsert Co",
+                       "contactName": "Updated Contact",
+                       "contactEmailAddress": "updated@example.com",
+                       "namespacePrefixes": "Test"
+                   }
+                  """
+             Then it should respond with 200
+              And the response headers include
+                  """
+                   {
+                       "location": "/v2/vendors/{vendorId}"
+                   }
+                  """
+              And the response body is empty

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
@@ -419,3 +419,13 @@ Feature: Vendors endpoints
                    }
                   """
               And the response body is empty
+              And the record can be retrieved with a GET request
+                  """
+                  {
+                      "id": {id},
+                      "company": "Upsert Co",
+                      "contactName": "Updated Contact",
+                      "contactEmailAddress": "updated@example.com",
+                      "namespacePrefixes": "Test"
+                  }
+                  """

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
@@ -395,6 +395,12 @@ Feature: Vendors endpoints
                    }
                   """
              Then it should respond with 201
+              And the response headers include
+                  """
+                    {
+                        "location": "/v2/vendors/{vendorId}"
+                    }
+                  """
               And the response body is empty
              When a POST request is made to "/v2/vendors" with
                   """

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -415,7 +415,7 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
     public async Task ThenTheResponseBodyIsEmpty()
     {
         string content = await _apiResponse.TextAsync();
-        content.Should().BeNullOrEmpty("POST response body should be empty per CMS-GAP-009");
+        content.Should().BeNullOrEmpty("response body should be empty per CMS-GAP-009");
     }
 
     [Then("the response body should not contain {string}")]

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -411,6 +411,13 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         await ResponseBodyIs(expectedBody);
     }
 
+    [Then("the response body is empty")]
+    public async Task ThenTheResponseBodyIsEmpty()
+    {
+        string content = await _apiResponse.TextAsync();
+        content.Should().BeNullOrEmpty("POST response body should be empty per CMS-GAP-009");
+    }
+
     [Then("the response body should not contain {string}")]
     public async Task ThenTheResponseBodyShouldNotContain(string text)
     {

--- a/src/dms/tests/RestClient/multi-tenancy-setup.http
+++ b/src/dms/tests/RestClient/multi-tenancy-setup.http
@@ -291,7 +291,16 @@ Tenant: {{tenant1Name}}
 }
 
 ###
-@vendor1Id = {{createVendor1.response.body.id}}
+@vendor1Location={{createVendor1.response.headers.location}}
+
+### Retrieve Vendor for Tenant 1 to extract the Id
+# @name getVendor1
+GET {{vendor1Location}}
+Authorization: bearer {{configToken}}
+Tenant: {{tenant1Name}}
+
+###
+@vendor1Id={{getVendor1.response.body.id}}
 
 ### Create Application for Tenant 1 (with access to both school year instances)
 # @name createApp1
@@ -332,7 +341,16 @@ Tenant: {{tenant2Name}}
 }
 
 ###
-@vendor2Id = {{createVendor2.response.body.id}}
+@vendor2Location={{createVendor2.response.headers.location}}
+
+### Retrieve Vendor for Tenant 2 to extract the Id
+# @name getVendor2
+GET {{vendor2Location}}
+Authorization: bearer {{configToken}}
+Tenant: {{tenant2Name}}
+
+###
+@vendor2Id={{getVendor2.response.body.id}}
 
 ### Create Application for Tenant 2
 # @name createApp2

--- a/src/dms/tests/RestClient/openiddict-demonstration.http
+++ b/src/dms/tests/RestClient/openiddict-demonstration.http
@@ -51,8 +51,17 @@ Authorization: bearer {{configToken}}
     "namespacePrefixes": "uri://ed-fi.org"
 }
 
-### Read the newly-created Vendor ID from the response body
-@vendorId={{createVendor.response.body.id}}
+### Read the newly-created Vendor ID from the Location header
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### Create a DMS instance
 # @name createDmsInstance

--- a/src/dms/tests/RestClient/openiddict-demonstration.http
+++ b/src/dms/tests/RestClient/openiddict-demonstration.http
@@ -57,7 +57,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/openiddict-demonstration.http
+++ b/src/dms/tests/RestClient/openiddict-demonstration.http
@@ -54,7 +54,7 @@ Authorization: bearer {{configToken}}
 ### Read the newly-created Vendor ID from the Location header
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/test.InstanceRouting.http
+++ b/src/dms/tests/RestClient/test.InstanceRouting.http
@@ -185,7 +185,6 @@ Content-Type: application/json
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: Bearer {{configAccessToken}}
-Content-Type: application/json
 
 ###
 

--- a/src/dms/tests/RestClient/test.InstanceRouting.http
+++ b/src/dms/tests/RestClient/test.InstanceRouting.http
@@ -179,8 +179,17 @@ Content-Type: application/json
 }
 
 ###
+@vendorLocation={{vendor.response.headers.location}}
 
-@vendorId = {{vendor.response.body.id}}
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Authorization: Bearer {{configAccessToken}}
+Content-Type: application/json
+
+###
+
+@vendorId = {{getVendor.response.body.id}}
 
 ###############################################################################
 # STEP 5: Create Application

--- a/src/dms/tests/RestClient/test.InstanceRouting.http
+++ b/src/dms/tests/RestClient/test.InstanceRouting.http
@@ -181,7 +181,7 @@ Content-Type: application/json
 ###
 @vendorLocation={{vendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: Bearer {{configAccessToken}}

--- a/src/dms/tests/RestClient/test.link-injection.http
+++ b/src/dms/tests/RestClient/test.link-injection.http
@@ -88,7 +88,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/test.link-injection.http
+++ b/src/dms/tests/RestClient/test.link-injection.http
@@ -85,7 +85,7 @@ Authorization: bearer {{configToken}}
 ###
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/test.link-injection.http
+++ b/src/dms/tests/RestClient/test.link-injection.http
@@ -83,7 +83,16 @@ Authorization: bearer {{configToken}}
 }
 
 ###
-@vendorId={{createVendor.response.body.id}}
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### 1.3 Create a DMS instance pointing at the RELATIONAL database
 # @name createDmsInstance

--- a/src/dms/tests/RestClient/test.profile-filtering.http
+++ b/src/dms/tests/RestClient/test.profile-filtering.http
@@ -87,7 +87,7 @@ Authorization: bearer {{configToken}}
 ###
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/test.profile-filtering.http
+++ b/src/dms/tests/RestClient/test.profile-filtering.http
@@ -85,7 +85,16 @@ Authorization: bearer {{configToken}}
 }
 
 ###
-@vendorId={{createVendor.response.body.id}}
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### Step 5: Create a DMS Instance (if not using default)
 # @name createDmsInstance

--- a/src/dms/tests/RestClient/test.profile-filtering.http
+++ b/src/dms/tests/RestClient/test.profile-filtering.http
@@ -90,7 +90,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/test.profile-write.http
+++ b/src/dms/tests/RestClient/test.profile-write.http
@@ -74,7 +74,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/test.profile-write.http
+++ b/src/dms/tests/RestClient/test.profile-write.http
@@ -69,7 +69,16 @@ Authorization: bearer {{configToken}}
 }
 
 ###
-@vendorId={{createVendor.response.body.id}}
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### Step 5: DMS instance (relational backend)
 # @name createDmsInstance

--- a/src/dms/tests/RestClient/test.profile-write.http
+++ b/src/dms/tests/RestClient/test.profile-write.http
@@ -71,7 +71,7 @@ Authorization: bearer {{configToken}}
 ###
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/test.query-parameters.http
+++ b/src/dms/tests/RestClient/test.query-parameters.http
@@ -65,7 +65,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve Alpha vendor so that we can extract the Id
 # @name getVendorAlpha
 GET {{vendorAlphaLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/test.query-parameters.http
+++ b/src/dms/tests/RestClient/test.query-parameters.http
@@ -62,7 +62,7 @@ Authorization: bearer {{configToken}}
 ###
 @vendorAlphaLocation={{createVendorAlpha.response.headers.location}}
 
-### Retrieve Alpha vendor so that we can extract the Id
+### Retrieve Alpha vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendorAlpha
 GET {{vendorAlphaLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/test.query-parameters.http
+++ b/src/dms/tests/RestClient/test.query-parameters.http
@@ -60,7 +60,16 @@ Authorization: bearer {{configToken}}
 }
 
 ###
-@vendorAlphaId={{createVendorAlpha.response.body.id}}
+@vendorAlphaLocation={{createVendorAlpha.response.headers.location}}
+
+### Retrieve Alpha vendor so that we can extract the Id
+# @name getVendorAlpha
+GET {{vendorAlphaLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorAlphaId={{getVendorAlpha.response.body.id}}
 
 # @name createVendorMango
 POST http://localhost:{{configPort}}/v2/vendors

--- a/src/dms/tests/RestClient/testRelationalDelete.http
+++ b/src/dms/tests/RestClient/testRelationalDelete.http
@@ -57,7 +57,6 @@ Authorization: bearer {{configToken}}
 ### Retrieve the vendor so that we can extract the Id
 # @name getVendor
 GET {{vendorLocation}}
-Content-Type: application/json
 Authorization: bearer {{configToken}}
 
 ###

--- a/src/dms/tests/RestClient/testRelationalDelete.http
+++ b/src/dms/tests/RestClient/testRelationalDelete.http
@@ -54,7 +54,7 @@ Authorization: bearer {{configToken}}
 ###
 @vendorLocation={{createVendor.response.headers.location}}
 
-### Retrieve the vendor so that we can extract the Id
+### Retrieve the vendor to read the Id (POST returns no body per DMS-1081; id is the last segment of the Location header)
 # @name getVendor
 GET {{vendorLocation}}
 Authorization: bearer {{configToken}}

--- a/src/dms/tests/RestClient/testRelationalDelete.http
+++ b/src/dms/tests/RestClient/testRelationalDelete.http
@@ -52,7 +52,16 @@ Authorization: bearer {{configToken}}
 }
 
 ###
-@vendorId={{createVendor.response.body.id}}
+@vendorLocation={{createVendor.response.headers.location}}
+
+### Retrieve the vendor so that we can extract the Id
+# @name getVendor
+GET {{vendorLocation}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+###
+@vendorId={{getVendor.response.body.id}}
 
 ### 1.3 Create a DMS instance pointing at the RELATIONAL database
 # The connection string MUST target the dedicated relational database provisioned by


### PR DESCRIPTION
Aligns CMS POST /v2/vendors with the Admin API creation contract by returning 201 Created with a Location header and no response body.

Changes

- Updated Vendor creation to return 201 Created with a Location header pointing to the created vendor.
- Removed the previous success response body from Vendor POST.
- Updated OpenAPI metadata to document the 201 response and Location header.
- Added/updated unit coverage for Vendor POST status, header, empty body, and OpenAPI metadata.
- Updated REST client examples to retrieve the new vendor ID from the Location header instead of the POST response body.
- Testing

Targeted CMS frontend unit tests passed:

- VendorModuleTests
- OpenApi_Vendor_Post_201_Response_Documents_Location_Header