### PR TITLE
[DMS-1168] Emit dms.GetMaxChangeVersion() Function (PostgreSQL + SQL Server)

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/CoreDdlEmitterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/CoreDdlEmitterTests.cs
@@ -174,6 +174,56 @@ public class Given_CoreDdlEmitter_With_PgsqlDialect
     }
 
     [Test]
+    public void It_should_create_get_max_change_version_function()
+    {
+        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint");
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_after_change_version_sequence()
+    {
+        var sequence = _ddl.IndexOf(
+            "CREATE SEQUENCE IF NOT EXISTS \"dms\".\"ChangeVersionSequence\"",
+            StringComparison.Ordinal
+        );
+        var function = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+
+        sequence.Should().BeGreaterThan(0);
+        function.Should().BeGreaterThan(sequence);
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_before_phase_5_tables()
+    {
+        var function = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+        var phase5 = _ddl.IndexOf("Phase 5: Tables", StringComparison.Ordinal);
+
+        function.Should().BeGreaterThan(0);
+        function.Should().BeLessThan(phase5);
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_first_among_functions()
+    {
+        var getMax = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+        var throwError = _ddl.IndexOf("\"dms\".\"throw_error\"", StringComparison.Ordinal);
+        var uuidv5 = _ddl.IndexOf("\"dms\".\"uuidv5\"", StringComparison.Ordinal);
+
+        getMax.Should().BeLessThan(throwError);
+        throwError.Should().BeLessThan(uuidv5);
+    }
+
+    [Test]
+    public void It_should_bind_get_max_change_version_to_document_content_version_sequence()
+    {
+        // Document.ContentVersion defaults to nextval('"dms"."ChangeVersionSequence"').
+        // GetMaxChangeVersion must read from the same sequence so change-query
+        // semantics stay coherent.
+        _ddl.Should().Contain("DEFAULT nextval('\"dms\".\"ChangeVersionSequence\"')");
+        _ddl.Should().Contain("SELECT last_value FROM \"dms\".\"ChangeVersionSequence\" INTO result;");
+    }
+
+    [Test]
     public void It_should_not_emit_user_defined_table_types()
     {
         _ddl.Should().NotContain("CREATE TYPE");
@@ -783,19 +833,6 @@ public class Given_CoreDdlEmitter_With_MssqlDialect
     }
 
     [Test]
-    public void It_should_emit_go_batch_separator_before_uuidv5_function()
-    {
-        var functionIndex = _ddl.IndexOf("CREATE OR ALTER FUNCTION", StringComparison.Ordinal);
-        functionIndex.Should().BeGreaterOrEqualTo(0, "expected CREATE OR ALTER FUNCTION in DDL");
-        var goIndex = _ddl.LastIndexOf("GO\n", functionIndex);
-
-        goIndex.Should().BeGreaterOrEqualTo(0, "expected GO batch separator in DDL");
-        functionIndex.Should().BeGreaterThan(goIndex);
-        var between = _ddl.Substring(goIndex + 3, functionIndex - goIndex - 3);
-        between.Trim().Should().BeEmpty("GO should immediately precede CREATE OR ALTER FUNCTION");
-    }
-
-    [Test]
     public void It_should_emit_go_batch_separator_after_uuidv5_function_before_tables()
     {
         var functionIndex = _ddl.IndexOf("CREATE OR ALTER FUNCTION", StringComparison.Ordinal);
@@ -1323,5 +1360,81 @@ public class Given_CoreDdlEmitter_With_MssqlDialect
         {
             line.Should().Be(line.TrimEnd(), $"Line has trailing whitespace: [{line}]");
         }
+    }
+
+    [Test]
+    public void It_should_create_get_max_change_version_function()
+    {
+        _ddl.Should().Contain("CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()");
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_after_change_version_sequence()
+    {
+        var sequence = _ddl.IndexOf(
+            "CREATE SEQUENCE [dms].[ChangeVersionSequence]",
+            StringComparison.Ordinal
+        );
+        var function = _ddl.IndexOf("[dms].[GetMaxChangeVersion]", StringComparison.Ordinal);
+
+        sequence.Should().BeGreaterThan(0);
+        function.Should().BeGreaterThan(sequence);
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_before_uuidv5()
+    {
+        var getMax = _ddl.IndexOf("[dms].[GetMaxChangeVersion]", StringComparison.Ordinal);
+        var uuidv5 = _ddl.IndexOf("[dms].[uuidv5]", StringComparison.Ordinal);
+
+        getMax.Should().BeGreaterThan(0);
+        getMax.Should().BeLessThan(uuidv5);
+    }
+
+    [Test]
+    public void It_should_emit_get_max_change_version_before_phase_5_tables()
+    {
+        var function = _ddl.IndexOf("[dms].[GetMaxChangeVersion]", StringComparison.Ordinal);
+        var phase5 = _ddl.IndexOf("Phase 5: Tables", StringComparison.Ordinal);
+
+        function.Should().BeGreaterThan(0);
+        function.Should().BeLessThan(phase5);
+    }
+
+    [Test]
+    public void It_should_isolate_each_function_in_its_own_go_batch()
+    {
+        var search = 0;
+        var occurrences = 0;
+        while (true)
+        {
+            var idx = _ddl.IndexOf("CREATE OR ALTER FUNCTION", search, StringComparison.Ordinal);
+            if (idx < 0)
+            {
+                break;
+            }
+            occurrences++;
+
+            var goIdx = _ddl.LastIndexOf("GO\n", idx, StringComparison.Ordinal);
+            goIdx
+                .Should()
+                .BeGreaterOrEqualTo(0, "every CREATE OR ALTER FUNCTION must be preceded by a GO line");
+            var between = _ddl.Substring(goIdx + 3, idx - goIdx - 3);
+            between.Trim().Should().BeEmpty("GO should immediately precede CREATE OR ALTER FUNCTION");
+
+            search = idx + 1;
+        }
+
+        occurrences.Should().Be(2, "expected exactly two function batches: GetMaxChangeVersion and uuidv5");
+    }
+
+    [Test]
+    public void It_should_bind_get_max_change_version_to_document_content_version_sequence()
+    {
+        _ddl.Should()
+            .Contain(
+                "CONSTRAINT [DF_Document_ContentVersion] DEFAULT (NEXT VALUE FOR [dms].[ChangeVersionSequence])"
+            );
+        _ddl.Should().Contain("seq.name = 'ChangeVersionSequence' AND sch.name = 'dms'");
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/CoreDdlEmitterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/CoreDdlEmitterTests.cs
@@ -176,7 +176,7 @@ public class Given_CoreDdlEmitter_With_PgsqlDialect
     [Test]
     public void It_should_create_get_max_change_version_function()
     {
-        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint");
+        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION \"dms\".GetMaxChangeVersion() RETURNS bigint");
     }
 
     [Test]
@@ -186,7 +186,7 @@ public class Given_CoreDdlEmitter_With_PgsqlDialect
             "CREATE SEQUENCE IF NOT EXISTS \"dms\".\"ChangeVersionSequence\"",
             StringComparison.Ordinal
         );
-        var function = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+        var function = _ddl.IndexOf("\"dms\".GetMaxChangeVersion()", StringComparison.Ordinal);
 
         sequence.Should().BeGreaterThan(0);
         function.Should().BeGreaterThan(sequence);
@@ -195,7 +195,7 @@ public class Given_CoreDdlEmitter_With_PgsqlDialect
     [Test]
     public void It_should_emit_get_max_change_version_before_phase_5_tables()
     {
-        var function = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+        var function = _ddl.IndexOf("\"dms\".GetMaxChangeVersion()", StringComparison.Ordinal);
         var phase5 = _ddl.IndexOf("Phase 5: Tables", StringComparison.Ordinal);
 
         function.Should().BeGreaterThan(0);
@@ -205,7 +205,7 @@ public class Given_CoreDdlEmitter_With_PgsqlDialect
     [Test]
     public void It_should_emit_get_max_change_version_first_among_functions()
     {
-        var getMax = _ddl.IndexOf("dms.GetMaxChangeVersion()", StringComparison.Ordinal);
+        var getMax = _ddl.IndexOf("\"dms\".GetMaxChangeVersion()", StringComparison.Ordinal);
         var throwError = _ddl.IndexOf("\"dms\".\"throw_error\"", StringComparison.Ordinal);
         var uuidv5 = _ddl.IndexOf("\"dms\".\"uuidv5\"", StringComparison.Ordinal);
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/DdlManifestEmitterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/DdlManifestEmitterTests.cs
@@ -856,3 +856,71 @@ public class Given_DdlManifestEmitter_Emit_Manifest_Schema
             .Be("ef05371c08d966f2229348542ec66ce0eec906e411cdb9b7f4c3cd4c69bd82eb");
     }
 }
+
+[TestFixture]
+public class Given_DdlManifestEmitter_CountStatements_With_GetMaxChangeVersion_Pgsql
+{
+    private int _count;
+
+    [SetUp]
+    public void Setup()
+    {
+        var sql = """
+            CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+            $GetMaxChangeVersion$
+            DECLARE
+                result bigint;
+            BEGIN
+                SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+                RETURN result;
+            END
+            $GetMaxChangeVersion$ LANGUAGE plpgsql;
+            """;
+
+        _count = DdlManifestEmitter.CountStatements(SqlDialect.Pgsql, sql);
+    }
+
+    [Test]
+    public void It_should_count_function_definition_as_one_statement()
+    {
+        _count.Should().Be(1);
+    }
+}
+
+[TestFixture]
+public class Given_DdlManifestEmitter_CountStatements_With_Two_Mssql_Function_Batches
+{
+    private int _count;
+
+    [SetUp]
+    public void Setup()
+    {
+        var sql = """
+            GO
+            CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+            RETURNS bigint
+            AS
+            BEGIN
+                DECLARE @Result bigint;
+                SELECT @Result = 1;
+                RETURN @Result;
+            END;
+            GO
+            CREATE OR ALTER FUNCTION [dms].[uuidv5](@a uniqueidentifier)
+            RETURNS uniqueidentifier
+            AS
+            BEGIN
+                RETURN @a;
+            END;
+            GO
+            """;
+
+        _count = DdlManifestEmitter.CountStatements(SqlDialect.Mssql, sql);
+    }
+
+    [Test]
+    public void It_should_count_each_function_batch_as_a_separate_statement()
+    {
+        _count.Should().Be(2);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/DdlManifestEmitterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/DdlManifestEmitterTests.cs
@@ -866,7 +866,7 @@ public class Given_DdlManifestEmitter_CountStatements_With_GetMaxChangeVersion_P
     public void Setup()
     {
         var sql = """
-            CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+            CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
             $GetMaxChangeVersion$
             DECLARE
                 result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/auth-edorg-hierarchy.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/auth-edorg-hierarchy.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "682d0f9664ca4748a37c7312f0441cd00e999280c36548cc26e7d20102f2937c",
-      "statement_count": 98
+      "normalized_sql_sha256": "eadc97d9fae07edb32eb7d3fed02a29f6ce5a18cba9df5d3f1a774687745f0f8",
+      "statement_count": 99
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "300e0fffa2914631480cf15f5b757051c52cd4de089c1d47a2b1ed428534ea83",
-      "statement_count": 96
+      "normalized_sql_sha256": "901f5d337f8ac8279cb5e2a9b6daeb2659d0152f0d2691c39716e190258dbf1b",
+      "statement_count": 97
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/auth-people-views.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/auth-people-views.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "ec5492f2394cbdb594e6011ef785715d1c92e5733011211eaf648df79cf7395e",
-      "statement_count": 91
+      "normalized_sql_sha256": "132902c6a77dfb10084bbbcfc123d9a0d2a2842d1923dcd0d9f471d9de455490",
+      "statement_count": 92
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "61b410256f6c689aa5d610c80a3ee99455f3373a684e2dc28835273b34cb3203",
-      "statement_count": 67
+      "normalized_sql_sha256": "076b676fcca6b239c3919c08f1edca97a24823b9664a4090ed12667b258611bc",
+      "statement_count": 68
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/extension-mapping.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/extension-mapping.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "69969a7254ce47362b21ce9bcd1ff978977051a1449327e195631ad973d86fca",
-      "statement_count": 89
+      "normalized_sql_sha256": "7bb5212fc8fb4ea66a29a35ded5a6f38a6e32d8312f642078710a446d0e4cc3a",
+      "statement_count": 90
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "5b6695be3d2cf2bfca9da136591fa07a4e7dc8d8cd990597efe52a802fe9a45a",
-      "statement_count": 75
+      "normalized_sql_sha256": "311dbe67a4bd443728483fb8adceacb4480fbdd18efe6d9378309602df20354c",
+      "statement_count": 76
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/fk-support-index.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/fk-support-index.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "a1d867c1843f208faa525c5587861787601a3e6440aba157cb3063db677803ea",
-      "statement_count": 82
+      "normalized_sql_sha256": "786f885b17a1889845fde848c389d08e209cdf796d6f3dc4b9ae447081865ea1",
+      "statement_count": 83
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "55f9fcea7410f8fb079a47cbb32ae565ee559c010c940d5ae29c13b10886e0f9",
-      "statement_count": 62
+      "normalized_sql_sha256": "5ad405351cfb67462654867ad7cb3f3b14bdc3412e7b6f0c9450c2adc2da6e04",
+      "statement_count": 63
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/identity-propagation.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/identity-propagation.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "c35017d2f8fd1f1114144492a3f03c55567afc164fe7b5010e67a03feb510e54",
-      "statement_count": 84
+      "normalized_sql_sha256": "c7be4863666a74d1030681f6af5b72efdd16e40e808e90f2fe1b9261fd94f571",
+      "statement_count": 85
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "ce80804d924b6545145a46347ade032bdd0df4e40212922dbf81a3b49d0a907d",
-      "statement_count": 67
+      "normalized_sql_sha256": "e94dae01745125cfd7d2a5bfe5c8a81a9db53e8b66915aa750a8b5cb01638138",
+      "statement_count": 68
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/key-unification.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/key-unification.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "78c1d3cd0170417f9c7772d295330057195aceba7d568e443c2c9bfc32237b2b",
-      "statement_count": 85
+      "normalized_sql_sha256": "48df09385aa98e3b20315963dc2460d8701fdf0b928ac6e4e4aea18d7ef0541f",
+      "statement_count": 86
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "e32b335b33f21cb68636413a0f31017fed5f7828aaad762ca3a7ac37a96d4c0e",
-      "statement_count": 68
+      "normalized_sql_sha256": "c50ae51eb01b02d67c53e031c4f817ab5f43e8db8d213f4b54bb9028c4736565",
+      "statement_count": 69
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/nested-collections.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/nested-collections.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "d959cf4e23672b888d962c335df67a53f09b2b4d46841a12eb477adf0b0cd55a",
-      "statement_count": 84
+      "normalized_sql_sha256": "5a65dcdab20e4539496436f96d5712f0b5e030e671e41e65162e0c99e1a6a140",
+      "statement_count": 85
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "6c08de1351f03d970e3c4ba5ab4e55545ee304bc87876f07a3403464c08bbbd6",
-      "statement_count": 68
+      "normalized_sql_sha256": "e561ebd19a47249d259649a7f41099acb4b45b884724fdd22767e1521c973363",
+      "statement_count": 69
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/polymorphic-abstract.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/ddl-emission/expected/ddl-manifest/polymorphic-abstract.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "1bcb760f04ce2e5925a2a2e13bbf2069168773a28a17e3e8d9ba294cab7cca8c",
-      "statement_count": 90
+      "normalized_sql_sha256": "02807a5c166fce9d9fe5f0875423f0d432aaab44c51e96d76f8b31e9e5e41d3e",
+      "statement_count": 91
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "4fd61be838e35279132f07294d96b5e3aa6f7da6905059f943ab576fb0e21e99",
-      "statement_count": 78
+      "normalized_sql_sha256": "92320c70f56110c77cf30183d970e8ff1096d408ce030b78963e851e58f62956",
+      "statement_count": 79
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "9cc096c8f24adc592f3ac09f75c12569ba4c1bb3715cdbb6a6b4b79beb4e98d1",
-      "statement_count": 112
+      "normalized_sql_sha256": "b718ea02bd38a53006181a65b96669fcc24982b2226fb888282c522c21d7fde9",
+      "statement_count": 113
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "18555b84b07fa1f132348ab42a88c756ea1581a0fcb14068ba04db9ddfd86341",
-      "statement_count": 110
+      "normalized_sql_sha256": "9db27017cbbf2725c84380d3421845b22d627dabda00361b42a4c262cc6e8106",
+      "statement_count": 111
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/stable-key-extension-child-collections/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "0f2a7c75e532be0c8199ac7823bc6857fe27f8d9b7fcf3bdc8bb556382a41224",
-      "statement_count": 89
+      "normalized_sql_sha256": "83391cd1a34b6f793171a0d68c525a0f1d910174ee63bf51be54542c7236baa2",
+      "statement_count": 90
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "ec58b6dcd3397939b2f581aefb480bf77392ad7357b1ed6ffc43a6e21e7493ea",
-      "statement_count": 75
+      "normalized_sql_sha256": "9f5e10832ffa767dd8a1892d5b2e8c75c97edc8d79aa68adac1037a2e09d49c3",
+      "statement_count": 76
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/focused/top-level-reference-backed-collection/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "ad295a28575ae29db3ebf49af88c4e6db2cb873264caff1d448f1cbe1d055e65",
-      "statement_count": 91
+      "normalized_sql_sha256": "e58b815088ce41261821c3fe069023b83786a5baa3a10be67868e9017f0086cd",
+      "statement_count": 92
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "09a6bb12f175d9e1056ab8c649288597ac57d621018b647961333d90d77ee6df",
-      "statement_count": 77
+      "normalized_sql_sha256": "e1b364d950eaca6c0a6c4994722ca42e77d615eea274ca132e6bac9ca8a0ba39",
+      "statement_count": 78
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/ext/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "0479da6eff3df56e3b4b9f1a132b6ad41b500460418e9b3a962b904d4fea422f",
-      "statement_count": 79
+      "normalized_sql_sha256": "48185718ed4510ab1742d8905dcff74d3b6749fb4ed957e9fe2890ddebcfe58d",
+      "statement_count": 80
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "bb1c7d60d50c4c663dabde085acb13a230e7eb7800fe504d1e992cc29948a15d",
-      "statement_count": 59
+      "normalized_sql_sha256": "1f736bb517fcf60f7c8ae6f889549fa3a387e4b4f9ca3e728866466d2302c546",
+      "statement_count": 60
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/minimal/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "781ab56bb5fa59a2bfe62e7f3b99d6704ebbd7b50c1f7c888c4cb31d4da32474",
-      "statement_count": 79
+      "normalized_sql_sha256": "67a982c1b0fec98f7ce453350bbb7fa97d6c78602165bbd69ccb3fd83eed875e",
+      "statement_count": 80
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "e954eefc5e8557af74ed6ca6adfb3a84b4104389cdc2896869ab3b2b18d42892",
-      "statement_count": 59
+      "normalized_sql_sha256": "9d330bdf3172d3c413dd933be9fbe03f60eb5b2040bfc73e0853e656201e1e9f",
+      "statement_count": 60
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/naming-stress/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "e8c0ebebc6352a4f46a7006926cea5c3e29121f193ac55e7412f4cceba371c25",
-      "statement_count": 87
+      "normalized_sql_sha256": "37a36cdba25de0c964e7bccd46627279afc407bc69a9a2244687c2acf1f8e1d6",
+      "statement_count": 88
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "4da9dc05a8514a85d402bd763c0fbce0d6884ee59ddf449b422c5608a61e5557",
-      "statement_count": 71
+      "normalized_sql_sha256": "e139ca11ecc02c17e6ac299e024d793dbc352400bbc0e8086112d949c3e0ec33",
+      "statement_count": 72
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/nested/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/no-ddl-manifest/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "5c2045787d01bab183c43ea5544d563a6d88493cba56c833d084cc06861b850e",
-      "statement_count": 97
+      "normalized_sql_sha256": "345043dcdfaa1f7c6e85820bb99ab433787bdc46654887c59b278d5227893717",
+      "statement_count": 98
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "0aed0f85f5ac170dcb9f40aed6c90e0bc78bb5b97416edf1836925af91a35a36",
-      "statement_count": 93
+      "normalized_sql_sha256": "d227aa4217d972e05084b7badb5426158dbde1a0ebbf048886e4c73a3d3b5522",
+      "statement_count": 94
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/polymorphic/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "cee79c99ba8ffb241a2b011c6e2ba0c84076e0db8e0cac0745ab131432a58301",
-      "statement_count": 89
+      "normalized_sql_sha256": "8b3e2e9c23c71e154d3600ff01ba22a449313d1d53d856ca57e8af5656a1a6b0",
+      "statement_count": 90
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "5a1eec113a0faeca6e304882dae57005126af2fa78d30fe30d5a528f5cbc93b0",
-      "statement_count": 73
+      "normalized_sql_sha256": "683a80e0ec50054f949154be1c6913e10a2ea3d320550d0114383c952d9ab33e",
+      "statement_count": 74
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/profile-root-only-merge/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "65bac2c03bdcf81f4b86b8f42d692c841be58ea7d362b13405acaccfe6f10053",
-      "statement_count": 161
+      "normalized_sql_sha256": "3b9c5f68f0512000fe04ff375ca5dadf6b83188b6f6cdc0f8e0c2e5d908dc722",
+      "statement_count": 162
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "1aabbfafeeebb964ab4cedc62245f13ecacb8c44eb07e43c6ad7fa3307028e65",
-      "statement_count": 181
+      "normalized_sql_sha256": "b11d9b813a463fbd2774f4133c155402bc2f281711fafdf28f023a14ab55139c",
+      "statement_count": 182
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/Fixtures/small/referential-identity/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/MssqlDialectTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/MssqlDialectTests.cs
@@ -1352,3 +1352,55 @@ public class Given_MssqlDialect_Rendering_Numeric_Literals
         _dialect.RenderIntegerLiteral(0).Should().Be("0");
     }
 }
+
+[TestFixture]
+public class Given_MssqlDialect_Emitting_GetMaxChangeVersion_Function
+{
+    private string _ddl = default!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var dialect = new MssqlDialect(new MssqlDialectRules());
+        _ddl = dialect.CreateGetMaxChangeVersionFunction(new DbSchemaName("dms"));
+    }
+
+    [Test]
+    public void It_should_emit_create_or_alter_function_with_bracketed_name()
+    {
+        _ddl.Should().Contain("CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()");
+    }
+
+    [Test]
+    public void It_should_return_bigint()
+    {
+        _ddl.Should().Contain("RETURNS bigint");
+    }
+
+    [Test]
+    public void It_should_query_sys_sequences_joined_to_sys_schemas()
+    {
+        _ddl.Should().Contain("FROM sys.sequences seq");
+        _ddl.Should().Contain("INNER JOIN sys.schemas sch");
+        _ddl.Should().Contain("ON seq.schema_id = sch.schema_id");
+    }
+
+    [Test]
+    public void It_should_filter_by_sequence_name_and_schema_name()
+    {
+        _ddl.Should().Contain("WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms'");
+    }
+
+    [Test]
+    public void It_should_convert_current_value_to_bigint()
+    {
+        _ddl.Should().Contain("CONVERT(bigint, seq.current_value)");
+    }
+
+    [Test]
+    public void It_should_not_include_go_separators_inside_returned_text()
+    {
+        _ddl.Should().NotContain("GO\n");
+        _ddl.Should().NotContain("\nGO");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/PgsqlDialectTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/PgsqlDialectTests.cs
@@ -1151,7 +1151,7 @@ public class Given_PgsqlDialect_Emitting_GetMaxChangeVersion_Function
     [Test]
     public void It_should_emit_create_or_replace_function_with_unquoted_name()
     {
-        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion()");
+        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION \"dms\".GetMaxChangeVersion()");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/PgsqlDialectTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit/PgsqlDialectTests.cs
@@ -1135,3 +1135,52 @@ public class Given_PgsqlDialect_Rendering_Numeric_Literals
         _dialect.RenderIntegerLiteral(0).Should().Be("0");
     }
 }
+
+[TestFixture]
+public class Given_PgsqlDialect_Emitting_GetMaxChangeVersion_Function
+{
+    private string _ddl = default!;
+
+    [SetUp]
+    public void Setup()
+    {
+        var dialect = new PgsqlDialect(new PgsqlDialectRules());
+        _ddl = dialect.CreateGetMaxChangeVersionFunction(new DbSchemaName("dms"));
+    }
+
+    [Test]
+    public void It_should_emit_create_or_replace_function_with_unquoted_name()
+    {
+        _ddl.Should().Contain("CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion()");
+    }
+
+    [Test]
+    public void It_should_return_bigint()
+    {
+        _ddl.Should().Contain("RETURNS bigint");
+    }
+
+    [Test]
+    public void It_should_reference_quoted_change_version_sequence()
+    {
+        _ddl.Should().Contain("\"dms\".\"ChangeVersionSequence\"");
+    }
+
+    [Test]
+    public void It_should_select_last_value_into_result_variable()
+    {
+        _ddl.Should().Contain("SELECT last_value FROM \"dms\".\"ChangeVersionSequence\" INTO result;");
+    }
+
+    [Test]
+    public void It_should_use_named_dollar_quote_tag()
+    {
+        _ddl.Should().Contain("$GetMaxChangeVersion$");
+    }
+
+    [Test]
+    public void It_should_be_plpgsql()
+    {
+        _ddl.Should().Contain("LANGUAGE plpgsql;");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/CoreDdlEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/CoreDdlEmitter.cs
@@ -21,7 +21,7 @@ namespace EdFi.DataManagementService.Backend.Ddl;
 /// <item>Schemas</item>
 /// <item>Extensions (pgcrypto for PostgreSQL; no-op for SQL Server)</item>
 /// <item>Sequences</item>
-/// <item>Functions (UUIDv5 helper)</item>
+/// <item>Functions (GetMaxChangeVersion, UUIDv5 helper)</item>
 /// <item>Tables (PK / UNIQUE / CHECK inline; no cross-table FKs)</item>
 /// <item>Foreign keys (ALTER TABLE ADD CONSTRAINT)</item>
 /// <item>Indexes</item>
@@ -189,8 +189,9 @@ public sealed class CoreDdlEmitter(ISqlDialect dialect)
 
     /// <summary>
     /// Emits database functions and type definitions required by core infrastructure.
-    /// Includes the UUIDv5 helper (both dialects), the <c>throw_error</c> function
-    /// (PostgreSQL), and user-defined table types for authorization TVPs (SQL Server).
+    /// Includes the <c>GetMaxChangeVersion</c> helper and the UUIDv5 helper (both dialects),
+    /// the <c>throw_error</c> function (PostgreSQL), and user-defined table types for
+    /// authorization TVPs (SQL Server).
     /// </summary>
     private void EmitFunctions(SqlWriter writer)
     {
@@ -201,7 +202,11 @@ public sealed class CoreDdlEmitter(ISqlDialect dialect)
 
         if (_dialect.Rules.Dialect == SqlDialect.Mssql)
         {
-            // CREATE OR ALTER FUNCTION must be the first and only statement in a T-SQL batch.
+            // Each CREATE OR ALTER FUNCTION must be the first statement in its T-SQL
+            // batch. Alphabetical (case-insensitive) within Phase 4:
+            //   GetMaxChangeVersion -> uuidv5 -> BigIntTable -> UniqueIdentifierTable.
+            writer.AppendLine("GO");
+            writer.AppendLine(_dialect.CreateGetMaxChangeVersionFunction(DmsTableNames.DmsSchema));
             writer.AppendLine("GO");
             writer.AppendLine(_dialect.CreateUuidv5Function(DmsTableNames.DmsSchema));
             writer.AppendLine("GO");
@@ -229,7 +234,9 @@ public sealed class CoreDdlEmitter(ISqlDialect dialect)
             return;
         }
 
-        // PostgreSQL: functions (alphabetical)
+        // PostgreSQL: functions (alphabetical, case-insensitive)
+        writer.AppendLine(_dialect.CreateGetMaxChangeVersionFunction(DmsTableNames.DmsSchema));
+        writer.AppendLine();
         writer.AppendLine(_dialect.CreateThrowErrorFunction(DmsTableNames.DmsSchema));
         writer.AppendLine();
         writer.AppendLine(_dialect.CreateUuidv5Function(DmsTableNames.DmsSchema));

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/ISqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/ISqlDialect.cs
@@ -230,6 +230,23 @@ public interface ISqlDialect
     string CreateUuidv5Function(DbSchemaName schema);
 
     /// <summary>
+    /// Returns the DDL statement to create the <c>GetMaxChangeVersion</c> helper function in the
+    /// specified schema. The function returns the current value of
+    /// <c>dms.ChangeVersionSequence</c> as a <c>bigint</c> and is the backing query for the
+    /// <c>/changeQueries/v1/availableChangeVersions</c> endpoint.
+    /// </summary>
+    /// <remarks>
+    /// PostgreSQL emits the function name unquoted (case-folded to <c>getmaxchangeversion</c>)
+    /// so a call <c>SELECT dms.GetMaxChangeVersion()</c> resolves; the body references the
+    /// case-preserved sequence as <c>"dms"."ChangeVersionSequence"</c>. SQL Server emits
+    /// <c>[dms].[GetMaxChangeVersion]</c> with a body that reads <c>sys.sequences.current_value</c>.
+    /// SQL Server callers are responsible for surrounding <c>GO</c> batch separators.
+    /// </remarks>
+    /// <param name="schema">The schema to create the function in (typically "dms").</param>
+    /// <returns>The complete CREATE FUNCTION statement.</returns>
+    string CreateGetMaxChangeVersionFunction(DbSchemaName schema);
+
+    /// <summary>
     /// Returns the DDL statement to create the <c>throw_error</c> helper function used by
     /// batched authorization checks to abort a batch with a custom error code and message.
     /// PostgreSQL emits a <c>CREATE OR REPLACE FUNCTION</c> using <c>RAISE EXCEPTION</c>;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/MssqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/MssqlDialect.cs
@@ -326,6 +326,30 @@ public sealed class MssqlDialect : SqlDialectBase
     }
 
     /// <inheritdoc />
+    public override string CreateGetMaxChangeVersionFunction(DbSchemaName schema)
+    {
+        var qualifiedName = $"{QuoteIdentifier(schema.Value)}.{QuoteIdentifier("GetMaxChangeVersion")}";
+        var escapedSchema = schema.Value.Replace("'", "''");
+
+        // Reads sys.sequences.current_value; cannot use WITH SCHEMABINDING because
+        // system catalog views are not bindable. CoreDdlEmitter is responsible for
+        // wrapping this statement in its own GO batch.
+        return $"""
+            CREATE OR ALTER FUNCTION {qualifiedName}()
+            RETURNS bigint
+            AS
+            BEGIN
+                DECLARE @Result bigint;
+                SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+                INNER JOIN sys.schemas sch
+                ON seq.schema_id = sch.schema_id
+                WHERE seq.name = 'ChangeVersionSequence' AND sch.name = '{escapedSchema}';
+                RETURN @Result;
+            END;
+            """;
+    }
+
+    /// <inheritdoc />
     public override string CreateThrowErrorFunction(DbSchemaName schema)
     {
         // SQL Server does not use a throw_error function; authorization error

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
@@ -296,7 +296,7 @@ public sealed class PgsqlDialect : SqlDialectBase
         // resolves. The sequence reference is quoted because the sequence is created
         // with PascalCase preserved via QuoteIdentifier.
         return $"""
-            CREATE OR REPLACE FUNCTION {schema.Value}.GetMaxChangeVersion() RETURNS bigint AS
+            CREATE OR REPLACE FUNCTION {QuoteIdentifier(schema.Value)}.GetMaxChangeVersion() RETURNS bigint AS
             $GetMaxChangeVersion$
             DECLARE
                 result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/PgsqlDialect.cs
@@ -287,6 +287,28 @@ public sealed class PgsqlDialect : SqlDialectBase
     }
 
     /// <inheritdoc />
+    public override string CreateGetMaxChangeVersionFunction(DbSchemaName schema)
+    {
+        var quotedSequence = $"{QuoteIdentifier(schema.Value)}.{QuoteIdentifier("ChangeVersionSequence")}";
+
+        // Function name is intentionally unquoted: PostgreSQL case-folds it to
+        // 'getmaxchangeversion' so an unquoted call SELECT dms.GetMaxChangeVersion()
+        // resolves. The sequence reference is quoted because the sequence is created
+        // with PascalCase preserved via QuoteIdentifier.
+        return $"""
+            CREATE OR REPLACE FUNCTION {schema.Value}.GetMaxChangeVersion() RETURNS bigint AS
+            $GetMaxChangeVersion$
+            DECLARE
+                result bigint;
+            BEGIN
+                SELECT last_value FROM {quotedSequence} INTO result;
+                RETURN result;
+            END
+            $GetMaxChangeVersion$ LANGUAGE plpgsql;
+            """;
+    }
+
+    /// <inheritdoc />
     public override string CreateThrowErrorFunction(DbSchemaName schema)
     {
         var qualifiedName = $"{QuoteIdentifier(schema.Value)}.{QuoteIdentifier("throw_error")}";

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/SqlDialectBase.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Ddl/SqlDialectBase.cs
@@ -185,6 +185,9 @@ public abstract class SqlDialectBase : ISqlDialect
     public abstract string CreateUuidv5Function(DbSchemaName schema);
 
     /// <inheritdoc />
+    public abstract string CreateGetMaxChangeVersionFunction(DbSchemaName schema);
+
+    /// <inheritdoc />
     public abstract string CreateThrowErrorFunction(DbSchemaName schema);
 
     /// <inheritdoc />

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "e2e4f5cc007e91d7936cb060f0aa6156c5534d3b47e3d64dd82fd13362ae315a",
-      "statement_count": 88
+      "normalized_sql_sha256": "bc142ed1e9b194c9ffd9e39ff5c8b73ad47de3e1e3d29809ada0ab8522a8d5ee",
+      "statement_count": 89
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "d673d1c17342a8b7d52684ab9ddafc6b00e8afe5662792f32a89d10c9a4c3810",
-      "statement_count": 72
+      "normalized_sql_sha256": "1bd0ac6898d6e35bbf71298cafada49ead9aea1707fee10f33463e1c56fc057f",
+      "statement_count": 73
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-hidden-descendant/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "d8f81a0ad6f248684b0ddc6cdf15689f18de963946c6b072145c5bea5e1cf34c",
-      "statement_count": 95
+      "normalized_sql_sha256": "88a2aad369fc040feddfc2740cc4df20e1298963806e899b79fca069599fdda7",
+      "statement_count": 96
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "05308d0720e95290e626eb416d7c16005c247921bf2149c82d7f9a3ede813e0b",
-      "statement_count": 83
+      "normalized_sql_sha256": "32471a1ce2ffcff162e0bd96f115fd387f3bab06d1063a6cd48e6671319cfb3b",
+      "statement_count": 84
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension-with-doc-ref/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "753b38075ee49579d0bec88240b4fd42bc13f9c09048dbce6e404520a12571a5",
-      "statement_count": 95
+      "normalized_sql_sha256": "141f2de5c280fc37448c5d150dad2c27bb2549a4eed873c8ebc8af5386cecae4",
+      "statement_count": 96
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "f32657973298cd5ff7d7d2050e975a2d40e9072b661a52f76796b6547b7f7681",
-      "statement_count": 83
+      "normalized_sql_sha256": "243b9041293b22218409603a9f288ae4b1a915dc866961607b4b723950c7a74d",
+      "statement_count": 84
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-collection-aligned-extension/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/ddl.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "50c0fafa84f9682c3358fdb5a181ce686eb3a42eb8453ad1c64d31a60d1cc358",
-      "statement_count": 94
+      "normalized_sql_sha256": "0e3671bc76035eea5fe85cf4c8bda9e82c435f111c889aff977943abd3534d02",
+      "statement_count": 95
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "b63e8d10386209c43379e89286cc8d5e787501c16b1f41f0f0006e185551e7e2",
-      "statement_count": 82
+      "normalized_sql_sha256": "687f094d7f31ef4c534eef7f8ad25bf11d11828b03803b51dcf14f34876a48e1",
+      "statement_count": 83
     }
   ]
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/mssql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/mssql.sql
@@ -46,6 +46,18 @@ CREATE SEQUENCE [dms].[CollectionItemIdSequence] START WITH 1;
 -- ==========================================================
 
 GO
+CREATE OR ALTER FUNCTION [dms].[GetMaxChangeVersion]()
+RETURNS bigint
+AS
+BEGIN
+    DECLARE @Result bigint;
+    SELECT @Result = CONVERT(bigint, seq.current_value) FROM sys.sequences seq
+    INNER JOIN sys.schemas sch
+    ON seq.schema_id = sch.schema_id
+    WHERE seq.name = 'ChangeVersionSequence' AND sch.name = 'dms';
+    RETURN @Result;
+END;
+GO
 CREATE OR ALTER FUNCTION [dms].[uuidv5](@namespace_uuid uniqueidentifier, @name_text nvarchar(max))
 RETURNS uniqueidentifier
 WITH SCHEMABINDING

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/pgsql.sql
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.IntegrationFixtures/profile-nested-and-root-extension-children/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/DatabaseSetupFixture.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/DatabaseSetupFixture.cs
@@ -40,7 +40,9 @@ public class DatabaseSetupFixture
         var schema = new DbSchemaName("dms");
 
         var createSchema = dialect.CreateSchemaIfNotExists(schema);
-        var createFunction = dialect.CreateUuidv5Function(schema);
+        var createSequence = dialect.CreateSequenceIfNotExists(schema, "ChangeVersionSequence");
+        var createGetMax = dialect.CreateGetMaxChangeVersionFunction(schema);
+        var createUuidv5 = dialect.CreateUuidv5Function(schema);
 
         await using SqlConnection connection = new(connectionString);
         await connection.OpenAsync();
@@ -51,8 +53,19 @@ public class DatabaseSetupFixture
             await cmd.ExecuteNonQueryAsync();
         }
 
-        // CREATE OR ALTER FUNCTION must be in its own batch — no transaction needed
-        await using (var cmd = new SqlCommand(createFunction, connection))
+        // Sequence must exist before GetMaxChangeVersion is invoked.
+        await using (var cmd = new SqlCommand(createSequence, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        // Each CREATE OR ALTER FUNCTION goes in its own SqlCommand (no GO in command text).
+        await using (var cmd = new SqlCommand(createGetMax, connection))
+        {
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        await using (var cmd = new SqlCommand(createUuidv5, connection))
         {
             await cmd.ExecuteNonQueryAsync();
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/GetMaxChangeVersionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/GetMaxChangeVersionTests.cs
@@ -78,6 +78,7 @@ public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVers
     [SetUp]
     public async Task Setup()
     {
+        await ResetSequenceToStart();
         await AdvanceSequence(3);
         Result = await CallFunction();
     }
@@ -85,7 +86,7 @@ public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVers
     [Test]
     public void It_should_return_the_last_allocated_value()
     {
-        Result.Should().BeGreaterOrEqualTo(3L);
+        Result.Should().Be(3L);
     }
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/GetMaxChangeVersionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/GetMaxChangeVersionTests.cs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Verifies the emitted dms.GetMaxChangeVersion() function tracks dms.ChangeVersionSequence
+/// via sys.sequences.current_value.
+/// </summary>
+public abstract class GetMaxChangeVersionTestBase
+{
+    protected long Result { get; set; }
+
+    public static async Task<long> CallFunction()
+    {
+        await using SqlConnection connection = new(Uuidv5ParityTestBase.ConnectionString);
+        await connection.OpenAsync();
+        await using SqlCommand cmd = new("SELECT dms.GetMaxChangeVersion()", connection);
+        var result = await cmd.ExecuteScalarAsync();
+        return (long)result!;
+    }
+
+    public static async Task AdvanceSequence(int times)
+    {
+        await using SqlConnection connection = new(Uuidv5ParityTestBase.ConnectionString);
+        await connection.OpenAsync();
+        for (var i = 0; i < times; i++)
+        {
+            await using SqlCommand cmd = new(
+                "SELECT NEXT VALUE FOR [dms].[ChangeVersionSequence]",
+                connection
+            );
+            await cmd.ExecuteScalarAsync();
+        }
+    }
+
+    // Resets the sequence so a sibling fixture that advanced it does not contaminate
+    // assertions that depend on the fresh start state.
+    public static async Task ResetSequenceToStart()
+    {
+        await using SqlConnection connection = new(Uuidv5ParityTestBase.ConnectionString);
+        await connection.OpenAsync();
+        await using SqlCommand cmd = new("ALTER SEQUENCE [dms].[ChangeVersionSequence] RESTART", connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Fresh_ChangeVersionSequence : GetMaxChangeVersionTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await ResetSequenceToStart();
+        Result = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_start_value_one()
+    {
+        // Per Microsoft sys.sequences docs, current_value returns START WITH
+        // if the sequence has never been used.
+        Result.Should().Be(1L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVersionTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await AdvanceSequence(3);
+        Result = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_the_last_allocated_value()
+    {
+        Result.Should().BeGreaterOrEqualTo(3L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Two_Consecutive_Calls_Without_Advancing : GetMaxChangeVersionTestBase
+{
+    private long _first;
+    private long _second;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _first = await CallFunction();
+        _second = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_the_same_value_on_both_calls()
+    {
+        _second.Should().Be(_first);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseSetupFixture.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/DatabaseSetupFixture.cs
@@ -28,7 +28,9 @@ public class DatabaseSetupFixture
 
         var createSchema = dialect.CreateSchemaIfNotExists(schema);
         var createExtension = dialect.CreateExtensionIfNotExists("pgcrypto");
-        var createFunction = dialect.CreateUuidv5Function(schema);
+        var createSequence = dialect.CreateSequenceIfNotExists(schema, "ChangeVersionSequence");
+        var createUuidv5 = dialect.CreateUuidv5Function(schema);
+        var createGetMax = dialect.CreateGetMaxChangeVersionFunction(schema);
 
         var dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
 
@@ -46,7 +48,17 @@ public class DatabaseSetupFixture
                 await cmd.ExecuteNonQueryAsync();
             }
 
-            await using (var cmd = new NpgsqlCommand(createFunction, connection))
+            await using (var cmd = new NpgsqlCommand(createSequence, connection))
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            await using (var cmd = new NpgsqlCommand(createUuidv5, connection))
+            {
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            await using (var cmd = new NpgsqlCommand(createGetMax, connection))
             {
                 await cmd.ExecuteNonQueryAsync();
             }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetMaxChangeVersionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetMaxChangeVersionTests.cs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Verifies the emitted dms.GetMaxChangeVersion() function tracks dms.ChangeVersionSequence.
+/// Calls via the unquoted name 'dms.GetMaxChangeVersion()' so the case-folded catalog entry
+/// is exercised.
+/// </summary>
+public abstract class GetMaxChangeVersionTestBase
+{
+    protected long Result { get; set; }
+
+    public static async Task<long> CallFunction()
+    {
+        await using var connection = await Uuidv5ParityTestBase.DataSource.OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand("SELECT dms.GetMaxChangeVersion()", connection);
+        var result = await cmd.ExecuteScalarAsync();
+        return (long)result!;
+    }
+
+    public static async Task AdvanceSequence(int times)
+    {
+        await using var connection = await Uuidv5ParityTestBase.DataSource.OpenConnectionAsync();
+        for (var i = 0; i < times; i++)
+        {
+            await using var cmd = new NpgsqlCommand(
+                "SELECT nextval('\"dms\".\"ChangeVersionSequence\"')",
+                connection
+            );
+            await cmd.ExecuteScalarAsync();
+        }
+    }
+
+    // Resets the sequence so a sibling fixture that advanced it does not contaminate
+    // assertions that depend on the fresh start state.
+    public static async Task ResetSequenceToStart()
+    {
+        await using var connection = await Uuidv5ParityTestBase.DataSource.OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand(
+            "ALTER SEQUENCE \"dms\".\"ChangeVersionSequence\" RESTART",
+            connection
+        );
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Fresh_ChangeVersionSequence : GetMaxChangeVersionTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await ResetSequenceToStart();
+        Result = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_start_value_one()
+    {
+        // PG last_value on a sequence with is_called=false returns START WITH.
+        // dms.ChangeVersionSequence is created with START WITH 1.
+        Result.Should().Be(1L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVersionTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await AdvanceSequence(3);
+        Result = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_the_last_allocated_value()
+    {
+        Result.Should().BeGreaterOrEqualTo(3L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Two_Consecutive_Calls_Without_Advancing : GetMaxChangeVersionTestBase
+{
+    private long _first;
+    private long _second;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        _first = await CallFunction();
+        _second = await CallFunction();
+    }
+
+    [Test]
+    public void It_should_return_the_same_value_on_both_calls()
+    {
+        _second.Should().Be(_first);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetMaxChangeVersionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/GetMaxChangeVersionTests.cs
@@ -79,6 +79,7 @@ public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVers
     [SetUp]
     public async Task Setup()
     {
+        await ResetSequenceToStart();
         await AdvanceSequence(3);
         Result = await CallFunction();
     }
@@ -86,7 +87,7 @@ public class Given_ChangeVersionSequence_Advanced_Three_Times : GetMaxChangeVers
     [Test]
     public void It_should_return_the_last_allocated_value()
     {
-        Result.Should().BeGreaterOrEqualTo(3L);
+        Result.Should().Be(3L);
     }
 }
 

--- a/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/ddl.manifest.json
+++ b/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "2a34014e386c7c8dac0969fa48a3fcaf2831efcf28953dc3dca7bab9c3c31331",
-      "statement_count": 4043
+      "normalized_sql_sha256": "445116b5ee3b3ebeb911c62c4a45625f6b5ecf072c8cf6530d2a903e800e8ceb",
+      "statement_count": 4044
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "1707a039c44c922cdfd393202c29801e49ef7f615b88c5924141f9eb85eb3734",
-      "statement_count": 5304
+      "normalized_sql_sha256": "e07121470fb6e8e4887974393b44ad0968b232b1b4e798644f61093eaebc4941",
+      "statement_count": 5305
     }
   ]
 }

--- a/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/pgsql.sql
+++ b/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/pgsql.sql
+++ b/src/dms/backend/Fixtures/authoritative/ds-5.2/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql

--- a/src/dms/backend/Fixtures/authoritative/sample/expected/ddl.manifest.json
+++ b/src/dms/backend/Fixtures/authoritative/sample/expected/ddl.manifest.json
@@ -4,13 +4,13 @@
   "ddl": [
     {
       "dialect": "mssql",
-      "normalized_sql_sha256": "9b0fd2787e37b6fb920267713e7cfe9865d245dfa437f9b74786cb571618d5b2",
-      "statement_count": 4330
+      "normalized_sql_sha256": "b977c848004135ece104501505385a95fa0747c251c1057d05b6c9d158076a24",
+      "statement_count": 4331
     },
     {
       "dialect": "pgsql",
-      "normalized_sql_sha256": "8a43a376d2336fe0240d985b02e82b846702b1ab6f445c21b1bcbfae7c388105",
-      "statement_count": 5713
+      "normalized_sql_sha256": "c2a1cfc41cf017ec390315ab0cf20c2023ef117dbdbdb3c6db174179ecf941be",
+      "statement_count": 5714
     }
   ]
 }

--- a/src/dms/backend/Fixtures/authoritative/sample/expected/pgsql.sql
+++ b/src/dms/backend/Fixtures/authoritative/sample/expected/pgsql.sql
@@ -40,7 +40,7 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
-CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+CREATE OR REPLACE FUNCTION "dms".GetMaxChangeVersion() RETURNS bigint AS
 $GetMaxChangeVersion$
 DECLARE
     result bigint;

--- a/src/dms/backend/Fixtures/authoritative/sample/expected/pgsql.sql
+++ b/src/dms/backend/Fixtures/authoritative/sample/expected/pgsql.sql
@@ -40,6 +40,16 @@ CREATE SEQUENCE IF NOT EXISTS "dms"."CollectionItemIdSequence" START WITH 1;
 -- Phase 4: Functions and Types
 -- ==========================================================
 
+CREATE OR REPLACE FUNCTION dms.GetMaxChangeVersion() RETURNS bigint AS
+$GetMaxChangeVersion$
+DECLARE
+    result bigint;
+BEGIN
+    SELECT last_value FROM "dms"."ChangeVersionSequence" INTO result;
+    RETURN result;
+END
+$GetMaxChangeVersion$ LANGUAGE plpgsql;
+
 CREATE OR REPLACE FUNCTION "dms"."throw_error"(code text, msg text)
 RETURNS integer
 LANGUAGE plpgsql


### PR DESCRIPTION
## Summary

- Emits a new `dms.GetMaxChangeVersion()` core DDL function in both PostgreSQL and SQL Server, returning the current value of `dms.ChangeVersionSequence` as `bigint`. This is the backing query for the future `/changeQueries/v1/availableChangeVersions` endpoint.
- Adds the function to Phase 4 of `CoreDdlEmitter`, alphabetically ordered, after the Phase 3 sequence creation, mirroring the `dms.uuidv5` precedent from DMS-946.
- Regenerates all affected DDL golden fixtures, the authoritative ds-5.2/sample fixtures, and both SchemaTools provisioned-schema manifest goldens.

## Implementation notes

- PostgreSQL: emits the function name unquoted (`dms.GetMaxChangeVersion()`) so PG case-folds it to `getmaxchangeversion`, letting the Jira-AC call `SELECT dms.GetMaxChangeVersion()` resolve. The sequence reference inside the body is quoted (`"dms"."ChangeVersionSequence"`) because the sequence is created with PascalCase preserved.
- SQL Server: emits `[dms].[GetMaxChangeVersion]()` with the function body querying `sys.sequences.current_value` joined to `sys.schemas`. Each `CREATE OR ALTER FUNCTION` in the emitter is isolated with `GO` batch separators; the new function uses a single `GO` between itself and `uuidv5` (no `GO\nGO` adjacency).
- Both function bodies match the ODS reference implementation verbatim with only the schema name substituted from `changes` to `dms`.

## Test coverage

- **Dialect unit tests:** new `Given_*_Emitting_GetMaxChangeVersion_Function` fixtures in `PgsqlDialectTests` / `MssqlDialectTests` covering CREATE header, return type, sequence reference, named dollar-quote tag (PG), and catalog WHERE clause (MSSQL).
- **CoreDdlEmitter unit tests:** new assertions covering Phase 4 alphabetical ordering, sequence-before-function ordering, function-before-tables ordering, and `It_should_isolate_each_function_in_its_own_go_batch` which enforces single-`GO` batch isolation for both `GetMaxChangeVersion` and `uuidv5`. New `It_should_bind_get_max_change_version_to_document_content_version_sequence` test pins the semantic contract that the function reads from the same sequence used by `Document.ContentVersion` defaults.
- **Manifest counter tests:** new `DdlManifestEmitterTests` fixtures pin that the PG `$GetMaxChangeVersion$` dollar-quote block counts as one statement and that two MSSQL function batches count as two statements.
- **Integration tests:** new `GetMaxChangeVersionTests.cs` in both `Backend.Postgresql.Tests.Integration` and `Backend.Mssql.Tests.Integration`. Cases: fresh sequence (returns 1 on both engines, with sequence RESTART in SetUp for parallel-safe ordering), advanced N times (returns ≥ N), and idempotent (two consecutive reads equal). All three fixtures marked `[NonParallelizable]` per the project convention for shared-state mutators.
- Both `DatabaseSetupFixture`s now provision `dms.ChangeVersionSequence` before the function.

## Test plan

- [x] `dotnet build src/dms/EdFi.DataManagementService.sln` — green.
- [x] `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Ddl.Tests.Unit` — 848 pass, 1 skip, 0 fail.
- [x] `dotnet test src/dms/clis/EdFi.DataManagementService.SchemaTools.Tests.Integration --filter "FullyQualifiedName~Given_Provisioned_*_Database_When_Introspecting_Schema"` — both engines green individually.
- [ ] PG and MSSQL integration GetMaxChangeVersion tests against the reviewer's local databases — run with `dotnet test src/dms/backend/EdFi.DataManagementService.Backend.{Postgresql,Mssql}.Tests.Integration --filter "FullyQualifiedName~GetMaxChangeVersion"`.
- [ ] Full E2E smoke against a freshly provisioned local stack.

## Acceptance criteria

- [x] DDL generation emits `dms.GetMaxChangeVersion()` for both PostgreSQL and SQL Server.
- [x] Matches the ODS reference implementation with only the schema changed from `changes` to `dms`.
- [x] DDL ordering ensures `dms.GetMaxChangeVersion()` is created after `dms.ChangeVersionSequence` (Phase 3 → Phase 4).
- [x] A direct call `SELECT dms.GetMaxChangeVersion()` returns the expected `bigint` value on both engines (covered by the new integration tests).