### PR TITLE
[DMS-1057] Implement Namespace-based Authorization Strategy

### DIFF
--- a/reference/design/backend-redesign/epics/14-authorization/08-namespace-auth-strategy.md
+++ b/reference/design/backend-redesign/epics/14-authorization/08-namespace-auth-strategy.md
@@ -21,9 +21,9 @@ Implement the namespace-based authorization strategy for all CRUD operations per
   - First, authorize using the currently stored namespace value (abort if unauthorized).
   - Second, authorize using the new namespace value from the request body (abort if unauthorized).
 - DELETE: An authorization check is executed against the stored namespace value before deletion. If unauthorized, the delete does not happen and a 403 Forbidden response is returned.
-- The namespace column to check is resolved from the resource's Namespace securable element in ApiSchema.json. The column is directly available on whichever table owns the reference, with no transitive joins needed. For non-nested paths this is the root resource table; for array-nested paths this is the child collection table that owns the reference.
+- Runtime NamespaceBased authorization checks the namespace assigned to the root entity per `auth.md`; resolve a usable root resource table namespace column and fail closed if one is not available. Array-nested Namespace securable paths are still resolved for physical column/index emission on the child collection table that owns the reference, but that index/resolution requirement does not make those child tables runtime authorization subjects.
 - When authorization fails, an AUTH1 error is thrown with the strategy index in the message (e.g., 'Unauthorized, index: 0'), aborting the batch and allowing C# to map the failure to the correct strategy for ProblemDetails.
-- Auth checks are batched in the same DB roundtrip as other statements (reconstitution, insert, delete, etc.) to match the roundtrip targets in the design doc.
+- Auth checks execute before mutation/reconstitution exposure and preserve auth-before-precondition ordering. Provider-command co-batching with persistence or hydration remains a backend-wide roundtrip optimization, not a required deliverable for this story, as long as the same correctness boundary is preserved.
 - Works for both PostgreSQL and SQL Server:
   - PostgreSQL: Use `LIKE ANY(ARRAY[...])` with parameterized prefix values.
   - SQL Server: When the client has fewer than 2,000 namespace prefixes, use parameterized OR chains of LIKE clauses. When >= 2,000, throw an error (no TVP is used for namespace prefixes).
@@ -83,7 +83,7 @@ Remove the DMS-1057 TODO comments in:
   - `DeleteDocumentById`
   - the non-If-Match DELETE execution branch in `DeleteDocumentByIdAsync`
 
-The restored behavior should run in the same transactional/roundtrip shape as the write operation:
+The restored behavior should run in the same transactional/session correctness shape as the write operation:
 
 - POST create: authorize the proposed namespace from the request body before insert.
 - POST upsert-as-update: authorize the stored namespace first, then authorize the proposed namespace before update.

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json
@@ -5134,7 +5134,7 @@
                       "name": "RelationshipsWithEdOrgsOnly"
                     },
                     {
-                      "name": "NamespaceBased"
+                      "name": "OwnershipBased"
                     }
                   ]
                 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/003c-edorgsonly-mixed-claimset.json
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/003c-edorgsonly-mixed-claimset.json
@@ -35,7 +35,7 @@
             },
             {
               "authStrategyId": 1,
-              "name": "NamespaceBased",
+              "name": "OwnershipBased",
               "isInheritedFromParent": false
             }
           ]
@@ -51,7 +51,7 @@
             },
             {
               "authStrategyId": 2,
-              "name": "NamespaceBased",
+              "name": "OwnershipBased",
               "isInheritedFromParent": false
             }
           ]
@@ -67,7 +67,7 @@
             },
             {
               "authStrategyId": 2,
-              "name": "NamespaceBased",
+              "name": "OwnershipBased",
               "isInheritedFromParent": false
             }
           ]
@@ -83,7 +83,7 @@
             },
             {
               "authStrategyId": 1,
-              "name": "NamespaceBased",
+              "name": "OwnershipBased",
               "isInheritedFromParent": false
             }
           ]
@@ -99,7 +99,7 @@
             },
             {
               "authStrategyId": 9,
-              "name": "NamespaceBased",
+              "name": "OwnershipBased",
               "isInheritedFromParent": false
             }
           ]

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/README.md
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/README.md
@@ -56,7 +56,7 @@ Fragment files must follow this naming pattern:
 **Claim Set Name**: `E2E-RelationshipsWithEdOrgsOnlyMixedStrategyClaimSet`
 - Demonstrates the staged DMS-1055 fail-fast behavior for known unsupported mixed GET-many strategies
 - Includes resource: academicWeeks
-- Authorization: RelationshipsWithEdOrgsOnly plus NamespaceBased
+- Authorization: RelationshipsWithEdOrgsOnly plus OwnershipBased
 
 ### 004-sample-extension-claimset.json
 **Claim Set Name**: `SampleExtensionResourceClaims`

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
@@ -8,13 +8,21 @@ using System.Globalization;
 namespace EdFi.DataManagementService.Backend.External;
 
 /// <summary>
-/// Single source for the two namespace-authorization security-configuration (HTTP 500) messages.
+/// Single source for the namespace-authorization security-configuration (HTTP 500) messages.
 /// Both the relational backend (when building the <c>Errors</c> array of a security-configuration
 /// result) and Core's ProblemDetails formatter reference these so the wording stays identical
 /// regardless of which layer produces the response.
 /// </summary>
 public static class NamespaceAuthorizationSecurityConfigurationMessages
 {
+    /// <summary>
+    /// A configured namespace prefix is null or empty, which cannot be parameterized into a <c>LIKE</c>
+    /// predicate for <c>NamespaceBased</c> authorization. Fails closed as a security-configuration
+    /// (HTTP 500) rather than escaping as a generic unknown failure from the parameterization factory.
+    /// </summary>
+    public const string InvalidNamespacePrefix =
+        "The API client's NamespaceBased authorization is configured with a null or empty namespace prefix, which cannot be used to authorize access. Configure non-empty namespace prefixes.";
+
     /// <summary>
     /// The namespace authorization failure payload returned by the authorization provider (the AUTH1
     /// <c>ns1|index|kind</c> metadata) is invalid and cannot be mapped to the configured namespace
@@ -44,18 +52,21 @@ public static class NamespaceAuthorizationSecurityConfigurationMessages
         );
 
     /// <summary>
-    /// The client's namespace prefixes and authorization education organization ids together exceed the
-    /// number of parameters SQL Server can bind for a single query that composes <c>NamespaceBased</c> and
-    /// relationship-based authorization, even though each list is within its own per-list limit.
+    /// The query's authorization parameters (namespace prefixes and/or authorization education organization
+    /// ids) together with its filter and paging parameters exceed the number of parameters SQL Server can
+    /// bind for a single command, even though each authorization list is within its own per-list limit.
+    /// Applies to namespace-only, relationship-only, and composed query shapes.
     /// </summary>
-    public static string CombinedAuthorizationParameterCapExceeded(
+    public static string CommandParameterCapExceeded(
         int namespacePrefixCount,
-        int claimEducationOrganizationIdCount
+        int claimEducationOrganizationIdCount,
+        int nonAuthorizationParameterCount
     ) =>
         string.Format(
             CultureInfo.InvariantCulture,
-            "The API client has {0} namespace prefixes and {1} authorization education organization ids, which together exceed the SQL Server parameter limit for combining NamespaceBased and relationship authorization on a single query. Configure fewer namespace prefixes or reduce the client's authorized education organizations.",
+            "The API client has {0} namespace prefixes and {1} authorization education organization ids, which together with {2} query and paging parameters exceed the SQL Server parameter limit for a single query. Configure fewer namespace prefixes, reduce the client's authorized education organizations, or use fewer query parameters.",
             namespacePrefixCount,
-            claimEducationOrganizationIdCount
+            claimEducationOrganizationIdCount,
+            nonAuthorizationParameterCount
         );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
@@ -32,4 +32,20 @@ public static class NamespaceAuthorizationSecurityConfigurationMessages
             "The API client has {0} namespace prefixes, which exceeds the SQL Server limit for NamespaceBased authorization. Configure fewer than 2,000 namespace prefixes.",
             prefixCount
         );
+
+    /// <summary>
+    /// The client's namespace prefixes and authorization education organization ids together exceed the
+    /// number of parameters SQL Server can bind for a single query that composes <c>NamespaceBased</c> and
+    /// relationship-based authorization, even though each list is within its own per-list limit.
+    /// </summary>
+    public static string CombinedAuthorizationParameterCapExceeded(
+        int namespacePrefixCount,
+        int claimEducationOrganizationIdCount
+    ) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "The API client has {0} namespace prefixes and {1} authorization education organization ids, which together exceed the SQL Server parameter limit for combining NamespaceBased and relationship authorization on a single query. Configure fewer namespace prefixes or reduce the client's authorized education organizations.",
+            namespacePrefixCount,
+            claimEducationOrganizationIdCount
+        );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
@@ -16,6 +16,16 @@ namespace EdFi.DataManagementService.Backend.External;
 public static class NamespaceAuthorizationSecurityConfigurationMessages
 {
     /// <summary>
+    /// The namespace authorization failure payload returned by the authorization provider (the AUTH1
+    /// <c>ns1|index|kind</c> metadata) is invalid and cannot be mapped to the configured namespace
+    /// authorization plan. Mirrors the relationship authorization invalid-payload diagnostic so a
+    /// malformed namespace AUTH1 payload fails closed as a security-configuration (HTTP 500) rather than
+    /// a generic unknown failure.
+    /// </summary>
+    public const string InvalidAuthorizationMetadata =
+        "The namespace authorization failure payload returned by the authorization provider is invalid and cannot be mapped to the configured namespace authorization plan.";
+
+    /// <summary>
     /// A resource is configured with <c>NamespaceBased</c> but no Namespace securable element resolves
     /// to a root-table column.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/NamespaceAuthorizationSecurityConfigurationMessages.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.External;
+
+/// <summary>
+/// Single source for the two namespace-authorization security-configuration (HTTP 500) messages.
+/// Both the relational backend (when building the <c>Errors</c> array of a security-configuration
+/// result) and Core's ProblemDetails formatter reference these so the wording stays identical
+/// regardless of which layer produces the response.
+/// </summary>
+public static class NamespaceAuthorizationSecurityConfigurationMessages
+{
+    /// <summary>
+    /// A resource is configured with <c>NamespaceBased</c> but no Namespace securable element resolves
+    /// to a root-table column.
+    /// </summary>
+    public static string NoUsableRootColumn(string resourceName) =>
+        $"The resource '{resourceName}' is configured with the 'NamespaceBased' authorization strategy, but no Namespace securable element resolves to a root table column. Collection-level Namespace paths are not eligible for namespace authorization.";
+
+    /// <summary>
+    /// The client has more namespace prefixes than SQL Server can bind as parameterized <c>LIKE</c>
+    /// clauses for <c>NamespaceBased</c> authorization.
+    /// </summary>
+    public static string PrefixCapExceeded(int prefixCount) =>
+        string.Format(
+            CultureInfo.InvariantCulture,
+            "The API client has {0} namespace prefixes, which exceeds the SQL Server limit for NamespaceBased authorization. Configure fewer than 2,000 namespace prefixes.",
+            prefixCount
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadGetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadGetTests.cs
@@ -200,7 +200,7 @@ public class Given_A_Mssql_DescriptorRead_Get_Request
             .Should()
             .BeEquivalentTo(
                 new GetResult.GetFailureNotImplemented(
-                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
                 )
             );
     }
@@ -248,7 +248,11 @@ public class Given_A_Mssql_DescriptorRead_Get_Request
 
         var failure = result.Should().BeOfType<GetResult.UnknownFailure>().Subject;
         failure.FailureMessage.Should().Contain($"DocumentId {documentId}");
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // The row reader treats Namespace as nullable so a stored null can flow into the
+        // namespace-authorization stored-namespace-uninitialized 403; CodeValue is the next
+        // required column, so the reader's invariant message names it when the LEFT JOIN
+        // finds no descriptor row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
@@ -319,7 +319,11 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
 
         var failure = result.Should().BeOfType<QueryResult.UnknownFailure>().Subject;
         failure.FailureMessage.Should().Contain($"DocumentId {corruptDocumentId}");
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // The row reader treats Namespace as nullable so a stored null can flow into the
+        // namespace-authorization stored-namespace-uninitialized 403; CodeValue is the next
+        // required column, so the reader's invariant message names it when the LEFT JOIN
+        // finds no descriptor row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
     }
 
     private static IEnumerable<TestCaseData> SupportedFilterCases()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalDeleteAuthorizationTests.cs
@@ -455,7 +455,7 @@ public class Given_A_Mssql_Relational_Delete_Authorization_With_A_Synthetic_EdOr
             .Subject;
         notImplemented
             .FailureMessage.Should()
-            .Contain(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+            .Contain(RelationshipAuthorizationCrudTestSupport.OwnershipBased);
         var securityConfiguration = securityConfigurationResult
             .Should()
             .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalGetByIdAuthorizationTests.cs
@@ -47,7 +47,7 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
     private static readonly IReadOnlyList<string> _normalPlusKnownUnsupportedStrategy =
     [
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
-        AuthorizationStrategyNameConstants.NamespaceBased,
+        AuthorizationStrategyNameConstants.OwnershipBased,
     ];
 
     private static readonly QuerySchoolSeed[] _schoolSeeds =
@@ -328,7 +328,7 @@ public class Given_A_Mssql_Relational_Get_By_Id_Authorization_With_A_Synthetic_E
         );
 
         var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.NamespaceBased);
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         _context.AssertNoHydration();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceAuthorizationTests.cs
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// MSSQL twin of <c>Given_A_Postgresql_Relational_Namespace_Authorization_With_A_Synthetic_Fixture</c>.
+/// The synthetic <c>authorization-query</c> fixture's
+/// <c>AuthorizationRootChildResource</c> has an empty <c>Namespace</c>
+/// securable element list, so every CRUD route must short-circuit with the
+/// security-configuration message from
+/// <c>NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn</c>
+/// before any database read or write is issued. Dialect parity is the
+/// reason this exists as a sibling of the PG fixture rather than as a
+/// parameterized base.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category("RelationalNamespace")]
+public class Given_A_Mssql_Relational_Namespace_Authorization_With_A_Synthetic_Fixture
+{
+    private const long ClaimEducationOrganizationId =
+        RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
+    private const string ProjectEndpointName = RelationshipAuthorizationCrudTestSupport.ProjectEndpointName;
+    private const string RootChildResourceName =
+        RelationshipAuthorizationCrudTestSupport.RootAndChildEdOrgResourceName;
+    private const string NoUsableRootColumnMarker =
+        "no Namespace securable element resolves to a root table column";
+
+    private static readonly IReadOnlyList<string> _namespaceBasedStrategy =
+    [
+        AuthorizationStrategyNameConstants.NamespaceBased,
+    ];
+
+    private static readonly QuerySchoolSeed[] _schoolSeeds =
+    [
+        new(new DocumentUuid(Guid.Parse("e1e1e1e1-0000-0000-0000-000000000001")), 100, "North School"),
+        new(
+            new DocumentUuid(Guid.Parse("e1e1e1e1-0000-0000-0000-000000000002")),
+            (int)ClaimEducationOrganizationId,
+            "Claim School"
+        ),
+    ];
+
+    private static readonly ClassPeriodSeed[] _classPeriodSeeds =
+    [
+        new(new DocumentUuid(Guid.Parse("e2e2e2e2-0000-0000-0000-000000000001")), 100, "P1"),
+    ];
+
+    private static readonly AuthorizationRootChildSeed _seededRootChild = new(
+        new DocumentUuid(Guid.Parse("e3e3e3e3-0000-0000-0000-000000000001")),
+        1,
+        "preexisting-row",
+        100,
+        []
+    );
+
+    private MssqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _context = new MssqlRelationalQueryAuthorizationTestContext();
+        await _context.InitializeAsync(
+            RelationshipAuthorizationCrudTestSupport.FixtureRelativePath,
+            strict: false,
+            replaceReadTargetLookup: false
+        );
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _context.Database.ResetAsync();
+        await _context.SeedSchoolDescriptorDataAsync();
+
+        foreach (var schoolSeed in _schoolSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateSchoolAsync(schoolSeed)
+            );
+        }
+
+        foreach (var classPeriodSeed in _classPeriodSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateClassPeriodAsync(classPeriodSeed)
+            );
+        }
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(_seededRootChild)
+        );
+
+        await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 100);
+        _context.ResetRecorder();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_query_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.QueryAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_get_by_id_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.GetByIdAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_post_create_when_no_usable_root_table_namespace_column()
+    {
+        var newSeed = new AuthorizationRootChildSeed(
+            new DocumentUuid(Guid.Parse("e4e4e4e4-0000-0000-0000-000000000001")),
+            99,
+            "post-attempt",
+            100,
+            []
+        );
+
+        var result = await _context.UpsertAuthorizationRootChildAsync(
+            newSeed,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(newSeed.DocumentUuid)).Should().Be(0);
+        (
+            await _context.CountResourceRootRowsAsync(
+                ProjectEndpointName,
+                RootChildResourceName,
+                newSeed.DocumentUuid
+            )
+        )
+            .Should()
+            .Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_put_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            _seededRootChild,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(_seededRootChild.DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_delete_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.DeleteByIdAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(_seededRootChild.DocumentUuid)).Should().Be(1);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/AuthorizationParameterBudgetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/AuthorizationParameterBudgetTests.cs
@@ -12,8 +12,12 @@ namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
 [TestFixture]
 public class Given_AuthorizationParameterBudget
 {
+    // The query binds two paging parameters on top of the authorization lists; tests that only exercise
+    // the authorization lists pass this as the non-authorization parameter count.
+    private const int PagingOnly = AuthorizationParameterBudget.PaginationParameterCount;
+
     [Test]
-    public void It_does_not_flag_postgresql_array_parameterizations()
+    public void It_never_flags_postgresql_even_when_the_total_would_exceed_the_sql_server_ceiling()
     {
         var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
             SqlDialect.Pgsql,
@@ -26,8 +30,16 @@ public class Given_AuthorizationParameterBudget
             "ClaimEducationOrganizationIds"
         );
 
+        // The 2,100 ceiling is SQL Server-specific. Even with a query parameter count that would blow that
+        // ceiling, PostgreSQL is never flagged: it allows far more command parameters and binds each list
+        // as a single array/table-valued parameter.
         AuthorizationParameterBudget
-            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Pgsql,
+                namespacePrefixParameterization,
+                claimParameterization,
+                nonAuthorizationParameterCount: 5000
+            )
             .Should()
             .BeFalse();
     }
@@ -47,48 +59,64 @@ public class Given_AuthorizationParameterBudget
         );
 
         AuthorizationParameterBudget
-            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimParameterization,
+                PagingOnly
+            )
             .Should()
             .BeTrue();
     }
 
     [Test]
-    public void It_does_not_flag_a_combined_count_exactly_at_the_limit()
+    public void It_does_not_flag_a_total_count_exactly_at_the_command_limit()
     {
         var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
             SqlDialect.Mssql,
-            CreateNamespacePrefixes(1000),
+            CreateNamespacePrefixes(1049),
             "namespacePrefixes"
         );
         var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
             SqlDialect.Mssql,
-            CreateClaimEducationOrganizationIds(1000),
+            CreateClaimEducationOrganizationIds(1049),
             "ClaimEducationOrganizationIds"
         );
 
-        // 1,000 + 1,000 == the 2,000 combined limit, which stays within the SQL Server ceiling.
+        // 1,049 + 1,049 + 2 paging == 2,100, exactly the SQL Server per-command ceiling, which is allowed.
         AuthorizationParameterBudget
-            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimParameterization,
+                PagingOnly
+            )
             .Should()
             .BeFalse();
     }
 
     [Test]
-    public void It_flags_a_combined_count_one_past_the_limit()
+    public void It_flags_a_total_count_one_past_the_command_limit()
     {
         var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
             SqlDialect.Mssql,
-            CreateNamespacePrefixes(1000),
+            CreateNamespacePrefixes(1050),
             "namespacePrefixes"
         );
         var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
             SqlDialect.Mssql,
-            CreateClaimEducationOrganizationIds(1001),
+            CreateClaimEducationOrganizationIds(1049),
             "ClaimEducationOrganizationIds"
         );
 
+        // 1,050 + 1,049 + 2 paging == 2,101, one past the SQL Server per-command ceiling.
         AuthorizationParameterBudget
-            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimParameterization,
+                PagingOnly
+            )
             .Should()
             .BeTrue();
     }
@@ -102,8 +130,8 @@ public class Given_AuthorizationParameterBudget
             "namespacePrefixes"
         );
         // 2,000 claim ids cross the structured-parameter threshold, so the claim list binds a single
-        // table-valued parameter; combined with 1,999 scalar prefix parameters that is 2,000 real
-        // parameters, which must not be flagged.
+        // table-valued parameter; combined with 1,999 scalar prefix parameters and 2 paging parameters
+        // that is 2,002 real parameters, which must not be flagged.
         var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
             SqlDialect.Mssql,
             CreateClaimEducationOrganizationIds(2000),
@@ -111,9 +139,80 @@ public class Given_AuthorizationParameterBudget
         );
 
         AuthorizationParameterBudget
-            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimParameterization,
+                PagingOnly
+            )
             .Should()
             .BeFalse();
+    }
+
+    [Test]
+    public void It_flags_a_namespace_only_list_that_with_query_parameters_exceeds_the_command_limit()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1999),
+            "namespacePrefixes"
+        );
+
+        // 1,999 scalar prefix parameters + 100 query filter parameters + 2 paging == 2,101, one past the
+        // ceiling, even though the prefix list alone is within its own per-list cap and no relationship
+        // parameterization is present.
+        AuthorizationParameterBudget
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimEducationOrganizationIdParameterization: null,
+                nonAuthorizationParameterCount: 100 + PagingOnly
+            )
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_does_not_flag_a_namespace_only_list_whose_total_is_within_the_command_limit()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1999),
+            "namespacePrefixes"
+        );
+
+        // 1,999 + 99 query filter parameters + 2 paging == 2,100, exactly at the ceiling.
+        AuthorizationParameterBudget
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization,
+                claimEducationOrganizationIdParameterization: null,
+                nonAuthorizationParameterCount: 99 + PagingOnly
+            )
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_flags_a_relationship_only_list_that_with_query_parameters_exceeds_the_command_limit()
+    {
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateClaimEducationOrganizationIds(1999),
+            "ClaimEducationOrganizationIds"
+        );
+
+        // 1,999 scalar claim parameters + 100 query filter parameters + 2 paging == 2,101, one past the
+        // ceiling, with no namespace parameterization present.
+        AuthorizationParameterBudget
+            .ExceedsCommandParameterLimit(
+                SqlDialect.Mssql,
+                namespacePrefixParameterization: null,
+                claimParameterization,
+                nonAuthorizationParameterCount: 100 + PagingOnly
+            )
+            .Should()
+            .BeTrue();
     }
 
     private static IReadOnlyList<string> CreateNamespacePrefixes(int count)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/AuthorizationParameterBudgetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/AuthorizationParameterBudgetTests.cs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+public class Given_AuthorizationParameterBudget
+{
+    [Test]
+    public void It_does_not_flag_postgresql_array_parameterizations()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            CreateNamespacePrefixes(1999),
+            "namespacePrefixes"
+        );
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            CreateClaimEducationOrganizationIds(1999),
+            "ClaimEducationOrganizationIds"
+        );
+
+        AuthorizationParameterBudget
+            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_flags_sql_server_scalar_lists_that_together_exceed_the_limit()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1500),
+            "namespacePrefixes"
+        );
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateClaimEducationOrganizationIds(1500),
+            "ClaimEducationOrganizationIds"
+        );
+
+        AuthorizationParameterBudget
+            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_does_not_flag_a_combined_count_exactly_at_the_limit()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1000),
+            "namespacePrefixes"
+        );
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateClaimEducationOrganizationIds(1000),
+            "ClaimEducationOrganizationIds"
+        );
+
+        // 1,000 + 1,000 == the 2,000 combined limit, which stays within the SQL Server ceiling.
+        AuthorizationParameterBudget
+            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .Should()
+            .BeFalse();
+    }
+
+    [Test]
+    public void It_flags_a_combined_count_one_past_the_limit()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1000),
+            "namespacePrefixes"
+        );
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateClaimEducationOrganizationIds(1001),
+            "ClaimEducationOrganizationIds"
+        );
+
+        AuthorizationParameterBudget
+            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_counts_a_structured_claim_parameter_as_one_so_a_near_cap_prefix_list_is_not_flagged()
+    {
+        var namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateNamespacePrefixes(1999),
+            "namespacePrefixes"
+        );
+        // 2,000 claim ids cross the structured-parameter threshold, so the claim list binds a single
+        // table-valued parameter; combined with 1,999 scalar prefix parameters that is 2,000 real
+        // parameters, which must not be flagged.
+        var claimParameterization = AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            CreateClaimEducationOrganizationIds(2000),
+            "ClaimEducationOrganizationIds"
+        );
+
+        AuthorizationParameterBudget
+            .ExceedsCombinedLimit(namespacePrefixParameterization, claimParameterization)
+            .Should()
+            .BeFalse();
+    }
+
+    private static IReadOnlyList<string> CreateNamespacePrefixes(int count)
+    {
+        string[] namespacePrefixes = new string[count];
+
+        for (var index = 0; index < count; index++)
+        {
+            namespacePrefixes[index] = $"uri://prefix-{index}/";
+        }
+
+        return namespacePrefixes;
+    }
+
+    private static IReadOnlyList<long> CreateClaimEducationOrganizationIds(int count)
+    {
+        long[] claimEducationOrganizationIds = new long[count];
+
+        for (var index = 0; index < count; index++)
+        {
+            claimEducationOrganizationIds[index] = index + 1L;
+        }
+
+        return claimEducationOrganizationIds;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderParameterBindingTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/HydrationBatchBuilderParameterBindingTests.cs
@@ -95,6 +95,42 @@ public class Given_HydrationBatchBuilder_Query_Parameter_Binding
     }
 
     [Test]
+    public void It_should_bind_postgresql_array_parameter_for_string_namespace_prefix_patterns()
+    {
+        using var command = new NpgsqlCommand();
+        var keyset = new PageKeysetSpec.Query(
+            CreateQueryPlan(
+                pageParametersInOrder:
+                [
+                    new QuerySqlParameter(
+                        QuerySqlParameterRole.Filter,
+                        "namespacePrefixes",
+                        QuerySqlParameterBinding.PgsqlArray
+                    ),
+                    new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                    new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                ],
+                totalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?>
+            {
+                ["namespacePrefixes"] = new[] { "uri://ed-fi.org/%", "uri://gbisd.edu/%" },
+                ["offset"] = 0L,
+                ["limit"] = 25L,
+            }
+        );
+
+        HydrationBatchBuilder.AddParameters(command, keyset);
+
+        command.Parameters.Count.Should().Be(3);
+        command.Parameters.Contains("@namespacePrefixes").Should().BeTrue();
+        command
+            .Parameters["@namespacePrefixes"]
+            .Value.Should()
+            .BeEquivalentTo(new[] { "uri://ed-fi.org/%", "uri://gbisd.edu/%" });
+    }
+
+    [Test]
     public void It_should_bind_mssql_structured_parameter_with_expected_type_and_table_value()
     {
         using var command = new SqlCommand();
@@ -174,7 +210,7 @@ public class Given_HydrationBatchBuilder_Query_Parameter_Binding
         act.Should()
             .Throw<InvalidOperationException>()
             .WithMessage(
-                "Hydration query keyset parameter 'ClaimEducationOrganizationIds' requires an IReadOnlyList<long> runtime value."
+                "Hydration query keyset parameter 'ClaimEducationOrganizationIds' requires an IReadOnlyList<long> or IReadOnlyList<string> runtime value."
             );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationAuth1FailurePayloadTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationAuth1FailurePayloadTests.cs
@@ -30,6 +30,7 @@ public class Given_NamespaceAuthorizationAuth1FailurePayloadCodec
     [TestCase(0, NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch, "ns1|0|m")]
     [TestCase(3, NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized, "ns1|3|u")]
     [TestCase(5, NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing, "ns1|5|r")]
+    [TestCase(2, NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing, "ns1|2|s")]
     public void It_should_round_trip_each_failure_kind(
         int emittedIndex,
         NamespaceAuthorizationAuth1FailureKind kind,
@@ -50,29 +51,40 @@ public class Given_NamespaceAuthorizationAuth1FailurePayloadCodec
     }
 
     [Test]
-    public void It_should_extract_postgresql_and_sql_server_wrappers_then_use_the_same_payload_parser()
+    public void It_should_dispatch_postgresql_and_sql_server_provider_failures_to_the_same_namespace_payload()
     {
+        // Production routes provider failures through the shared dispatcher rather than codec-specific
+        // wrappers, so the namespace payload is recovered identically from the PostgreSQL SqlState
+        // transport and the SQL Server message transport.
         var payloadText = "ns1|7|m";
         var sqlServerMessage =
             $"Conversion failed when converting the varchar value 'AUTH1 - {payloadText}' to data type int.";
 
-        var postgresqlParsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+        var postgresqlDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
             SqlDialect.Pgsql,
             NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
             payloadText,
-            out var postgresqlPayload
+            out var postgresqlResult
         );
-        var sqlServerParsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+        var sqlServerDispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
             SqlDialect.Mssql,
             null,
             sqlServerMessage,
-            out var sqlServerPayload
+            out var sqlServerResult
         );
 
-        postgresqlParsed.Should().BeTrue();
-        sqlServerParsed.Should().BeTrue();
+        postgresqlDispatched.Should().BeTrue();
+        sqlServerDispatched.Should().BeTrue();
+        var postgresqlPayload = postgresqlResult
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.Namespace>()
+            .Subject.Payload;
+        var sqlServerPayload = sqlServerResult
+            .Should()
+            .BeOfType<RelationalAuthorizationAuth1DispatchResult.Namespace>()
+            .Subject.Payload;
         sqlServerPayload.Should().BeEquivalentTo(postgresqlPayload);
-        sqlServerPayload!.EmittedAuth1Index.Should().Be(7);
+        sqlServerPayload.EmittedAuth1Index.Should().Be(7);
         sqlServerPayload.FailureKind.Should().Be(NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
     }
 
@@ -98,30 +110,30 @@ public class Given_NamespaceAuthorizationAuth1FailurePayloadCodec
     }
 
     [Test]
-    public void It_should_not_extract_a_payload_when_postgresql_error_code_is_not_AUTH1()
+    public void It_should_not_dispatch_a_payload_when_postgresql_error_code_is_not_AUTH1()
     {
-        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
             SqlDialect.Pgsql,
             "P0001",
             "ns1|0|m",
-            out var payload
+            out var result
         );
 
-        parsed.Should().BeFalse();
-        payload.Should().BeNull();
+        dispatched.Should().BeFalse();
+        result.Should().BeNull();
     }
 
     [Test]
-    public void It_should_not_extract_a_payload_when_sql_server_message_lacks_the_AUTH1_marker()
+    public void It_should_not_dispatch_a_payload_when_sql_server_message_lacks_the_AUTH1_marker()
     {
-        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
             SqlDialect.Mssql,
             null,
             "Some unrelated SQL Server error message.",
-            out var payload
+            out var result
         );
 
-        parsed.Should().BeFalse();
-        payload.Should().BeNull();
+        dispatched.Should().BeFalse();
+        result.Should().BeNull();
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationAuth1FailurePayloadTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationAuth1FailurePayloadTests.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespaceAuthorizationAuth1FailurePayloadCodec
+{
+    [Test]
+    public void It_should_encode_a_mismatch_payload_with_the_ns1_discriminator()
+    {
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+        );
+
+        var encoded = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(payload);
+
+        encoded.Should().Be("ns1|0|m");
+    }
+
+    [TestCase(0, NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch, "ns1|0|m")]
+    [TestCase(3, NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized, "ns1|3|u")]
+    [TestCase(5, NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing, "ns1|5|r")]
+    public void It_should_round_trip_each_failure_kind(
+        int emittedIndex,
+        NamespaceAuthorizationAuth1FailureKind kind,
+        string expectedEncoding
+    )
+    {
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(emittedIndex, kind);
+
+        var encoded = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(payload);
+        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            encoded,
+            out var parsedPayload
+        );
+
+        encoded.Should().Be(expectedEncoding);
+        parsed.Should().BeTrue();
+        parsedPayload.Should().BeEquivalentTo(payload);
+    }
+
+    [Test]
+    public void It_should_extract_postgresql_and_sql_server_wrappers_then_use_the_same_payload_parser()
+    {
+        var payloadText = "ns1|7|m";
+        var sqlServerMessage =
+            $"Conversion failed when converting the varchar value 'AUTH1 - {payloadText}' to data type int.";
+
+        var postgresqlParsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+            SqlDialect.Pgsql,
+            NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+            payloadText,
+            out var postgresqlPayload
+        );
+        var sqlServerParsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+            SqlDialect.Mssql,
+            null,
+            sqlServerMessage,
+            out var sqlServerPayload
+        );
+
+        postgresqlParsed.Should().BeTrue();
+        sqlServerParsed.Should().BeTrue();
+        sqlServerPayload.Should().BeEquivalentTo(postgresqlPayload);
+        sqlServerPayload!.EmittedAuth1Index.Should().Be(7);
+        sqlServerPayload.FailureKind.Should().Be(NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
+    }
+
+    [TestCase("ns2|0|m")] // unknown version
+    [TestCase("1|0|m")] // relationship discriminator, must be rejected
+    [TestCase("ns1|0|x")] // unknown failure kind
+    [TestCase("ns1|0|")] // missing failure kind
+    [TestCase("ns1|0")] // missing failure kind segment entirely
+    [TestCase("ns1||m")] // missing index
+    [TestCase("ns1|-1|m")] // negative index
+    [TestCase("ns1|0|m|extra")] // extra trailing segment
+    [TestCase("")] // empty
+    [TestCase("   ")] // whitespace
+    public void It_should_fail_closed_for_malformed_or_unknown_payloads(string payloadText)
+    {
+        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+            payloadText,
+            out var payload
+        );
+
+        parsed.Should().BeFalse();
+        payload.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_extract_a_payload_when_postgresql_error_code_is_not_AUTH1()
+    {
+        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+            SqlDialect.Pgsql,
+            "P0001",
+            "ns1|0|m",
+            out var payload
+        );
+
+        parsed.Should().BeFalse();
+        payload.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_not_extract_a_payload_when_sql_server_message_lacks_the_AUTH1_marker()
+    {
+        var parsed = NamespaceAuthorizationAuth1FailurePayloadCodec.TryParseProviderFailure(
+            SqlDialect.Mssql,
+            null,
+            "Some unrelated SQL Server error message.",
+            out var payload
+        );
+
+        parsed.Should().BeFalse();
+        payload.Should().BeNull();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationFailureMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationFailureMapperTests.cs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespaceAuthorizationFailureMapper
+{
+    private static readonly string[] _twoPrefixes = ["uri://ed-fi.org/", "uri://gbisd.edu/"];
+
+    [Test]
+    public void It_should_map_a_mismatch_payload_for_a_stored_check_to_a_stored_value_source_failure()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Stored) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure.Should().NotBeNull();
+        failure!.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        failure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+        failure.EmittedAuth1Index.Should().Be(0);
+        failure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        failure.ConfiguredNamespacePrefixes.Should().Equal(_twoPrefixes);
+    }
+
+    [Test]
+    public void It_should_map_a_mismatch_payload_for_a_proposed_check_to_a_proposed_value_source_failure()
+    {
+        var plannedChecks = new[]
+        {
+            CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Stored),
+            CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Proposed),
+        };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            1,
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        failure.EmittedAuth1Index.Should().Be(1);
+    }
+
+    [Test]
+    public void It_should_map_a_stored_uninitialized_payload_to_a_stored_uninitialized_failure()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Stored) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        failure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public void It_should_map_a_proposed_missing_payload_to_a_proposed_missing_failure()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Proposed) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeTrue();
+        failure!.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.ProposedNamespaceMissing);
+        failure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Proposed);
+    }
+
+    [Test]
+    public void It_should_fail_closed_when_the_emitted_index_is_out_of_range()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Stored) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            5,
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_fail_closed_when_planned_checks_are_empty()
+    {
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            [],
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_fail_closed_when_a_stored_uninitialized_failure_is_paired_with_a_proposed_check()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Proposed) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    [Test]
+    public void It_should_fail_closed_when_a_proposed_missing_failure_is_paired_with_a_stored_check()
+    {
+        var plannedChecks = new[] { CreatePlannedCheck(NamespaceAuthorizationCheckValueSource.Stored) };
+        var payload = new NamespaceAuthorizationAuth1FailurePayload(
+            0,
+            NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+        );
+
+        var mapped = NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+            payload,
+            plannedChecks,
+            _twoPrefixes,
+            out var failure
+        );
+
+        mapped.Should().BeFalse();
+        failure.Should().BeNull();
+    }
+
+    private static NamespaceAuthorizationCheckValueSource CreatePlannedCheck(
+        NamespaceAuthorizationCheckValueSource valueSource
+    ) => valueSource;
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationPlannerTests.cs
@@ -305,23 +305,6 @@ public class Given_NamespaceAuthorizationPlanner
     }
 
     [Test]
-    public void It_emits_a_single_proposed_check_for_create()
-    {
-        var resource = RootNamespaceResource();
-
-        var outcome = NamespaceAuthorizationPlanner.Plan(
-            resource,
-            NamespaceAuthorizationOperation.Create,
-            TwoPrefixContext()
-        );
-
-        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
-        plan.Checks.Should().HaveCount(1);
-        plan.Checks[0].Index.Should().Be(0);
-        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
-    }
-
-    [Test]
     public void It_emits_ordered_stored_then_proposed_checks_for_update()
     {
         var resource = RootNamespaceResource();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationPlannerTests.cs
@@ -1,0 +1,625 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespaceAuthorizationPlanner
+{
+    private static readonly DbSchemaName _edfiSchema = new("edfi");
+    private static readonly DbColumnName _documentId = new("DocumentId");
+
+    private static DbTableName Table(string name) => new(_edfiSchema, name);
+
+    private static DbColumnName Col(string name) => new(name);
+
+    private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    private static ResourceKeyEntry ResourceKey(short id, string resource) =>
+        new(id, new QualifiedResourceName("Ed-Fi", resource), "1.0", false);
+
+    private static DbTableModel RootTable(string name, IReadOnlyList<DbColumnModel> columns) =>
+        new(
+            Table(name),
+            Path("$"),
+            new TableKey("PK_" + name, [new DbKeyColumn(_documentId, ColumnKind.Scalar)]),
+            columns,
+            []
+        );
+
+    private static DbTableModel ChildTable(
+        string name,
+        string scopePath,
+        IReadOnlyList<DbColumnModel> columns
+    ) =>
+        new(
+            Table(name),
+            Path(scopePath),
+            new TableKey("PK_" + name, [new DbKeyColumn(Col("CollectionItemId"), ColumnKind.ParentKeyPart)]),
+            columns,
+            []
+        );
+
+    private static ConcreteResourceModel RootNamespaceResource()
+    {
+        // AcademicWeek-shape: root-table scalar Namespace at $.namespace.
+        var root = RootTable(
+            "AcademicWeek",
+            [new DbColumnModel(Col("Namespace"), ColumnKind.Scalar, null, false, Path("$.namespace"), null)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "AcademicWeek"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            [],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(1, "AcademicWeek"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], ["$.namespace"], [], [], []),
+        };
+    }
+
+    private static ConcreteResourceModel ChildCollectionOnlyNamespaceResource()
+    {
+        // GraduationPlan-shape: only securable element is array-nested at
+        // $.requiredAssessments[*].assessmentReference.namespace. The resolver returns a
+        // child-table source, which the planner must reject.
+        var root = RootTable("GraduationPlanLike", []);
+        var childName = Table("GraduationPlanLikeRequiredAssessment");
+        var nestedCol = Col("RequiredAssessmentAssessment_Namespace");
+        const string nestedPath = "$.requiredAssessments[*].assessmentReference.namespace";
+        var child = ChildTable(
+            "GraduationPlanLikeRequiredAssessment",
+            "$.requiredAssessments[*]",
+            [
+                new DbColumnModel(Col("CollectionItemId"), ColumnKind.Scalar, null, false, null, null),
+                new DbColumnModel(
+                    Col("RequiredAssessmentAssessment_DocumentId"),
+                    ColumnKind.DocumentFk,
+                    null,
+                    false,
+                    null,
+                    new QualifiedResourceName("Ed-Fi", "Assessment")
+                ),
+                new DbColumnModel(nestedCol, ColumnKind.Scalar, null, false, null, null),
+            ]
+        );
+        var binding = new DocumentReferenceBinding(
+            true,
+            Path("$.requiredAssessments[*].assessmentReference"),
+            childName,
+            Col("RequiredAssessmentAssessment_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Assessment"),
+            [new ReferenceIdentityBinding(Path("$.namespace"), Path(nestedPath), nestedCol)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "GraduationPlanLike"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root, child],
+            [binding],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(2, "GraduationPlanLike"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], [nestedPath], [], [], []),
+        };
+    }
+
+    private static ConcreteResourceModel MixedNamespaceResource()
+    {
+        // Resource declares two Namespace securable element paths: one root-level scalar and one
+        // array-nested. The planner must keep the root-table column and discard the child one.
+        var rootNamespaceCol = Col("Namespace");
+        var nestedNamespaceCol = Col("RequiredAssessmentAssessment_Namespace");
+        const string nestedPath = "$.requiredAssessments[*].assessmentReference.namespace";
+
+        var root = RootTable(
+            "MixedNamespace",
+            [new DbColumnModel(rootNamespaceCol, ColumnKind.Scalar, null, false, Path("$.namespace"), null)]
+        );
+        var childName = Table("MixedNamespaceRequiredAssessment");
+        var child = ChildTable(
+            "MixedNamespaceRequiredAssessment",
+            "$.requiredAssessments[*]",
+            [
+                new DbColumnModel(Col("CollectionItemId"), ColumnKind.Scalar, null, false, null, null),
+                new DbColumnModel(
+                    Col("RequiredAssessmentAssessment_DocumentId"),
+                    ColumnKind.DocumentFk,
+                    null,
+                    false,
+                    null,
+                    new QualifiedResourceName("Ed-Fi", "Assessment")
+                ),
+                new DbColumnModel(nestedNamespaceCol, ColumnKind.Scalar, null, false, null, null),
+            ]
+        );
+        var binding = new DocumentReferenceBinding(
+            true,
+            Path("$.requiredAssessments[*].assessmentReference"),
+            childName,
+            Col("RequiredAssessmentAssessment_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Assessment"),
+            [new ReferenceIdentityBinding(Path("$.namespace"), Path(nestedPath), nestedNamespaceCol)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "MixedNamespace"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root, child],
+            [binding],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(3, "MixedNamespace"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], ["$.namespace", nestedPath], [], [], []),
+        };
+    }
+
+    private static RelationalAuthorizationContext TwoPrefixContext() =>
+        new([], ["uri://ed-fi.org/", "uri://gbisd.edu/"]);
+
+    private static RelationalAuthorizationContext EmptyPrefixContext() => new([], []);
+
+    [Test]
+    public void It_returns_no_usable_root_column_when_only_child_collection_namespace_paths_resolve()
+    {
+        var resource = ChildCollectionOnlyNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoUsableRootColumn>();
+        ((NamespaceAuthorizationPlanOutcome.NoUsableRootColumn)outcome)
+            .Resource.Should()
+            .Be(new QualifiedResourceName("Ed-Fi", "GraduationPlanLike"));
+    }
+
+    [Test]
+    public void It_keeps_only_the_root_table_namespace_when_both_root_and_child_collection_paths_resolve()
+    {
+        var resource = MixedNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>();
+        var plan = (NamespaceAuthorizationPlanOutcome.Plan)outcome;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].RootTable.Should().Be(Table("MixedNamespace"));
+        plan.Checks[0].NamespaceColumn.Should().Be(Col("Namespace"));
+    }
+
+    [Test]
+    public void It_returns_no_usable_root_column_before_no_prefixes_when_metadata_is_broken_and_prefixes_are_empty()
+    {
+        var resource = ChildCollectionOnlyNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadMany,
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoUsableRootColumn>();
+    }
+
+    [Test]
+    public void It_returns_no_prefixes_configured_when_metadata_is_valid_but_client_prefixes_are_empty()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured>();
+        ((NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured)outcome)
+            .StrategyName.Should()
+            .Be("NamespaceBased");
+    }
+
+    [Test]
+    public void It_emits_a_single_stored_check_for_read_single()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].Index.Should().Be(0);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+        plan.Checks[0].RootTable.Should().Be(Table("AcademicWeek"));
+        plan.Checks[0].NamespaceColumn.Should().Be(Col("Namespace"));
+    }
+
+    [Test]
+    public void It_emits_a_single_stored_check_for_read_many()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadMany,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+    }
+
+    [Test]
+    public void It_emits_a_single_stored_check_for_delete()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.Delete,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+    }
+
+    [Test]
+    public void It_emits_a_single_proposed_check_for_create()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.Create,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].Index.Should().Be(0);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
+    }
+
+    [Test]
+    public void It_emits_ordered_stored_then_proposed_checks_for_update()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.Update,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(2);
+        plan.Checks[0].Index.Should().Be(0);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+        plan.Checks[1].Index.Should().Be(1);
+        plan.Checks[1].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
+    }
+
+    [Test]
+    public void It_carries_the_strategy_name_on_every_emitted_check()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.Update,
+            TwoPrefixContext()
+        );
+
+        var plan = (NamespaceAuthorizationPlanOutcome.Plan)outcome;
+        plan.Checks.Select(static c => c.StrategyName).Should().AllBe("NamespaceBased");
+    }
+
+    [Test]
+    public void It_emits_a_plan_when_unrelated_securable_metadata_is_unresolvable_alongside_a_valid_root_namespace()
+    {
+        // The resource declares a valid root Namespace path plus unrelated Student / Contact /
+        // Staff / EducationOrganization paths that cannot be resolved. Namespace planning must
+        // ignore the unrelated metadata and produce a normal Plan outcome.
+        var rootNamespaceCol = Col("Namespace");
+        var root = RootTable(
+            "ResourceWithUnrelatedBrokenMetadata",
+            [new DbColumnModel(rootNamespaceCol, ColumnKind.Scalar, null, false, Path("$.namespace"), null)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "ResourceWithUnrelatedBrokenMetadata"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            [],
+            []
+        );
+        var resource = new ConcreteResourceModel(
+            ResourceKey(4, "ResourceWithUnrelatedBrokenMetadata"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements(
+                EducationOrganization: [new EdOrgSecurableElement("$.schoolReference.schoolId", "SchoolId")],
+                Namespace: ["$.namespace"],
+                Student: ["$.studentReference.studentUniqueId"],
+                Contact: ["$.contactReference.contactUniqueId"],
+                Staff: ["$.staffReference.staffUniqueId"]
+            ),
+        };
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].RootTable.Should().Be(Table("ResourceWithUnrelatedBrokenMetadata"));
+        plan.Checks[0].NamespaceColumn.Should().Be(rootNamespaceCol);
+    }
+
+    [Test]
+    public void It_returns_no_usable_root_column_when_a_namespace_path_cannot_be_resolved_at_all()
+    {
+        // Resource declares a Namespace securable element whose JSON path does not match any
+        // column on the root or child tables. The planner returns NoUsableRootColumn rather
+        // than letting the unresolved path bubble up as an exception.
+        var root = RootTable("ResourceWithUnresolvableNamespace", []);
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "ResourceWithUnresolvableNamespace"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            [],
+            []
+        );
+        var resource = new ConcreteResourceModel(
+            ResourceKey(5, "ResourceWithUnresolvableNamespace"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements(
+                EducationOrganization: [],
+                Namespace: ["$.assessmentAdministrationReference.namespace"],
+                Student: [],
+                Contact: [],
+                Staff: []
+            ),
+        };
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoUsableRootColumn>();
+        ((NamespaceAuthorizationPlanOutcome.NoUsableRootColumn)outcome)
+            .Resource.Should()
+            .Be(new QualifiedResourceName("Ed-Fi", "ResourceWithUnresolvableNamespace"));
+    }
+
+    private static ConcreteResourceModel DescriptorResource(bool includeDescriptorMetadata = true)
+    {
+        // Descriptor resources store their Namespace on the shared dms.Descriptor root table and carry
+        // empty SecurableElements; the planner must resolve the column from DescriptorMetadata rather
+        // than from securable-element paths.
+        var descriptorSchema = new DbSchemaName("dms");
+        var root = new DbTableModel(
+            new DbTableName(descriptorSchema, "Descriptor"),
+            Path("$"),
+            new TableKey("PK_Descriptor", [new DbKeyColumn(_documentId, ColumnKind.Scalar)]),
+            [new DbColumnModel(Col("Namespace"), ColumnKind.Scalar, null, false, Path("$.namespace"), null)],
+            []
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"),
+            descriptorSchema,
+            ResourceStorageKind.SharedDescriptorTable,
+            root,
+            [root],
+            [],
+            []
+        );
+        var descriptorMetadata = includeDescriptorMetadata
+            ? new DescriptorMetadata(
+                new DescriptorColumnContract(
+                    Namespace: Col("Namespace"),
+                    CodeValue: Col("CodeValue"),
+                    ShortDescription: Col("ShortDescription"),
+                    Description: Col("Description"),
+                    EffectiveBeginDate: Col("EffectiveBeginDate"),
+                    EffectiveEndDate: Col("EffectiveEndDate"),
+                    Discriminator: null
+                ),
+                DiscriminatorStrategy.ResourceKeyId
+            )
+            : null;
+
+        return new ConcreteResourceModel(
+            new ResourceKeyEntry(7, new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"), "1.0", true),
+            ResourceStorageKind.SharedDescriptorTable,
+            model,
+            descriptorMetadata
+        );
+    }
+
+    [Test]
+    public void It_resolves_the_descriptor_namespace_column_from_descriptor_metadata_when_securable_elements_are_empty()
+    {
+        var resource = DescriptorResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(1);
+        plan.Checks[0].RootTable.Should().Be(new DbTableName(new DbSchemaName("dms"), "Descriptor"));
+        plan.Checks[0].NamespaceColumn.Should().Be(Col("Namespace"));
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+    }
+
+    [Test]
+    public void It_emits_ordered_stored_then_proposed_descriptor_checks_for_update()
+    {
+        var resource = DescriptorResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.Update,
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.Plan>().Subject;
+        plan.Checks.Should().HaveCount(2);
+        plan.Checks[0].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+        plan.Checks[1].ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
+    }
+
+    [Test]
+    public void It_returns_no_prefixes_configured_for_a_descriptor_when_client_prefixes_are_empty()
+    {
+        var resource = DescriptorResource();
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured>();
+    }
+
+    [Test]
+    public void It_fails_closed_with_no_usable_root_column_for_a_shared_descriptor_resource_missing_descriptor_metadata()
+    {
+        // Defensive: a SharedDescriptorTable resource with no DescriptorMetadata is impossible metadata.
+        // The planner must fail closed (500) rather than authorize against an unknown column.
+        var resource = DescriptorResource(includeDescriptorMetadata: false);
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoUsableRootColumn>();
+    }
+
+    [Test]
+    public void It_returns_no_usable_root_column_when_namespace_path_resolves_only_to_a_child_collection_table_and_other_securable_metadata_is_unresolvable()
+    {
+        // Combines two namespace-planning guards: child-collection-only Namespace path plus
+        // unrelated unresolved Student metadata. Namespace planning must not let the unrelated
+        // metadata throw, and must still surface NoUsableRootColumn for the child-only path.
+        var childName = Table("GraduationPlanLikeWithBrokenStudentRequiredAssessment");
+        var nestedCol = Col("RequiredAssessmentAssessment_Namespace");
+        const string nestedPath = "$.requiredAssessments[*].assessmentReference.namespace";
+
+        var root = RootTable("GraduationPlanLikeWithBrokenStudent", []);
+        var child = ChildTable(
+            "GraduationPlanLikeWithBrokenStudentRequiredAssessment",
+            "$.requiredAssessments[*]",
+            [
+                new DbColumnModel(Col("CollectionItemId"), ColumnKind.Scalar, null, false, null, null),
+                new DbColumnModel(
+                    Col("RequiredAssessmentAssessment_DocumentId"),
+                    ColumnKind.DocumentFk,
+                    null,
+                    false,
+                    null,
+                    new QualifiedResourceName("Ed-Fi", "Assessment")
+                ),
+                new DbColumnModel(nestedCol, ColumnKind.Scalar, null, false, null, null),
+            ]
+        );
+        var binding = new DocumentReferenceBinding(
+            true,
+            Path("$.requiredAssessments[*].assessmentReference"),
+            childName,
+            Col("RequiredAssessmentAssessment_DocumentId"),
+            new QualifiedResourceName("Ed-Fi", "Assessment"),
+            [new ReferenceIdentityBinding(Path("$.namespace"), Path(nestedPath), nestedCol)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "GraduationPlanLikeWithBrokenStudent"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root, child],
+            [binding],
+            []
+        );
+        var resource = new ConcreteResourceModel(
+            ResourceKey(6, "GraduationPlanLikeWithBrokenStudent"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements(
+                EducationOrganization: [],
+                Namespace: [nestedPath],
+                Student: ["$.studentReference.studentUniqueId"],
+                Contact: [],
+                Staff: []
+            ),
+        };
+
+        var outcome = NamespaceAuthorizationPlanner.Plan(
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<NamespaceAuthorizationPlanOutcome.NoUsableRootColumn>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationSqlCompilerTests.cs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespaceAuthorizationSqlCompiler
+{
+    private static readonly DbSchemaName _edfiSchema = new("edfi");
+    private static readonly DbTableName _rootTable = new(_edfiSchema, "GradebookEntry");
+    private static readonly DbColumnName _namespaceColumn = new("Namespace");
+
+    private static NamespaceAuthorizationCheckSpec StoredCheck(int index = 0) =>
+        new(index, NamespaceAuthorizationCheckValueSource.Stored, _rootTable, _namespaceColumn);
+
+    private static NamespaceAuthorizationCheckSpec ProposedCheck(int index = 0) =>
+        new(index, NamespaceAuthorizationCheckValueSource.Proposed, _rootTable, _namespaceColumn);
+
+    [Test]
+    public void It_compiles_a_pgsql_stored_check_with_null_guarded_LIKE_ANY_and_AUTH1_throw_paths()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"GradebookEntry\" r WHERE r.\"DocumentId\" = @documentId AND r.\"Namespace\" IS NOT NULL AND r.\"Namespace\" LIKE ANY(@namespacePrefixes)) THEN 1"
+            );
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"GradebookEntry\" r WHERE r.\"DocumentId\" = @documentId AND (r.\"Namespace\" IS NULL OR r.\"Namespace\" = '')) THEN \"dms\".\"throw_error\"('AUTH1', 'ns1|0|u')"
+            );
+        plan.AuthorizationSql.Should().Contain("ELSE \"dms\".\"throw_error\"('AUTH1', 'ns1|0|m')");
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("documentId", "namespacePrefixes");
+    }
+
+    [Test]
+    public void It_compiles_a_mssql_stored_check_with_OR_chain_LIKE_and_CAST_AUTH1_dash_throw_paths()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Mssql,
+                    ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN EXISTS (SELECT 1 FROM [edfi].[GradebookEntry] r WHERE r.[DocumentId] = @documentId AND r.[Namespace] IS NOT NULL AND (r.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' OR r.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\')) THEN 1"
+            );
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN EXISTS (SELECT 1 FROM [edfi].[GradebookEntry] r WHERE r.[DocumentId] = @documentId AND (r.[Namespace] IS NULL OR r.[Namespace] = '')) THEN CAST('AUTH1 - ns1|0|u' AS INT)"
+            );
+        plan.AuthorizationSql.Should().Contain("ELSE CAST('AUTH1 - ns1|0|m' AS INT)");
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("documentId", "namespacePrefixes_0", "namespacePrefixes_1");
+    }
+
+    [Test]
+    public void It_compiles_a_pgsql_proposed_check_with_null_guard_then_LIKE_ANY_match_then_mismatch_throw()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [ProposedCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN (@proposedNamespace IS NULL OR @proposedNamespace = '') THEN \"dms\".\"throw_error\"('AUTH1', 'ns1|0|r')"
+            );
+        plan.AuthorizationSql.Should().Contain("WHEN @proposedNamespace LIKE ANY(@namespacePrefixes) THEN 1");
+        plan.AuthorizationSql.Should().Contain("ELSE \"dms\".\"throw_error\"('AUTH1', 'ns1|0|m')");
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("proposedNamespace", "namespacePrefixes");
+    }
+
+    [Test]
+    public void It_compiles_a_mssql_proposed_check_with_null_guard_then_OR_chain_match_then_mismatch_throw()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [ProposedCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Mssql,
+                    ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN (@proposedNamespace IS NULL OR @proposedNamespace = '') THEN CAST('AUTH1 - ns1|0|r' AS INT)"
+            );
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN (@proposedNamespace LIKE @namespacePrefixes_0 ESCAPE '\\' OR @proposedNamespace LIKE @namespacePrefixes_1 ESCAPE '\\') THEN 1"
+            );
+        plan.AuthorizationSql.Should().Contain("ELSE CAST('AUTH1 - ns1|0|m' AS INT)");
+    }
+
+    [Test]
+    public void It_classifies_empty_namespace_values_identically_to_null_on_both_stored_and_proposed_checks()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0), ProposedCheck(1)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        // Stored uninitialized branch matches NULL or empty so legacy rows with empty namespace
+        // are classified as uninitialized rather than mismatch.
+        plan.AuthorizationSql.Should().Contain("(r.\"Namespace\" IS NULL OR r.\"Namespace\" = '')");
+        // Proposed missing branch matches NULL or empty so an empty proposed value classifies as
+        // missing rather than mismatch.
+        plan.AuthorizationSql.Should().Contain("(@proposedNamespace IS NULL OR @proposedNamespace = '')");
+    }
+
+    [Test]
+    public void It_co_batches_a_stored_then_proposed_pair_into_one_command_with_statements_separated_by_semicolon_and_distinct_indices()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0), ProposedCheck(1)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.AuthorizationSql.Should().Contain("'ns1|0|u'");
+        plan.AuthorizationSql.Should().Contain("'ns1|0|m'");
+        plan.AuthorizationSql.Should().Contain("'ns1|1|r'");
+        plan.AuthorizationSql.Should().Contain("'ns1|1|m'");
+
+        var storedIndex = plan.AuthorizationSql.IndexOf("'ns1|0|", StringComparison.Ordinal);
+        var proposedIndex = plan.AuthorizationSql.IndexOf("'ns1|1|", StringComparison.Ordinal);
+        storedIndex.Should().BeGreaterThan(-1);
+        proposedIndex.Should().BeGreaterThan(storedIndex);
+
+        plan.AuthorizationSql.Split(';').Where(part => part.Trim().Length > 0).Should().HaveCount(2);
+
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("documentId", "proposedNamespace", "namespacePrefixes");
+    }
+
+    [Test]
+    public void It_emits_AUTH1_payloads_strictly_in_the_form_ns1_pipe_index_pipe_kind()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0), ProposedCheck(1)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        // No relationship-discriminator payloads should ever leak into namespace SQL.
+        plan.AuthorizationSql.Should().NotContain("'1|");
+        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|0\|[^urm]");
+        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|1\|[^urm]");
+    }
+
+    [Test]
+    public void It_throws_when_namespace_check_specs_target_different_root_tables()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var spec = new NamespaceAuthorizationSqlSpec(
+            [
+                StoredCheck(0),
+                new NamespaceAuthorizationCheckSpec(
+                    1,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    new DbTableName(_edfiSchema, "OtherRootTable"),
+                    _namespaceColumn
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            ),
+            DocumentIdParameterName: "documentId",
+            ProposedNamespaceParameterName: "proposedNamespace"
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*share one root table*");
+    }
+
+    [Test]
+    public void It_throws_when_namespace_checks_are_empty()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var spec = new NamespaceAuthorizationSqlSpec(
+            [],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            ),
+            DocumentIdParameterName: "documentId",
+            ProposedNamespaceParameterName: "proposedNamespace"
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*at least one check*");
+    }
+
+    [Test]
+    public void It_does_not_include_the_documentId_parameter_when_only_proposed_checks_are_planned()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [ProposedCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("proposedNamespace", "namespacePrefixes");
+    }
+
+    [Test]
+    public void It_does_not_include_the_proposed_namespace_parameter_when_only_stored_checks_are_planned()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                ),
+                DocumentIdParameterName: "documentId",
+                ProposedNamespaceParameterName: "proposedNamespace"
+            )
+        );
+
+        plan.ParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("documentId", "namespacePrefixes");
+    }
+
+    [Test]
+    public void It_throws_when_a_pgsql_array_parameterization_is_handed_to_a_mssql_compiler()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Mssql);
+
+        var spec = new NamespaceAuthorizationSqlSpec(
+            [StoredCheck(0)],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            ),
+            DocumentIdParameterName: "documentId",
+            ProposedNamespaceParameterName: "proposedNamespace"
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not supported by SQL dialect 'Mssql'*");
+    }
+
+    [Test]
+    public void It_throws_when_a_mssql_scalar_parameterization_is_handed_to_a_pgsql_compiler()
+    {
+        var compiler = new NamespaceAuthorizationSqlCompiler(SqlDialect.Pgsql);
+
+        var spec = new NamespaceAuthorizationSqlSpec(
+            [StoredCheck(0)],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Mssql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            ),
+            DocumentIdParameterName: "documentId",
+            ProposedNamespaceParameterName: "proposedNamespace"
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not supported by SQL dialect 'Pgsql'*");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationSqlCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespaceAuthorizationSqlCompilerTests.cs
@@ -51,6 +51,11 @@ public class Given_NamespaceAuthorizationSqlCompiler
             .Contain(
                 "WHEN EXISTS (SELECT 1 FROM \"edfi\".\"GradebookEntry\" r WHERE r.\"DocumentId\" = @documentId AND (r.\"Namespace\" IS NULL OR r.\"Namespace\" = '')) THEN \"dms\".\"throw_error\"('AUTH1', 'ns1|0|u')"
             );
+        // A target row missing entirely raises the stale stored-target kind ('s') rather than mismatch.
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN NOT EXISTS (SELECT 1 FROM \"edfi\".\"GradebookEntry\" r WHERE r.\"DocumentId\" = @documentId) THEN \"dms\".\"throw_error\"('AUTH1', 'ns1|0|s')"
+            );
         plan.AuthorizationSql.Should().Contain("ELSE \"dms\".\"throw_error\"('AUTH1', 'ns1|0|m')");
         plan.ParametersInOrder.Select(static p => p.ParameterName)
             .Should()
@@ -82,6 +87,10 @@ public class Given_NamespaceAuthorizationSqlCompiler
         plan.AuthorizationSql.Should()
             .Contain(
                 "WHEN EXISTS (SELECT 1 FROM [edfi].[GradebookEntry] r WHERE r.[DocumentId] = @documentId AND (r.[Namespace] IS NULL OR r.[Namespace] = '')) THEN CAST('AUTH1 - ns1|0|u' AS INT)"
+            );
+        plan.AuthorizationSql.Should()
+            .Contain(
+                "WHEN NOT EXISTS (SELECT 1 FROM [edfi].[GradebookEntry] r WHERE r.[DocumentId] = @documentId) THEN CAST('AUTH1 - ns1|0|s' AS INT)"
             );
         plan.AuthorizationSql.Should().Contain("ELSE CAST('AUTH1 - ns1|0|m' AS INT)");
         plan.ParametersInOrder.Select(static p => p.ParameterName)
@@ -226,10 +235,11 @@ public class Given_NamespaceAuthorizationSqlCompiler
             )
         );
 
-        // No relationship-discriminator payloads should ever leak into namespace SQL.
+        // No relationship-discriminator payloads should ever leak into namespace SQL. The stored check
+        // emits the 's' (stale stored-target) kind in addition to 'u' and 'm'.
         plan.AuthorizationSql.Should().NotContain("'1|");
-        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|0\|[^urm]");
-        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|1\|[^urm]");
+        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|0\|[^urms]");
+        plan.AuthorizationSql.Should().NotMatchRegex(@"AUTH1[^']*\bns1\|1\|[^urms]");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespacePrefixParameterizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NamespacePrefixParameterizationTests.cs
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespacePrefixParameterizationFactory
+{
+    [Test]
+    public void It_creates_a_pgsql_array_parameterization_carrying_one_parameter_with_each_prefix_already_carrying_a_trailing_percent()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.Kind.Should().Be(NamespacePrefixParameterizationKind.PgsqlArray);
+        parameterization.BaseParameterName.Should().Be("namespacePrefixes");
+        parameterization.LikePatternsInOrder.Should().Equal("uri://ed-fi.org/%", "uri://gbisd.edu/%");
+        parameterization.ParameterNamesInOrder.Should().Equal("namespacePrefixes");
+    }
+
+    [Test]
+    public void It_creates_a_mssql_scalar_parameterization_with_one_indexed_parameter_per_prefix()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/", "uri://acme.test/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.Kind.Should().Be(NamespacePrefixParameterizationKind.MssqlScalar);
+        parameterization
+            .LikePatternsInOrder.Should()
+            .Equal("uri://acme.test/%", "uri://ed-fi.org/%", "uri://gbisd.edu/%");
+        parameterization
+            .ParameterNamesInOrder.Should()
+            .Equal("namespacePrefixes_0", "namespacePrefixes_1", "namespacePrefixes_2");
+    }
+
+    [Test]
+    public void It_deduplicates_and_orders_prefixes_before_appending_the_trailing_percent()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://b.org/", "uri://a.org/", "uri://b.org/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.LikePatternsInOrder.Should().Equal("uri://a.org/%", "uri://b.org/%");
+    }
+
+    [Test]
+    public void It_carries_raw_configured_prefixes_separately_from_the_escaped_like_patterns()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            ["uri://b_org/", "uri://a.org/"],
+            "namespacePrefixes"
+        );
+
+        // Raw prefixes are deduped + ordinal-sorted but neither escaped nor wildcard-suffixed; the
+        // escaped LIKE patterns line up 1:1 for SQL binding.
+        parameterization.ConfiguredPrefixesInOrder.Should().Equal("uri://a.org/", "uri://b_org/");
+        parameterization.LikePatternsInOrder.Should().Equal("uri://a.org/%", "uri://b\\_org/%");
+    }
+
+    [Test]
+    public void It_escapes_like_metacharacters_in_pgsql_prefixes_keeping_the_trailing_percent_a_wildcard()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://a_b/", "uri://c%d/", "uri://e\\f/"],
+            "namespacePrefixes"
+        );
+
+        // Underscore, percent, and backslash in the prefix are escaped with a backslash; the trailing
+        // wildcard percent is appended after escaping so it remains a wildcard.
+        parameterization
+            .LikePatternsInOrder.Should()
+            .Equal("uri://a\\_b/%", "uri://c\\%d/%", "uri://e\\\\f/%");
+    }
+
+    [Test]
+    public void It_escapes_square_brackets_only_for_mssql()
+    {
+        var mssql = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            ["uri://a[b]/"],
+            "namespacePrefixes"
+        );
+        var pgsql = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://a[b]/"],
+            "namespacePrefixes"
+        );
+
+        // SQL Server LIKE treats '[' as a character-class opener, so it must be escaped; PostgreSQL
+        // does not, so the bracket is left untouched there.
+        mssql.LikePatternsInOrder.Should().Equal("uri://a\\[b]/%");
+        pgsql.LikePatternsInOrder.Should().Equal("uri://a[b]/%");
+    }
+
+    [Test]
+    public void It_throws_when_mssql_prefix_count_reaches_2000()
+    {
+        var prefixes = Enumerable
+            .Range(0, NamespacePrefixLimitExceededException.MssqlScalarParameterLimit)
+            .Select(static index => $"uri://prefix-{index:D5}/")
+            .ToArray();
+
+        var act = () =>
+            NamespacePrefixParameterizationFactory.Create(SqlDialect.Mssql, prefixes, "namespacePrefixes");
+
+        act.Should()
+            .Throw<NamespacePrefixLimitExceededException>()
+            .Which.PrefixCount.Should()
+            .Be(NamespacePrefixLimitExceededException.MssqlScalarParameterLimit);
+    }
+
+    [Test]
+    public void It_allows_mssql_prefix_count_of_1999_just_below_the_limit()
+    {
+        var prefixes = Enumerable
+            .Range(0, NamespacePrefixLimitExceededException.MssqlScalarParameterLimit - 1)
+            .Select(static index => $"uri://prefix-{index:D5}/")
+            .ToArray();
+
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            prefixes,
+            "namespacePrefixes"
+        );
+
+        parameterization
+            .LikePatternsInOrder.Should()
+            .HaveCount(NamespacePrefixLimitExceededException.MssqlScalarParameterLimit - 1);
+        parameterization
+            .ParameterNamesInOrder.Should()
+            .HaveCount(NamespacePrefixLimitExceededException.MssqlScalarParameterLimit - 1);
+    }
+
+    [Test]
+    public void It_does_not_apply_the_prefix_cap_to_pgsql()
+    {
+        var prefixes = Enumerable
+            .Range(0, NamespacePrefixLimitExceededException.MssqlScalarParameterLimit + 1)
+            .Select(static index => $"uri://prefix-{index:D5}/")
+            .ToArray();
+
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            prefixes,
+            "namespacePrefixes"
+        );
+
+        parameterization.Kind.Should().Be(NamespacePrefixParameterizationKind.PgsqlArray);
+        parameterization
+            .LikePatternsInOrder.Should()
+            .HaveCount(NamespacePrefixLimitExceededException.MssqlScalarParameterLimit + 1);
+        parameterization.ParameterNamesInOrder.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void It_matches_a_stored_value_that_starts_with_a_configured_prefix()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.MatchesAnyPrefix("uri://gbisd.edu/SchoolTypeDescriptor").Should().BeTrue();
+    }
+
+    [Test]
+    public void It_does_not_match_a_stored_value_that_starts_with_no_configured_prefix()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.MatchesAnyPrefix("uri://other.org/SchoolTypeDescriptor").Should().BeFalse();
+    }
+
+    [Test]
+    public void It_matches_case_sensitively_for_pgsql_mirroring_the_case_sensitive_like()
+    {
+        // PostgreSQL LIKE is case-sensitive under the Namespace column's deterministic default
+        // collation, so an in-memory match must reject a value that only case-differs from a prefix.
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.MatchesAnyPrefix("uri://ED-FI.ORG/SchoolTypeDescriptor").Should().BeFalse();
+    }
+
+    [Test]
+    public void It_matches_case_insensitively_for_mssql_mirroring_the_case_insensitive_like()
+    {
+        // SQL Server LIKE is case-insensitive under the Namespace column's default collation, so an
+        // in-memory match must accept a value that only case-differs from a prefix.
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            ["uri://ed-fi.org/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.MatchesAnyPrefix("uri://ED-FI.ORG/SchoolTypeDescriptor").Should().BeTrue();
+    }
+
+    [Test]
+    public void It_treats_like_metacharacters_in_a_prefix_as_literals_mirroring_the_escaped_like_pattern()
+    {
+        // The raw prefix contains an underscore. The SQL path escapes it so it matches literally; the
+        // in-memory starts-with over the raw prefix must do the same, accepting only a literal
+        // underscore and rejecting an arbitrary single character in that position.
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://a_b/"],
+            "namespacePrefixes"
+        );
+
+        parameterization.MatchesAnyPrefix("uri://a_b/Descriptor").Should().BeTrue();
+        parameterization.MatchesAnyPrefix("uri://aXb/Descriptor").Should().BeFalse();
+    }
+
+    [Test]
+    public void It_throws_when_the_stored_value_is_null()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/"],
+            "namespacePrefixes"
+        );
+
+        var act = () => parameterization.MatchesAnyPrefix(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Test]
+    public void It_throws_when_prefixes_are_empty()
+    {
+        var act = () =>
+            NamespacePrefixParameterizationFactory.Create(SqlDialect.Pgsql, [], "namespacePrefixes");
+
+        act.Should().Throw<ArgumentException>().WithParameterName("namespacePrefixes");
+    }
+
+    [Test]
+    public void It_throws_when_any_prefix_is_null_or_empty()
+    {
+        var actNull = () =>
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/", null!],
+                "namespacePrefixes"
+            );
+        var actEmpty = () =>
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/", ""],
+                "namespacePrefixes"
+            );
+
+        actNull.Should().Throw<ArgumentException>().WithParameterName("namespacePrefixes");
+        actEmpty.Should().Throw<ArgumentException>().WithParameterName("namespacePrefixes");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/PageDocumentIdSqlCompilerNamespaceTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/PageDocumentIdSqlCompilerNamespaceTests.cs
@@ -1,0 +1,738 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+public class Given_PageDocumentIdSqlCompiler_with_namespace_authorization
+{
+    private static readonly DbSchemaName _edfiSchema = new("edfi");
+    private static readonly DbSchemaName _dmsSchema = new("dms");
+    private static readonly DbTableName _rootTable = new(_edfiSchema, "GradebookEntry");
+    private static readonly DbTableName _documentTable = new(_dmsSchema, "Document");
+    private static readonly DbTableName _descriptorTable = new(_dmsSchema, "Descriptor");
+    private static readonly DbColumnName _namespaceColumn = new("Namespace");
+
+    [Test]
+    public void It_emits_a_pgsql_LIKE_ANY_predicate_against_the_root_namespace_column_with_a_null_guard()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://ed-fi.org/", "uri://gbisd.edu/"])
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain("(r.\"Namespace\" IS NOT NULL AND r.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+        plan.PageDocumentIdSql.Should().NotContain("OR r.\"Namespace\" LIKE");
+        plan.PageParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("namespacePrefixes", "offset", "limit");
+        plan.PageParametersInOrder.First(static p => p.ParameterName == "namespacePrefixes")
+            .Binding.Kind.Should()
+            .Be(QuerySqlParameterBindingKind.PgsqlArray);
+    }
+
+    [Test]
+    public void It_emits_a_mssql_OR_chain_LIKE_predicate_against_the_root_namespace_column_with_a_null_guard()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(
+            CreateNamespaceOnlySpec(
+                SqlDialect.Mssql,
+                ["uri://ed-fi.org/", "uri://gbisd.edu/", "uri://acme.test/"]
+            )
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain(
+                "(r.[Namespace] IS NOT NULL AND ("
+                    + "r.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' "
+                    + "OR r.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\' "
+                    + "OR r.[Namespace] LIKE @namespacePrefixes_2 ESCAPE '\\'"
+                    + "))"
+            );
+        plan.PageParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("namespacePrefixes_0", "namespacePrefixes_1", "namespacePrefixes_2", "offset", "limit");
+    }
+
+    [Test]
+    public void It_emits_a_pgsql_LIKE_ANY_predicate_when_only_one_prefix_is_configured()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(CreateNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://ed-fi.org/"]));
+
+        plan.PageDocumentIdSql.Should()
+            .Contain("(r.\"Namespace\" IS NOT NULL AND r.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_emits_namespace_AND_group_outside_relationship_OR_group_in_mixed_strategy_configs_pgsql()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateMixedSpec(
+                SqlDialect.Pgsql,
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                claimEducationOrganizationIds: [255901L, 100L]
+            )
+        );
+
+        var namespaceIndex = plan.PageDocumentIdSql.IndexOf(
+            "(r.\"Namespace\" IS NOT NULL AND r.\"Namespace\" LIKE ANY(@namespacePrefixes))",
+            StringComparison.Ordinal
+        );
+        var relationshipGroupIndex = plan.PageDocumentIdSql.IndexOf(
+            "AND (((r.\"SchoolId\"",
+            StringComparison.Ordinal
+        );
+
+        namespaceIndex.Should().BeGreaterThan(-1);
+        relationshipGroupIndex.Should().BeGreaterThan(namespaceIndex);
+    }
+
+    [Test]
+    public void It_emits_namespace_AND_group_outside_relationship_OR_group_in_mixed_strategy_configs_mssql()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(
+            CreateMixedSpec(
+                SqlDialect.Mssql,
+                namespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                claimEducationOrganizationIds: [255901L]
+            )
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain(
+                "(r.[Namespace] IS NOT NULL AND ("
+                    + "r.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' "
+                    + "OR r.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\'"
+                    + "))"
+            );
+        plan.PageDocumentIdSql.Should().Contain("AND (((r.[SchoolId]");
+    }
+
+    [Test]
+    public void It_brackets_the_relationship_OR_group_inside_its_own_parens_so_namespace_AND_does_not_flatten_it()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateMixedSpec(
+                SqlDialect.Pgsql,
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                claimEducationOrganizationIds: [255901L, 100L],
+                includeInvertedRelationshipStrategy: true
+            )
+        );
+
+        // The relationship OR group must always appear as one outer-parens predicate, with each
+        // OR strategy in its own inner parens. If the compiler ever flattened the group so that
+        // the namespace AND associated with the first OR strategy alone, the SQL would read
+        // "AND (strat1) OR (strat2)" without the outer wrapper — these two assertions both fail
+        // in that regression.
+        plan.PageDocumentIdSql.Should().Contain("AND ((");
+        plan.PageDocumentIdSql.Should().Contain(") OR (");
+    }
+
+    [Test]
+    public void It_throws_when_a_namespace_check_spec_targets_a_table_other_than_the_query_root_table()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        new DbTableName(_edfiSchema, "OtherRootTable"),
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*root-table*");
+    }
+
+    [Test]
+    public void It_throws_when_a_namespace_check_entry_is_null()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _rootTable,
+                        _namespaceColumn
+                    ),
+                    null!,
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*NamespaceChecks must not contain null entries*");
+    }
+
+    [Test]
+    public void It_throws_rather_than_compiling_without_authorization_when_namespace_checks_contains_only_null()
+    {
+        // A namespace check list whose only entry is null must fail closed. If the compiler silently
+        // dropped the null entry, the spec would normalize to no namespace checks and no strategies,
+        // emitting an unauthorized query that returns every row.
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks: [null!],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should()
+            .Throw<ArgumentException>()
+            .WithMessage("*NamespaceChecks must not contain null entries*");
+    }
+
+    [Test]
+    public void It_escapes_like_metacharacters_in_pgsql_prefixes_so_underscore_and_percent_match_literally()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(CreateNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://a_b/", "uri://c%d/"]));
+
+        // The escaped prefixes are bound parameter VALUES, not part of the SQL text, so assert
+        // through the parameterization the spec carries. The trailing % stays an unescaped wildcard.
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Pgsql,
+            ["uri://a_b/", "uri://c%d/"],
+            "namespacePrefixes"
+        );
+        parameterization.LikePatternsInOrder.Should().Equal("uri://a\\_b/%", "uri://c\\%d/%");
+        plan.PageDocumentIdSql.Should().Contain("LIKE ANY(@namespacePrefixes)");
+        plan.PageDocumentIdSql.Should().NotContain("ESCAPE");
+    }
+
+    [Test]
+    public void It_escapes_like_metacharacters_in_mssql_prefixes_and_emits_an_escape_clause()
+    {
+        var parameterization = NamespacePrefixParameterizationFactory.Create(
+            SqlDialect.Mssql,
+            ["uri://a_b/", "uri://c%d/", "uri://e[f/"],
+            "namespacePrefixes"
+        );
+
+        parameterization
+            .LikePatternsInOrder.Should()
+            .Equal("uri://a\\_b/%", "uri://c\\%d/%", "uri://e\\[f/%");
+
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Mssql);
+        var plan = compiler.Compile(
+            CreateNamespaceOnlySpec(SqlDialect.Mssql, ["uri://a_b/", "uri://c%d/", "uri://e[f/"])
+        );
+
+        plan.PageDocumentIdSql.Should().Contain("LIKE @namespacePrefixes_0 ESCAPE '\\'");
+    }
+
+    [Test]
+    public void It_throws_when_a_pgsql_array_parameterization_is_handed_to_a_mssql_compiler()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Mssql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _rootTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not supported by SQL dialect 'Mssql'*");
+    }
+
+    [Test]
+    public void It_throws_when_a_mssql_scalar_parameterization_is_handed_to_a_pgsql_compiler()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _rootTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Mssql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*not supported by SQL dialect 'Pgsql'*");
+    }
+
+    [Test]
+    public void It_emits_namespace_AND_group_before_the_relationship_OR_group_in_the_WHERE_clause_order()
+    {
+        // Namespace AND group is emitted before the relationship OR group so the composed WHERE
+        // clause is deterministic and the AND-around-OR bracketing reads top-to-bottom.
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateMixedSpec(
+                SqlDialect.Pgsql,
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                claimEducationOrganizationIds: [255901L]
+            )
+        );
+
+        var namespaceIndex = plan.PageDocumentIdSql.IndexOf("Namespace", StringComparison.Ordinal);
+        var schoolIdIndex = plan.PageDocumentIdSql.IndexOf("SchoolId", StringComparison.Ordinal);
+
+        namespaceIndex.Should().BeLessThan(schoolIdIndex);
+    }
+
+    [Test]
+    public void It_produces_the_total_count_sql_with_the_same_namespace_predicate_shape()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateNamespaceOnlySpec(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                includeTotalCountSql: true
+            )
+        );
+
+        plan.TotalCountSql.Should().NotBeNull();
+        plan.TotalCountSql!.Should()
+            .Contain("(r.\"Namespace\" IS NOT NULL AND r.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_emits_a_pgsql_descriptor_alias_LIKE_ANY_predicate_when_the_namespace_check_targets_dms_Descriptor()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://ed-fi.org/", "uri://gbisd.edu/"])
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+        plan.PageDocumentIdSql.Should().NotContain("r.\"Namespace\"");
+    }
+
+    [Test]
+    public void It_emits_a_mssql_descriptor_alias_OR_chain_LIKE_predicate_when_the_namespace_check_targets_dms_Descriptor()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Mssql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorNamespaceOnlySpec(SqlDialect.Mssql, ["uri://ed-fi.org/", "uri://gbisd.edu/"])
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain(
+                "(d.[Namespace] IS NOT NULL AND ("
+                    + "d.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' "
+                    + "OR d.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\'"
+                    + "))"
+            );
+        plan.PageDocumentIdSql.Should().NotContain("r.[Namespace]");
+    }
+
+    [Test]
+    public void It_triggers_the_descriptor_join_when_only_a_descriptor_namespace_check_is_present()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://ed-fi.org/"])
+        );
+
+        plan.PageDocumentIdSql.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+    }
+
+    [Test]
+    public void It_triggers_the_descriptor_join_in_total_count_sql_when_only_a_descriptor_namespace_check_is_present()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorNamespaceOnlySpec(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                includeTotalCountSql: true
+            )
+        );
+
+        plan.TotalCountSql.Should().NotBeNull();
+        plan.TotalCountSql!.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+        plan.TotalCountSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_keeps_the_document_alias_for_root_predicates_when_a_descriptor_namespace_check_is_emitted()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorSpecWithResourceKeyAndNamespace(SqlDialect.Pgsql, ["uri://ed-fi.org/"])
+        );
+
+        plan.PageDocumentIdSql.Should().Contain("r.\"ResourceKeyId\" = @resourceKeyId");
+        plan.PageDocumentIdSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_brackets_the_descriptor_namespace_AND_group_alongside_a_descriptor_column_predicate()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorSpecWithCodeValueAndNamespace(SqlDialect.Pgsql, ["uri://ed-fi.org/"])
+        );
+
+        plan.PageDocumentIdSql.Should().Contain("d.\"CodeValue\" = @codeValue");
+        plan.PageDocumentIdSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+        plan.PageDocumentIdSql.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+    }
+
+    [Test]
+    public void It_lists_descriptor_namespace_prefix_parameters_in_the_page_parameter_inventory()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+
+        var plan = compiler.Compile(
+            CreateDescriptorNamespaceOnlySpec(SqlDialect.Pgsql, ["uri://ed-fi.org/", "uri://gbisd.edu/"])
+        );
+
+        plan.PageParametersInOrder.Select(static p => p.ParameterName)
+            .Should()
+            .Equal("namespacePrefixes", "offset", "limit");
+        plan.PageParametersInOrder.First(static p => p.ParameterName == "namespacePrefixes")
+            .Binding.Kind.Should()
+            .Be(QuerySqlParameterBindingKind.PgsqlArray);
+    }
+
+    [Test]
+    public void It_still_throws_when_a_namespace_check_targets_a_table_that_is_neither_the_query_root_nor_dms_Descriptor()
+    {
+        var compiler = new PageDocumentIdSqlCompiler(SqlDialect.Pgsql);
+        var spec = new PageDocumentIdQuerySpec(
+            RootTable: _documentTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        new DbTableName(_edfiSchema, "SomeOtherTable"),
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var act = () => compiler.Compile(spec);
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    private static PageDocumentIdQuerySpec CreateDescriptorNamespaceOnlySpec(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes,
+        bool includeTotalCountSql = false
+    ) =>
+        new(
+            RootTable: _documentTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            IncludeTotalCountSql: includeTotalCountSql,
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _descriptorTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    dialect,
+                    namespacePrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+    private static PageDocumentIdQuerySpec CreateDescriptorSpecWithResourceKeyAndNamespace(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes
+    ) =>
+        new(
+            RootTable: _documentTable,
+            Predicates:
+            [
+                new QueryValuePredicate(
+                    new DbColumnName("ResourceKeyId"),
+                    QueryComparisonOperator.Equal,
+                    "resourceKeyId"
+                ),
+            ],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _descriptorTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    dialect,
+                    namespacePrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+    private static PageDocumentIdQuerySpec CreateDescriptorSpecWithCodeValueAndNamespace(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes
+    ) =>
+        new(
+            RootTable: _documentTable,
+            Predicates:
+            [
+                new QueryValuePredicate(
+                    new DbColumnName("ResourceKeyId"),
+                    QueryComparisonOperator.Equal,
+                    "resourceKeyId"
+                ),
+                new QueryValuePredicate(
+                    new QueryPredicateTarget.DescriptorColumn(new DbColumnName("CodeValue")),
+                    QueryComparisonOperator.Equal,
+                    "codeValue",
+                    ScalarKind.String
+                ),
+            ],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _descriptorTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    dialect,
+                    namespacePrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+    private static PageDocumentIdQuerySpec CreateNamespaceOnlySpec(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes,
+        bool includeTotalCountSql = false
+    ) =>
+        new(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            IncludeTotalCountSql: includeTotalCountSql,
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _rootTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    dialect,
+                    namespacePrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+    private static PageDocumentIdAuthorizationEdOrgSubject CreateEdOrgSchoolSubject(
+        RelationshipAuthorizationHierarchyDirection direction
+    ) =>
+        new(
+            _rootTable,
+            new DbColumnName("SchoolId"),
+            RelationshipAuthorizationAuthObject.CreateEdOrgHierarchy(direction),
+            [
+                new RelationshipAuthorizationSubjectContributor(
+                    SecurableElementKind.EducationOrganization,
+                    "$.SchoolId",
+                    "SchoolId"
+                ),
+            ]
+        );
+
+    private static PageDocumentIdQuerySpec CreateMixedSpec(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        bool includeInvertedRelationshipStrategy = false
+    )
+    {
+        var strategies = new List<PageDocumentIdAuthorizationStrategy>
+        {
+            new(
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+                [CreateEdOrgSchoolSubject(RelationshipAuthorizationHierarchyDirection.Normal)]
+            ),
+        };
+
+        if (includeInvertedRelationshipStrategy)
+        {
+            strategies.Add(
+                new PageDocumentIdAuthorizationStrategy(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnlyInverted,
+                    [CreateEdOrgSchoolSubject(RelationshipAuthorizationHierarchyDirection.Inverted)]
+                )
+            );
+        }
+
+        return new PageDocumentIdQuerySpec(
+            RootTable: _rootTable,
+            Predicates: [],
+            UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
+            Authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: strategies,
+                ClaimEducationOrganizationIdParameterization: AuthorizationClaimEducationOrganizationIdParameterizationFactory.Create(
+                    dialect,
+                    claimEducationOrganizationIds,
+                    RelationalAuthorizationParameterNameConstants.ClaimEducationOrganizationIds
+                ),
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        _rootTable,
+                        _namespaceColumn
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    dialect,
+                    namespacePrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationAuth1DispatcherTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_RelationalAuthorizationAuth1Dispatcher
+{
+    [Test]
+    public void It_routes_a_postgresql_relationship_payload_to_the_relationship_codec()
+    {
+        var payloadText = "1|7|2|0:0:s,1:0:n";
+
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: payloadText,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Relationship>();
+        var relationship = (RelationalAuthorizationAuth1DispatchResult.Relationship)result!;
+        relationship.Payload.EmittedAuth1Index.Should().Be(7);
+        relationship.Payload.SubjectFailures.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void It_routes_a_sql_server_relationship_payload_via_the_AUTH1_dash_marker()
+    {
+        var sqlServerMessage =
+            "Conversion failed when converting the varchar value 'AUTH1 - 1|3|1|0:0:p' to data type int.";
+
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Mssql,
+            providerErrorCode: null,
+            providerMessage: sqlServerMessage,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Relationship>();
+    }
+
+    [Test]
+    public void It_routes_a_postgresql_namespace_payload_to_the_namespace_codec()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: "ns1|2|m",
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Namespace>();
+        var ns = (RelationalAuthorizationAuth1DispatchResult.Namespace)result!;
+        ns.Payload.EmittedAuth1Index.Should().Be(2);
+        ns.Payload.FailureKind.Should().Be(NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
+    }
+
+    [Test]
+    public void It_routes_a_sql_server_namespace_payload_via_the_AUTH1_dash_marker()
+    {
+        var sqlServerMessage =
+            "Conversion failed when converting the varchar value 'AUTH1 - ns1|4|u' to data type int.";
+
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Mssql,
+            providerErrorCode: null,
+            providerMessage: sqlServerMessage,
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.Namespace>();
+        var ns = (RelationalAuthorizationAuth1DispatchResult.Namespace)result!;
+        ns.Payload.FailureKind.Should()
+            .Be(NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized);
+    }
+
+    [Test]
+    public void It_returns_invalid_payload_for_an_unknown_discriminator()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "AUTH1",
+            providerMessage: "v2|0|x",
+            out var result
+        );
+
+        dispatched.Should().BeTrue();
+        result.Should().BeOfType<RelationalAuthorizationAuth1DispatchResult.InvalidPayload>();
+        var invalid = (RelationalAuthorizationAuth1DispatchResult.InvalidPayload)result!;
+        invalid.RawPayload.Should().Be("v2|0|x");
+    }
+
+    [Test]
+    public void It_returns_false_when_postgresql_error_code_is_not_AUTH1()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Pgsql,
+            providerErrorCode: "P0001",
+            providerMessage: "ns1|0|m",
+            out var result
+        );
+
+        dispatched.Should().BeFalse();
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void It_returns_false_when_sql_server_message_has_no_AUTH1_marker()
+    {
+        var dispatched = RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+            SqlDialect.Mssql,
+            providerErrorCode: null,
+            providerMessage: "Some unrelated SQL Server exception.",
+            out var result
+        );
+
+        dispatched.Should().BeFalse();
+        result.Should().BeNull();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationalAuthorizationPlannerTests.cs
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Plans.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_RelationalAuthorizationPlanner
+{
+    private static readonly DbSchemaName _edfiSchema = new("edfi");
+    private static readonly DbColumnName _documentId = new("DocumentId");
+
+    private static DbTableName Table(string name) => new(_edfiSchema, name);
+
+    private static DbColumnName Col(string name) => new(name);
+
+    private static JsonPathExpression Path(string canonical) => new(canonical, []);
+
+    private static ResourceKeyEntry ResourceKey(short id, string resource) =>
+        new(id, new QualifiedResourceName("Ed-Fi", resource), "1.0", false);
+
+    private static DbTableModel RootTable(string name, IReadOnlyList<DbColumnModel> columns) =>
+        new(
+            Table(name),
+            Path("$"),
+            new TableKey("PK_" + name, [new DbKeyColumn(_documentId, ColumnKind.Scalar)]),
+            columns,
+            []
+        );
+
+    private static ConcreteResourceModel RootNamespaceResource()
+    {
+        var root = RootTable(
+            "AcademicWeek",
+            [new DbColumnModel(Col("Namespace"), ColumnKind.Scalar, null, false, Path("$.namespace"), null)]
+        );
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "AcademicWeek"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            [],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(1, "AcademicWeek"),
+            ResourceStorageKind.RelationalTables,
+            model
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], ["$.namespace"], [], [], []),
+        };
+    }
+
+    private static ConcreteResourceModel ResourceWithoutSecurableElements()
+    {
+        var root = RootTable("PlainResource", []);
+        var model = new RelationalResourceModel(
+            new QualifiedResourceName("Ed-Fi", "PlainResource"),
+            _edfiSchema,
+            ResourceStorageKind.RelationalTables,
+            root,
+            [root],
+            [],
+            []
+        );
+        return new ConcreteResourceModel(
+            ResourceKey(2, "PlainResource"),
+            ResourceStorageKind.RelationalTables,
+            model
+        );
+    }
+
+    private static MappingSet EmptyMappingSet() =>
+        new(
+            Key: new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
+            Model: new DerivedRelationalModelSet(
+                EffectiveSchema: new EffectiveSchemaInfo(
+                    ApiSchemaFormatVersion: "1.0",
+                    RelationalMappingVersion: "v1",
+                    EffectiveSchemaHash: "schema-hash",
+                    ResourceKeyCount: 0,
+                    ResourceKeySeedHash: [1, 2, 3],
+                    SchemaComponentsInEndpointOrder: [],
+                    ResourceKeysInIdOrder: []
+                ),
+                Dialect: SqlDialect.Pgsql,
+                ProjectSchemasInEndpointOrder: [],
+                ConcreteResourcesInNameOrder: [],
+                AbstractIdentityTablesInNameOrder: [],
+                AbstractUnionViewsInNameOrder: [],
+                IndexesInCreateOrder: [],
+                TriggersInCreateOrder: []
+            ),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>(),
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>(),
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+
+    private static ConfiguredAuthorizationStrategy Strategy(string name, int index) => new(name, index);
+
+    private static RelationalAuthorizationContext TwoPrefixContext() =>
+        new([], ["uri://ed-fi.org/", "uri://gbisd.edu/"]);
+
+    private static RelationalAuthorizationContext EmptyPrefixContext() => new([], []);
+
+    [Test]
+    public void It_returns_a_plan_with_namespace_checks_when_only_NamespaceBased_is_configured()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0)],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().HaveCount(1);
+        plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_returns_a_plan_with_relationship_strategies_passed_through_when_no_NamespaceBased_is_configured()
+    {
+        var resource = ResourceWithoutSecurableElements();
+        var relationshipStrategy = Strategy(
+            AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+            0
+        );
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [relationshipStrategy],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().BeEmpty();
+        plan.NonNamespaceConfiguredStrategies.Should().Equal(relationshipStrategy);
+    }
+
+    [Test]
+    public void It_returns_a_plan_when_both_NamespaceBased_and_relationship_strategies_are_configured()
+    {
+        var resource = RootNamespaceResource();
+        var relationshipStrategy = Strategy(
+            AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+            1
+        );
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), relationshipStrategy],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().HaveCount(1);
+        plan.NonNamespaceConfiguredStrategies.Should().Equal(relationshipStrategy);
+    }
+
+    [Test]
+    public void It_returns_still_unsupported_when_OwnershipBased_is_configured_alongside_NamespaceBased()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    [Test]
+    public void It_returns_still_unsupported_when_OwnershipBased_is_configured_alone()
+    {
+        var resource = ResourceWithoutSecurableElements();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 0)],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>();
+    }
+
+    [Test]
+    public void It_carries_the_non_namespace_strategies_on_a_still_unsupported_outcome()
+    {
+        var resource = RootNamespaceResource();
+        var ownership = Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1);
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), ownership],
+            TwoPrefixContext()
+        );
+
+        var stillUnsupported = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.StillUnsupported>()
+            .Subject;
+        stillUnsupported.NonNamespaceConfiguredStrategies.Should().Equal(ownership);
+    }
+
+    [Test]
+    public void It_carries_the_non_namespace_strategies_on_a_security_configuration_error_outcome()
+    {
+        var resource = RootNamespaceResource();
+        var madeUp = Strategy("MadeUpStrategy", 1);
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), madeUp],
+            TwoPrefixContext()
+        );
+
+        var securityError = outcome
+            .Should()
+            .BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>()
+            .Subject;
+        securityError.NonNamespaceConfiguredStrategies.Should().Equal(madeUp);
+    }
+
+    [Test]
+    public void It_returns_security_configuration_error_when_an_unknown_strategy_is_configured()
+    {
+        var resource = ResourceWithoutSecurableElements();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy("MadeUpStrategy", 0)],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>();
+    }
+
+    [Test]
+    public void It_propagates_no_usable_root_column_when_NamespaceBased_resource_has_only_invalid_metadata()
+    {
+        var resource = ResourceWithoutSecurableElements();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0)],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoUsableRootColumn>();
+    }
+
+    [Test]
+    public void It_returns_no_usable_root_column_before_still_unsupported_when_both_are_present()
+    {
+        var resource = ResourceWithoutSecurableElements();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoUsableRootColumn>();
+    }
+
+    [Test]
+    public void It_propagates_no_prefixes_configured_when_metadata_is_valid_and_client_prefixes_are_empty()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0)],
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoPrefixesConfigured>();
+    }
+
+    [Test]
+    public void It_returns_no_prefixes_before_still_unsupported_when_unsupported_strategy_is_also_configured()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [
+                Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0),
+                Strategy(AuthorizationStrategyNameConstants.OwnershipBased, 1),
+            ],
+            EmptyPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.NoPrefixesConfigured>();
+    }
+
+    [Test]
+    public void It_returns_security_configuration_error_before_namespace_outcomes_when_unknown_strategy_is_present()
+    {
+        var resource = RootNamespaceResource();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), Strategy("MadeUpStrategy", 1)],
+            TwoPrefixContext()
+        );
+
+        outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.SecurityConfigurationError>();
+    }
+
+    [Test]
+    public void It_treats_NoFurtherAuthorizationRequired_as_a_non_namespace_strategy_passed_through_to_the_caller()
+    {
+        var resource = ResourceWithoutSecurableElements();
+        var nfar = Strategy(AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired, 0);
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [nfar],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().BeEmpty();
+        plan.NonNamespaceConfiguredStrategies.Should().Equal(nfar);
+    }
+
+    [Test]
+    public void It_returns_an_empty_plan_when_no_strategies_are_configured()
+    {
+        var resource = ResourceWithoutSecurableElements();
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NamespaceChecks.Should().BeEmpty();
+        plan.NonNamespaceConfiguredStrategies.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_preserves_the_relative_order_of_non_namespace_strategies()
+    {
+        var resource = RootNamespaceResource();
+        var rwedoo = Strategy(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly, 1);
+        var rwedooi = Strategy(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnlyInverted, 2);
+
+        var outcome = RelationalAuthorizationPlanner.Plan(
+            EmptyMappingSet(),
+            resource,
+            NamespaceAuthorizationOperation.ReadSingle,
+            [Strategy(AuthorizationStrategyNameConstants.NamespaceBased, 0), rwedoo, rwedooi],
+            TwoPrefixContext()
+        );
+
+        var plan = outcome.Should().BeOfType<RelationalAuthorizationPlanOutcome.Plan>().Subject;
+        plan.NonNamespaceConfiguredStrategies.Should().Equal(rwedoo, rwedooi);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationPlannerTests.cs
@@ -2105,7 +2105,7 @@ public class Given_RelationshipAuthorizationPlannerTests
             resource,
             CreateConfiguredAuthorizationStrategies(
                 AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
-                AuthorizationStrategyNameConstants.NamespaceBased
+                AuthorizationStrategyNameConstants.OwnershipBased
             ),
             new RelationalAuthorizationContext([42L], [])
         );
@@ -2128,7 +2128,7 @@ public class Given_RelationshipAuthorizationPlannerTests
             .Should()
             .Equal(
                 AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
-                AuthorizationStrategyNameConstants.NamespaceBased
+                AuthorizationStrategyNameConstants.OwnershipBased
             );
         securityConfigurationErrorResult
             .Failures.Select(static failure => failure.RelationshipLocalOrder)
@@ -2236,7 +2236,7 @@ public class Given_RelationshipAuthorizationPlannerTests
         var result = planner.PlanStoredValues(
             CreateMinimalMappingSet(resource),
             resource,
-            CreateConfiguredAuthorizationStrategies(AuthorizationStrategyNameConstants.NamespaceBased),
+            CreateConfiguredAuthorizationStrategies(AuthorizationStrategyNameConstants.OwnershipBased),
             new RelationalAuthorizationContext([42L], [])
         );
 
@@ -2252,7 +2252,7 @@ public class Given_RelationshipAuthorizationPlannerTests
         knownButNotEnabledResult
             .Failures[0]
             .ConfiguredStrategy?.StrategyName.Should()
-            .Be(AuthorizationStrategyNameConstants.NamespaceBased);
+            .Be(AuthorizationStrategyNameConstants.OwnershipBased);
     }
 
     [Test]
@@ -2323,7 +2323,7 @@ public class Given_RelationshipAuthorizationPlannerTests
             CreateMinimalMappingSet(resource),
             resource,
             CreateConfiguredAuthorizationStrategies(
-                AuthorizationStrategyNameConstants.NamespaceBased,
+                AuthorizationStrategyNameConstants.OwnershipBased,
                 "CustomAuthorizationStrategy"
             ),
             new RelationalAuthorizationContext([42L], [])
@@ -2342,7 +2342,7 @@ public class Given_RelationshipAuthorizationPlannerTests
         securityConfigurationErrorResult
             .Failures[0]
             .ConfiguredStrategy?.StrategyName.Should()
-            .Be(AuthorizationStrategyNameConstants.NamespaceBased);
+            .Be(AuthorizationStrategyNameConstants.OwnershipBased);
         securityConfigurationErrorResult.Failures[0].RelationshipLocalOrder.Should().Be(0);
         securityConfigurationErrorResult
             .Failures[1]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationStrategyClassifierTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/RelationshipAuthorizationStrategyClassifierTests.cs
@@ -152,7 +152,7 @@ public class Given_RelationshipAuthorizationStrategyClassifier
         var classification = Classify(
             CreateMappingSet(_queryResource),
             AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
-            AuthorizationStrategyNameConstants.NamespaceBased,
+            AuthorizationStrategyNameConstants.RelationshipsWithStudentsOnly,
             AuthorizationStrategyNameConstants.OwnershipBased,
             AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired
         );
@@ -161,18 +161,18 @@ public class Given_RelationshipAuthorizationStrategyClassifier
         classification
             .SupportedStrategies.Select(static strategy => strategy.Kind)
             .Should()
-            .Equal(RelationshipAuthorizationStrategyKind.RelationshipsWithEdOrgsOnly);
+            .Equal(
+                RelationshipAuthorizationStrategyKind.RelationshipsWithEdOrgsOnly,
+                RelationshipAuthorizationStrategyKind.RelationshipsWithStudentsOnly
+            );
         classification
             .KnownButNotEnabledStrategies.Select(static strategy => strategy.Kind)
             .Should()
-            .Equal(
-                RelationshipAuthorizationStrategyKind.NamespaceBased,
-                RelationshipAuthorizationStrategyKind.OwnershipBased
-            );
+            .Equal(RelationshipAuthorizationStrategyKind.OwnershipBased);
         classification
             .KnownButNotEnabledStrategies.Select(static strategy => strategy.RelationshipLocalOrder)
             .Should()
-            .Equal(1, 2);
+            .Equal(2);
         classification.NoFurtherAuthorizationRequiredStrategies.Should().ContainSingle();
         classification.SecurityConfigurationFailures.Should().BeEmpty();
     }
@@ -282,7 +282,7 @@ public class Given_RelationshipAuthorizationStrategyClassifier
     {
         var classification = Classify(
             CreateMappingSet(_queryResource),
-            AuthorizationStrategyNameConstants.NamespaceBased,
+            AuthorizationStrategyNameConstants.OwnershipBased,
             "CustomAuthorizationStrategy"
         );
 
@@ -293,13 +293,36 @@ public class Given_RelationshipAuthorizationStrategyClassifier
         classification
             .KnownButNotEnabledStrategies[0]
             .Kind.Should()
-            .Be(RelationshipAuthorizationStrategyKind.NamespaceBased);
+            .Be(RelationshipAuthorizationStrategyKind.OwnershipBased);
         classification.SecurityConfigurationFailures.Should().ContainSingle();
         classification
             .SecurityConfigurationFailures[0]
             .FailureKind.Should()
             .Be(RelationshipAuthorizationFailureKind.InvalidAuthorizationStrategy);
         classification.SecurityConfigurationFailures[0].RelationshipLocalOrder.Should().Be(1);
+    }
+
+    [Test]
+    public void It_no_longer_classifies_NamespaceBased_as_known_but_not_enabled()
+    {
+        // NamespaceBased is now routed through the relational authorization orchestrator's namespace
+        // bucket and never reaches the relationship classifier; if a configured strategy with that name
+        // does leak through, it must be treated as an unknown invalid strategy rather than a known
+        // out-of-scope one.
+        var classification = Classify(
+            CreateMappingSet(_queryResource),
+            AuthorizationStrategyNameConstants.NamespaceBased
+        );
+
+        classification
+            .Outcome.Should()
+            .Be(RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError);
+        classification.KnownButNotEnabledStrategies.Should().BeEmpty();
+        classification.SecurityConfigurationFailures.Should().ContainSingle();
+        classification
+            .SecurityConfigurationFailures[0]
+            .FailureKind.Should()
+            .Be(RelationshipAuthorizationFailureKind.InvalidAuthorizationStrategy);
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/AuthorizationParameterBudget.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/AuthorizationParameterBudget.cs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Cross-checks the two list-shaped authorization parameterizations that a single GET-many page query can
+/// compose — the NamespaceBased prefix <c>LIKE</c> chain and the relationship claim education organization
+/// id list — against SQL Server's per-command parameter ceiling.
+/// </summary>
+/// <remarks>
+/// Each list is capped independently below 2,000 SQL Server scalar parameters
+/// (<see cref="NamespacePrefixLimitExceededException.MssqlScalarParameterLimit"/> and the claim
+/// parameterization's structured-parameter threshold). SQL Server, however, binds at most
+/// <see cref="MssqlMaxCommandParameters"/> parameters per command, so a query that composes both lists can
+/// exceed that ceiling even when each list is within its own cap, which would otherwise surface as an
+/// execution-time SQL error rather than a controlled authorization/configuration failure. Counting
+/// <see cref="NamespacePrefixParameterization.ParameterNamesInOrder"/> and
+/// <see cref="AuthorizationClaimEducationOrganizationIdParameterization.ParameterNamesInOrder"/> reflects
+/// the real bound parameter count per shape — a PostgreSQL array or SQL Server table-valued parameter is a
+/// single parameter, a SQL Server scalar list is one parameter per value — so PostgreSQL composition never
+/// approaches the limit and only the SQL Server scalar-plus-scalar case can.
+/// </remarks>
+public static class AuthorizationParameterBudget
+{
+    /// <summary>SQL Server's documented maximum number of parameters per command.</summary>
+    public const int MssqlMaxCommandParameters = 2100;
+
+    /// <summary>
+    /// Parameters reserved below <see cref="MssqlMaxCommandParameters"/> for the query-filter predicate
+    /// parameters and the two paging parameters the page query binds alongside the authorization lists.
+    /// </summary>
+    public const int ReservedNonAuthorizationParameters = 100;
+
+    /// <summary>
+    /// The maximum combined number of authorization parameters the two lists may bind together before the
+    /// composed page query risks exceeding SQL Server's per-command parameter ceiling.
+    /// </summary>
+    public const int MssqlCombinedAuthorizationParameterLimit =
+        MssqlMaxCommandParameters - ReservedNonAuthorizationParameters;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when composing the namespace prefix and claim education organization
+    /// id parameterizations into a single command would bind more authorization parameters than
+    /// <see cref="MssqlCombinedAuthorizationParameterLimit"/> permits.
+    /// </summary>
+    public static bool ExceedsCombinedLimit(
+        NamespacePrefixParameterization namespacePrefixParameterization,
+        AuthorizationClaimEducationOrganizationIdParameterization claimEducationOrganizationIdParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization);
+        ArgumentNullException.ThrowIfNull(claimEducationOrganizationIdParameterization);
+
+        var combinedAuthorizationParameterCount =
+            namespacePrefixParameterization.ParameterNamesInOrder.Count
+            + claimEducationOrganizationIdParameterization.ParameterNamesInOrder.Count;
+
+        return combinedAuthorizationParameterCount > MssqlCombinedAuthorizationParameterLimit;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/AuthorizationParameterBudget.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/AuthorizationParameterBudget.cs
@@ -3,61 +3,82 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend.External;
+
 namespace EdFi.DataManagementService.Backend.Plans;
 
 /// <summary>
-/// Cross-checks the two list-shaped authorization parameterizations that a single GET-many page query can
-/// compose — the NamespaceBased prefix <c>LIKE</c> chain and the relationship claim education organization
-/// id list — against SQL Server's per-command parameter ceiling.
+/// Checks the list-shaped authorization parameterizations a single GET-many page query can bind — the
+/// NamespaceBased prefix <c>LIKE</c> chain and/or the relationship claim education organization id list —
+/// together with the query's filter and paging parameters against SQL Server's per-command parameter
+/// ceiling.
 /// </summary>
 /// <remarks>
-/// Each list is capped independently below 2,000 SQL Server scalar parameters
+/// Each authorization list is capped independently below 2,000 SQL Server scalar parameters
 /// (<see cref="NamespacePrefixLimitExceededException.MssqlScalarParameterLimit"/> and the claim
 /// parameterization's structured-parameter threshold). SQL Server, however, binds at most
-/// <see cref="MssqlMaxCommandParameters"/> parameters per command, so a query that composes both lists can
-/// exceed that ceiling even when each list is within its own cap, which would otherwise surface as an
-/// execution-time SQL error rather than a controlled authorization/configuration failure. Counting
+/// <see cref="MssqlMaxCommandParameters"/> parameters per command, so the page query can still exceed that
+/// ceiling — whether it composes both authorization lists, or a single near-cap list alongside enough
+/// query-filter parameters — which would otherwise surface as an execution-time SQL error rather than a
+/// controlled authorization/configuration failure. Counting
 /// <see cref="NamespacePrefixParameterization.ParameterNamesInOrder"/> and
 /// <see cref="AuthorizationClaimEducationOrganizationIdParameterization.ParameterNamesInOrder"/> reflects
 /// the real bound parameter count per shape — a PostgreSQL array or SQL Server table-valued parameter is a
 /// single parameter, a SQL Server scalar list is one parameter per value — so PostgreSQL composition never
-/// approaches the limit and only the SQL Server scalar-plus-scalar case can.
+/// approaches the limit and only the SQL Server scalar case can.
 /// </remarks>
 public static class AuthorizationParameterBudget
 {
     /// <summary>SQL Server's documented maximum number of parameters per command.</summary>
     public const int MssqlMaxCommandParameters = 2100;
 
-    /// <summary>
-    /// Parameters reserved below <see cref="MssqlMaxCommandParameters"/> for the query-filter predicate
-    /// parameters and the two paging parameters the page query binds alongside the authorization lists.
-    /// </summary>
-    public const int ReservedNonAuthorizationParameters = 100;
+    /// <summary>The number of paging parameters (offset and limit) every page query binds.</summary>
+    public const int PaginationParameterCount = 2;
 
     /// <summary>
-    /// The maximum combined number of authorization parameters the two lists may bind together before the
-    /// composed page query risks exceeding SQL Server's per-command parameter ceiling.
+    /// The number of SQL parameters the supplied authorization parameterizations bind. Either argument may
+    /// be <see langword="null"/> for a shape that does not use that strategy (namespace-only or
+    /// relationship-only), in which case that list contributes nothing.
     /// </summary>
-    public const int MssqlCombinedAuthorizationParameterLimit =
-        MssqlMaxCommandParameters - ReservedNonAuthorizationParameters;
+    public static int CountAuthorizationParameters(
+        NamespacePrefixParameterization? namespacePrefixParameterization,
+        AuthorizationClaimEducationOrganizationIdParameterization? claimEducationOrganizationIdParameterization
+    ) =>
+        (namespacePrefixParameterization?.ParameterNamesInOrder.Count ?? 0)
+        + (claimEducationOrganizationIdParameterization?.ParameterNamesInOrder.Count ?? 0);
 
     /// <summary>
-    /// Returns <see langword="true"/> when composing the namespace prefix and claim education organization
-    /// id parameterizations into a single command would bind more authorization parameters than
-    /// <see cref="MssqlCombinedAuthorizationParameterLimit"/> permits.
+    /// Returns <see langword="true"/> when the authorization parameters this query binds, together with
+    /// <paramref name="nonAuthorizationParameterCount"/> (the query-filter predicate parameters plus the
+    /// paging parameters), exceed SQL Server's per-command parameter ceiling. Applies to every shape —
+    /// namespace-only, relationship-only, and composed — because either authorization parameterization may
+    /// be <see langword="null"/>. The ceiling is specific to SQL Server, so this always returns
+    /// <see langword="false"/> for other dialects; the gate lives here so no call site can apply the limit
+    /// to a dialect that does not share it.
     /// </summary>
-    public static bool ExceedsCombinedLimit(
-        NamespacePrefixParameterization namespacePrefixParameterization,
-        AuthorizationClaimEducationOrganizationIdParameterization claimEducationOrganizationIdParameterization
+    public static bool ExceedsCommandParameterLimit(
+        SqlDialect dialect,
+        NamespacePrefixParameterization? namespacePrefixParameterization,
+        AuthorizationClaimEducationOrganizationIdParameterization? claimEducationOrganizationIdParameterization,
+        int nonAuthorizationParameterCount
     )
     {
-        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization);
-        ArgumentNullException.ThrowIfNull(claimEducationOrganizationIdParameterization);
+        ArgumentOutOfRangeException.ThrowIfNegative(nonAuthorizationParameterCount);
 
-        var combinedAuthorizationParameterCount =
-            namespacePrefixParameterization.ParameterNamesInOrder.Count
-            + claimEducationOrganizationIdParameterization.ParameterNamesInOrder.Count;
+        if (dialect is not SqlDialect.Mssql)
+        {
+            // PostgreSQL binds each authorization list as a single array/table-valued parameter and allows
+            // far more command parameters than SQL Server, so it cannot reach this limit; only the SQL
+            // Server scalar lists can.
+            return false;
+        }
 
-        return combinedAuthorizationParameterCount > MssqlCombinedAuthorizationParameterLimit;
+        var totalParameterCount =
+            CountAuthorizationParameters(
+                namespacePrefixParameterization,
+                claimEducationOrganizationIdParameterization
+            ) + nonAuthorizationParameterCount;
+
+        return totalParameterCount > MssqlMaxCommandParameters;
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/HydrationBatchBuilder.cs
@@ -392,7 +392,17 @@ public static class HydrationBatchBuilder
     {
         var parameter = command.CreateParameter();
         parameter.ParameterName = $"@{bareName}";
-        parameter.Value = RequireInt64List(value, bareName).ToArray();
+        // PostgreSQL array parameters carry either claim EdOrg ids (long[]) or namespace prefix LIKE
+        // patterns (string[]); Npgsql infers the element type from the runtime array.
+        parameter.Value = value switch
+        {
+            IReadOnlyList<long> int64Values => int64Values.ToArray(),
+            IReadOnlyList<string> stringValues => stringValues.ToArray(),
+            _ => throw new InvalidOperationException(
+                "Hydration query keyset parameter "
+                    + $"'{bareName}' requires an IReadOnlyList<long> or IReadOnlyList<string> runtime value."
+            ),
+        };
         command.Parameters.Add(parameter);
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationAuth1FailurePayload.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationAuth1FailurePayload.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Globalization;
-using EdFi.DataManagementService.Backend.External;
 
 namespace EdFi.DataManagementService.Backend.Plans;
 
@@ -25,6 +24,14 @@ public enum NamespaceAuthorizationAuth1FailureKind
 
     /// <summary>The proposed namespace value is null or empty.</summary>
     ProposedNamespaceMissing,
+
+    /// <summary>
+    /// The stored target row no longer exists. The row was deleted between the unlocked target lookup
+    /// and the stored namespace check, so the check has nothing to authorize. Read paths re-resolve the
+    /// target and surface the resulting 404; locked write/delete paths never observe this because the
+    /// row is row-locked before the check runs.
+    /// </summary>
+    StoredTargetMissing,
 }
 
 /// <summary>
@@ -68,8 +75,6 @@ public static class NamespaceAuthorizationAuth1FailurePayloadCodec
     public const string ProviderFailureCode = "AUTH1";
     public const string PayloadDiscriminator = "ns1";
 
-    private const string MssqlPayloadMarker = "AUTH1 - ";
-
     public static string Encode(NamespaceAuthorizationAuth1FailurePayload payload)
     {
         ArgumentNullException.ThrowIfNull(payload);
@@ -108,48 +113,6 @@ public static class NamespaceAuthorizationAuth1FailurePayloadCodec
         return true;
     }
 
-    public static bool TryParseProviderFailure(
-        SqlDialect dialect,
-        string? providerErrorCode,
-        string providerMessage,
-        out NamespaceAuthorizationAuth1FailurePayload? payload
-    )
-    {
-        if (!TryExtractProviderPayload(dialect, providerErrorCode, providerMessage, out var payloadText))
-        {
-            payload = null;
-            return false;
-        }
-
-        return TryParsePayload(payloadText, out payload);
-    }
-
-    public static bool TryExtractProviderPayload(
-        SqlDialect dialect,
-        string? providerErrorCode,
-        string providerMessage,
-        out string payloadText
-    )
-    {
-        payloadText = string.Empty;
-
-        if (string.IsNullOrWhiteSpace(providerMessage))
-        {
-            return false;
-        }
-
-        return dialect switch
-        {
-            SqlDialect.Pgsql => TryExtractPostgresqlPayload(
-                providerErrorCode,
-                providerMessage,
-                out payloadText
-            ),
-            SqlDialect.Mssql => TryExtractMssqlPayload(providerMessage, out payloadText),
-            _ => false,
-        };
-    }
-
     private static bool TryParseNonNegativeInt(string text, out int value)
     {
         if (int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value) && value >= 0)
@@ -167,6 +130,7 @@ public static class NamespaceAuthorizationAuth1FailurePayloadCodec
             NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch => "m",
             NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized => "u",
             NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing => "r",
+            NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing => "s",
             _ => throw new ArgumentOutOfRangeException(
                 nameof(failureKind),
                 failureKind,
@@ -190,58 +154,12 @@ public static class NamespaceAuthorizationAuth1FailurePayloadCodec
             case "r":
                 failureKind = NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing;
                 return true;
+            case "s":
+                failureKind = NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing;
+                return true;
             default:
                 failureKind = NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch;
                 return false;
         }
     }
-
-    private static bool TryExtractPostgresqlPayload(
-        string? providerErrorCode,
-        string providerMessage,
-        out string payloadText
-    )
-    {
-        if (!string.Equals(providerErrorCode, ProviderFailureCode, StringComparison.Ordinal))
-        {
-            payloadText = string.Empty;
-            return false;
-        }
-
-        payloadText = providerMessage;
-        return true;
-    }
-
-    private static bool TryExtractMssqlPayload(string providerMessage, out string payloadText)
-    {
-        payloadText = string.Empty;
-        var markerIndex = providerMessage.IndexOf(MssqlPayloadMarker, StringComparison.Ordinal);
-
-        if (markerIndex < 0)
-        {
-            return false;
-        }
-
-        var payloadStartIndex = markerIndex + MssqlPayloadMarker.Length;
-        var payloadEndIndex = payloadStartIndex;
-
-        while (
-            payloadEndIndex < providerMessage.Length
-            && IsMssqlPayloadCharacter(providerMessage[payloadEndIndex])
-        )
-        {
-            payloadEndIndex++;
-        }
-
-        if (payloadEndIndex == payloadStartIndex)
-        {
-            return false;
-        }
-
-        payloadText = providerMessage[payloadStartIndex..payloadEndIndex];
-        return true;
-    }
-
-    private static bool IsMssqlPayloadCharacter(char value) =>
-        value is >= '0' and <= '9' || value is >= 'a' and <= 'z' || value is '|' or ':' or ',';
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationAuth1FailurePayload.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationAuth1FailurePayload.cs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Runtime failure kinds encoded in the compact AUTH1 namespace-authorization payload.
+/// </summary>
+/// <remarks>
+/// The §2.9 "no namespace prefixes configured" case is emitted at planner/preflight time and does not
+/// reach the AUTH1 channel, so it has no encoding here.
+/// </remarks>
+public enum NamespaceAuthorizationAuth1FailureKind
+{
+    /// <summary>The namespace value does not start with any configured prefix.</summary>
+    NamespaceMismatch,
+
+    /// <summary>The stored namespace value is null or empty.</summary>
+    StoredNamespaceUninitialized,
+
+    /// <summary>The proposed namespace value is null or empty.</summary>
+    ProposedNamespaceMissing,
+}
+
+/// <summary>
+/// Provider-independent AUTH1 failure payload for one failed namespace authorization check.
+/// </summary>
+public sealed record NamespaceAuthorizationAuth1FailurePayload
+{
+    public NamespaceAuthorizationAuth1FailurePayload(
+        int emittedAuth1Index,
+        NamespaceAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        if (emittedAuth1Index < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(emittedAuth1Index),
+                emittedAuth1Index,
+                "Emitted AUTH1 index cannot be negative."
+            );
+        }
+
+        EmittedAuth1Index = emittedAuth1Index;
+        FailureKind = failureKind;
+    }
+
+    public int EmittedAuth1Index { get; init; }
+
+    public NamespaceAuthorizationAuth1FailureKind FailureKind { get; init; }
+}
+
+/// <summary>
+/// Encodes, extracts, and parses the compact AUTH1 namespace-authorization payload (<c>ns1|index|kind</c>).
+/// </summary>
+/// <remarks>
+/// The payload shares the AUTH1 SqlState / message-prefix transport with the relationship-authorization
+/// codec, but carries a distinct <c>ns1</c> discriminator so a dispatcher can route each payload to the
+/// correct codec without modifying the relationship v1 payload.
+/// </remarks>
+public static class NamespaceAuthorizationAuth1FailurePayloadCodec
+{
+    public const string ProviderFailureCode = "AUTH1";
+    public const string PayloadDiscriminator = "ns1";
+
+    private const string MssqlPayloadMarker = "AUTH1 - ";
+
+    public static string Encode(NamespaceAuthorizationAuth1FailurePayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{PayloadDiscriminator}|{payload.EmittedAuth1Index}|{EncodeFailureKind(payload.FailureKind)}"
+        );
+    }
+
+    public static bool TryParsePayload(
+        string payloadText,
+        out NamespaceAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        payload = null;
+
+        if (string.IsNullOrWhiteSpace(payloadText))
+        {
+            return false;
+        }
+
+        var payloadSections = payloadText.Split('|');
+
+        if (
+            payloadSections.Length is not 3
+            || !string.Equals(payloadSections[0], PayloadDiscriminator, StringComparison.Ordinal)
+            || !TryParseNonNegativeInt(payloadSections[1], out var emittedAuth1Index)
+            || !TryDecodeFailureKind(payloadSections[2], out var failureKind)
+        )
+        {
+            return false;
+        }
+
+        payload = new NamespaceAuthorizationAuth1FailurePayload(emittedAuth1Index, failureKind);
+        return true;
+    }
+
+    public static bool TryParseProviderFailure(
+        SqlDialect dialect,
+        string? providerErrorCode,
+        string providerMessage,
+        out NamespaceAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        if (!TryExtractProviderPayload(dialect, providerErrorCode, providerMessage, out var payloadText))
+        {
+            payload = null;
+            return false;
+        }
+
+        return TryParsePayload(payloadText, out payload);
+    }
+
+    public static bool TryExtractProviderPayload(
+        SqlDialect dialect,
+        string? providerErrorCode,
+        string providerMessage,
+        out string payloadText
+    )
+    {
+        payloadText = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(providerMessage))
+        {
+            return false;
+        }
+
+        return dialect switch
+        {
+            SqlDialect.Pgsql => TryExtractPostgresqlPayload(
+                providerErrorCode,
+                providerMessage,
+                out payloadText
+            ),
+            SqlDialect.Mssql => TryExtractMssqlPayload(providerMessage, out payloadText),
+            _ => false,
+        };
+    }
+
+    private static bool TryParseNonNegativeInt(string text, out int value)
+    {
+        if (int.TryParse(text, NumberStyles.None, CultureInfo.InvariantCulture, out value) && value >= 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static string EncodeFailureKind(NamespaceAuthorizationAuth1FailureKind failureKind) =>
+        failureKind switch
+        {
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch => "m",
+            NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized => "u",
+            NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing => "r",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failureKind),
+                failureKind,
+                "Unsupported AUTH1 namespace failure kind."
+            ),
+        };
+
+    private static bool TryDecodeFailureKind(
+        string failureKindCode,
+        out NamespaceAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        switch (failureKindCode)
+        {
+            case "m":
+                failureKind = NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch;
+                return true;
+            case "u":
+                failureKind = NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized;
+                return true;
+            case "r":
+                failureKind = NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing;
+                return true;
+            default:
+                failureKind = NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch;
+                return false;
+        }
+    }
+
+    private static bool TryExtractPostgresqlPayload(
+        string? providerErrorCode,
+        string providerMessage,
+        out string payloadText
+    )
+    {
+        if (!string.Equals(providerErrorCode, ProviderFailureCode, StringComparison.Ordinal))
+        {
+            payloadText = string.Empty;
+            return false;
+        }
+
+        payloadText = providerMessage;
+        return true;
+    }
+
+    private static bool TryExtractMssqlPayload(string providerMessage, out string payloadText)
+    {
+        payloadText = string.Empty;
+        var markerIndex = providerMessage.IndexOf(MssqlPayloadMarker, StringComparison.Ordinal);
+
+        if (markerIndex < 0)
+        {
+            return false;
+        }
+
+        var payloadStartIndex = markerIndex + MssqlPayloadMarker.Length;
+        var payloadEndIndex = payloadStartIndex;
+
+        while (
+            payloadEndIndex < providerMessage.Length
+            && IsMssqlPayloadCharacter(providerMessage[payloadEndIndex])
+        )
+        {
+            payloadEndIndex++;
+        }
+
+        if (payloadEndIndex == payloadStartIndex)
+        {
+            return false;
+        }
+
+        payloadText = providerMessage[payloadStartIndex..payloadEndIndex];
+        return true;
+    }
+
+    private static bool IsMssqlPayloadCharacter(char value) =>
+        value is >= '0' and <= '9' || value is >= 'a' and <= 'z' || value is '|' or ':' or ',';
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationCheckSpec.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationCheckSpec.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// One planned namespace authorization check, addressing a resolved root-table column.
+/// </summary>
+/// <param name="Index">
+/// Zero-based position in the namespace planner's emitted check list. Matches the AUTH1
+/// payload index emitted by the SQL batch on failure.
+/// </param>
+/// <param name="ValueSource">Whether this check evaluates the stored row or the proposed request body.</param>
+/// <param name="RootTable">The concrete root table of the subject resource. Always a root table — never a child collection.</param>
+/// <param name="NamespaceColumn">The resolved root-table column carrying the Namespace value.</param>
+/// <param name="StrategyName">The configured strategy name — always <c>NamespaceBased</c>.</param>
+public sealed record NamespaceAuthorizationCheckSpec(
+    int Index,
+    NamespaceAuthorizationCheckValueSource ValueSource,
+    DbTableName RootTable,
+    DbColumnName NamespaceColumn,
+    string StrategyName = AuthorizationStrategyNameConstants.NamespaceBased
+);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationCheckValueSource.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationCheckValueSource.cs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Whether a planned namespace authorization check evaluates the stored row or the proposed request body.
+/// </summary>
+/// <remarks>
+/// Used by the AUTH1 failure mapper to interpret a failed check ordinal as stored- or proposed-valued.
+/// </remarks>
+public enum NamespaceAuthorizationCheckValueSource
+{
+    Stored,
+    Proposed,
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationFailureMapper.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Maps a decoded namespace AUTH1 payload back to a cross-boundary <see cref="NamespaceAuthorizationFailure"/>.
+/// </summary>
+/// <remarks>
+/// The mapper is the runtime-to-external translation point for namespace failures coming out of the SQL
+/// batch. The §2.9 "no namespace prefixes configured" case never reaches AUTH1 and is constructed by the
+/// planner directly, not here.
+/// </remarks>
+public static class NamespaceAuthorizationFailureMapper
+{
+    public static bool TryMapAuth1Failure(
+        NamespaceAuthorizationAuth1FailurePayload payload,
+        IReadOnlyList<NamespaceAuthorizationCheckValueSource> plannedCheckValueSources,
+        IReadOnlyList<string> configuredNamespacePrefixes,
+        out NamespaceAuthorizationFailure? failure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        ArgumentNullException.ThrowIfNull(plannedCheckValueSources);
+        ArgumentNullException.ThrowIfNull(configuredNamespacePrefixes);
+
+        failure = null;
+
+        if (
+            plannedCheckValueSources.Count == 0
+            || payload.EmittedAuth1Index >= plannedCheckValueSources.Count
+        )
+        {
+            return false;
+        }
+
+        var valueSource = plannedCheckValueSources[payload.EmittedAuth1Index];
+
+        if (!IsFailureKindCompatibleWithValueSource(payload.FailureKind, valueSource))
+        {
+            return false;
+        }
+
+        failure = new NamespaceAuthorizationFailure(
+            MapFailureKind(payload.FailureKind),
+            MapValueSource(valueSource),
+            payload.EmittedAuth1Index,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            [.. configuredNamespacePrefixes]
+        );
+        return true;
+    }
+
+    private static bool IsFailureKindCompatibleWithValueSource(
+        NamespaceAuthorizationAuth1FailureKind failureKind,
+        NamespaceAuthorizationCheckValueSource valueSource
+    ) =>
+        (failureKind, valueSource) switch
+        {
+            (NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch, _) => true,
+            (
+                NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized,
+                NamespaceAuthorizationCheckValueSource.Stored
+            ) => true,
+            (
+                NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing,
+                NamespaceAuthorizationCheckValueSource.Proposed
+            ) => true,
+            _ => false,
+        };
+
+    private static NamespaceAuthorizationFailureKind MapFailureKind(
+        NamespaceAuthorizationAuth1FailureKind failureKind
+    ) =>
+        failureKind switch
+        {
+            NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch =>
+                NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized =>
+                NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing =>
+                NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failureKind),
+                failureKind,
+                "Unsupported AUTH1 namespace failure kind."
+            ),
+        };
+
+    private static NamespaceAuthorizationFailureValueSource MapValueSource(
+        NamespaceAuthorizationCheckValueSource valueSource
+    ) =>
+        valueSource switch
+        {
+            NamespaceAuthorizationCheckValueSource.Stored => NamespaceAuthorizationFailureValueSource.Stored,
+            NamespaceAuthorizationCheckValueSource.Proposed =>
+                NamespaceAuthorizationFailureValueSource.Proposed,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(valueSource),
+                valueSource,
+                "Unsupported namespace authorization value source."
+            ),
+        };
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationOperation.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationOperation.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// The CRUD operation a namespace authorization plan is being built for.
+/// Drives which value-source checks the planner emits.
+/// </summary>
+public enum NamespaceAuthorizationOperation
+{
+    /// <summary>GET-by-id: stored-value check only.</summary>
+    ReadSingle,
+
+    /// <summary>GET-many: stored-value filter only.</summary>
+    ReadMany,
+
+    /// <summary>
+    /// Pure create: proposed-value check only. Production POST planning does not use this — POST may
+    /// resolve as upsert-as-update, so the write paths intentionally plan <see cref="Update"/> (stored
+    /// then proposed). Retained as the complete operation taxonomy and exercised by planner unit tests.
+    /// </summary>
+    Create,
+
+    /// <summary>PUT and POST upsert-as-update: stored-value check then proposed-value check.</summary>
+    Update,
+
+    /// <summary>DELETE: stored-value check only.</summary>
+    Delete,
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationOperation.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationOperation.cs
@@ -18,13 +18,10 @@ public enum NamespaceAuthorizationOperation
     ReadMany,
 
     /// <summary>
-    /// Pure create: proposed-value check only. Production POST planning does not use this — POST may
-    /// resolve as upsert-as-update, so the write paths intentionally plan <see cref="Update"/> (stored
-    /// then proposed). Retained as the complete operation taxonomy and exercised by planner unit tests.
+    /// PUT and POST (create or upsert-as-update): stored-value check then proposed-value check. POST
+    /// resolves as either a create or an upsert-as-update, so both write verbs plan the same
+    /// stored-then-proposed pair rather than a create-only proposed check.
     /// </summary>
-    Create,
-
-    /// <summary>PUT and POST upsert-as-update: stored-value check then proposed-value check.</summary>
     Update,
 
     /// <summary>DELETE: stored-value check only.</summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationPlanner.cs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.RelationalModel;
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Outcome of planning the namespace-authorization portion of a request.
+/// </summary>
+public abstract record NamespaceAuthorizationPlanOutcome
+{
+    private NamespaceAuthorizationPlanOutcome() { }
+
+    /// <summary>One or more namespace checks the SQL layer must execute, in emission order.</summary>
+    public sealed record Plan(IReadOnlyList<NamespaceAuthorizationCheckSpec> Checks)
+        : NamespaceAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// The resource is configured with <c>NamespaceBased</c> but no securable element resolves to
+    /// the resource's concrete root-table column. Maps to a 500 Security Configuration Error.
+    /// </summary>
+    public sealed record NoUsableRootColumn(QualifiedResourceName Resource)
+        : NamespaceAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// The client has no namespace prefixes assigned. Maps to a 403 <c>§2.9</c> ProblemDetails at
+    /// planner/preflight time — no DB roundtrip is issued.
+    /// </summary>
+    public sealed record NoPrefixesConfigured(string StrategyName) : NamespaceAuthorizationPlanOutcome;
+}
+
+/// <summary>
+/// Plans namespace-authorization checks for a single CRUD operation. Filters out securable element
+/// resolutions that land on child-collection tables and operates only on the resource's concrete
+/// root-table column.
+/// </summary>
+/// <remarks>
+/// Outcome precedence (within the namespace planner):
+/// <list type="number">
+/// <item>No resolved Namespace securable element targets the root table → <see cref="NamespaceAuthorizationPlanOutcome.NoUsableRootColumn"/>.</item>
+/// <item>The client has no namespace prefixes assigned → <see cref="NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured"/>.</item>
+/// <item>Otherwise → <see cref="NamespaceAuthorizationPlanOutcome.Plan"/> with one or two checks driven by <paramref name="operation"/>.</item>
+/// </list>
+/// Filtering compares the resolved <c>(table)</c> against the resource's root table — it does not
+/// rely on JSON path string heuristics.
+/// </remarks>
+public static class NamespaceAuthorizationPlanner
+{
+    public static NamespaceAuthorizationPlanOutcome Plan(
+        ConcreteResourceModel resource,
+        NamespaceAuthorizationOperation operation,
+        RelationalAuthorizationContext context
+    )
+    {
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var rootColumn = ResolveSingleRootTableNamespaceColumn(resource);
+
+        if (rootColumn is not { } namespaceColumn)
+        {
+            return new NamespaceAuthorizationPlanOutcome.NoUsableRootColumn(
+                resource.RelationalModel.Resource
+            );
+        }
+
+        if (context.NamespacePrefixes.Count == 0)
+        {
+            return new NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured(
+                AuthorizationStrategyNameConstants.NamespaceBased
+            );
+        }
+
+        var rootTable = resource.RelationalModel.Root.Table;
+        return new NamespaceAuthorizationPlanOutcome.Plan(BuildChecks(operation, rootTable, namespaceColumn));
+    }
+
+    /// <summary>
+    /// Iterates the resource's Namespace securable element paths, resolves each via
+    /// <see cref="SecurableElementLocationResolver.ResolvePreferred"/>, and returns the first
+    /// column whose resolved source table equals the resource's concrete root table. Unresolved
+    /// or child-collection paths are skipped — neither category aborts namespace planning, and
+    /// unrelated securable element metadata (EdOrg, Student, Contact, Staff) is never touched.
+    /// Returns <see langword="null"/> when no root-table Namespace column survives.
+    /// </summary>
+    private static DbColumnName? ResolveSingleRootTableNamespaceColumn(ConcreteResourceModel resource)
+    {
+        var rootTable = resource.RelationalModel.Root.Table;
+
+        // Descriptor resources persist their Namespace on the shared dms.Descriptor root table and carry
+        // empty securable-element metadata. They are root tables by definition, so the namespace column
+        // comes directly from the descriptor column contract. A SharedDescriptorTable resource with no
+        // descriptor metadata is impossible metadata: fall through so the planner fails closed with
+        // NoUsableRootColumn rather than authorizing against an unknown column.
+        if (
+            resource.StorageKind == ResourceStorageKind.SharedDescriptorTable
+            && resource.DescriptorMetadata is { } descriptorMetadata
+        )
+        {
+            return descriptorMetadata.ColumnContract.Namespace;
+        }
+
+        foreach (var namespacePath in resource.SecurableElements.Namespace)
+        {
+            var step = SecurableElementLocationResolver.ResolvePreferred(resource, namespacePath);
+
+            if (step is null)
+            {
+                continue;
+            }
+
+            if (step.SourceTable == rootTable)
+            {
+                return step.SourceColumnName;
+            }
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<NamespaceAuthorizationCheckSpec> BuildChecks(
+        NamespaceAuthorizationOperation operation,
+        DbTableName rootTable,
+        DbColumnName namespaceColumn
+    ) =>
+        operation switch
+        {
+            NamespaceAuthorizationOperation.ReadSingle
+            or NamespaceAuthorizationOperation.ReadMany
+            or NamespaceAuthorizationOperation.Delete =>
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Stored,
+                    rootTable,
+                    namespaceColumn
+                ),
+            ],
+            NamespaceAuthorizationOperation.Create =>
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    rootTable,
+                    namespaceColumn
+                ),
+            ],
+            NamespaceAuthorizationOperation.Update =>
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Stored,
+                    rootTable,
+                    namespaceColumn
+                ),
+                new NamespaceAuthorizationCheckSpec(
+                    1,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    rootTable,
+                    namespaceColumn
+                ),
+            ],
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(operation),
+                operation,
+                "Unsupported namespace authorization operation."
+            ),
+        };
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationPlanner.cs
@@ -141,15 +141,6 @@ public static class NamespaceAuthorizationPlanner
                     namespaceColumn
                 ),
             ],
-            NamespaceAuthorizationOperation.Create =>
-            [
-                new NamespaceAuthorizationCheckSpec(
-                    0,
-                    NamespaceAuthorizationCheckValueSource.Proposed,
-                    rootTable,
-                    namespaceColumn
-                ),
-            ],
             NamespaceAuthorizationOperation.Update =>
             [
                 new NamespaceAuthorizationCheckSpec(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationSqlCompiler.cs
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Input specification for compiling single-record namespace authorization SQL. Carries the planned
+/// namespace checks (typically one for read/delete, one or two for write), the dialect-specific
+/// namespace prefix parameterization, and the parameter names used for stored-row identification and
+/// the proposed-value namespace.
+/// </summary>
+/// <param name="Checks">The planned namespace authorization checks in emission order.</param>
+/// <param name="NamespacePrefixParameterization">Dialect-specific namespace prefix parameterization.</param>
+/// <param name="DocumentIdParameterName">Bare parameter name used for the stored row's DocumentId.</param>
+/// <param name="ProposedNamespaceParameterName">Bare parameter name carrying the proposed namespace value.</param>
+public sealed record NamespaceAuthorizationSqlSpec(
+    IReadOnlyList<NamespaceAuthorizationCheckSpec> Checks,
+    NamespacePrefixParameterization NamespacePrefixParameterization,
+    string DocumentIdParameterName,
+    string ProposedNamespaceParameterName
+);
+
+/// <summary>
+/// Compiled single-record namespace authorization SQL plan.
+/// </summary>
+/// <param name="AuthorizationSql">The compiled SQL command body.</param>
+/// <param name="ParametersInOrder">Deterministic parameter metadata in plan order.</param>
+public sealed record NamespaceAuthorizationSqlPlan(
+    string AuthorizationSql,
+    IReadOnlyList<QuerySqlParameter> ParametersInOrder
+);
+
+/// <summary>
+/// Compiles co-batched single-record namespace authorization SQL. Each planned check becomes one
+/// <c>SELECT CASE</c> statement; the first failure raises AUTH1 with payload
+/// <c>ns1|&lt;index&gt;|&lt;kind&gt;</c> and aborts the batch.
+/// </summary>
+/// <remarks>
+/// The null-guarded prefix LIKE predicate is built by <see cref="NamespacePrefixSqlHelper"/> — the same
+/// builder used by GET-many — so PostgreSQL and SQL Server emit the same shape on both paths.
+/// </remarks>
+public sealed class NamespaceAuthorizationSqlCompiler(SqlDialect dialect)
+{
+    private const string RootAlias = "r";
+
+    private readonly SqlDialect _dialect = dialect;
+    private readonly ISqlDialect _sqlDialect = SqlDialectFactory.Create(dialect);
+
+    public NamespaceAuthorizationSqlPlan Compile(NamespaceAuthorizationSqlSpec spec)
+    {
+        ArgumentNullException.ThrowIfNull(spec);
+        ArgumentNullException.ThrowIfNull(spec.Checks);
+        ArgumentNullException.ThrowIfNull(spec.NamespacePrefixParameterization);
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            spec.DocumentIdParameterName,
+            nameof(spec.DocumentIdParameterName)
+        );
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            spec.ProposedNamespaceParameterName,
+            nameof(spec.ProposedNamespaceParameterName)
+        );
+
+        if (spec.Checks.Count == 0)
+        {
+            throw new ArgumentException(
+                "Single-record namespace authorization requires at least one check spec.",
+                nameof(spec)
+            );
+        }
+
+        NamespacePrefixParameterizationValidator.ValidateOrThrow(
+            spec.NamespacePrefixParameterization,
+            _dialect,
+            nameof(NamespaceAuthorizationSqlSpec.NamespacePrefixParameterization),
+            "Single-record namespace authorization SQL"
+        );
+
+        var rootTable = spec.Checks[0].RootTable;
+        var mismatchedTable = spec
+            .Checks.Select(static check => check.RootTable)
+            .FirstOrDefault(table => !table.Equals(rootTable));
+
+        if (mismatchedTable != default)
+        {
+            throw new ArgumentException(
+                $"Namespace authorization check specs must share one root table. Found '{mismatchedTable}' and '{rootTable}'.",
+                nameof(spec)
+            );
+        }
+
+        var writer = new SqlWriter(_sqlDialect);
+        var hasStored = spec.Checks.Any(static check =>
+            check.ValueSource is NamespaceAuthorizationCheckValueSource.Stored
+        );
+        var hasProposed = spec.Checks.Any(static check =>
+            check.ValueSource is NamespaceAuthorizationCheckValueSource.Proposed
+        );
+
+        for (var index = 0; index < spec.Checks.Count; index++)
+        {
+            var check = spec.Checks[index];
+
+            switch (check.ValueSource)
+            {
+                case NamespaceAuthorizationCheckValueSource.Stored:
+                    AppendStoredCheckSql(writer, check, spec);
+                    break;
+                case NamespaceAuthorizationCheckValueSource.Proposed:
+                    AppendProposedCheckSql(writer, check, spec);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(
+                        nameof(spec),
+                        check.ValueSource,
+                        "Unsupported namespace authorization value source."
+                    );
+            }
+
+            writer.AppendLine(";");
+        }
+
+        return new NamespaceAuthorizationSqlPlan(
+            writer.ToString(),
+            BuildParametersInOrder(spec, hasStored, hasProposed)
+        );
+    }
+
+    private void AppendStoredCheckSql(
+        SqlWriter writer,
+        NamespaceAuthorizationCheckSpec check,
+        NamespaceAuthorizationSqlSpec spec
+    )
+    {
+        writer.AppendLine("SELECT CASE");
+
+        using (writer.Indent())
+        {
+            // Authorized: row exists with non-null namespace matching at least one prefix.
+            writer.Append("WHEN EXISTS (");
+            AppendStoredRowSelect(
+                writer,
+                check,
+                spec.DocumentIdParameterName,
+                appendNamespacePredicate: predicateWriter =>
+                {
+                    NamespacePrefixSqlHelper.AppendRootTableNamespacePredicate(
+                        predicateWriter,
+                        RootAlias,
+                        check.NamespaceColumn,
+                        spec.NamespacePrefixParameterization
+                    );
+                }
+            );
+            writer.AppendLine(") THEN 1");
+
+            // Stored namespace is null or empty → 'u'. Empty strings classify identically to NULL
+            // so legacy rows with empty namespace map to the uninitialized branch rather than
+            // mismatch.
+            writer.Append("WHEN EXISTS (");
+            AppendStoredRowSelect(
+                writer,
+                check,
+                spec.DocumentIdParameterName,
+                appendNamespacePredicate: predicateWriter =>
+                {
+                    predicateWriter.Append("(");
+                    predicateWriter.Append($"{RootAlias}.").AppendQuoted(check.NamespaceColumn.Value);
+                    predicateWriter.Append(" IS NULL OR ");
+                    predicateWriter.Append($"{RootAlias}.").AppendQuoted(check.NamespaceColumn.Value);
+                    predicateWriter.Append(" = '')");
+                }
+            );
+            writer.Append(") THEN ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                NamespaceAuthorizationAuth1FailureKind.StoredNamespaceUninitialized
+            );
+            writer.AppendLine();
+
+            // Otherwise → 'm'. This covers both "row exists, namespace not null, but no prefix matches"
+            // and "no row at all": a target concurrently deleted between the lookup and this check
+            // matches neither EXISTS branch and intentionally fails closed as a namespace mismatch
+            // denial. Namespace authorization has no stale-target result by design (see
+            // NamespaceAuthorizationExecutor remarks); do not add a missing-row branch here.
+            writer.Append("ELSE ");
+            AppendAuth1Throw(writer, check.Index, NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
+            writer.AppendLine();
+        }
+
+        writer.Append("END");
+    }
+
+    private void AppendProposedCheckSql(
+        SqlWriter writer,
+        NamespaceAuthorizationCheckSpec check,
+        NamespaceAuthorizationSqlSpec spec
+    )
+    {
+        writer.AppendLine("SELECT CASE");
+
+        using (writer.Indent())
+        {
+            // Proposed value is null or empty → 'r'.
+            writer.Append("WHEN ");
+            NamespacePrefixSqlHelper.AppendParameterIsNullOrEmpty(
+                writer,
+                spec.ProposedNamespaceParameterName
+            );
+            writer.Append(" THEN ");
+            AppendAuth1Throw(
+                writer,
+                check.Index,
+                NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+            );
+            writer.AppendLine();
+
+            // Proposed value matches at least one prefix → authorized.
+            writer.Append("WHEN ");
+            NamespacePrefixSqlHelper.AppendLikeMatch(
+                writer,
+                lhsWriter => lhsWriter.AppendParameter(spec.ProposedNamespaceParameterName),
+                spec.NamespacePrefixParameterization
+            );
+            writer.AppendLine(" THEN 1");
+
+            // Otherwise → 'm'.
+            writer.Append("ELSE ");
+            AppendAuth1Throw(writer, check.Index, NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
+            writer.AppendLine();
+        }
+
+        writer.Append("END");
+    }
+
+    private void AppendAuth1Throw(
+        SqlWriter writer,
+        int emittedIndex,
+        NamespaceAuthorizationAuth1FailureKind failureKind
+    )
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(emittedIndex, failureKind)
+        );
+
+        switch (_dialect)
+        {
+            case SqlDialect.Pgsql:
+                writer.AppendQuoted("dms");
+                writer.Append(".");
+                writer.AppendQuoted("throw_error");
+                writer.Append("('");
+                writer.Append(NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append("', '");
+                writer.Append(payload);
+                writer.Append("')");
+                return;
+
+            case SqlDialect.Mssql:
+                writer.Append("CAST('");
+                writer.Append(NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode);
+                writer.Append(" - ");
+                writer.Append(payload);
+                writer.Append("' AS INT)");
+                return;
+
+            default:
+                throw new NotSupportedException(
+                    $"Single-record namespace authorization SQL does not support SQL dialect '{_dialect}'."
+                );
+        }
+    }
+
+    private static void AppendStoredRowSelect(
+        SqlWriter writer,
+        NamespaceAuthorizationCheckSpec check,
+        string documentIdParameterName,
+        Action<SqlWriter> appendNamespacePredicate
+    )
+    {
+        writer.Append("SELECT 1 FROM ");
+        writer.AppendRelation(new SqlRelationRef.PhysicalTable(check.RootTable));
+        writer.Append($" {RootAlias} WHERE {RootAlias}.");
+        writer.AppendQuoted("DocumentId");
+        writer.Append(" = ");
+        writer.AppendParameter(documentIdParameterName);
+        writer.Append(" AND ");
+        appendNamespacePredicate(writer);
+    }
+
+    private static IReadOnlyList<QuerySqlParameter> BuildParametersInOrder(
+        NamespaceAuthorizationSqlSpec spec,
+        bool hasStored,
+        bool hasProposed
+    )
+    {
+        List<QuerySqlParameter> parameters = [];
+
+        if (hasStored)
+        {
+            parameters.Add(new QuerySqlParameter(QuerySqlParameterRole.Filter, spec.DocumentIdParameterName));
+        }
+
+        if (hasProposed)
+        {
+            parameters.Add(
+                new QuerySqlParameter(QuerySqlParameterRole.Filter, spec.ProposedNamespaceParameterName)
+            );
+        }
+
+        parameters.AddRange(
+            NamespacePrefixSqlHelper.BuildFilterParametersInOrder(spec.NamespacePrefixParameterization)
+        );
+
+        return parameters;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespaceAuthorizationSqlCompiler.cs
@@ -184,11 +184,17 @@ public sealed class NamespaceAuthorizationSqlCompiler(SqlDialect dialect)
             );
             writer.AppendLine();
 
-            // Otherwise → 'm'. This covers both "row exists, namespace not null, but no prefix matches"
-            // and "no row at all": a target concurrently deleted between the lookup and this check
-            // matches neither EXISTS branch and intentionally fails closed as a namespace mismatch
-            // denial. Namespace authorization has no stale-target result by design (see
-            // NamespaceAuthorizationExecutor remarks); do not add a missing-row branch here.
+            // No row for the target DocumentId at all → 's' (stale). The target was deleted between the
+            // unlocked target lookup and this check. Read paths re-resolve the target and surface the
+            // resulting 404 rather than a namespace mismatch; locked write/delete paths row-lock the
+            // target before this check, so they never reach this branch.
+            writer.Append("WHEN NOT EXISTS (");
+            AppendStoredRowByDocumentId(writer, check, spec.DocumentIdParameterName);
+            writer.Append(") THEN ");
+            AppendAuth1Throw(writer, check.Index, NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing);
+            writer.AppendLine();
+
+            // Otherwise → 'm'. The row exists with a non-null namespace that matches no configured prefix.
             writer.Append("ELSE ");
             AppendAuth1Throw(writer, check.Index, NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch);
             writer.AppendLine();
@@ -284,14 +290,23 @@ public sealed class NamespaceAuthorizationSqlCompiler(SqlDialect dialect)
         Action<SqlWriter> appendNamespacePredicate
     )
     {
+        AppendStoredRowByDocumentId(writer, check, documentIdParameterName);
+        writer.Append(" AND ");
+        appendNamespacePredicate(writer);
+    }
+
+    private static void AppendStoredRowByDocumentId(
+        SqlWriter writer,
+        NamespaceAuthorizationCheckSpec check,
+        string documentIdParameterName
+    )
+    {
         writer.Append("SELECT 1 FROM ");
         writer.AppendRelation(new SqlRelationRef.PhysicalTable(check.RootTable));
         writer.Append($" {RootAlias} WHERE {RootAlias}.");
         writer.AppendQuoted("DocumentId");
         writer.Append(" = ");
         writer.AppendParameter(documentIdParameterName);
-        writer.Append(" AND ");
-        appendNamespacePredicate(writer);
     }
 
     private static IReadOnlyList<QuerySqlParameter> BuildParametersInOrder(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixLimitExceededException.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixLimitExceededException.cs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Thrown when a SQL Server namespace authorization would require more than the supported number of
+/// parameterized OR-chain LIKE clauses. The repository layer maps this to a 500 Security Configuration
+/// Error so the client can diagnose the configuration limit without seeing an internal SQL error.
+/// </summary>
+public sealed class NamespacePrefixLimitExceededException : InvalidOperationException
+{
+    public const int MssqlScalarParameterLimit = 2000;
+
+    public NamespacePrefixLimitExceededException(int prefixCount)
+        : base(BuildMessage(prefixCount))
+    {
+        PrefixCount = prefixCount;
+    }
+
+    public int PrefixCount { get; }
+
+    private static string BuildMessage(int prefixCount) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"The API client has {prefixCount} namespace prefixes, which exceeds the SQL Server limit of {MssqlScalarParameterLimit} parameterized LIKE clauses for NamespaceBased authorization."
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixParameterization.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixParameterization.cs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Dialect-specific runtime shape for the namespace prefix list bound to a SQL <c>LIKE</c> filter.
+/// </summary>
+public enum NamespacePrefixParameterizationKind
+{
+    /// <summary>One PostgreSQL array parameter carrying every prefix-with-trailing-percent value.</summary>
+    PgsqlArray,
+
+    /// <summary>One SQL Server scalar parameter per prefix, OR-chained at the SQL site.</summary>
+    MssqlScalar,
+}
+
+/// <summary>
+/// Dialect-specific namespace prefix parameterization. Carries both the raw configured prefixes (for
+/// user-facing ProblemDetails) and the prefix values already shaped for <c>LIKE</c> with a trailing
+/// <c>%</c> wildcard (for SQL binding) so the SQL writer never has to append one.
+/// </summary>
+/// <param name="Kind">The emitted SQL/binding shape for the prefix list.</param>
+/// <param name="BaseParameterName">The logical base parameter name.</param>
+/// <param name="ConfiguredPrefixesInOrder">
+/// The caller's raw namespace prefixes, deduplicated and ordinal-sorted, with no escaping or trailing
+/// wildcard. These are what authorization-failure ProblemDetails present to the client.
+/// </param>
+/// <param name="LikePatternsInOrder">
+/// Prefix values escaped for <c>LIKE</c> and normalized to <c>prefix%</c>, aligned 1:1 with
+/// <paramref name="ConfiguredPrefixesInOrder"/>. These are the SQL-bound values.
+/// </param>
+/// <param name="ParameterNamesInOrder">Concrete SQL parameter names in deterministic binding order.</param>
+public sealed record NamespacePrefixParameterization(
+    NamespacePrefixParameterizationKind Kind,
+    string BaseParameterName,
+    IReadOnlyList<string> ConfiguredPrefixesInOrder,
+    IReadOnlyList<string> LikePatternsInOrder,
+    IReadOnlyList<string> ParameterNamesInOrder
+)
+{
+    /// <summary>
+    /// Evaluates in memory whether <paramref name="storedNamespace"/> starts with any configured
+    /// prefix, mirroring the emitted SQL <c>LIKE</c> prefix filter so a single-record check accepts and
+    /// rejects exactly the namespaces the <c>LIKE</c>-based GET-many and write paths do.
+    /// </summary>
+    /// <remarks>
+    /// The match is an ordinal starts-with over <see cref="ConfiguredPrefixesInOrder"/> (the raw,
+    /// unescaped prefixes), not over <see cref="LikePatternsInOrder"/>. Escaping in the LIKE patterns
+    /// only neutralizes the wildcard metacharacters (<c>%</c>, <c>_</c>, and <c>[</c> on SQL Server) so
+    /// each prefix matches literally; an ordinal starts-with over the raw prefix is exactly that literal
+    /// <c>prefix%</c> match, so the two are equivalent without re-deriving the escaped form here. Case
+    /// sensitivity follows the dialect's default Namespace column collation that the <c>LIKE</c> runs
+    /// under: PostgreSQL's deterministic default is case-sensitive (<see cref="StringComparison.Ordinal"/>),
+    /// the SQL Server default is case-insensitive (<see cref="StringComparison.OrdinalIgnoreCase"/>).
+    /// </remarks>
+    public bool MatchesAnyPrefix(string storedNamespace)
+    {
+        ArgumentNullException.ThrowIfNull(storedNamespace);
+
+        var prefixComparison = Kind switch
+        {
+            NamespacePrefixParameterizationKind.PgsqlArray => StringComparison.Ordinal,
+            NamespacePrefixParameterizationKind.MssqlScalar => StringComparison.OrdinalIgnoreCase,
+            _ => throw new InvalidOperationException(
+                $"Unsupported namespace prefix parameterization kind '{Kind}'."
+            ),
+        };
+
+        return ConfiguredPrefixesInOrder.Any(configuredPrefix =>
+            storedNamespace.StartsWith(configuredPrefix, prefixComparison)
+        );
+    }
+}
+
+/// <summary>
+/// Builds the namespace prefix parameterization for a SQL dialect. Each configured prefix is meant to be
+/// a literal "starts-with" match, so C# escapes any <c>LIKE</c> metacharacters in the prefix
+/// (using <see cref="LikeEscapeCharacter"/> as the escape character) before appending the trailing
+/// <c>%</c> wildcard. The SQL emitter therefore sees only <c>LIKE @param</c> / <c>LIKE ANY(...)</c>
+/// over pre-escaped patterns. SQL Server fails closed with <see cref="NamespacePrefixLimitExceededException"/>
+/// when the prefix count would exceed the parameterized OR-chain limit.
+/// </summary>
+public static class NamespacePrefixParameterizationFactory
+{
+    /// <summary>
+    /// The escape character used in the emitted <c>LIKE</c> patterns. PostgreSQL treats backslash as the
+    /// default <c>LIKE</c> escape; SQL Server requires an explicit <c>ESCAPE '\'</c> clause at the SQL site.
+    /// </summary>
+    public const char LikeEscapeCharacter = '\\';
+
+    public static NamespacePrefixParameterization Create(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes,
+        string baseParameterName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(namespacePrefixes);
+        PlanSqlWriterExtensions.ValidateBareParameterName(baseParameterName, nameof(baseParameterName));
+
+        if (namespacePrefixes.Any(string.IsNullOrEmpty))
+        {
+            throw new ArgumentException(
+                "Namespace prefixes must not contain null or empty values.",
+                nameof(namespacePrefixes)
+            );
+        }
+
+        // Raw configured prefixes, deduplicated and ordinal-sorted, drive both the user-facing
+        // ProblemDetails and the escaped SQL patterns so the two stay aligned 1:1.
+        var configuredPrefixes = namespacePrefixes
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(static prefix => prefix, StringComparer.Ordinal)
+            .ToArray();
+
+        if (configuredPrefixes.Length == 0)
+        {
+            throw new ArgumentException(
+                "Namespace prefix parameterization requires at least one prefix.",
+                nameof(namespacePrefixes)
+            );
+        }
+
+        // Escape LIKE metacharacters per dialect so a prefix containing '%', '_', or (SQL Server)
+        // '[' is matched literally instead of as a wildcard, preserving starts-with semantics.
+        var escapeSquareBracket = dialect is SqlDialect.Mssql;
+        var likePatterns = configuredPrefixes
+            .Select(prefix => EscapeLikePrefix(prefix, escapeSquareBracket) + "%")
+            .ToArray();
+
+        if (
+            dialect is SqlDialect.Mssql
+            && likePatterns.Length >= NamespacePrefixLimitExceededException.MssqlScalarParameterLimit
+        )
+        {
+            throw new NamespacePrefixLimitExceededException(likePatterns.Length);
+        }
+
+        return dialect switch
+        {
+            SqlDialect.Pgsql => new NamespacePrefixParameterization(
+                NamespacePrefixParameterizationKind.PgsqlArray,
+                baseParameterName,
+                configuredPrefixes,
+                likePatterns,
+                [baseParameterName]
+            ),
+            SqlDialect.Mssql => new NamespacePrefixParameterization(
+                NamespacePrefixParameterizationKind.MssqlScalar,
+                baseParameterName,
+                configuredPrefixes,
+                likePatterns,
+                [
+                    .. Enumerable
+                        .Range(0, likePatterns.Length)
+                        .Select(index => CreateScalarParameterName(baseParameterName, index)),
+                ]
+            ),
+            _ => throw new NotSupportedException(
+                $"Namespace prefix parameterization does not support SQL dialect '{dialect}'."
+            ),
+        };
+    }
+
+    private static string CreateScalarParameterName(string baseParameterName, int index)
+    {
+        var parameterName = string.Create(CultureInfo.InvariantCulture, $"{baseParameterName}_{index}");
+
+        PlanSqlWriterExtensions.ValidateBareParameterName(parameterName, nameof(baseParameterName));
+        return parameterName;
+    }
+
+    /// <summary>
+    /// Escapes <c>LIKE</c> metacharacters in a prefix so it matches literally. Always escapes the escape
+    /// character itself plus <c>%</c> and <c>_</c>; also escapes <c>[</c> for SQL Server, whose <c>LIKE</c>
+    /// treats it as a character-class opener.
+    /// </summary>
+    private static string EscapeLikePrefix(string prefix, bool escapeSquareBracket)
+    {
+        var builder = new StringBuilder(prefix.Length + 8);
+
+        foreach (var character in prefix)
+        {
+            if (character is LikeEscapeCharacter or '%' or '_' || (escapeSquareBracket && character is '['))
+            {
+                builder.Append(LikeEscapeCharacter);
+            }
+
+            builder.Append(character);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixParameterizationValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixParameterizationValidator.cs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Validates that a <see cref="NamespacePrefixParameterization"/> matches the target SQL dialect and is
+/// internally consistent, so a compiler cannot, for example, accept a PostgreSQL array parameterization
+/// and emit <c>LIKE ANY(...)</c> against SQL Server.
+/// </summary>
+internal static class NamespacePrefixParameterizationValidator
+{
+    public static void ValidateOrThrow(
+        NamespacePrefixParameterization namespacePrefixParameterization,
+        SqlDialect dialect,
+        string parameterizationName,
+        string unsupportedDialectMessagePrefix
+    )
+    {
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization);
+        PlanSqlWriterExtensions.ValidateBareParameterName(
+            namespacePrefixParameterization.BaseParameterName,
+            $"{parameterizationName}.{nameof(NamespacePrefixParameterization.BaseParameterName)}"
+        );
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization.LikePatternsInOrder);
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization.ParameterNamesInOrder);
+
+        if (namespacePrefixParameterization.LikePatternsInOrder.Count == 0)
+        {
+            throw new ArgumentException(
+                "Namespace prefix parameterization requires at least one prefix pattern.",
+                nameof(namespacePrefixParameterization)
+            );
+        }
+
+        if (namespacePrefixParameterization.ParameterNamesInOrder.Count == 0)
+        {
+            throw new ArgumentException(
+                "Namespace prefix parameterization requires at least one parameter name.",
+                nameof(namespacePrefixParameterization)
+            );
+        }
+
+        foreach (var parameterName in namespacePrefixParameterization.ParameterNamesInOrder)
+        {
+            PlanSqlWriterExtensions.ValidateBareParameterName(
+                parameterName,
+                $"{parameterizationName}.{nameof(NamespacePrefixParameterization.ParameterNamesInOrder)}"
+            );
+        }
+
+        ValidateMatchesDialect(
+            namespacePrefixParameterization.Kind,
+            dialect,
+            unsupportedDialectMessagePrefix
+        );
+        ValidateShape(namespacePrefixParameterization);
+    }
+
+    private static void ValidateMatchesDialect(
+        NamespacePrefixParameterizationKind kind,
+        SqlDialect dialect,
+        string unsupportedDialectMessagePrefix
+    )
+    {
+        switch (dialect)
+        {
+            case SqlDialect.Pgsql:
+                if (kind is not NamespacePrefixParameterizationKind.PgsqlArray)
+                {
+                    throw CreateDialectMismatchException(kind, dialect);
+                }
+
+                return;
+
+            case SqlDialect.Mssql:
+                if (kind is not NamespacePrefixParameterizationKind.MssqlScalar)
+                {
+                    throw CreateDialectMismatchException(kind, dialect);
+                }
+
+                return;
+
+            default:
+                throw new NotSupportedException(
+                    $"{unsupportedDialectMessagePrefix} does not support SQL dialect '{dialect}'."
+                );
+        }
+    }
+
+    private static void ValidateShape(NamespacePrefixParameterization namespacePrefixParameterization)
+    {
+        switch (namespacePrefixParameterization.Kind)
+        {
+            case NamespacePrefixParameterizationKind.PgsqlArray:
+                if (
+                    namespacePrefixParameterization.ParameterNamesInOrder.Count is not 1
+                    || !string.Equals(
+                        namespacePrefixParameterization.ParameterNamesInOrder[0],
+                        namespacePrefixParameterization.BaseParameterName,
+                        StringComparison.Ordinal
+                    )
+                )
+                {
+                    throw new ArgumentException(
+                        "PostgreSQL array namespace prefix parameterizations require exactly the base parameter name.",
+                        nameof(namespacePrefixParameterization)
+                    );
+                }
+
+                return;
+
+            case NamespacePrefixParameterizationKind.MssqlScalar:
+                if (
+                    namespacePrefixParameterization.ParameterNamesInOrder.Count
+                    != namespacePrefixParameterization.LikePatternsInOrder.Count
+                )
+                {
+                    throw new ArgumentException(
+                        "SQL Server scalar namespace prefix parameterizations require one parameter name per prefix pattern.",
+                        nameof(namespacePrefixParameterization)
+                    );
+                }
+
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(namespacePrefixParameterization),
+                    namespacePrefixParameterization.Kind,
+                    "Unsupported namespace prefix parameterization kind."
+                );
+        }
+    }
+
+    private static ArgumentException CreateDialectMismatchException(
+        NamespacePrefixParameterizationKind kind,
+        SqlDialect dialect
+    ) =>
+        new(
+            $"Namespace prefix parameterization kind '{kind}' is not supported by SQL dialect '{dialect}'.",
+            nameof(kind)
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixSqlHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/NamespacePrefixSqlHelper.cs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// SQL emission and parameter helpers shared by the GET-many and single-record namespace authorization
+/// SQL compilers. Centralizes the null-guarded prefix-LIKE predicate so both call sites emit identical
+/// shape: PG <c>col IS NOT NULL AND col LIKE ANY(ARRAY[...])</c> and SQL Server
+/// <c>col IS NOT NULL AND (col LIKE @p0 ESCAPE '\' OR col LIKE @p1 ESCAPE '\' OR ...)</c>.
+/// Prefix patterns are pre-escaped by <see cref="NamespacePrefixParameterizationFactory"/>; PostgreSQL
+/// uses the default backslash <c>LIKE</c> escape, while SQL Server requires the explicit
+/// <c>ESCAPE '\'</c> clause emitted here.
+/// </summary>
+internal static class NamespacePrefixSqlHelper
+{
+    private const string MssqlEscapeClause = " ESCAPE '\\'";
+
+    /// <summary>
+    /// Builds the runtime parameter metadata for a namespace prefix parameterization.
+    /// </summary>
+    public static IReadOnlyList<QuerySqlParameter> BuildFilterParametersInOrder(
+        NamespacePrefixParameterization namespacePrefixParameterization
+    ) =>
+        namespacePrefixParameterization.Kind switch
+        {
+            NamespacePrefixParameterizationKind.PgsqlArray =>
+            [
+                new QuerySqlParameter(
+                    QuerySqlParameterRole.Filter,
+                    namespacePrefixParameterization.BaseParameterName,
+                    QuerySqlParameterBinding.PgsqlArray
+                ),
+            ],
+            NamespacePrefixParameterizationKind.MssqlScalar =>
+            [
+                .. namespacePrefixParameterization.ParameterNamesInOrder.Select(
+                    static parameterName => new QuerySqlParameter(QuerySqlParameterRole.Filter, parameterName)
+                ),
+            ],
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(namespacePrefixParameterization),
+                namespacePrefixParameterization.Kind,
+                "Unsupported namespace prefix parameterization kind."
+            ),
+        };
+
+    /// <summary>
+    /// Appends a null-guarded root-table namespace LIKE predicate using the table's fixed alias.
+    /// </summary>
+    /// <remarks>
+    /// Emits <c>{alias}."Col" IS NOT NULL AND {alias}."Col" LIKE ANY(@base)</c> for PostgreSQL or
+    /// <c>{alias}.[Col] IS NOT NULL AND ({alias}.[Col] LIKE @base_0 OR {alias}.[Col] LIKE @base_1 OR ...)</c>
+    /// for SQL Server. The predicate is never wrapped in outer parentheses — callers control bracketing.
+    /// </remarks>
+    public static void AppendRootTableNamespacePredicate(
+        SqlWriter writer,
+        string tableAlias,
+        DbColumnName namespaceColumn,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        AppendIsNotNull(writer, tableAlias, namespaceColumn);
+        writer.Append(" AND ");
+        AppendLikeMatch(writer, tableAlias, namespaceColumn, namespacePrefixParameterization);
+    }
+
+    /// <summary>
+    /// Appends just the LIKE-match portion of a namespace check (no <c>IS NOT NULL</c> guard).
+    /// Used by single-record proposed-value checks where the subject value is a SQL parameter, not a
+    /// stored column, and the null case is reported separately as a <c>'r'</c> failure kind.
+    /// </summary>
+    public static void AppendLikeMatch(
+        SqlWriter writer,
+        string tableAlias,
+        DbColumnName namespaceColumn,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    ) =>
+        AppendLikeMatch(
+            writer,
+            lhsWriter => AppendQualifiedColumn(lhsWriter, tableAlias, namespaceColumn),
+            namespacePrefixParameterization
+        );
+
+    /// <summary>
+    /// Appends the dialect-specific prefix-LIKE match over a caller-supplied left-hand side. The LHS
+    /// emitter is invoked once per emitted <c>LIKE</c> (once for PostgreSQL, once per prefix parameter
+    /// for SQL Server) so the subject may be a stored column or a bound parameter. SQL Server emits a
+    /// parenthesized OR-chain of <c>&lt;lhs&gt; LIKE @p ESCAPE '\'</c>; PostgreSQL emits
+    /// <c>&lt;lhs&gt; LIKE ANY(@base)</c>. No outer parentheses are added beyond the SQL Server chain
+    /// grouping — callers control surrounding bracketing.
+    /// </summary>
+    public static void AppendLikeMatch(
+        SqlWriter writer,
+        Action<SqlWriter> appendLeftHandSide,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        switch (namespacePrefixParameterization.Kind)
+        {
+            case NamespacePrefixParameterizationKind.PgsqlArray:
+                appendLeftHandSide(writer);
+                writer.Append(" LIKE ANY(");
+                writer.AppendParameter(namespacePrefixParameterization.BaseParameterName);
+                writer.Append(")");
+                return;
+
+            case NamespacePrefixParameterizationKind.MssqlScalar:
+                writer.Append("(");
+                for (
+                    var parameterIndex = 0;
+                    parameterIndex < namespacePrefixParameterization.ParameterNamesInOrder.Count;
+                    parameterIndex++
+                )
+                {
+                    if (parameterIndex > 0)
+                    {
+                        writer.Append(" OR ");
+                    }
+
+                    appendLeftHandSide(writer);
+                    writer.Append(" LIKE ");
+                    writer.AppendParameter(
+                        namespacePrefixParameterization.ParameterNamesInOrder[parameterIndex]
+                    );
+                    writer.Append(MssqlEscapeClause);
+                }
+                writer.Append(")");
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(namespacePrefixParameterization),
+                    namespacePrefixParameterization.Kind,
+                    "Unsupported namespace prefix parameterization kind."
+                );
+        }
+    }
+
+    /// <summary>
+    /// Appends a parameter-only <c>IS NULL OR = ''</c> check used by single-record proposed-value
+    /// classification. Empty strings classify identically to NULL so a proposed namespace bound from
+    /// an empty value maps to the missing branch rather than mismatch.
+    /// </summary>
+    public static void AppendParameterIsNullOrEmpty(SqlWriter writer, string parameterName)
+    {
+        writer.Append("(");
+        writer.AppendParameter(parameterName);
+        writer.Append(" IS NULL OR ");
+        writer.AppendParameter(parameterName);
+        writer.Append(" = '')");
+    }
+
+    private static void AppendIsNotNull(SqlWriter writer, string tableAlias, DbColumnName column)
+    {
+        AppendQualifiedColumn(writer, tableAlias, column);
+        writer.Append(" IS NOT NULL");
+    }
+
+    private static void AppendQualifiedColumn(SqlWriter writer, string tableAlias, DbColumnName column)
+    {
+        writer.Append($"{tableAlias}.").AppendQuoted(column.Value);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdQueryModels.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdQueryModels.cs
@@ -110,7 +110,7 @@ public sealed record PageDocumentIdAuthorizationStrategy(
 );
 
 /// <summary>
-/// Optional DMS-1055 authorization inputs for page-<c>DocumentId</c> query compilation.
+/// Optional authorization inputs for page-<c>DocumentId</c> query compilation.
 /// </summary>
 /// <param name="Strategies">
 /// Effective relationship authorization strategies. Strategies are combined with OR.
@@ -119,10 +119,20 @@ public sealed record PageDocumentIdAuthorizationStrategy(
 /// Dialect-specific claim EdOrg parameterization shared by SQL emission and runtime binding. Required when
 /// <paramref name="Strategies" /> is non-empty; ignored when the strategy list is empty.
 /// </param>
+/// <param name="NamespaceChecks">
+/// Namespace authorization checks. The compiler emits each as a root-table <c>IS NOT NULL</c> + prefix-LIKE
+/// predicate and AND-combines them into a single outer group placed before the relationship OR group.
+/// </param>
+/// <param name="NamespacePrefixParameterization">
+/// Dialect-specific namespace prefix parameterization shared by SQL emission and runtime binding. Required
+/// when <paramref name="NamespaceChecks" /> is non-empty; ignored otherwise.
+/// </param>
 public sealed record PageDocumentIdAuthorizationSpec(
     IReadOnlyList<PageDocumentIdAuthorizationStrategy> Strategies,
     AuthorizationClaimEducationOrganizationIdParameterization? ClaimEducationOrganizationIdParameterization =
-        null
+        null,
+    IReadOnlyList<NamespaceAuthorizationCheckSpec>? NamespaceChecks = null,
+    NamespacePrefixParameterization? NamespacePrefixParameterization = null
 );
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PageDocumentIdSqlCompiler.cs
@@ -67,15 +67,25 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
         );
         var authorization = NormalizeAuthorization(spec.Authorization);
         var authorizationClaimParameterization = authorization?.ClaimEducationOrganizationIdParameterization;
+        var namespacePrefixParameterization = authorization?.NamespacePrefixParameterization;
         var requiresDocumentUuidJoin = rewrittenPredicates.Any(static predicate =>
             predicate.Target is QueryPredicateTarget.DocumentUuid
         );
-        var requiresDescriptorJoin = rewrittenPredicates.Any(static predicate =>
-            predicate.Target is QueryPredicateTarget.DescriptorColumn
-        );
+        // The descriptor join also covers the descriptor-alias namespace check used by descriptor
+        // queries: the page subquery roots on dms.Document for ResourceKeyId paging, while the
+        // Namespace column lives on the joined dms.Descriptor row.
+        var requiresDescriptorJoin =
+            rewrittenPredicates.Any(static predicate =>
+                predicate.Target is QueryPredicateTarget.DescriptorColumn
+            )
+            || (
+                authorization?.NamespaceChecks?.Any(check => check.RootTable.Equals(_descriptorTable))
+                ?? false
+            );
         var filterParametersInOrder = BuildFilterParametersInOrder(
             rewrittenPredicates,
-            authorizationClaimParameterization
+            authorizationClaimParameterization,
+            namespacePrefixParameterization
         );
         var filterParameterNamesInOrder = filterParametersInOrder
             .Select(static parameter => parameter.ParameterName)
@@ -326,7 +336,8 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
     /// </summary>
     private static IReadOnlyList<QuerySqlParameter> BuildFilterParametersInOrder(
         IReadOnlyList<RewrittenPredicate> predicates,
-        AuthorizationClaimEducationOrganizationIdParameterization? authorizationClaimParameterization
+        AuthorizationClaimEducationOrganizationIdParameterization? authorizationClaimParameterization,
+        NamespacePrefixParameterization? namespacePrefixParameterization
     )
     {
         List<QuerySqlParameter> filterParametersInOrder =
@@ -336,6 +347,13 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                 predicate.ParameterName
             )),
         ];
+
+        if (namespacePrefixParameterization is not null)
+        {
+            filterParametersInOrder.AddRange(
+                NamespacePrefixSqlHelper.BuildFilterParametersInOrder(namespacePrefixParameterization)
+            );
+        }
 
         if (authorizationClaimParameterization is not null)
         {
@@ -425,19 +443,47 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
             }
         }
 
-        if (normalizedStrategies.Length == 0)
+        if (
+            authorization.NamespaceChecks is not null
+            && authorization.NamespaceChecks.Any(static check => check is null)
+        )
+        {
+            throw new ArgumentException(
+                $"{nameof(PageDocumentIdAuthorizationSpec.NamespaceChecks)} must not contain null entries.",
+                nameof(authorization)
+            );
+        }
+
+        var normalizedNamespaceChecks = (authorization.NamespaceChecks ?? []).ToArray();
+
+        if (normalizedStrategies.Length == 0 && normalizedNamespaceChecks.Length == 0)
         {
             return null;
         }
 
-        ArgumentNullException.ThrowIfNull(authorization.ClaimEducationOrganizationIdParameterization);
-        ValidateAuthorizationClaimParameterization(
-            authorization.ClaimEducationOrganizationIdParameterization
-        );
+        if (normalizedStrategies.Length > 0)
+        {
+            ArgumentNullException.ThrowIfNull(authorization.ClaimEducationOrganizationIdParameterization);
+            ValidateAuthorizationClaimParameterization(
+                authorization.ClaimEducationOrganizationIdParameterization
+            );
+        }
+
+        if (normalizedNamespaceChecks.Length > 0)
+        {
+            ArgumentNullException.ThrowIfNull(authorization.NamespacePrefixParameterization);
+            NamespacePrefixParameterizationValidator.ValidateOrThrow(
+                authorization.NamespacePrefixParameterization,
+                _dialect,
+                nameof(PageDocumentIdAuthorizationSpec.NamespacePrefixParameterization),
+                "Page document-id SQL compilation"
+            );
+        }
 
         return authorization with
         {
             Strategies = normalizedStrategies,
+            NamespaceChecks = normalizedNamespaceChecks,
         };
     }
 
@@ -572,7 +618,9 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
         AuthorizationClaimEducationOrganizationIdParameterization? authorizationClaimParameterization
     )
     {
-        var predicateCount = predicates.Count + (authorization is null ? 0 : 1);
+        var hasNamespaceGroup = (authorization?.NamespaceChecks?.Count ?? 0) > 0;
+        var hasRelationshipGroup = (authorization?.Strategies.Count ?? 0) > 0;
+        var predicateCount = predicates.Count + (hasNamespaceGroup ? 1 : 0) + (hasRelationshipGroup ? 1 : 0);
 
         writer.AppendWhereClause(
             predicateCount,
@@ -581,6 +629,22 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                 if (index < predicates.Count)
                 {
                     AppendPredicateSql(predicateWriter, predicates[index]);
+                    return;
+                }
+
+                var groupIndex = index - predicates.Count;
+
+                if (hasNamespaceGroup && groupIndex == 0)
+                {
+                    AppendNamespaceChecksSql(
+                        predicateWriter,
+                        rootTable,
+                        authorization!.NamespaceChecks!,
+                        authorization.NamespacePrefixParameterization
+                            ?? throw new InvalidOperationException(
+                                "Namespace authorization SQL emission requires a namespace prefix parameterization when namespace checks are present."
+                            )
+                    );
                     return;
                 }
 
@@ -594,6 +658,56 @@ public sealed class PageDocumentIdSqlCompiler(SqlDialect dialect)
                         )
                 );
             }
+        );
+    }
+
+    private static void AppendNamespaceChecksSql(
+        SqlWriter writer,
+        DbTableName rootTable,
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        for (var checkIndex = 0; checkIndex < namespaceChecks.Count; checkIndex++)
+        {
+            if (checkIndex > 0)
+            {
+                writer.Append(" AND ");
+            }
+
+            var check = namespaceChecks[checkIndex];
+            var tableAlias = ResolveNamespaceCheckAlias(check.RootTable, rootTable);
+
+            NamespacePrefixSqlHelper.AppendRootTableNamespacePredicate(
+                writer,
+                tableAlias,
+                check.NamespaceColumn,
+                namespacePrefixParameterization
+            );
+        }
+    }
+
+    /// <summary>
+    /// Resolves the SQL alias to qualify a namespace check column. Resource queries always check
+    /// against the query root table. Descriptor queries root the page subquery on
+    /// <c>dms.Document</c> but the namespace column lives on the joined <c>dms.Descriptor</c> row;
+    /// in that case the check binds to the shared descriptor alias rather than the document root.
+    /// </summary>
+    private static string ResolveNamespaceCheckAlias(DbTableName checkRootTable, DbTableName queryRootTable)
+    {
+        if (checkRootTable.Equals(queryRootTable))
+        {
+            return _rootAlias;
+        }
+
+        if (queryRootTable.Equals(_documentTable) && checkRootTable.Equals(_descriptorTable))
+        {
+            return _descriptorAlias;
+        }
+
+        throw new InvalidOperationException(
+            $"Namespace authorization check spec table '{checkRootTable}' does not match query root table '{queryRootTable}'. "
+                + "Namespace authorization SQL emission supports only concrete root-table columns (or the shared dms.Descriptor join for descriptor queries)."
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationAuth1Dispatcher.cs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Result of dispatching an AUTH1 provider failure to the codec that owns its payload shape.
+/// </summary>
+public abstract record RelationalAuthorizationAuth1DispatchResult
+{
+    private RelationalAuthorizationAuth1DispatchResult() { }
+
+    public sealed record Relationship(RelationshipAuthorizationAuth1FailurePayload Payload)
+        : RelationalAuthorizationAuth1DispatchResult;
+
+    public sealed record Namespace(NamespaceAuthorizationAuth1FailurePayload Payload)
+        : RelationalAuthorizationAuth1DispatchResult;
+
+    public sealed record InvalidPayload(string RawPayload) : RelationalAuthorizationAuth1DispatchResult;
+}
+
+/// <summary>
+/// Routes an AUTH1 provider failure to either the relationship or namespace payload codec based on the
+/// payload's leading discriminator. Relationship payloads start with <c>1|</c>; namespace payloads start
+/// with <c>ns1|</c>. Any other payload returns <see cref="RelationalAuthorizationAuth1DispatchResult.InvalidPayload"/>
+/// so the caller can log and fall through to a generic security failure.
+/// </summary>
+public static class RelationalAuthorizationAuth1Dispatcher
+{
+    private const string RelationshipDiscriminatorPrefix =
+        RelationshipAuthorizationAuth1FailurePayloadCodec.PayloadVersion + "|";
+    private const string NamespaceDiscriminatorPrefix =
+        NamespaceAuthorizationAuth1FailurePayloadCodec.PayloadDiscriminator + "|";
+
+    /// <summary>
+    /// Attempts to extract and dispatch an AUTH1 payload from a provider exception.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the provider failure carries an AUTH1 payload (regardless of whether
+    /// the payload decoded successfully); <see langword="false"/> when no AUTH1 payload is present.
+    /// </returns>
+    public static bool TryDispatch(
+        SqlDialect dialect,
+        string? providerErrorCode,
+        string providerMessage,
+        out RelationalAuthorizationAuth1DispatchResult? result
+    )
+    {
+        result = null;
+
+        if (
+            !TryExtractAuth1Payload(dialect, providerErrorCode, providerMessage, out var payloadText)
+            || string.IsNullOrWhiteSpace(payloadText)
+        )
+        {
+            return false;
+        }
+
+        if (
+            payloadText.StartsWith(RelationshipDiscriminatorPrefix, StringComparison.Ordinal)
+            && RelationshipAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                payloadText,
+                out var relationshipPayload
+            )
+            && relationshipPayload is not null
+        )
+        {
+            result = new RelationalAuthorizationAuth1DispatchResult.Relationship(relationshipPayload);
+            return true;
+        }
+
+        if (
+            payloadText.StartsWith(NamespaceDiscriminatorPrefix, StringComparison.Ordinal)
+            && NamespaceAuthorizationAuth1FailurePayloadCodec.TryParsePayload(
+                payloadText,
+                out var namespacePayload
+            )
+            && namespacePayload is not null
+        )
+        {
+            result = new RelationalAuthorizationAuth1DispatchResult.Namespace(namespacePayload);
+            return true;
+        }
+
+        result = new RelationalAuthorizationAuth1DispatchResult.InvalidPayload(payloadText);
+        return true;
+    }
+
+    private static bool TryExtractAuth1Payload(
+        SqlDialect dialect,
+        string? providerErrorCode,
+        string providerMessage,
+        out string payloadText
+    )
+    {
+        // Both codecs share the same transport extraction logic (PG SqlState == "AUTH1", or MSSQL
+        // message containing "AUTH1 - "). Use the relationship codec's extractor as the single source
+        // of truth so a future change to either codec cannot silently diverge from the other.
+        return RelationshipAuthorizationAuth1FailurePayloadCodec.TryExtractProviderPayload(
+            dialect,
+            providerErrorCode,
+            providerMessage,
+            out payloadText
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -80,7 +80,7 @@ public abstract record RelationalAuthorizationPlanOutcome
 /// ahead of relationship OR-combined strategies, so its 403 wins over a sibling
 /// known-but-not-enabled relationship strategy.</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — the relationship classifier reports a
-/// known-but-not-enabled strategy in the non-namespace bucket (403, fail closed).</item>
+/// known-but-not-enabled strategy in the non-namespace bucket (501 NotImplemented, fail closed).</item>
 /// <item><see cref="RelationalAuthorizationPlanOutcome.Plan"/> — everything else.</item>
 /// </list>
 /// </remarks>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationalAuthorizationPlanner.cs
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Security;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// Outcome of the relational authorization orchestrator. Conveys the namespace check plan and the
+/// non-namespace configured strategies the caller must still feed through the relationship planner,
+/// or a terminal failure outcome that short-circuits the request.
+/// </summary>
+public abstract record RelationalAuthorizationPlanOutcome
+{
+    private RelationalAuthorizationPlanOutcome() { }
+
+    /// <summary>
+    /// Proceed: execute the namespace checks (if any) and route any non-namespace configured
+    /// strategies through the relationship planner. Both lists may be empty.
+    /// </summary>
+    public sealed record Plan(
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> NamespaceChecks,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies
+    ) : RelationalAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// <c>NamespaceBased</c> is configured but no securable element resolves to the resource's
+    /// concrete root-table column. Maps to a 500 Security Configuration Error.
+    /// </summary>
+    public sealed record NoUsableRootColumn(QualifiedResourceName Resource)
+        : RelationalAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// <c>NamespaceBased</c> is configured and the client has no namespace prefixes assigned.
+    /// Maps to the no-prefixes-configured 403 ProblemDetails at planner/preflight time — no DB
+    /// roundtrip is issued.
+    /// </summary>
+    public sealed record NoPrefixesConfigured(string StrategyName) : RelationalAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// At least one configured strategy is known but not yet supported (e.g. <c>OwnershipBased</c> or
+    /// a custom view-based strategy). The request fails closed. The non-namespace strategies are carried
+    /// so the caller can re-run the relationship planner and surface the exact fail-closed result.
+    /// </summary>
+    public sealed record StillUnsupported(
+        IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies
+    ) : RelationalAuthorizationPlanOutcome;
+
+    /// <summary>
+    /// At least one configured strategy is unrecognized or otherwise invalid. The relationship
+    /// classifier reports a security configuration error and the request fails with 500. The
+    /// non-namespace strategies are carried so the caller can re-run the relationship planner and
+    /// surface the exact security-configuration diagnostics.
+    /// </summary>
+    public sealed record SecurityConfigurationError(
+        IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies
+    ) : RelationalAuthorizationPlanOutcome;
+}
+
+/// <summary>
+/// Higher-level relational authorization planner. Splits the configured strategy list into a
+/// namespace bucket and a non-namespace bucket, delegates namespace planning to
+/// <see cref="NamespaceAuthorizationPlanner"/>, and uses
+/// <see cref="RelationshipAuthorizationStrategyClassifier"/> to detect still-unsupported and
+/// security-configuration outcomes on the non-namespace bucket. Composes the result so callers can
+/// dispatch on a single outcome value.
+/// </summary>
+/// <remarks>
+/// Outcome precedence:
+/// <list type="number">
+/// <item><see cref="RelationalAuthorizationPlanOutcome.SecurityConfigurationError"/> — the relationship classifier
+/// reports an unrecognized or invalid strategy in the non-namespace bucket (500).</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.NoUsableRootColumn"/> — <c>NamespaceBased</c> is configured
+/// but no root-table column resolves (500).</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.NoPrefixesConfigured"/> — <c>NamespaceBased</c> is configured
+/// and the client has no namespace prefixes (403, preflight). Namespace-based is AND-combined and executes
+/// ahead of relationship OR-combined strategies, so its 403 wins over a sibling
+/// known-but-not-enabled relationship strategy.</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.StillUnsupported"/> — the relationship classifier reports a
+/// known-but-not-enabled strategy in the non-namespace bucket (403, fail closed).</item>
+/// <item><see cref="RelationalAuthorizationPlanOutcome.Plan"/> — everything else.</item>
+/// </list>
+/// </remarks>
+public static class RelationalAuthorizationPlanner
+{
+    public static RelationalAuthorizationPlanOutcome Plan(
+        MappingSet mappingSet,
+        ConcreteResourceModel resource,
+        NamespaceAuthorizationOperation operation,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> configuredAuthorizationStrategies,
+        RelationalAuthorizationContext context
+    )
+    {
+        ArgumentNullException.ThrowIfNull(mappingSet);
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentNullException.ThrowIfNull(configuredAuthorizationStrategies);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var (namespaceStrategies, nonNamespaceStrategies) = SplitByNamespaceBased(
+            configuredAuthorizationStrategies
+        );
+
+        // SecurityConfigurationError (500) and StillUnsupported (403) are detected by the existing
+        // relationship classifier; invoke it only when the non-namespace bucket is non-empty.
+        RelationshipAuthorizationClassification? relationshipClassification =
+            nonNamespaceStrategies.Count == 0
+                ? null
+                : RelationshipAuthorizationStrategyClassifier.Classify(
+                    mappingSet,
+                    resource.RelationalModel.Resource,
+                    nonNamespaceStrategies
+                );
+
+        if (
+            relationshipClassification is
+            { Outcome: RelationshipAuthorizationClassificationOutcome.SecurityConfigurationError }
+        )
+        {
+            return new RelationalAuthorizationPlanOutcome.SecurityConfigurationError(nonNamespaceStrategies);
+        }
+
+        NamespaceAuthorizationPlanOutcome? namespaceOutcome =
+            namespaceStrategies.Count == 0
+                ? null
+                : NamespaceAuthorizationPlanner.Plan(resource, operation, context);
+
+        if (namespaceOutcome is NamespaceAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot)
+        {
+            return new RelationalAuthorizationPlanOutcome.NoUsableRootColumn(noUsableRoot.Resource);
+        }
+
+        if (namespaceOutcome is NamespaceAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes)
+        {
+            return new RelationalAuthorizationPlanOutcome.NoPrefixesConfigured(noPrefixes.StrategyName);
+        }
+
+        if (
+            relationshipClassification is
+            { Outcome: RelationshipAuthorizationClassificationOutcome.KnownButNotEnabled }
+        )
+        {
+            return new RelationalAuthorizationPlanOutcome.StillUnsupported(nonNamespaceStrategies);
+        }
+
+        var namespaceChecks = namespaceOutcome is NamespaceAuthorizationPlanOutcome.Plan namespacePlan
+            ? namespacePlan.Checks
+            : (IReadOnlyList<NamespaceAuthorizationCheckSpec>)[];
+
+        return new RelationalAuthorizationPlanOutcome.Plan(namespaceChecks, nonNamespaceStrategies);
+    }
+
+    private static (
+        IReadOnlyList<ConfiguredAuthorizationStrategy> Namespace,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespace
+    ) SplitByNamespaceBased(IReadOnlyList<ConfiguredAuthorizationStrategy> configuredAuthorizationStrategies)
+    {
+        List<ConfiguredAuthorizationStrategy> namespaceStrategies = [];
+        List<ConfiguredAuthorizationStrategy> nonNamespaceStrategies = [];
+
+        foreach (var configuredStrategy in configuredAuthorizationStrategies)
+        {
+            if (
+                string.Equals(
+                    configuredStrategy.StrategyName,
+                    AuthorizationStrategyNameConstants.NamespaceBased,
+                    StringComparison.Ordinal
+                )
+            )
+            {
+                namespaceStrategies.Add(configuredStrategy);
+            }
+            else
+            {
+                nonNamespaceStrategies.Add(configuredStrategy);
+            }
+        }
+
+        return (namespaceStrategies, nonNamespaceStrategies);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationContracts.cs
@@ -20,7 +20,6 @@ public enum RelationshipAuthorizationStrategyKind
 {
     RelationshipsWithEdOrgsOnly,
     RelationshipsWithEdOrgsOnlyInverted,
-    NamespaceBased,
     OwnershipBased,
     RelationshipsWithEdOrgsAndPeople,
     RelationshipsWithEdOrgsAndPeopleInverted,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationStrategyClassifier.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/RelationshipAuthorizationStrategyClassifier.cs
@@ -105,8 +105,6 @@ internal static class RelationshipAuthorizationStrategyClassifier
         StringComparer.Ordinal
     )
     {
-        [AuthorizationStrategyNameConstants.NamespaceBased] =
-            RelationshipAuthorizationStrategyKind.NamespaceBased,
         [AuthorizationStrategyNameConstants.OwnershipBased] =
             RelationshipAuthorizationStrategyKind.OwnershipBased,
     };

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadGetTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadGetTests.cs
@@ -198,7 +198,7 @@ public class Given_A_Postgresql_DescriptorRead_Get_Request
             .Should()
             .BeEquivalentTo(
                 new GetResult.GetFailureNotImplemented(
-                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
                 )
             );
     }
@@ -246,7 +246,11 @@ public class Given_A_Postgresql_DescriptorRead_Get_Request
 
         var failure = result.Should().BeOfType<GetResult.UnknownFailure>().Subject;
         failure.FailureMessage.Should().Contain($"DocumentId {documentId}");
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // The row reader treats Namespace as nullable so a stored null can flow into the
+        // namespace-authorization stored-namespace-uninitialized 403; CodeValue is the next
+        // required column, so the reader's invariant message names it when the LEFT JOIN
+        // finds no descriptor row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
@@ -309,7 +309,11 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
 
         var failure = result.Should().BeOfType<QueryResult.UnknownFailure>().Subject;
         failure.FailureMessage.Should().Contain($"DocumentId {corruptDocumentId}");
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // The row reader treats Namespace as nullable so a stored null can flow into the
+        // namespace-authorization stored-namespace-uninitialized 403; CodeValue is the next
+        // required column, so the reader's invariant message names it when the LEFT JOIN
+        // finds no descriptor row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
     }
 
     private static IEnumerable<TestCaseData> SupportedFilterCases()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalDeleteAuthorizationTests.cs
@@ -447,7 +447,7 @@ public class Given_A_Postgresql_Relational_Delete_Authorization_With_A_Synthetic
             .Subject;
         notImplemented
             .FailureMessage.Should()
-            .Contain(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+            .Contain(RelationshipAuthorizationCrudTestSupport.OwnershipBased);
         var securityConfiguration = securityConfigurationResult
             .Should()
             .BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalGetByIdAuthorizationTests.cs
@@ -46,7 +46,7 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
     private static readonly IReadOnlyList<string> _normalPlusKnownUnsupportedStrategy =
     [
         AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
-        AuthorizationStrategyNameConstants.NamespaceBased,
+        AuthorizationStrategyNameConstants.OwnershipBased,
     ];
 
     private static readonly QuerySchoolSeed[] _schoolSeeds =
@@ -320,7 +320,7 @@ public class Given_A_Postgresql_Relational_Get_By_Id_Authorization_With_A_Synthe
         );
 
         var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.NamespaceBased);
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         _context.AssertNoHydration();
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalNamespaceAuthorizationTests.cs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Integration coverage for the NamespaceBased fail-closed 500 "no usable
+/// root-table Namespace column" preflight terminal. The synthetic
+/// <c>authorization-query</c> fixture's <c>AuthorizationRootChildResource</c>
+/// has an empty <c>Namespace</c> securable element list, so every CRUD route
+/// must short-circuit with the security-configuration message from
+/// <c>NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn</c>
+/// before any database read or write is issued. The shape mirrors the
+/// relationship-strategy integration tests in this project so the harness
+/// (write-session recorder, row-count assertions, fixture lifecycle) is reused.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+[Category("RelationalNamespace")]
+public class Given_A_Postgresql_Relational_Namespace_Authorization_With_A_Synthetic_Fixture
+{
+    private const long ClaimEducationOrganizationId =
+        RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
+    private const string ProjectEndpointName = RelationshipAuthorizationCrudTestSupport.ProjectEndpointName;
+    private const string RootChildResourceName =
+        RelationshipAuthorizationCrudTestSupport.RootAndChildEdOrgResourceName;
+    private const string NoUsableRootColumnMarker =
+        "no Namespace securable element resolves to a root table column";
+
+    private static readonly IReadOnlyList<string> _namespaceBasedStrategy =
+    [
+        AuthorizationStrategyNameConstants.NamespaceBased,
+    ];
+
+    private static readonly QuerySchoolSeed[] _schoolSeeds =
+    [
+        new(new DocumentUuid(Guid.Parse("d1d1d1d1-0000-0000-0000-000000000001")), 100, "North School"),
+        new(
+            new DocumentUuid(Guid.Parse("d1d1d1d1-0000-0000-0000-000000000002")),
+            (int)ClaimEducationOrganizationId,
+            "Claim School"
+        ),
+    ];
+
+    private static readonly ClassPeriodSeed[] _classPeriodSeeds =
+    [
+        new(new DocumentUuid(Guid.Parse("d2d2d2d2-0000-0000-0000-000000000001")), 100, "P1"),
+    ];
+
+    private static readonly AuthorizationRootChildSeed _seededRootChild = new(
+        new DocumentUuid(Guid.Parse("d3d3d3d3-0000-0000-0000-000000000001")),
+        1,
+        "preexisting-row",
+        100,
+        []
+    );
+
+    private PostgresqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _context = new PostgresqlRelationalQueryAuthorizationTestContext();
+        await _context.InitializeAsync(
+            RelationshipAuthorizationCrudTestSupport.FixtureRelativePath,
+            strict: false,
+            replaceReadTargetLookup: false
+        );
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _context.Database.ResetAsync();
+        await _context.SeedSchoolDescriptorDataAsync();
+
+        foreach (var schoolSeed in _schoolSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateSchoolAsync(schoolSeed)
+            );
+        }
+
+        foreach (var classPeriodSeed in _classPeriodSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateClassPeriodAsync(classPeriodSeed)
+            );
+        }
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationRootChildAsync(_seededRootChild)
+        );
+
+        await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, 100);
+        _context.ResetRecorder();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_query_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.QueryAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_get_by_id_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.GetByIdAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_post_create_when_no_usable_root_table_namespace_column()
+    {
+        var newSeed = new AuthorizationRootChildSeed(
+            new DocumentUuid(Guid.Parse("d4d4d4d4-0000-0000-0000-000000000001")),
+            99,
+            "post-attempt",
+            100,
+            []
+        );
+
+        var result = await _context.UpsertAuthorizationRootChildAsync(
+            newSeed,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(newSeed.DocumentUuid)).Should().Be(0);
+        (
+            await _context.CountResourceRootRowsAsync(
+                ProjectEndpointName,
+                RootChildResourceName,
+                newSeed.DocumentUuid
+            )
+        )
+            .Should()
+            .Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_put_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.UpdateAuthorizationRootChildByIdAsync(
+            _seededRootChild,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(_seededRootChild.DocumentUuid)).Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_500_security_configuration_for_delete_when_no_usable_root_table_namespace_column()
+    {
+        var result = await _context.DeleteByIdAsync(
+            ProjectEndpointName,
+            RootChildResourceName,
+            _seededRootChild.DocumentUuid,
+            [ClaimEducationOrganizationId],
+            _namespaceBasedStrategy
+        );
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>().Subject;
+        failure.Errors.Should().ContainSingle().Which.Should().Contain(NoUsableRootColumnMarker);
+        (await _context.CountDocumentRowsAsync(_seededRootChild.DocumentUuid)).Should().Be(1);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
@@ -28,7 +28,7 @@ public static class RelationshipAuthorizationCrudTestSupport
     public const string RelationshipsWithEdOrgsOnly = "RelationshipsWithEdOrgsOnly";
     public const string RelationshipsWithEdOrgsOnlyInverted = "RelationshipsWithEdOrgsOnlyInverted";
     public const string NoFurtherAuthorizationRequired = "NoFurtherAuthorizationRequired";
-    public const string NamespaceBased = "NamespaceBased";
+    public const string OwnershipBased = "OwnershipBased";
 
     public static IReadOnlyList<string> EdOrgOnlyStrategyNames { get; } = [RelationshipsWithEdOrgsOnly];
 
@@ -42,7 +42,7 @@ public static class RelationshipAuthorizationCrudTestSupport
     [RelationshipsWithEdOrgsOnly, NoFurtherAuthorizationRequired];
 
     public static IReadOnlyList<string> EdOrgOnlyPlusKnownUnsupportedStrategyNames { get; } =
-    [RelationshipsWithEdOrgsOnly, NamespaceBased];
+    [RelationshipsWithEdOrgsOnly, OwnershipBased];
 
     public static RelationshipAuthorizationCrudScenario SupportedEdOrgOnlyScenario { get; } =
         new("supported-edorg-only", RootAndChildEdOrgResourceName, EdOrgOnlyStrategyNames);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -4701,6 +4701,477 @@ public class Given_Default_Relational_Write_Executor
     }
 
     [Test]
+    public async Task It_authorizes_a_post_create_when_the_finalized_proposed_namespace_matches()
+    {
+        var request = CreateNamespacePostCreateRequest("uri://ed-fi.org/Survey");
+
+        var result = await _sut.ExecuteAsync(request);
+
+        result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.InsertSuccess>();
+        _noProfilePersister.TryPersistCallCount.Should().Be(1);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_binds_the_finalized_merged_namespace_value_and_not_the_request_body()
+    {
+        var request = CreateNamespacePostCreateRequest(
+            mergedNamespace: "uri://ed-fi.org/Survey",
+            selectedBody: JsonNode.Parse("""{"namespace":"uri://request-body-ignored/"}""")!
+        );
+
+        await _sut.ExecuteAsync(request);
+
+        var namespaceCommand = _writeSessionFactory
+            .Session.RelationshipAuthorizationCommands.Should()
+            .ContainSingle()
+            .Subject;
+        namespaceCommand
+            .Parameters.Single(parameter => parameter.Name == "@proposedNamespace")
+            .Value.Should()
+            .Be("uri://ed-fi.org/Survey");
+    }
+
+    [Test]
+    public async Task It_returns_namespace_not_authorized_and_does_not_persist_on_a_proposed_mismatch()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        var request = CreateNamespacePostCreateRequest("uri://other.org/Survey");
+
+        var result = await _sut.ExecuteAsync(request);
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_not_authorized_when_the_proposed_namespace_is_missing()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        var request = CreateNamespacePostCreateRequest(mergedNamespace: null);
+
+        var result = await _sut.ExecuteAsync(request);
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.ProposedNamespaceMissing);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_fails_closed_to_unknown_failure_when_the_namespace_auth1_payload_cannot_be_mapped()
+    {
+        // An emitted index with no matching planned check is unmappable; fail closed rather than allow.
+        UseNamespaceProviderFailureExtractor("ns1|9|m");
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        var request = CreateNamespacePostCreateRequest("uri://ed-fi.org/Survey");
+
+        var result = await _sut.ExecuteAsync(request);
+
+        result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UnknownFailure>();
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_runs_the_proposed_namespace_check_for_an_existing_target_post()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        var existingDocumentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
+        var rootPlan = CreateNamespaceRootPlan();
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Post,
+            rootWritePlan: rootPlan,
+            targetContext: new RelationalWriteTargetContext.ExistingDocument(345L, existingDocumentUuid, 44L)
+        );
+        _writeFlattener.ResultToReturn = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [
+                    FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                    new FlattenedWriteValue.Literal("uri://other.org/Survey"),
+                ]
+            )
+        );
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                ProposedNamespaceAuthorization = CreateProposedNamespaceAuthorization(),
+            }
+        );
+
+        // The proposed namespace check now runs for an existing target rather than failing closed.
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_proposed_namespace_failure_before_proposed_relationship_failure_for_existing_put()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Put,
+            selectedBody: JsonNode.Parse("""{"schoolId":255901,"name":"Lincoln High"}""")!
+        );
+        _noProfileMergeSynthesizer.ResultToReturn = CreateMergeResult(
+            request.WritePlan.TablePlansInDependencyOrder[0],
+            currentSchoolId: 255901,
+            mergedSchoolId: 255901,
+            currentName: "Lincoln High",
+            mergedName: "Lincoln High"
+        );
+        // The persister throws if proposed relationship authorization is reached; a regression to
+        // relationship-before-namespace would surface the relationship failure instead of the
+        // namespace failure asserted below.
+        var relationshipFailure = CreateProposedSchoolIdRelationshipFailure(request);
+        _noProfilePersister.ProposedAuthorizationExceptionToThrow =
+            new RelationalWriteRelationshipAuthorizationNotAuthorizedException(relationshipFailure);
+        var rootTable = request.WritePlan.TablePlansInDependencyOrder[0].TableModel.Table;
+        var namespaceAuth = new RelationalWriteNamespaceAuthorization(
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    rootTable,
+                    new DbColumnName("Name")
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            )
+        );
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                ProposedNamespaceAuthorization = namespaceAuth,
+                ProposedRelationshipAuthorization = CreateProposedSchoolIdRelationshipAuthorization(request),
+            }
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        _noProfilePersister.AuthorizeProposedRelationshipCallCount.Should().Be(0);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_not_authorized_before_if_match_precondition_for_a_post_create()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        // A stale If-Match alongside a namespace denial must yield the namespace 403, not a 412.
+        var request = CreateNamespacePostCreateRequest(
+            "uri://other.org/Survey",
+            writePrecondition: new WritePrecondition.IfMatch("\"stale-etag\"")
+        );
+
+        var result = await _sut.ExecuteAsync(request);
+
+        result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_stored_namespace_not_authorized_before_if_match_precondition_for_a_put()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        // A stale If-Match on a PUT must lose to a stored namespace denial evaluated in the locked boundary.
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Put,
+            writePrecondition: new WritePrecondition.IfMatch("\"stale-etag\"")
+        );
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            }
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Stored);
+        _currentEtagPreconditionChecker.CheckCallCount.Should().Be(0);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_stored_namespace_not_authorized_before_if_match_precondition_for_a_post_as_update()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        // The POST resolves to an existing target in-session; the stored namespace denial in the locked
+        // boundary must win over the stale If-Match precondition.
+        var existingDocumentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
+        _targetLookupResolver.PostResults.Enqueue(
+            new RelationalWriteTargetLookupResult.ExistingDocument(345L, existingDocumentUuid, 44L)
+        );
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Post,
+            writePrecondition: new WritePrecondition.IfMatch("\"stale-etag\"")
+        );
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                StoredNamespaceAuthorization = CreateStoredNamespaceAuthorization(),
+            }
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Stored);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_proposed_namespace_not_authorized_before_relationship_no_claims_for_a_post_create()
+    {
+        var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        UseNamespaceProviderFailureExtractor(payload);
+        _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
+            new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
+        // Mixed POST-create: NamespaceBased AND-composes ahead of the relationship OR-group, so an
+        // unauthorized proposed namespace must surface over the deferred relationship NoClaims denial.
+        var request = CreateNamespacePostCreateRequest("uri://other.org/Survey");
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                ProposedRelationshipAuthorization = CreateNamespaceRootNoClaimsAuthorization(request),
+            }
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        _noProfilePersister.AuthorizeProposedRelationshipCallCount.Should().Be(0);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_relationship_no_claims_after_the_proposed_namespace_authorizes_for_a_post_create()
+    {
+        // The proposed namespace check authorizes (no AUTH1 raised), so the relationship NoClaims denial
+        // that POST preflight deferred — rather than short-circuiting — now surfaces from the relationship
+        // orchestrator that runs after the namespace orchestrator.
+        var request = CreateNamespacePostCreateRequest("uri://ed-fi.org/Survey");
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                ProposedRelationshipAuthorization = CreateNamespaceRootNoClaimsAuthorization(request),
+            }
+        );
+
+        var relationshipFailure = result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureRelationshipNotAuthorized>()
+            .Subject.RelationshipFailure;
+        relationshipFailure.ClaimEducationOrganizationIds.Should().BeEmpty();
+        relationshipFailure
+            .FailedStrategies.Should()
+            .ContainSingle()
+            .Which.FailedSubjects.Should()
+            .ContainSingle()
+            .Which.FailureKind.Should()
+            .Be(RelationshipAuthorizationSubjectFailureKind.NoRelationship);
+        _noProfilePersister.AuthorizeProposedRelationshipCallCount.Should().Be(0);
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    private RelationalWriteExecutorRequest CreateNamespacePostCreateRequest(
+        string? mergedNamespace,
+        JsonNode? selectedBody = null,
+        WritePrecondition? writePrecondition = null
+    )
+    {
+        var rootPlan = CreateNamespaceRootPlan();
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Post,
+            rootWritePlan: rootPlan,
+            selectedBody: selectedBody ?? JsonNode.Parse("""{"namespace":"uri://ed-fi.org/Survey"}""")!,
+            writePrecondition: writePrecondition
+        );
+        _writeFlattener.ResultToReturn = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [
+                    FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                    new FlattenedWriteValue.Literal(mergedNamespace),
+                ]
+            )
+        );
+
+        return request with
+        {
+            ProposedNamespaceAuthorization = CreateProposedNamespaceAuthorization(),
+        };
+    }
+
+    private void UseNamespaceProviderFailureExtractor(string providerMessage)
+    {
+        _sut = new DefaultRelationalWriteExecutor(
+            _writeSessionFactory,
+            _referenceResolverAdapterFactory,
+            _writeFlattener,
+            _currentStateLoader,
+            _currentEtagPreconditionChecker,
+            _committedRepresentationReader,
+            _targetLookupResolver,
+            _writeFreshnessChecker,
+            _noProfileMergeSynthesizer,
+            _profileMergeSynthesizer,
+            _noProfilePersister,
+            _writeExceptionClassifier,
+            _writeConstraintResolver,
+            _readMaterializer,
+            relationshipAuthorizationProviderFailureExtractor: new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                providerMessage
+            )
+        );
+    }
+
+    [Test]
     public async Task It_authorizes_proposed_relationship_values_for_existing_put_before_persist()
     {
         var request = CreateRequest(
@@ -5701,6 +6172,56 @@ public class Given_Default_Relational_Write_Executor
         );
     }
 
+    private static RelationshipAuthorizationResult.NoClaims CreateNamespaceRootNoClaimsAuthorization(
+        RelationalWriteExecutorRequest request
+    )
+    {
+        var rootPlan = request.WritePlan.TablePlansInDependencyOrder[0];
+        var subject = CreateRelationshipAuthorizationSubject(
+            request,
+            rootPlan,
+            "Namespace",
+            "$.namespace",
+            "Namespace"
+        );
+        var checkSpec = new RelationshipAuthorizationCheckSpec(
+            new ConfiguredAuthorizationStrategy(
+                AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly,
+                0
+            ),
+            0,
+            RelationshipAuthorizationHierarchyDirection.Normal,
+            RelationshipAuthorizationValueSource.Proposed,
+            [subject],
+            new RelationshipAuthorizationCheckTarget.Stored(
+                rootPlan.TableModel.Table,
+                new DbColumnName("DocumentId")
+            )
+        );
+
+        return new RelationshipAuthorizationResult.NoClaims(
+            [checkSpec],
+            [
+                new RelationshipAuthorizationFailureMetadata(
+                    RelationshipAuthorizationFailureKind.NoClaimEducationOrganizationIds,
+                    request.WritePlan.Model.Resource,
+                    checkSpec.ConfiguredStrategy,
+                    checkSpec.RelationshipLocalOrder,
+                    checkSpec.ValueSource,
+                    checkSpec.Subjects[0].AuthObject,
+                    new RelationshipAuthorizationFailureLocation(
+                        Kind: SecurableElementKind.EducationOrganization,
+                        JsonPath: "$.namespace",
+                        ReadableName: "Namespace",
+                        Table: rootPlan.TableModel.Table,
+                        Column: _namespaceColumn
+                    ),
+                    Hint: "Relationship authorization requires at least one claim EducationOrganizationId."
+                ),
+            ]
+        );
+    }
+
     private static RelationshipAuthorizationFailure CreateProposedSchoolIdRelationshipFailure(
         RelationalWriteExecutorRequest request
     ) =>
@@ -6197,6 +6718,116 @@ public class Given_Default_Relational_Write_Executor
             DescriptorEdgeSources: []
         );
     }
+
+    private static readonly DbTableName _namespaceRootTable = new(new DbSchemaName("edfi"), "Survey");
+    private static readonly DbColumnName _namespaceColumn = new("Namespace");
+
+    private static TableWritePlan CreateNamespaceRootPlan()
+    {
+        var tableModel = new DbTableModel(
+            _namespaceRootTable,
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_Survey",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    _namespaceColumn,
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 255),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        return new TableWritePlan(
+            tableModel,
+            InsertSql: "insert into edfi.\"Survey\" values (@DocumentId, @Namespace)",
+            UpdateSql: "update edfi.\"Survey\" set \"Namespace\" = @Namespace where \"DocumentId\" = @DocumentId",
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
+            ColumnBindings:
+            [
+                new WriteColumnBinding(
+                    tableModel.Columns[0],
+                    new WriteValueSource.DocumentId(),
+                    "DocumentId"
+                ),
+                new WriteColumnBinding(
+                    tableModel.Columns[1],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.namespace", []),
+                        new RelationalScalarType(ScalarKind.String, MaxLength: 255)
+                    ),
+                    "Namespace"
+                ),
+            ],
+            KeyUnificationPlans: []
+        );
+    }
+
+    private static RelationalWriteNamespaceAuthorization CreateProposedNamespaceAuthorization(
+        SqlDialect dialect = SqlDialect.Pgsql,
+        string[]? prefixes = null
+    ) =>
+        new(
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    _namespaceRootTable,
+                    _namespaceColumn
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(
+                dialect,
+                prefixes ?? ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            )
+        );
+
+    private static RelationalWriteNamespaceAuthorization CreateStoredNamespaceAuthorization(
+        SqlDialect dialect = SqlDialect.Pgsql,
+        string[]? prefixes = null
+    ) =>
+        new(
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Stored,
+                    _namespaceRootTable,
+                    _namespaceColumn
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(
+                dialect,
+                prefixes ?? ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            )
+        );
 
     private static TableWritePlan CreateRootPlan()
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -4820,6 +4820,60 @@ public class Given_Default_Relational_Write_Executor
     }
 
     [Test]
+    public async Task It_fails_closed_to_security_configuration_when_the_proposed_namespace_plan_cannot_be_reconciled_with_the_root_row()
+    {
+        // The planned namespace column has no binding in the finalized root row, so proposed-value
+        // extraction returns InvalidAuthorizationPlan. The write must fail closed as a
+        // security-configuration error (matching the proposed relationship sibling and the read-path
+        // namespace mapping), not a generic unknown failure.
+        var rootPlan = CreateNamespaceRootPlan();
+        var request = CreateRequest(
+            RelationalWriteOperationKind.Post,
+            rootWritePlan: rootPlan,
+            selectedBody: JsonNode.Parse("""{"namespace":"uri://ed-fi.org/Survey"}""")!
+        );
+        _writeFlattener.ResultToReturn = new FlattenedWriteSet(
+            new RootWriteRowBuffer(
+                rootPlan,
+                [
+                    FlattenedWriteValue.UnresolvedRootDocumentId.Instance,
+                    new FlattenedWriteValue.Literal("uri://ed-fi.org/Survey"),
+                ]
+            )
+        );
+        var unreconcilableNamespaceAuth = new RelationalWriteNamespaceAuthorization(
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Proposed,
+                    _namespaceRootTable,
+                    new DbColumnName("NotABoundColumn")
+                ),
+            ],
+            NamespacePrefixParameterizationFactory.Create(
+                SqlDialect.Pgsql,
+                ["uri://ed-fi.org/"],
+                "namespacePrefixes"
+            )
+        );
+
+        var result = await _sut.ExecuteAsync(
+            request with
+            {
+                ProposedNamespaceAuthorization = unreconcilableNamespaceAuth,
+            }
+        );
+
+        result
+            .Should()
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
+        _noProfilePersister.TryPersistCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
     public async Task It_runs_the_proposed_namespace_check_for_an_existing_target_post()
     {
         var payload = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -4799,9 +4799,10 @@ public class Given_Default_Relational_Write_Executor
     }
 
     [Test]
-    public async Task It_fails_closed_to_unknown_failure_when_the_namespace_auth1_payload_cannot_be_mapped()
+    public async Task It_fails_closed_to_security_configuration_when_the_namespace_auth1_payload_cannot_be_mapped()
     {
-        // An emitted index with no matching planned check is unmappable; fail closed rather than allow.
+        // An emitted index with no matching planned check is unmappable; fail closed as a
+        // security-configuration error (matching relationship authorization) rather than allow.
         UseNamespaceProviderFailureExtractor("ns1|9|m");
         _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
             new ThrowingRelationalCommandExecutor(SqlDialect.Pgsql, new StubDbException("namespace AUTH1"));
@@ -4813,7 +4814,7 @@ public class Given_Default_Relational_Write_Executor
             .Should()
             .BeOfType<RelationalWriteExecutorResult.Upsert>()
             .Which.Result.Should()
-            .BeOfType<UpsertResult.UnknownFailure>();
+            .BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
         _noProfilePersister.TryPersistCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorQueryPageKeysetPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorQueryPageKeysetPlannerTests.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Core.External.Model;
 using FluentAssertions;
 using NUnit.Framework;
@@ -444,6 +445,189 @@ public class Given_DescriptorQueryPageKeysetPlanner
                 "Descriptor query page planning requires preprocessing results in the continue state.*"
             );
     }
+
+    [Test]
+    public void It_should_emit_pgsql_descriptor_namespace_filter_in_page_and_total_count_sql_when_authorization_is_supplied()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var authorization = CreateNamespaceAuthorization(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(new RelationalQueryPreprocessingOutcome.Continue(), []),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: true, MaximumPageSize: 500),
+            authorization
+        );
+
+        keyset
+            .Plan.PageDocumentIdSql.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+        keyset
+            .Plan.PageDocumentIdSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+        keyset.Plan.TotalCountSql.Should().NotBeNull();
+        keyset
+            .Plan.TotalCountSql!.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+        keyset
+            .Plan.TotalCountSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_should_emit_mssql_descriptor_namespace_filter_in_page_and_total_count_sql_when_authorization_is_supplied()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Mssql);
+        var authorization = CreateNamespaceAuthorization(
+            SqlDialect.Mssql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(new RelationalQueryPreprocessingOutcome.Continue(), []),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: true, MaximumPageSize: 500),
+            authorization
+        );
+
+        keyset
+            .Plan.PageDocumentIdSql.Should()
+            .Contain("INNER JOIN [dms].[Descriptor] d ON d.[DocumentId] = r.[DocumentId]");
+        keyset
+            .Plan.PageDocumentIdSql.Should()
+            .Contain(
+                "(d.[Namespace] IS NOT NULL AND ("
+                    + "d.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' "
+                    + "OR d.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\'"
+                    + "))"
+            );
+        keyset.Plan.TotalCountSql.Should().NotBeNull();
+        keyset
+            .Plan.TotalCountSql!.Should()
+            .Contain("(d.[Namespace] IS NOT NULL AND (d.[Namespace] LIKE @namespacePrefixes_0");
+    }
+
+    [Test]
+    public void It_should_bind_pgsql_namespace_prefix_array_parameter_value_to_the_escaped_like_patterns()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var authorization = CreateNamespaceAuthorization(
+            SqlDialect.Pgsql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(new RelationalQueryPreprocessingOutcome.Continue(), []),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            authorization
+        );
+
+        keyset.ParameterValues.Should().ContainKey("namespacePrefixes");
+        keyset
+            .ParameterValues["namespacePrefixes"]
+            .Should()
+            .BeAssignableTo<IReadOnlyList<string>>()
+            .Which.Should()
+            .Equal("uri://ed-fi.org/%", "uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public void It_should_bind_mssql_scalar_namespace_prefix_parameter_values_in_order()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Mssql);
+        var authorization = CreateNamespaceAuthorization(
+            SqlDialect.Mssql,
+            ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(new RelationalQueryPreprocessingOutcome.Continue(), []),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            authorization
+        );
+
+        keyset.ParameterValues["namespacePrefixes_0"].Should().Be("uri://ed-fi.org/%");
+        keyset.ParameterValues["namespacePrefixes_1"].Should().Be("uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public void It_should_compose_descriptor_namespace_filter_with_a_descriptor_column_predicate_in_pgsql()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var authorization = CreateNamespaceAuthorization(SqlDialect.Pgsql, ["uri://ed-fi.org/"]);
+
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(
+                new RelationalQueryPreprocessingOutcome.Continue(),
+                [
+                    CreateElement(
+                        "codeValue",
+                        "$.codeValue",
+                        "Alternative",
+                        "string",
+                        new DescriptorQueryFieldTarget.CodeValue(new DbColumnName("CodeValue")),
+                        new PreprocessedDescriptorQueryValue.Raw("Alternative")
+                    ),
+                ]
+            ),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            authorization
+        );
+
+        keyset.Plan.PageDocumentIdSql.Should().Contain("d.\"CodeValue\" = @codeValue");
+        keyset
+            .Plan.PageDocumentIdSql.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+    }
+
+    [Test]
+    public void It_should_leave_descriptor_page_sql_unchanged_when_no_authorization_is_supplied()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(new RelationalQueryPreprocessingOutcome.Continue(), []),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500)
+        );
+
+        keyset.Plan.PageDocumentIdSql.Should().NotContain("Namespace");
+        keyset.Plan.PageDocumentIdSql.Should().NotContain("namespacePrefixes");
+        keyset.ParameterValues.Keys.Should().NotContain("namespacePrefixes");
+    }
+
+    private static PageDocumentIdAuthorizationSpec CreateNamespaceAuthorization(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes
+    ) =>
+        new(
+            Strategies: [],
+            NamespaceChecks:
+            [
+                new NamespaceAuthorizationCheckSpec(
+                    0,
+                    NamespaceAuthorizationCheckValueSource.Stored,
+                    new DbTableName(new DbSchemaName("dms"), "Descriptor"),
+                    new DbColumnName("Namespace")
+                ),
+            ],
+            NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                dialect,
+                namespacePrefixes,
+                "namespacePrefixes"
+            )
+        );
 
     private static PreprocessedDescriptorQueryElement CreateElement(
         string queryFieldName,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorQueryPageKeysetPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorQueryPageKeysetPlannerTests.cs
@@ -292,6 +292,38 @@ public class Given_DescriptorQueryPageKeysetPlanner
     }
 
     [Test]
+    public void It_should_assign_collision_free_parameter_names_when_a_query_field_collides_with_a_namespace_authorization_parameter()
+    {
+        var planner = new DescriptorQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var keyset = planner.Plan(
+            RelationalAccessTestData.CreateMappingSet(_requestResource),
+            _descriptorResource,
+            new DescriptorQueryPreprocessingResult(
+                new RelationalQueryPreprocessingOutcome.Continue(),
+                [
+                    CreateElement(
+                        "namespacePrefixes",
+                        "$.namespacePrefixes",
+                        "collides with auth parameter",
+                        "string",
+                        new DescriptorQueryFieldTarget.CodeValue(new DbColumnName("CodeValue")),
+                        new PreprocessedDescriptorQueryValue.Raw("collides with auth parameter")
+                    ),
+                ]
+            ),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            CreateNamespaceAuthorization(SqlDialect.Pgsql, ["uri://ed-fi.org/"])
+        );
+
+        // The authorization parameter keeps the bare name; the colliding query field is suffixed so the
+        // single-binding namespace LIKE and the query predicate never share a parameter.
+        keyset.ParameterValues.Keys.Should().Contain("namespacePrefixes");
+        keyset.ParameterValues.Keys.Should().Contain("namespacePrefixes_2");
+        keyset.Plan.PageDocumentIdSql.Should().Contain("LIKE ANY(@namespacePrefixes)");
+        keyset.Plan.PageDocumentIdSql.Should().Contain("@namespacePrefixes_2");
+    }
+
+    [Test]
     [TestCase(SqlDialect.Pgsql, "\"dms\".\"Document\" r")]
     [TestCase(SqlDialect.Mssql, "[dms].[Document] r")]
     public void It_should_plan_descriptor_total_count_sql_without_optional_joins_when_only_resource_type_discrimination_is_required(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -1,0 +1,752 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using DescriptorQueryCapability = EdFi.DataManagementService.Backend.External.Plans.DescriptorQueryCapability;
+using DescriptorQuerySupport = EdFi.DataManagementService.Backend.External.Plans.DescriptorQuerySupport;
+using ResourceReadPlan = EdFi.DataManagementService.Backend.External.Plans.ResourceReadPlan;
+using ResourceWritePlan = EdFi.DataManagementService.Backend.External.Plans.ResourceWritePlan;
+using SupportedDescriptorQueryField = EdFi.DataManagementService.Backend.External.Plans.SupportedDescriptorQueryField;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_Descriptor_Read_Handler_Namespace_Authorization
+{
+    private static readonly QualifiedResourceName _descriptorResource = new("Ed-Fi", "SchoolTypeDescriptor");
+    private static readonly DocumentUuid _documentUuid = new(
+        Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb")
+    );
+
+    [Test]
+    public void It_carries_authorization_strategy_evaluators_and_a_relational_authorization_context_on_the_get_by_id_request()
+    {
+        var evaluators = new[] { NamespaceStrategy() };
+        var context = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+
+        var request = new DescriptorGetByIdRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            RelationalGetRequestReadMode.ExternalResponse,
+            evaluators,
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-get-contract"),
+            context
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeSameAs(evaluators);
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().ContainSingle();
+        request.RelationalAuthorizationContext.NamespacePrefixes[0].Should().Be("uri://ed-fi.org/");
+    }
+
+    [Test]
+    public void It_defaults_the_get_by_id_request_relational_authorization_context_to_empty_prefixes()
+    {
+        var request = new DescriptorGetByIdRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            RelationalGetRequestReadMode.ExternalResponse,
+            [],
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-get-contract-default")
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeEmpty();
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_carries_authorization_strategy_evaluators_and_a_relational_authorization_context_on_the_query_request()
+    {
+        var evaluators = new[] { NamespaceStrategy() };
+        var context = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+
+        var request = new DescriptorQueryRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            [],
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            evaluators,
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-query-contract"),
+            context
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeSameAs(evaluators);
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().ContainSingle();
+        request.RelationalAuthorizationContext.NamespacePrefixes[0].Should().Be("uri://ed-fi.org/");
+    }
+
+    [Test]
+    public void It_defaults_the_query_request_relational_authorization_context_to_empty_prefixes()
+    {
+        var request = new DescriptorQueryRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            [],
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            [],
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-query-contract-default")
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeEmpty();
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
+    }
+
+    [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
+    [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
+    public async Task It_fails_closed_for_descriptor_get_by_id_with_an_unsupported_strategy_without_executing_sql(
+        string authorizationStrategyName
+    )
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: new AuthorizationStrategyEvaluator(
+                    authorizationStrategyName,
+                    [],
+                    FilterOperator.And
+                )
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureNotImplemented>();
+        result
+            .As<GetResult.GetFailureNotImplemented>()
+            .FailureMessage.Should()
+            .Contain(authorizationStrategyName);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_for_descriptor_get_by_id_without_executing_sql_when_the_client_has_no_prefixes()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_for_descriptor_get_by_id_when_the_stored_namespace_does_not_match_a_prefix()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://other.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Which;
+        failure.NamespaceFailure.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public async Task It_returns_get_success_when_the_stored_descriptor_namespace_matches_a_configured_prefix()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ed-fi.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    [Test]
+    public async Task It_rejects_a_case_differing_stored_descriptor_namespace_on_pgsql_to_match_the_case_sensitive_like()
+    {
+        // PostgreSQL LIKE is case-sensitive under the deterministic default collation the Namespace
+        // column uses, so the descriptor GET-many and write paths (SQL LIKE) reject a stored namespace
+        // that only case-differs from a configured prefix. The single-record GET-by-id in-memory check
+        // must reject the same value so a descriptor cannot be read by id that the other paths exclude.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ED-FI.ORG/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                dialect: SqlDialect.Pgsql
+            )
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Which;
+        failure.NamespaceFailure.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public async Task It_accepts_a_case_differing_stored_descriptor_namespace_on_mssql_to_match_the_case_insensitive_like()
+    {
+        // SQL Server LIKE is case-insensitive under the default collation the Namespace column inherits,
+        // so the descriptor GET-many and write paths accept a stored namespace that case-differs from a
+        // configured prefix. The single-record GET-by-id in-memory check must accept the same value.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ED-FI.ORG/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                dialect: SqlDialect.Mssql
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_stored_uninitialized_for_descriptor_get_by_id_when_the_stored_namespace_is_empty()
+    {
+        // An existing descriptor row whose Namespace is empty is not "not found": it fails closed as a
+        // 403 with StoredNamespaceUninitialized rather than a 404, so a caller cannot tell an
+        // unauthorized uninitialized row apart from a missing one.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow(ns: "")),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Which;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_stored_uninitialized_for_descriptor_get_by_id_when_the_stored_namespace_is_null()
+    {
+        // A stored null Namespace under namespace authorization is the
+        // StoredNamespaceUninitialized case. The row reader exposes the null and the handler
+        // emits a 403 with that failure kind rather than letting the row-reader invariant mask it
+        // as a 500. The empty-string sibling case (covered above) maps to the same outcome.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow(ns: null)),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Which;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public async Task It_returns_not_exists_when_the_target_row_is_missing_under_namespace_authorization()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+    }
+
+    [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
+    [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
+    public async Task It_fails_closed_for_descriptor_query_with_an_unsupported_strategy_without_executing_sql(
+        string authorizationStrategyName
+    )
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: new AuthorizationStrategyEvaluator(
+                    authorizationStrategyName,
+                    [],
+                    FilterOperator.And
+                )
+            )
+        );
+
+        result.Should().BeOfType<QueryResult.QueryFailureNotImplemented>();
+        result
+            .As<QueryResult.QueryFailureNotImplemented>()
+            .FailureMessage.Should()
+            .Contain(authorizationStrategyName);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_for_descriptor_query_without_executing_sql_when_the_client_has_no_prefixes()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(namespacePrefixes: [], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result
+            .Should()
+            .BeOfType<QueryResult.QueryFailureNamespaceNotAuthorized>()
+            .Which.NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_emits_a_pgsql_descriptor_namespace_filter_and_binds_the_prefix_array_when_querying_with_namespace_authorization()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ed-fi.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                authorizationStrategy: NamespaceStrategy(),
+                dialect: SqlDialect.Pgsql
+            )
+        );
+
+        result.Should().BeOfType<QueryResult.QuerySuccess>();
+        commandExecutor.Commands.Should().ContainSingle();
+        var command = commandExecutor.Commands[0];
+        command
+            .CommandText.Should()
+            .Contain("INNER JOIN \"dms\".\"Descriptor\" d ON d.\"DocumentId\" = r.\"DocumentId\"");
+        command
+            .CommandText.Should()
+            .Contain("(d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes))");
+        var namespaceParameter = command.Parameters.Single(static p => p.Name == "@namespacePrefixes");
+        namespaceParameter
+            .Value.Should()
+            .BeAssignableTo<IReadOnlyList<string>>()
+            .Which.Should()
+            .Equal("uri://ed-fi.org/%", "uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public async Task It_emits_a_mssql_descriptor_namespace_filter_and_binds_scalar_prefix_parameters_when_querying_with_namespace_authorization()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ed-fi.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"],
+                authorizationStrategy: NamespaceStrategy(),
+                dialect: SqlDialect.Mssql
+            )
+        );
+
+        result.Should().BeOfType<QueryResult.QuerySuccess>();
+        commandExecutor.Commands.Should().ContainSingle();
+        var command = commandExecutor.Commands[0];
+        command
+            .CommandText.Should()
+            .Contain("INNER JOIN [dms].[Descriptor] d ON d.[DocumentId] = r.[DocumentId]");
+        command
+            .CommandText.Should()
+            .Contain(
+                "(d.[Namespace] IS NOT NULL AND ("
+                    + "d.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\' "
+                    + "OR d.[Namespace] LIKE @namespacePrefixes_1 ESCAPE '\\'"
+                    + "))"
+            );
+        command
+            .Parameters.Single(static p => p.Name == "@namespacePrefixes_0")
+            .Value.Should()
+            .Be("uri://ed-fi.org/%");
+        command
+            .Parameters.Single(static p => p.Name == "@namespacePrefixes_1")
+            .Value.Should()
+            .Be("uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public async Task It_emits_the_descriptor_namespace_filter_in_the_total_count_sql_too()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(new Dictionary<string, object?> { ["count"] = 1L }),
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://ed-fi.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                totalCount: true
+            )
+        );
+
+        result.Should().BeOfType<QueryResult.QuerySuccess>();
+        var command = commandExecutor.Commands.Single();
+        command.CommandText.Should().Contain("SELECT COUNT(1)");
+        // The namespace filter shape appears twice: once in COUNT, once in the page subquery.
+        var namespacePredicateOccurrences = CountOccurrences(
+            command.CommandText,
+            "d.\"Namespace\" IS NOT NULL AND d.\"Namespace\" LIKE ANY(@namespacePrefixes)"
+        );
+        namespacePredicateOccurrences.Should().Be(2);
+    }
+
+    [Test]
+    public async Task It_returns_rows_unchanged_from_the_executor_so_filtering_remains_in_sql_and_not_in_c_sharp()
+    {
+        // The handler must not post-filter rows in C#: it relies on the SQL predicate to scope the
+        // page. Returning a row that the SQL predicate would have excluded proves the handler does
+        // no second-pass namespace check after fetch (a regression here would re-introduce the
+        // pagination-breaking C# filter the spec rules out).
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://other.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Which;
+        success.EdfiDocs.Should().HaveCount(1);
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_500_for_descriptor_query_without_executing_sql_when_mssql_prefix_cap_is_exceeded()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+        var prefixes = Enumerable
+            .Range(0, NamespacePrefixLimitExceededException.MssqlScalarParameterLimit)
+            .Select(static index => $"uri://prefix-{index}/")
+            .ToArray();
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: prefixes,
+                authorizationStrategy: NamespaceStrategy(),
+                dialect: SqlDialect.Mssql
+            )
+        );
+
+        result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>();
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_returns_an_empty_query_page_when_the_sql_predicate_returns_no_rows()
+    {
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleQueryAsync(
+            CreateQueryRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Which;
+        success.EdfiDocs.Should().BeEmpty();
+        commandExecutor.Commands.Should().ContainSingle();
+    }
+
+    private static int CountOccurrences(string source, string token)
+    {
+        var count = 0;
+        var index = source.IndexOf(token, StringComparison.Ordinal);
+        while (index >= 0)
+        {
+            count++;
+            index = source.IndexOf(token, index + token.Length, StringComparison.Ordinal);
+        }
+        return count;
+    }
+
+    private static DescriptorGetByIdRequest CreateGetByIdRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator authorizationStrategy,
+        SqlDialect dialect = SqlDialect.Pgsql
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            _documentUuid,
+            RelationalGetRequestReadMode.ExternalResponse,
+            [authorizationStrategy],
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-get-namespace"),
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorQueryRequest CreateQueryRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator authorizationStrategy,
+        SqlDialect dialect = SqlDialect.Pgsql,
+        bool totalCount = false
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            [],
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: totalCount, MaximumPageSize: 500),
+            [authorizationStrategy],
+            readableProfileProjectionContext: null,
+            new TraceId("descriptor-query-namespace"),
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorReadHandler CreateSut(InMemoryRelationalCommandExecutor commandExecutor) =>
+        new(
+            commandExecutor,
+            A.Fake<Core.Profile.IReadableProfileProjector>(),
+            NullLogger<DescriptorReadHandler>.Instance
+        );
+
+    private static IReadOnlyDictionary<string, object?> CreateDescriptorRow(
+        string? ns = "uri://ed-fi.org/SchoolTypeDescriptor",
+        long documentId = 101L,
+        string? codeValue = "Charter",
+        string? shortDescription = "Charter",
+        string? description = "Charter school"
+    ) =>
+        new Dictionary<string, object?>
+        {
+            ["DocumentId"] = documentId,
+            ["DocumentUuid"] = _documentUuid.Value,
+            ["ContentLastModifiedAt"] = new DateTimeOffset(2026, 5, 5, 14, 30, 45, TimeSpan.Zero),
+            ["ResourceKeyId"] = (short)1,
+            ["Namespace"] = ns,
+            ["CodeValue"] = codeValue,
+            ["ShortDescription"] = shortDescription,
+            ["Description"] = description,
+            ["EffectiveBeginDate"] = (DateOnly?)null,
+            ["EffectiveEndDate"] = (DateOnly?)null,
+            ["Discriminator"] = "SchoolTypeDescriptor",
+        };
+
+    private static AuthorizationStrategyEvaluator NamespaceStrategy() =>
+        new(AuthorizationStrategyNameConstants.NamespaceBased, [], FilterOperator.Or);
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect)
+    {
+        var resourceKey = new ResourceKeyEntry(1, _descriptorResource, "1.0.0", true);
+        var descriptorSchema = new DbSchemaName("dms");
+        var rootTable = new DbTableModel(
+            new DbTableName(descriptorSchema, "Descriptor"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_Descriptor",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+        var resourceModel = new RelationalResourceModel(
+            Resource: resourceKey.Resource,
+            PhysicalSchema: descriptorSchema,
+            StorageKind: ResourceStorageKind.SharedDescriptorTable,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+        var descriptorMetadata = new DescriptorMetadata(
+            new DescriptorColumnContract(
+                Namespace: new DbColumnName("Namespace"),
+                CodeValue: new DbColumnName("CodeValue"),
+                ShortDescription: new DbColumnName("ShortDescription"),
+                Description: new DbColumnName("Description"),
+                EffectiveBeginDate: new DbColumnName("EffectiveBeginDate"),
+                EffectiveEndDate: new DbColumnName("EffectiveEndDate"),
+                Discriminator: null
+            ),
+            DiscriminatorStrategy.ResourceKeyId
+        );
+
+        return new MappingSet(
+            Key: new MappingSetKey("schema-hash", dialect, "v1"),
+            Model: new DerivedRelationalModelSet(
+                EffectiveSchema: new EffectiveSchemaInfo(
+                    ApiSchemaFormatVersion: "1.0",
+                    RelationalMappingVersion: "v1",
+                    EffectiveSchemaHash: "schema-hash",
+                    ResourceKeyCount: 1,
+                    ResourceKeySeedHash: [1, 2, 3],
+                    SchemaComponentsInEndpointOrder:
+                    [
+                        new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash"),
+                    ],
+                    ResourceKeysInIdOrder: [resourceKey]
+                ),
+                Dialect: dialect,
+                ProjectSchemasInEndpointOrder:
+                [
+                    new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, descriptorSchema),
+                ],
+                ConcreteResourcesInNameOrder:
+                [
+                    new ConcreteResourceModel(
+                        resourceKey,
+                        ResourceStorageKind.SharedDescriptorTable,
+                        resourceModel,
+                        descriptorMetadata
+                    ),
+                ],
+                AbstractIdentityTablesInNameOrder: [],
+                AbstractUnionViewsInNameOrder: [],
+                IndexesInCreateOrder: [],
+                TriggersInCreateOrder: []
+            ),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>
+            {
+                [resourceKey.Resource] = resourceKey.ResourceKeyId,
+            },
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>
+            {
+                [resourceKey.ResourceKeyId] = resourceKey,
+            },
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        )
+        {
+            DescriptorQueryCapabilitiesByResource = new Dictionary<
+                QualifiedResourceName,
+                DescriptorQueryCapability
+            >
+            {
+                [resourceKey.Resource] = new DescriptorQueryCapability(
+                    new DescriptorQuerySupport.Supported(),
+                    new Dictionary<string, SupportedDescriptorQueryField>(StringComparer.OrdinalIgnoreCase)
+                ),
+            },
+        };
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -154,6 +154,29 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
     }
 
     [Test]
+    public async Task It_returns_security_configuration_500_for_descriptor_get_by_id_when_a_namespace_prefix_is_empty()
+    {
+        // An empty namespace prefix cannot be parameterized into a LIKE predicate. Rather than escaping as
+        // an uncontrolled 500 from the parameterization factory, it fails closed as a controlled
+        // security-configuration result before any SQL roundtrip.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(namespacePrefixes: [""], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureSecurityConfiguration>()
+            .Which.Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(NamespaceAuthorizationSecurityConfigurationMessages.InvalidNamespacePrefix);
+        commandExecutor.Commands.Should().BeEmpty();
+    }
+
+    [Test]
     public async Task It_returns_namespace_403_for_descriptor_get_by_id_when_the_stored_namespace_does_not_match_a_prefix()
     {
         var commandExecutor = new InMemoryRelationalCommandExecutor([
@@ -175,6 +198,32 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
         var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Which;
         failure.NamespaceFailure.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
         failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+    }
+
+    [Test]
+    public async Task It_bypasses_namespace_authorization_for_descriptor_get_by_id_stored_document_reads()
+    {
+        // StoredDocument reads are internal read-modify-write fetches that bypass per-record
+        // authorization, mirroring the generic single-record path. A stored namespace that an
+        // external response would reject with a 403 must still be returned for a StoredDocument read.
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(
+                    CreateDescriptorRow(ns: "uri://other.org/SchoolTypeDescriptor")
+                ),
+            ]),
+        ]);
+        var sut = CreateSut(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(
+            CreateGetByIdRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                readMode: RelationalGetRequestReadMode.StoredDocument
+            )
+        );
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
     }
 
     [Test]
@@ -570,13 +619,14 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
     private static DescriptorGetByIdRequest CreateGetByIdRequest(
         IReadOnlyList<string> namespacePrefixes,
         AuthorizationStrategyEvaluator authorizationStrategy,
-        SqlDialect dialect = SqlDialect.Pgsql
+        SqlDialect dialect = SqlDialect.Pgsql,
+        RelationalGetRequestReadMode readMode = RelationalGetRequestReadMode.ExternalResponse
     ) =>
         new(
             CreateMappingSet(dialect),
             _descriptorResource,
             _documentUuid,
-            RelationalGetRequestReadMode.ExternalResponse,
+            readMode,
             [authorizationStrategy],
             readableProfileProjectionContext: null,
             new TraceId("descriptor-get-namespace"),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -99,7 +99,7 @@ public class Given_DescriptorReadHandler
             .Should()
             .BeEquivalentTo(
                 new GetResult.GetFailureNotImplemented(
-                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+                    "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
                 )
             );
         commandExecutor.Commands.Should().BeEmpty();
@@ -130,7 +130,11 @@ public class Given_DescriptorReadHandler
         var result = await sut.HandleGetByIdAsync(CreateRequest(SqlDialect.Pgsql, documentUuid));
 
         var failure = result.Should().BeOfType<GetResult.UnknownFailure>().Subject;
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // The row reader treats Namespace as nullable so a stored null can flow into the
+        // namespace-authorization stored-namespace-uninitialized 403; CodeValue is the next
+        // required column, so the reader's invariant message names it when the LEFT JOIN finds
+        // no descriptor row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
         failure.FailureMessage.Should().Contain("DocumentId 101");
         failure.FailureMessage.Should().Contain("ResourceKeyId=13");
     }
@@ -285,7 +289,7 @@ public class Given_DescriptorReadHandler
             .Should()
             .BeEquivalentTo(
                 new QueryResult.QueryFailureNotImplemented(
-                    "Relational descriptor query authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET-many authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+                    "Relational descriptor query authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET-many authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
                 )
             );
         commandExecutor.Commands.Should().BeEmpty();
@@ -431,7 +435,9 @@ public class Given_DescriptorReadHandler
         var result = await sut.HandleQueryAsync(CreateQueryRequest(SqlDialect.Pgsql));
 
         var failure = result.Should().BeOfType<QueryResult.UnknownFailure>().Subject;
-        failure.FailureMessage.Should().Contain("dms.Descriptor.Namespace must not be null.");
+        // See sibling GET-by-id test: Namespace is read nullably so CodeValue is now the first
+        // required column whose null value the reader trips on when the LEFT JOIN finds no row.
+        failure.FailureMessage.Should().Contain("dms.Descriptor.CodeValue must not be null.");
         failure.FailureMessage.Should().Contain("DocumentId 101");
         failure.FailureMessage.Should().Contain("ResourceKeyId=13");
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadRowReaderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadRowReaderTests.cs
@@ -82,7 +82,6 @@ public class Given_DescriptorReadRowReader
         result.Discriminator.Should().BeNull();
     }
 
-    [TestCase("Namespace")]
     [TestCase("CodeValue")]
     [TestCase("ShortDescription")]
     public async Task It_classifies_required_descriptor_nulls_as_invariant_failures(string columnName)
@@ -114,6 +113,38 @@ public class Given_DescriptorReadRowReader
             .Contain($"dms.Descriptor.{columnName} must not be null.")
             .And.Contain("DocumentId 303")
             .And.Contain("ResourceKeyId=13");
+    }
+
+    [Test]
+    public async Task It_returns_a_null_namespace_when_the_descriptor_row_has_a_null_namespace()
+    {
+        // Namespace is read nullably so the namespace-authorization path (DescriptorReadHandler)
+        // can surface the stored-namespace-uninitialized 403. Without this, an invariant
+        // exception would mask the namespace 403 as an UnknownFailure 500.
+        var row = RelationalAccessTestData
+            .CreateRow(
+                ("DocumentId", 304L),
+                ("DocumentUuid", Guid.Parse("bbbbbbbb-1111-2222-3333-dddddddddddd")),
+                ("ContentLastModifiedAt", new DateTimeOffset(2026, 5, 5, 16, 0, 0, TimeSpan.Zero)),
+                ("ResourceKeyId", (short)13),
+                ("Namespace", "uri://ed-fi.org/SchoolTypeDescriptor"),
+                ("CodeValue", "Magnet"),
+                ("ShortDescription", "Magnet"),
+                ("Description", "Magnet school type"),
+                ("EffectiveBeginDate", new DateOnly(2025, 1, 1)),
+                ("EffectiveEndDate", null)
+            )
+            .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
+
+        row["Namespace"] = null;
+
+        await using var reader = CreateReader(row);
+
+        var result = await DescriptorReadRowReader.ReadSingleOrDefaultAsync(reader);
+
+        result.Should().NotBeNull();
+        result!.Namespace.Should().BeNull();
+        result.CodeValue.Should().Be("Magnet");
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerDeleteTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerDeleteTests.cs
@@ -27,8 +27,10 @@ public class Given_Descriptor_Write_Handler_Delete
         "EducationOrganizationCategoryDescriptor"
     );
 
+    // NamespaceBased is now authorized for descriptors through the relational authorization planner, so
+    // only strategies with no descriptor-applicable filter remain fail-closed here.
     [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
-    [TestCase(AuthorizationStrategyNameConstants.NamespaceBased)]
+    [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
     public async Task It_fails_closed_for_descriptor_delete_authorization_without_executing_sql(
         string authorizationStrategyName
     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -1,0 +1,1405 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_Descriptor_Write_Handler_Namespace_Authorization
+{
+    private static readonly QualifiedResourceName _descriptorResource = new("Ed-Fi", "SchoolTypeDescriptor");
+    private static readonly DocumentUuid _documentUuid = new(
+        Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb")
+    );
+
+    private static NamespaceAuthorizationFailure StoredMismatchFailure() =>
+        new(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+    private static NamespaceAuthorizationFailure ProposedMismatchFailure() =>
+        new(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+    private static NamespaceAuthorizationFailure ProposedMissingFailure() =>
+        new(
+            NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+            NamespaceAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+    [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
+    [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
+    public async Task It_fails_closed_for_descriptor_post_with_an_unsupported_strategy_without_executing_sql(
+        string authorizationStrategyName
+    )
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService();
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: UnsupportedStrategy(authorizationStrategyName)
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>();
+        result
+            .As<UpsertResult.UpsertFailureNotImplemented>()
+            .FailureMessage.Should()
+            .Contain(authorizationStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [TestCase(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly)]
+    [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
+    public async Task It_fails_closed_for_descriptor_put_with_an_unsupported_strategy_without_executing_sql(
+        string authorizationStrategyName
+    )
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService();
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: UnsupportedStrategy(authorizationStrategyName)
+            )
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>();
+        result
+            .As<UpdateResult.UpdateFailureNotImplemented>()
+            .FailureMessage.Should()
+            .Contain(authorizationStrategyName);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_without_opening_a_session_for_descriptor_post_when_the_client_has_no_prefixes()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService();
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(namespacePrefixes: [], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_without_opening_a_session_for_descriptor_put_when_the_client_has_no_prefixes()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService();
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(namespacePrefixes: [], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>();
+        result
+            .As<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_without_inserting_when_descriptor_post_create_proposed_namespace_does_not_match_a_prefix()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                @namespace: "uri://other.org/SchoolTypeDescriptor"
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("INSERT INTO dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+        sessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_without_inserting_when_descriptor_post_create_proposed_namespace_is_missing()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMissingFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.ProposedNamespaceMissing);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("INSERT INTO dms.\"Document\"", StringComparison.Ordinal)
+            );
+    }
+
+    [Test]
+    public async Task It_inserts_a_descriptor_when_post_create_proposed_namespace_matches_a_prefix()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .Contain(command =>
+                command.CommandText.Contains("INSERT INTO dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_not_precondition_failed_when_descriptor_post_create_under_stale_if_match_has_a_proposed_namespace_denial()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+        var request = CreatePostRequest(
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            authorizationStrategy: NamespaceStrategy(),
+            @namespace: "uri://other.org/SchoolTypeDescriptor"
+        ) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var result = await sut.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("INSERT INTO dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_and_does_not_update_when_descriptor_post_upsert_stored_namespace_is_not_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // Lock scalar then persisted-row read, then a denied stored namespace check.
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Stored);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+        sessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_and_does_not_update_when_descriptor_post_upsert_proposed_namespace_is_not_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                @namespace: "uri://other.org/SchoolTypeDescriptor"
+            )
+        );
+
+        result
+            .As<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_updates_descriptor_when_post_upsert_stored_and_proposed_namespaces_are_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        // Persisted row has a different shortDescription so the no-op check doesn't kick in.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRowWithEdFiNamespace()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                codeValue: "ChangedCode"
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UpdateSuccess>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .Contain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_and_does_not_update_when_descriptor_put_stored_namespace_is_not_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result
+            .As<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Stored);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_and_does_not_update_when_descriptor_put_proposed_namespace_is_not_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(ProposedMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                @namespace: "uri://other.org/SchoolTypeDescriptor"
+            )
+        );
+
+        result
+            .As<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+    }
+
+    [Test]
+    public async Task It_updates_descriptor_when_put_stored_and_proposed_namespaces_are_authorized()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        // Persisted has Description set; the request body sends no description so IsUnchanged is false
+        // and the handler issues an UPDATE rather than a no-op rollback.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRowWithEdFiNamespace()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        // Keep the codeValue (and Uri) identical to persisted to satisfy descriptor immutable identity
+        // for PUT; the body's null Description differs from persisted "Original Description" so the
+        // no-op path is bypassed.
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .Contain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_not_precondition_failed_when_descriptor_post_upsert_under_stale_if_match_has_stored_namespace_denial()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService();
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // IfMatch POST path: resolve target -> lock scalar -> load persisted -> stored ns check.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            CreateResolvedExistingDocumentRowWithId(documentId),
+        ]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+        var request = CreatePostRequest(
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            authorizationStrategy: NamespaceStrategy()
+        ) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var result = await sut.HandlePostAsync(request);
+
+        result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_not_precondition_failed_when_descriptor_put_under_stale_if_match_has_stored_namespace_denial()
+    {
+        var documentId = 345L;
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // IfMatch PUT path: resolve target via session executor -> lock scalar -> load persisted -> ns check.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            CreateResolvedExistingDocumentRowWithId(documentId),
+        ]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory);
+        var request = CreatePutRequest(
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            authorizationStrategy: NamespaceStrategy()
+        ) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var result = await sut.HandlePutAsync(request);
+
+        result.Should().BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure_for_post()
+    {
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+            )
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UnknownFailure>();
+    }
+
+    [Test]
+    public async Task It_maps_a_postgresql_namespace_auth1_denial_to_namespace_not_authorized_for_descriptor_post_create()
+    {
+        // PostgreSQL surfaces the AUTH1 discriminator in SqlState, so the provider failure extractor
+        // must recover it. With the extractor threaded through, the handler's namespace executor maps
+        // the provider failure to a 403 namespace denial rather than letting it escape as a 500.
+        var payloadText = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceAuthorizationException = new StubDbException(
+            "PostgreSQL provider exception"
+        );
+        var sut = CreateSut(
+            sessionFactory,
+            targetLookupService,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                payloadText
+            )
+        );
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                @namespace: "uri://other.org/SchoolTypeDescriptor"
+            )
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+            .Subject;
+        notAuthorized
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        notAuthorized
+            .NamespaceFailure.ValueSource.Should()
+            .Be(NamespaceAuthorizationFailureValueSource.Proposed);
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+        sessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_escapes_a_postgresql_namespace_auth1_denial_as_an_unknown_failure_for_descriptor_post_create_with_the_default_message_only_extractor()
+    {
+        // Regression guard for the threading fix: the default extractor reads only the provider message,
+        // never SqlState, so it cannot recover a PostgreSQL AUTH1 namespace payload. Without the
+        // SqlState-aware extractor the denial escapes the namespace mapping and surfaces as a 500.
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PostResult = new RelationalWriteTargetLookupResult.CreateNew(_documentUuid),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.NamespaceAuthorizationException = new StubDbException(
+            "PostgreSQL provider exception"
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePostAsync(
+            CreatePostRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy(),
+                @namespace: "uri://other.org/SchoolTypeDescriptor"
+            )
+        );
+
+        result.Should().BeOfType<UpsertResult.UnknownFailure>();
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure_for_put()
+    {
+        var documentId = 345L;
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(
+                documentId,
+                _documentUuid,
+                44L
+            ),
+        };
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+            )
+        );
+        var sut = CreateSut(sessionFactory, targetLookupService);
+
+        var result = await sut.HandlePutAsync(
+            CreatePutRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<UpdateResult.UnknownFailure>();
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_without_opening_a_session_when_the_client_has_no_prefixes()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(namespacePrefixes: [], authorizationStrategy: NamespaceStrategy())
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        result
+            .As<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        sessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_and_does_not_delete_when_the_stored_namespace_is_not_authorized()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // No-IfMatch DELETE: resolve target -> lock (scalar) -> namespace check.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("DELETE FROM dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+        sessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_when_the_stored_namespace_is_uninitialized()
+    {
+        var uninitializedFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(uninitializedFailure)
+        );
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result
+            .As<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("DELETE FROM dms.\"Document\"", StringComparison.Ordinal)
+            );
+    }
+
+    [Test]
+    public async Task It_deletes_when_the_stored_namespace_is_authorized()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.Authorized()
+        );
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            InMemoryRelationalResultSet.Create(new Dictionary<string, object?> { ["DocumentId"] = 345L }),
+        ]);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .Contain(command =>
+                command.CommandText.Contains("DELETE FROM dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_403_not_precondition_failed_when_the_stored_namespace_denies_under_a_stale_if_match()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // Resolve target → lock (scalar) → load persisted → namespace check (denied before ETag compare).
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(StoredMismatchFailure())
+        );
+        var sut = CreateSut(sessionFactory);
+        var request = CreateDeleteRequest(
+            namespacePrefixes: ["uri://ed-fi.org/"],
+            authorizationStrategy: NamespaceStrategy()
+        ) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var result = await sut.HandleDeleteAsync(request);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("DELETE FROM dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.NamespaceResults.Enqueue(
+            new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+            )
+        );
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.UnknownFailure>();
+    }
+
+    [Test]
+    public async Task It_returns_not_exists_when_the_descriptor_delete_target_is_unlocked_to_a_concurrent_delete()
+    {
+        var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
+        // No-IfMatch DELETE: resolve target succeeds, but the FOR UPDATE lock returns no row
+        // because a concurrent committed delete removed the document between resolve and lock.
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
+        sessionFactory.Session.ScalarResults.Enqueue(null);
+        var sut = CreateSut(sessionFactory);
+
+        var result = await sut.HandleDeleteAsync(
+            CreateDeleteRequest(
+                namespacePrefixes: ["uri://ed-fi.org/"],
+                authorizationStrategy: NamespaceStrategy()
+            )
+        );
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNotExists>();
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("DELETE FROM dms.\"Document\"", StringComparison.Ordinal)
+            );
+        sessionFactory
+            .Session.ScalarCommands.Should()
+            .ContainSingle("the lock probe must run between resolve and namespace authorization");
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public void It_carries_authorization_strategy_evaluators_and_a_relational_authorization_context_on_the_delete_request()
+    {
+        var evaluators = new[] { NamespaceStrategy() };
+        var context = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+
+        var request = new DescriptorDeleteRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            new TraceId("descriptor-delete-contract"),
+            evaluators,
+            context
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeSameAs(evaluators);
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().ContainSingle();
+        request.RelationalAuthorizationContext.NamespacePrefixes[0].Should().Be("uri://ed-fi.org/");
+    }
+
+    [Test]
+    public void It_defaults_the_delete_request_relational_authorization_context_to_empty_prefixes()
+    {
+        var request = new DescriptorDeleteRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            new TraceId("descriptor-delete-contract-default")
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeEmpty();
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_carries_authorization_strategy_evaluators_and_a_relational_authorization_context_on_the_write_request()
+    {
+        var evaluators = new[] { NamespaceStrategy() };
+        var context = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+
+        var request = new DescriptorWriteRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            CreateDescriptorRequestBody("uri://ed-fi.org/SchoolTypeDescriptor", "Charter"),
+            _documentUuid,
+            new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+            new TraceId("descriptor-write-contract"),
+            evaluators,
+            context
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeSameAs(evaluators);
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().ContainSingle();
+        request.RelationalAuthorizationContext.NamespacePrefixes[0].Should().Be("uri://ed-fi.org/");
+    }
+
+    [Test]
+    public void It_defaults_the_write_request_relational_authorization_context_to_empty_prefixes()
+    {
+        var request = new DescriptorWriteRequest(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            CreateDescriptorRequestBody("uri://ed-fi.org/SchoolTypeDescriptor", "Charter"),
+            _documentUuid,
+            new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+            new TraceId("descriptor-write-contract-default")
+        );
+
+        request.AuthorizationStrategyEvaluators.Should().BeEmpty();
+        request.RelationalAuthorizationContext.NamespacePrefixes.Should().BeEmpty();
+    }
+
+    private static System.Text.Json.Nodes.JsonNode CreateDescriptorRequestBody(
+        string @namespace,
+        string codeValue
+    )
+    {
+        return System.Text.Json.Nodes.JsonNode.Parse(
+            $$"""
+            {
+                "namespace": "{{@namespace}}",
+                "codeValue": "{{codeValue}}",
+                "shortDescription": "{{codeValue}}"
+            }
+            """
+        )!;
+    }
+
+    private static AuthorizationStrategyEvaluator NamespaceStrategy() =>
+        new(AuthorizationStrategyNameConstants.NamespaceBased, [], FilterOperator.Or);
+
+    private static AuthorizationStrategyEvaluator UnsupportedStrategy(string name) =>
+        new(name, [], FilterOperator.And);
+
+    private static DescriptorDeleteRequest CreateDeleteRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator authorizationStrategy
+    ) =>
+        new(
+            CreateMappingSet(SqlDialect.Pgsql),
+            _descriptorResource,
+            _documentUuid,
+            new TraceId("descriptor-delete-namespace"),
+            [authorizationStrategy],
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorWriteRequest CreatePostRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator authorizationStrategy,
+        string @namespace = "uri://ed-fi.org/SchoolTypeDescriptor",
+        string codeValue = "Charter",
+        SqlDialect dialect = SqlDialect.Pgsql
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            CreateDescriptorRequestBody(@namespace, codeValue),
+            _documentUuid,
+            new ReferentialId(Guid.Parse("11111111-2222-3333-4444-555555555555")),
+            new TraceId("descriptor-post-namespace"),
+            [authorizationStrategy],
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorWriteRequest CreatePutRequest(
+        IReadOnlyList<string> namespacePrefixes,
+        AuthorizationStrategyEvaluator authorizationStrategy,
+        string @namespace = "uri://ed-fi.org/SchoolTypeDescriptor",
+        string codeValue = "Charter",
+        SqlDialect dialect = SqlDialect.Pgsql
+    ) =>
+        new(
+            CreateMappingSet(dialect),
+            _descriptorResource,
+            CreateDescriptorRequestBody(@namespace, codeValue),
+            _documentUuid,
+            referentialId: null,
+            new TraceId("descriptor-put-namespace"),
+            [authorizationStrategy],
+            new RelationalAuthorizationContext([], namespacePrefixes)
+        );
+
+    private static DescriptorWriteHandler CreateSut(
+        RecordingNamespaceWriteSessionFactory sessionFactory,
+        IRelationalWriteTargetLookupService? targetLookupService = null,
+        IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+    ) =>
+        new(
+            targetLookupService ?? A.Fake<IRelationalWriteTargetLookupService>(),
+            new NoOpRelationalWriteExceptionClassifier(),
+            A.Fake<IRelationalDeleteConstraintResolver>(),
+            sessionFactory,
+            NullLogger<DescriptorWriteHandler>.Instance,
+            providerFailureExtractor
+        );
+
+    private sealed class StubRelationalWriteTargetLookupService : IRelationalWriteTargetLookupService
+    {
+        public RelationalWriteTargetLookupResult PostResult { get; set; } =
+            new RelationalWriteTargetLookupResult.NotFound();
+
+        public RelationalWriteTargetLookupResult PutResult { get; set; } =
+            new RelationalWriteTargetLookupResult.NotFound();
+
+        public Task<RelationalWriteTargetLookupResult> ResolveForPostAsync(
+            MappingSet mappingSet,
+            QualifiedResourceName resource,
+            ReferentialId referentialId,
+            DocumentUuid candidateDocumentUuid,
+            CancellationToken cancellationToken = default
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(PostResult);
+        }
+
+        public Task<RelationalWriteTargetLookupResult> ResolveForPutAsync(
+            MappingSet mappingSet,
+            QualifiedResourceName resource,
+            DocumentUuid documentUuid,
+            CancellationToken cancellationToken = default
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(PutResult);
+        }
+    }
+
+    private static InMemoryRelationalResultSet CreateResolvedExistingDocumentRow() =>
+        CreateResolvedExistingDocumentRowWithId(345L);
+
+    private static InMemoryRelationalResultSet CreateResolvedExistingDocumentRowWithId(long documentId) =>
+        InMemoryRelationalResultSet.Create(
+            new Dictionary<string, object?>
+            {
+                ["DocumentId"] = documentId,
+                ["DocumentUuid"] = _documentUuid.Value,
+                ["ResourceKeyId"] = 1,
+                ["ContentVersion"] = 44L,
+            }
+        );
+
+    private static InMemoryRelationalResultSet CreatePersistedDescriptorRow() =>
+        InMemoryRelationalResultSet.Create(
+            new Dictionary<string, object?>
+            {
+                ["Namespace"] = "uri://other.org/SchoolTypeDescriptor",
+                ["CodeValue"] = "Charter",
+                ["Uri"] = "uri://other.org/SchoolTypeDescriptor#Charter",
+                ["ShortDescription"] = "Charter",
+                ["Description"] = "Charter",
+                ["EffectiveBeginDate"] = new DateOnly(2024, 1, 1),
+                ["EffectiveEndDate"] = null,
+            }
+        );
+
+    private static InMemoryRelationalResultSet CreatePersistedDescriptorRowWithEdFiNamespace() =>
+        InMemoryRelationalResultSet.Create(
+            new Dictionary<string, object?>
+            {
+                ["Namespace"] = "uri://ed-fi.org/SchoolTypeDescriptor",
+                ["CodeValue"] = "Charter",
+                ["Uri"] = "uri://ed-fi.org/SchoolTypeDescriptor#Charter",
+                ["ShortDescription"] = "Charter",
+                ["Description"] = "Original Description",
+                ["EffectiveBeginDate"] = new DateOnly(2024, 1, 1),
+                ["EffectiveEndDate"] = null,
+            }
+        );
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect)
+    {
+        var resourceKey = new ResourceKeyEntry(1, _descriptorResource, "1.0.0", true);
+        var descriptorSchema = new DbSchemaName("dms");
+        var rootTable = new DbTableModel(
+            new DbTableName(descriptorSchema, "Descriptor"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_Descriptor",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+        var resourceModel = new RelationalResourceModel(
+            Resource: resourceKey.Resource,
+            PhysicalSchema: descriptorSchema,
+            StorageKind: ResourceStorageKind.SharedDescriptorTable,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+        var descriptorMetadata = new DescriptorMetadata(
+            new DescriptorColumnContract(
+                Namespace: new DbColumnName("Namespace"),
+                CodeValue: new DbColumnName("CodeValue"),
+                ShortDescription: new DbColumnName("ShortDescription"),
+                Description: new DbColumnName("Description"),
+                EffectiveBeginDate: new DbColumnName("EffectiveBeginDate"),
+                EffectiveEndDate: new DbColumnName("EffectiveEndDate"),
+                Discriminator: null
+            ),
+            DiscriminatorStrategy.ResourceKeyId
+        );
+
+        return new MappingSet(
+            Key: new MappingSetKey("schema-hash", dialect, "v1"),
+            Model: new DerivedRelationalModelSet(
+                EffectiveSchema: new EffectiveSchemaInfo(
+                    ApiSchemaFormatVersion: "1.0",
+                    RelationalMappingVersion: "v1",
+                    EffectiveSchemaHash: "schema-hash",
+                    ResourceKeyCount: 1,
+                    ResourceKeySeedHash: [1, 2, 3],
+                    SchemaComponentsInEndpointOrder:
+                    [
+                        new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash"),
+                    ],
+                    ResourceKeysInIdOrder: [resourceKey]
+                ),
+                Dialect: dialect,
+                ProjectSchemasInEndpointOrder:
+                [
+                    new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, descriptorSchema),
+                ],
+                ConcreteResourcesInNameOrder:
+                [
+                    new ConcreteResourceModel(
+                        resourceKey,
+                        ResourceStorageKind.SharedDescriptorTable,
+                        resourceModel,
+                        descriptorMetadata
+                    ),
+                ],
+                AbstractIdentityTablesInNameOrder: [],
+                AbstractUnionViewsInNameOrder: [],
+                IndexesInCreateOrder: [],
+                TriggersInCreateOrder: []
+            ),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>
+            {
+                [resourceKey.Resource] = resourceKey.ResourceKeyId,
+            },
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>
+            {
+                [resourceKey.ResourceKeyId] = resourceKey,
+            },
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+    }
+
+    private sealed class StubDbException(string message) : DbException(message);
+
+    private sealed class StubRelationshipAuthorizationProviderFailureExtractor(
+        string? providerErrorCode,
+        string providerMessage
+    ) : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            return new RelationshipAuthorizationProviderFailure(providerErrorCode, providerMessage);
+        }
+    }
+
+    private sealed class RecordingNamespaceWriteSessionFactory(SqlDialect dialect)
+        : IRelationalWriteSessionFactory
+    {
+        public int CreateAsyncCallCount { get; private set; }
+
+        public RecordingNamespaceWriteSession Session { get; } = new(dialect);
+
+        public Task<IRelationalWriteSession> CreateAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CreateAsyncCallCount++;
+            return Task.FromResult<IRelationalWriteSession>(Session);
+        }
+    }
+
+    private sealed class RecordingNamespaceWriteSession : IRelationalWriteSession
+    {
+        private readonly RecordingDbConnection _connection = new(
+            new RecordingDbCommand(new DataTable().CreateDataReader())
+        );
+        private readonly RecordingDbTransaction _transaction;
+
+        public RecordingNamespaceWriteSession(SqlDialect dialect)
+        {
+            _transaction = new RecordingDbTransaction(_connection, IsolationLevel.ReadCommitted);
+            Executor = new RecordingNamespaceCommandExecutor(dialect);
+        }
+
+        public System.Data.Common.DbConnection Connection => _connection;
+
+        public System.Data.Common.DbTransaction Transaction => _transaction;
+
+        public RecordingNamespaceCommandExecutor Executor { get; }
+
+        public Queue<object?> ScalarResults { get; } = [];
+
+        public List<RelationalCommand> ScalarCommands { get; } = [];
+
+        public int CommitCallCount { get; private set; }
+
+        public int RollbackCallCount { get; private set; }
+
+        public int DisposeCallCount { get; private set; }
+
+        public System.Data.Common.DbCommand CreateCommand(RelationalCommand command)
+        {
+            ScalarCommands.Add(command);
+
+            return new RecordingDbCommand(new DataTable().CreateDataReader())
+            {
+                CommandText = command.CommandText,
+                ScalarResult = ScalarResults.Count == 0 ? null : ScalarResults.Dequeue(),
+            };
+        }
+
+        public IRelationalCommandExecutor CreateCommandExecutor() => Executor;
+
+        public Task CommitAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CommitCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task RollbackAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RollbackCallCount++;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingNamespaceCommandExecutor(SqlDialect dialect) : IRelationalCommandExecutor
+    {
+        public SqlDialect Dialect { get; } = dialect;
+
+        public Queue<IReadOnlyList<InMemoryRelationalResultSet>> ResultSets { get; } = [];
+
+        public Queue<NamespaceAuthorizationExecutionResult> NamespaceResults { get; } = [];
+
+        public List<RelationalCommand> Commands { get; } = [];
+
+        /// <summary>
+        /// When set, the namespace authorization command raises this provider exception instead of
+        /// returning a canned <see cref="NamespaceAuthorizationExecutionResult"/>. This lets the handler's
+        /// real <see cref="NamespaceAuthorizationExecutor"/> run its AUTH1 mapping against the injected
+        /// provider failure extractor rather than bypassing it with a pre-built result.
+        /// </summary>
+        public DbException? NamespaceAuthorizationException { get; set; }
+
+        public async Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        )
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Commands.Add(command);
+
+            if (typeof(TResult) == typeof(NamespaceAuthorizationExecutionResult))
+            {
+                if (NamespaceAuthorizationException is not null)
+                {
+                    throw NamespaceAuthorizationException;
+                }
+
+                NamespaceAuthorizationExecutionResult namespaceResult =
+                    NamespaceResults.Count == 0
+                        ? new NamespaceAuthorizationExecutionResult.Authorized()
+                        : NamespaceResults.Dequeue();
+                return (TResult)(object)namespaceResult;
+            }
+
+            IReadOnlyList<InMemoryRelationalResultSet> resultSets =
+                ResultSets.Count == 0 ? [] : ResultSets.Dequeue();
+
+            await using var reader = new InMemoryRelationalCommandReader(resultSets);
+            return await readAsync(reader, cancellationToken);
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -593,7 +593,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
-    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure_for_post()
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_a_security_configuration_failure_for_post()
     {
         var targetLookupService = new StubRelationalWriteTargetLookupService
         {
@@ -614,7 +614,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             )
         );
 
-        result.Should().BeOfType<UpsertResult.UnknownFailure>();
+        result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>();
     }
 
     [Test]
@@ -697,7 +697,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
-    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure_for_put()
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_a_security_configuration_failure_for_put()
     {
         var documentId = 345L;
         var targetLookupService = new StubRelationalWriteTargetLookupService
@@ -725,7 +725,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             )
         );
 
-        result.Should().BeOfType<UpdateResult.UnknownFailure>();
+        result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>();
     }
 
     [Test]
@@ -873,7 +873,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
     }
 
     [Test]
-    public async Task It_maps_invalid_namespace_authorization_metadata_to_an_unknown_failure()
+    public async Task It_maps_invalid_namespace_authorization_metadata_to_a_security_configuration_failure()
     {
         var sessionFactory = new RecordingNamespaceWriteSessionFactory(SqlDialect.Pgsql);
         sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow()]);
@@ -892,7 +892,7 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             )
         );
 
-        result.Should().BeOfType<DeleteResult.UnknownFailure>();
+        result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>();
     }
 
     [Test]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/NamespaceAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/NamespaceAuthorizationExecutorTests.cs
@@ -303,6 +303,115 @@ public class Given_NamespaceAuthorizationExecutor
         result.Should().BeOfType<NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure>();
     }
 
+    [Test]
+    public async Task It_maps_a_stale_stored_target_auth1_failure_to_a_stale_target_result()
+    {
+        // 'ns1|0|s' is the stale stored-target kind: the row was deleted between the unlocked target
+        // lookup and the stored check, so the executor surfaces StaleTarget instead of a denial.
+        var payloadText = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing
+            )
+        );
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                payloadText
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 351L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.StaleTarget>();
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_a_stale_payload_index_is_out_of_range()
+    {
+        // 'ns1|9|s' has no matching planned check; the stale kind must not bypass the invalid-metadata
+        // fail-closed path just because it decodes to StoredTargetMissing.
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                "ns1|9|s"
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 352L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure>();
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_a_stale_payload_targets_a_proposed_check_index()
+    {
+        // 'ns1|1|s' points at the proposed check of an update plan. The compiler only ever raises the
+        // stale kind from a stored check, so a stale kind on a proposed index is malformed and must fail
+        // closed as invalid metadata rather than become a stale-target result.
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                "ns1|1|s"
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 353L,
+                ProposedNamespace: "uri://ed-fi.org/Thing",
+                [StoredCheck(0), ProposedCheck(1)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure>();
+    }
+
     [TestCase("ns1|bad|m")] // malformed index
     [TestCase("ns1|0|x")] // unknown failure kind
     [TestCase("v2|0|m")] // unknown AUTH1 discriminator

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/NamespaceAuthorizationExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/NamespaceAuthorizationExecutorTests.cs
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_NamespaceAuthorizationExecutor
+{
+    private static readonly DbSchemaName _edfiSchema = new("edfi");
+    private static readonly DbTableName _rootTable = new(_edfiSchema, "GradebookEntry");
+    private static readonly DbColumnName _namespaceColumn = new("Namespace");
+
+    private static readonly string[] _twoPrefixes = ["uri://ed-fi.org/", "uri://gbisd.edu/"];
+
+    private static NamespaceAuthorizationCheckSpec StoredCheck(int index = 0) =>
+        new(index, NamespaceAuthorizationCheckValueSource.Stored, _rootTable, _namespaceColumn);
+
+    private static NamespaceAuthorizationCheckSpec ProposedCheck(int index = 0) =>
+        new(index, NamespaceAuthorizationCheckValueSource.Proposed, _rootTable, _namespaceColumn);
+
+    [Test]
+    public async Task It_authorizes_a_stored_check_and_binds_postgresql_prefixes_as_a_string_array()
+    {
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            [new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()])]
+        );
+        var sut = new NamespaceAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 345L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.Authorized>();
+        commandExecutor.Commands.Should().ContainSingle();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@documentId", "@namespacePrefixes");
+        commandExecutor.Commands[0].Parameters[0].Value.Should().Be(345L);
+        commandExecutor
+            .Commands[0]
+            .Parameters[1]
+            .Value.Should()
+            .BeAssignableTo<string[]>()
+            .Which.Should()
+            .Equal("uri://ed-fi.org/%", "uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public async Task It_binds_sql_server_prefixes_as_one_scalar_parameter_per_prefix()
+    {
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Mssql,
+            [new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()])]
+        );
+        var sut = new NamespaceAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Mssql),
+                DocumentId: 346L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Mssql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.Authorized>();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@documentId", "@namespacePrefixes_0", "@namespacePrefixes_1");
+        commandExecutor.Commands[0].Parameters[1].Value.Should().Be("uri://ed-fi.org/%");
+        commandExecutor.Commands[0].Parameters[2].Value.Should().Be("uri://gbisd.edu/%");
+    }
+
+    [Test]
+    public async Task It_binds_the_proposed_namespace_parameter_for_a_proposed_check()
+    {
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            [new InMemoryRelationalCommandExecution([InMemoryRelationalResultSet.Create()])]
+        );
+        var sut = new NamespaceAuthorizationExecutor(commandExecutor);
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 0L,
+                ProposedNamespace: "uri://ed-fi.org/Thing",
+                [ProposedCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.Authorized>();
+        commandExecutor
+            .Commands[0]
+            .Parameters.Select(static parameter => parameter.Name)
+            .Should()
+            .Equal("@proposedNamespace", "@namespacePrefixes");
+        commandExecutor.Commands[0].Parameters[0].Value.Should().Be("uri://ed-fi.org/Thing");
+    }
+
+    [Test]
+    public async Task It_maps_a_postgresql_namespace_auth1_failure_to_a_namespace_denial()
+    {
+        var payloadText = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                payloadText
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 347L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<NamespaceAuthorizationExecutionResult.NotAuthorized>()
+            .Subject;
+        notAuthorized.Failure.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        notAuthorized.Failure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+        notAuthorized.Failure.EmittedAuth1Index.Should().Be(0);
+        notAuthorized.Failure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        // ProblemDetails must present the caller's raw prefixes, not the escaped SQL LIKE patterns.
+        notAuthorized
+            .Failure.ConfiguredNamespacePrefixes.Should()
+            .Equal("uri://ed-fi.org/", "uri://gbisd.edu/");
+    }
+
+    [Test]
+    public async Task It_maps_failures_with_raw_prefixes_even_when_prefixes_contain_like_metacharacters()
+    {
+        var payloadText = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.NamespaceMismatch
+            )
+        );
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                payloadText
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 347L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://a_b/", "uri://c%d/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<NamespaceAuthorizationExecutionResult.NotAuthorized>()
+            .Subject;
+        // The raw prefixes flow to ProblemDetails verbatim; the backslash-escaped SQL patterns
+        // (uri://a\_b/%, uri://c\%d/%) never reach the user-facing message.
+        notAuthorized.Failure.ConfiguredNamespacePrefixes.Should().Equal("uri://a_b/", "uri://c%d/");
+    }
+
+    [Test]
+    public async Task It_maps_a_proposed_missing_failure_for_a_proposed_check()
+    {
+        var payloadText = NamespaceAuthorizationAuth1FailurePayloadCodec.Encode(
+            new NamespaceAuthorizationAuth1FailurePayload(
+                0,
+                NamespaceAuthorizationAuth1FailureKind.ProposedNamespaceMissing
+            )
+        );
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Mssql,
+            exceptionToThrow: new StubDbException("AUTH1 - ns1|0|r")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(null, "AUTH1 - " + payloadText)
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Mssql),
+                DocumentId: 0L,
+                ProposedNamespace: null,
+                [ProposedCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Mssql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        var notAuthorized = result
+            .Should()
+            .BeOfType<NamespaceAuthorizationExecutionResult.NotAuthorized>()
+            .Subject;
+        notAuthorized
+            .Failure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.ProposedNamespaceMissing);
+        notAuthorized.Failure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Proposed);
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_a_namespace_auth1_payload_cannot_be_mapped()
+    {
+        // ns1 payload whose index is out of range for the single planned check.
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                "ns1|9|m"
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 348L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure>();
+    }
+
+    [TestCase("ns1|bad|m")] // malformed index
+    [TestCase("ns1|0|x")] // unknown failure kind
+    [TestCase("v2|0|m")] // unknown AUTH1 discriminator
+    public async Task It_fails_closed_for_malformed_or_unknown_auth1_payloads(string rawPayload)
+    {
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                rawPayload
+            )
+        );
+
+        var result = await sut.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                CreateMappingSet(SqlDialect.Pgsql),
+                DocumentId: 350L,
+                ProposedNamespace: null,
+                [StoredCheck(0)],
+                NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    _twoPrefixes,
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        result.Should().BeOfType<NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure>();
+    }
+
+    [Test]
+    public async Task It_rethrows_a_relationship_auth1_payload_instead_of_treating_it_as_a_namespace_failure()
+    {
+        var commandExecutor = new RecordingRelationalCommandExecutor(
+            SqlDialect.Pgsql,
+            exceptionToThrow: new StubDbException("PostgreSQL provider exception")
+        );
+        var sut = new NamespaceAuthorizationExecutor(
+            commandExecutor,
+            new StubRelationshipAuthorizationProviderFailureExtractor(
+                NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
+                "1|0|1|0:0:n"
+            )
+        );
+
+        var act = async () =>
+            await sut.ExecuteAsync(
+                new NamespaceAuthorizationExecutionRequest(
+                    CreateMappingSet(SqlDialect.Pgsql),
+                    DocumentId: 349L,
+                    ProposedNamespace: null,
+                    [StoredCheck(0)],
+                    NamespacePrefixParameterizationFactory.Create(
+                        SqlDialect.Pgsql,
+                        _twoPrefixes,
+                        "namespacePrefixes"
+                    )
+                )
+            );
+
+        // A relationship payload surfacing in a namespace-only execution is unexpected; the
+        // executor does not swallow it as a namespace failure.
+        await act.Should().ThrowAsync<DbException>();
+    }
+
+    private static MappingSet CreateMappingSet(SqlDialect dialect) =>
+        new(
+            new MappingSetKey("schema-hash", dialect, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo("5.2.0", "v1", "schema-hash", 1, [], [], []),
+                dialect,
+                [],
+                [],
+                [],
+                [],
+                [],
+                []
+            ),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>(),
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>(),
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>(),
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+
+    private sealed class StubDbException(string message) : DbException(message);
+
+    private sealed class StubRelationshipAuthorizationProviderFailureExtractor(
+        string? providerErrorCode,
+        string providerMessage
+    ) : IRelationshipAuthorizationProviderFailureExtractor
+    {
+        public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+        {
+            ArgumentNullException.ThrowIfNull(exception);
+
+            return new RelationshipAuthorizationProviderFailure(providerErrorCode, providerMessage);
+        }
+    }
+
+    private sealed class RecordingRelationalCommandExecutor(
+        SqlDialect dialect,
+        IReadOnlyList<InMemoryRelationalCommandExecution>? executions = null,
+        DbException? exceptionToThrow = null
+    ) : IRelationalCommandExecutor
+    {
+        private readonly Queue<InMemoryRelationalCommandExecution> _executions = new(executions ?? []);
+        private readonly DbException? _exceptionToThrow = exceptionToThrow;
+
+        public SqlDialect Dialect { get; } = dialect;
+
+        public List<RelationalCommand> Commands { get; } = [];
+
+        public async Task<TResult> ExecuteReaderAsync<TResult>(
+            RelationalCommand command,
+            Func<IRelationalCommandReader, CancellationToken, Task<TResult>> readAsync,
+            CancellationToken cancellationToken = default
+        )
+        {
+            ArgumentNullException.ThrowIfNull(command);
+            ArgumentNullException.ThrowIfNull(readAsync);
+
+            Commands.Add(command);
+
+            if (_exceptionToThrow is not null)
+            {
+                throw _exceptionToThrow;
+            }
+
+            if (!_executions.TryDequeue(out var execution))
+            {
+                throw new AssertionException(
+                    "No in-memory namespace authorization execution was configured for this call."
+                );
+            }
+
+            await using var reader = new InMemoryRelationalCommandReader(execution.ResultSets);
+            return await readAsync(reader, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Profile/ProfileWriteOrchestrationTests.cs
@@ -84,7 +84,8 @@ public class Given_No_Profile_Relational_Post
             A.Fake<IRelationalDeleteConstraintResolver>(),
             A.Fake<IRelationalWriteSessionFactory>(),
             AuthorizationSubjectSelectorTestSupport.Create(),
-            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>()
+            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
+            A.Fake<INamespaceAuthorizationExecutor>()
         );
 
         var upsertRequest = A.Fake<IRelationalUpsertRequest>();
@@ -199,7 +200,8 @@ public class Given_No_Profile_Relational_Put
             A.Fake<IRelationalDeleteConstraintResolver>(),
             A.Fake<IRelationalWriteSessionFactory>(),
             AuthorizationSubjectSelectorTestSupport.Create(),
-            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>()
+            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
+            A.Fake<INamespaceAuthorizationExecutor>()
         );
 
         var updateRequest = A.Fake<IRelationalUpdateRequest>();
@@ -314,7 +316,8 @@ public class Given_A_Profiled_Relational_Post
             A.Fake<IRelationalDeleteConstraintResolver>(),
             A.Fake<IRelationalWriteSessionFactory>(),
             AuthorizationSubjectSelectorTestSupport.Create(),
-            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>()
+            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
+            A.Fake<INamespaceAuthorizationExecutor>()
         );
 
         var upsertRequest = A.Fake<IRelationalUpsertRequest>();
@@ -428,7 +431,8 @@ public class Given_A_Profiled_Relational_Put
             A.Fake<IRelationalDeleteConstraintResolver>(),
             A.Fake<IRelationalWriteSessionFactory>(),
             AuthorizationSubjectSelectorTestSupport.Create(),
-            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>()
+            A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
+            A.Fake<INamespaceAuthorizationExecutor>()
         );
 
         var updateRequest = A.Fake<IRelationalUpdateRequest>();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ProposedNamespaceValueExtractorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/ProposedNamespaceValueExtractorTests.cs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class Given_a_proposed_namespace_value_extractor
+{
+    private static readonly DbTableName _rootTable = new(new DbSchemaName("edfi"), "Survey");
+    private static readonly DbColumnName _namespaceColumn = new("Namespace");
+
+    private static NamespaceAuthorizationCheckSpec ProposedCheck(DbColumnName? column = null) =>
+        new(0, NamespaceAuthorizationCheckValueSource.Proposed, _rootTable, column ?? _namespaceColumn);
+
+    [Test]
+    public void It_extracts_the_proposed_namespace_from_the_finalized_root_row_binding()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal("uri://ed-fi.org/Survey"));
+
+        var result = ProposedNamespaceValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        result
+            .Should()
+            .BeOfType<ProposedNamespaceValueExtractionResult.Ready>()
+            .Which.ProposedNamespace.Should()
+            .Be("uri://ed-fi.org/Survey");
+    }
+
+    [Test]
+    public void It_extracts_a_null_proposed_namespace_when_the_finalized_value_is_null()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(null));
+
+        var result = ProposedNamespaceValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        result
+            .Should()
+            .BeOfType<ProposedNamespaceValueExtractionResult.Ready>()
+            .Which.ProposedNamespace.Should()
+            .BeNull();
+    }
+
+    [Test]
+    public void It_normalizes_an_empty_string_finalized_value_to_a_null_proposed_namespace()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal(string.Empty));
+
+        var result = ProposedNamespaceValueExtractor.Extract([ProposedCheck()], rootRow);
+
+        result
+            .Should()
+            .BeOfType<ProposedNamespaceValueExtractionResult.Ready>()
+            .Which.ProposedNamespace.Should()
+            .BeNull();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_no_root_binding_matches_the_namespace_column()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal("uri://ed-fi.org/Survey"));
+
+        var result = ProposedNamespaceValueExtractor.Extract(
+            [ProposedCheck(new DbColumnName("NotAColumn"))],
+            rootRow
+        );
+
+        result.Should().BeOfType<ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_a_check_is_not_a_proposed_value_source()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal("uri://ed-fi.org/Survey"));
+        var storedCheck = new NamespaceAuthorizationCheckSpec(
+            0,
+            NamespaceAuthorizationCheckValueSource.Stored,
+            _rootTable,
+            _namespaceColumn
+        );
+
+        var result = ProposedNamespaceValueExtractor.Extract([storedCheck], rootRow);
+
+        result.Should().BeOfType<ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    [Test]
+    public void It_returns_invalid_when_no_checks_are_supplied()
+    {
+        var rootRow = CreateRootRow(new FlattenedWriteValue.Literal("uri://ed-fi.org/Survey"));
+
+        var result = ProposedNamespaceValueExtractor.Extract([], rootRow);
+
+        result.Should().BeOfType<ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan>();
+    }
+
+    private static RootWriteRowBuffer CreateRootRow(FlattenedWriteValue namespaceValue)
+    {
+        var tableModel = new DbTableModel(
+            _rootTable,
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_Survey",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    _namespaceColumn,
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 255),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        var writePlan = new TableWritePlan(
+            tableModel,
+            InsertSql: "insert into edfi.\"Survey\" values (@DocumentId, @Namespace)",
+            UpdateSql: "update edfi.\"Survey\" set \"Namespace\" = @Namespace where \"DocumentId\" = @DocumentId",
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
+            ColumnBindings:
+            [
+                new WriteColumnBinding(
+                    tableModel.Columns[0],
+                    new WriteValueSource.DocumentId(),
+                    "DocumentId"
+                ),
+                new WriteColumnBinding(
+                    tableModel.Columns[1],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.namespace", []),
+                        new RelationalScalarType(ScalarKind.String, MaxLength: 255)
+                    ),
+                    "Namespace"
+                ),
+            ],
+            KeyUnificationPlans: []
+        );
+
+        return new RootWriteRowBuffer(
+            writePlan,
+            [FlattenedWriteValue.UnresolvedRootDocumentId.Instance, namespaceValue]
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -4651,6 +4651,135 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_returns_an_empty_page_rather_than_a_parameter_budget_failure_when_preprocessing_short_circuits()
+    {
+        // A filter that resolves to no matches (an invalid UUID) short-circuits to an empty page during
+        // preprocessing. The SQL Server parameter-budget guard must run after that short-circuit, so the
+        // empty page wins over a security-configuration failure for a command that never executes — even
+        // though the composed authorization lists would otherwise exceed the per-command parameter ceiling.
+        var resource = new QualifiedResourceName("Ed-Fi", "School");
+        var baseMappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var mappingSet = baseMappingSet with
+        {
+            Key = baseMappingSet.Key with { Dialect = SqlDialect.Mssql },
+            QueryCapabilitiesByResource = new Dictionary<QualifiedResourceName, RelationalQueryCapability>
+            {
+                [resource] = new RelationalQueryCapability(
+                    new RelationalQuerySupport.Supported(),
+                    new Dictionary<string, SupportedRelationalQueryField>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["id"] = CreateSupportedQueryField(
+                            "id",
+                            "$.id",
+                            "string",
+                            new RelationalQueryFieldTarget.DocumentUuid()
+                        ),
+                    },
+                    new Dictionary<string, UnsupportedRelationalQueryField>(StringComparer.OrdinalIgnoreCase)
+                ),
+            },
+        };
+        string[] namespacePrefixes = [.. Enumerable.Range(0, 1500).Select(index => $"uri://prefix-{index}/")];
+        long[] claimEducationOrganizationIds =
+        [
+            .. Enumerable.Range(0, 1500).Select(index => 100000L + index),
+        ];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [CreateQueryElement("id", "$.id", "not-a-guid", "string")],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: claimEducationOrganizationIds,
+            namespacePrefixes: namespacePrefixes
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null));
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_an_empty_page_rather_than_a_parameter_budget_failure_when_planning_short_circuits()
+    {
+        // A scalar root-column filter whose value cannot convert to the column type (1.5 for an integer
+        // column) short-circuits to an empty page during planning, not preprocessing. The SQL Server
+        // parameter-budget guard runs off the final planned parameter count, after planning, so this empty
+        // page also wins over a security-configuration failure for a command that never executes — even
+        // though the composed authorization lists would otherwise exceed the per-command parameter ceiling.
+        var resource = new QualifiedResourceName("Ed-Fi", "School");
+        var baseMappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var mappingSet = baseMappingSet with
+        {
+            Key = baseMappingSet.Key with { Dialect = SqlDialect.Mssql },
+            QueryCapabilitiesByResource = new Dictionary<QualifiedResourceName, RelationalQueryCapability>
+            {
+                [resource] = new RelationalQueryCapability(
+                    new RelationalQuerySupport.Supported(),
+                    new Dictionary<string, SupportedRelationalQueryField>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["schoolId"] = CreateSupportedQueryField(
+                            "schoolId",
+                            "$.localEducationAgencyId",
+                            "number",
+                            new RelationalQueryFieldTarget.RootColumn(
+                                new DbColumnName("LocalEducationAgencyId")
+                            )
+                        ),
+                    },
+                    new Dictionary<string, UnsupportedRelationalQueryField>(StringComparer.OrdinalIgnoreCase)
+                ),
+            },
+        };
+        string[] namespacePrefixes = [.. Enumerable.Range(0, 1500).Select(index => $"uri://prefix-{index}/")];
+        long[] claimEducationOrganizationIds =
+        [
+            .. Enumerable.Range(0, 1500).Select(index => 100000L + index),
+        ];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [CreateQueryElement("schoolId", "$.localEducationAgencyId", "1.5", "number")],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: claimEducationOrganizationIds,
+            namespacePrefixes: namespacePrefixes
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result.Should().BeEquivalentTo(new QueryResult.QuerySuccess([], null));
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
     public async Task It_returns_security_configuration_failure_when_query_authorization_strategy_metadata_is_invalid()
     {
         var queryRequest = CreateQueryRequest(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -44,7 +44,6 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     private static readonly ResourceInfo _schoolResourceInfo = CreateResourceInfo("School");
-    private static readonly ResourceInfo _studentResourceInfo = CreateResourceInfo("Student");
     private const string StampStyleEtagPattern = "^\"\\d+\"$";
     private static readonly BaseResourceInfo _localEducationAgencyResourceInfo = new(
         new ProjectName("Ed-Fi"),
@@ -78,6 +77,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     private RecordingWriteSessionFactory _writeSessionFactory = null!;
     private ISingleRecordRelationshipAuthorizationExecutor _singleRecordRelationshipAuthorizationExecutor =
         null!;
+    private INamespaceAuthorizationExecutor _namespaceAuthorizationExecutor = null!;
     private RelationalWriteExecutorRequest _capturedExecutorRequest = null!;
     private List<RelationalWriteExecutorRequest> _capturedExecutorRequests = null!;
 
@@ -103,6 +103,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         _writeSessionFactory = new RecordingWriteSessionFactory(_commandExecutor);
         _singleRecordRelationshipAuthorizationExecutor =
             A.Fake<ISingleRecordRelationshipAuthorizationExecutor>();
+        _namespaceAuthorizationExecutor = A.Fake<INamespaceAuthorizationExecutor>();
         _capturedExecutorRequests = [];
         A.CallTo(() =>
                 _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
@@ -161,7 +162,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
     }
 
@@ -183,7 +185,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
     }
 
@@ -313,7 +316,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var getRequest = CreateGetRequest(
@@ -393,7 +397,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     public async Task It_delegates_descriptor_get_authorization_that_requires_filtering_to_the_descriptor_read_handler()
     {
         var expectedResult = new GetResult.GetFailureNotImplemented(
-            "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+            "Relational descriptor GET authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
         );
 
         A.CallTo(() =>
@@ -890,10 +894,66 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(
                     AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
                 ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            claimEducationOrganizationIds: [255901L]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        A.CallTo(() =>
+                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
+                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_the_document_when_stored_namespace_matches_a_prefix()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-aaaaaaaaaaaa"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
             ],
-            claimEducationOrganizationIds: [255901L]
+            namespacePrefixes: ["uri://ed-fi.org/"]
         );
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 91L),
+            (345L, "uri://ed-fi.org/Thing")
+        );
+        NamespaceAuthorizationExecutionRequest capturedNamespaceRequest = null!;
 
         A.CallTo(() =>
                 _readTargetLookupService.ResolveForGetByIdAsync(
@@ -904,34 +964,60 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
-
-        var result = await _sut.GetDocumentById(getRequest);
-
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
-        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.NamespaceBased);
         A.CallTo(() =>
-                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
-                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
                     A<CancellationToken>._
                 )
             )
-            .MustNotHaveHappened();
+            .Invokes(call =>
+                capturedNamespaceRequest = call.GetArgument<NamespaceAuthorizationExecutionRequest>(0)!
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
-                    A<ResourceReadPlan>._,
-                    A<PageKeysetSpec>._,
+                    readPlan,
+                    new PageKeysetSpec.Single(345L),
                     A<HydrationExecutionOptions>._,
                     A<CancellationToken>._
                 )
             )
-            .MustNotHaveHappened();
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
+            .Returns(JsonNode.Parse("""{"id":"authorized-by-namespace"}""")!);
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+        capturedNamespaceRequest.Should().NotBeNull();
+        capturedNamespaceRequest.DocumentId.Should().Be(345L);
+        capturedNamespaceRequest.ProposedNamespace.Should().BeNull();
+        capturedNamespaceRequest
+            .Checks.Should()
+            .ContainSingle()
+            .Which.ValueSource.Should()
+            .Be(NamespaceAuthorizationCheckValueSource.Stored);
+        capturedNamespaceRequest
+            .NamespacePrefixParameterization.ConfiguredPrefixesInOrder.Should()
+            .Equal("uri://ed-fi.org/");
     }
 
     [Test]
-    public async Task It_keeps_people_get_by_id_relationship_authorization_staged_until_crud_integration()
+    public async Task It_returns_a_namespace_mismatch_403_and_skips_hydration_when_stored_namespace_does_not_match()
     {
-        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-2222-3333-4444-cacacacacaca"));
-        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-bbbbbbbbbbbb"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
         var getRequest = CreateGetRequest(
             documentUuid,
             mappingSet,
@@ -939,11 +1025,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
             new RecordingResourceAuthorizationHandler(),
             authorizationStrategyEvaluators:
             [
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
             ],
-            claimEducationOrganizationIds: [255901L]
+            namespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"]
         );
 
         A.CallTo(() =>
@@ -955,17 +1039,128 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+                )
+            );
 
         var result = await _sut.GetDocumentById(getRequest);
 
-        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject;
+        failure.NamespaceFailure.Should().BeSameAs(namespaceFailure);
         failure
-            .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople)
-            .And.Contain("single-record EdOrg-only relationship execution boundary");
+            .NamespaceFailure.ConfiguredNamespacePrefixes.Should()
+            .Equal("uri://ed-fi.org/", "uri://gbisd.edu/");
         A.CallTo(() =>
-                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
-                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+        A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_namespace_uninitialized_403_when_stored_namespace_is_null()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccccc"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+    }
+
+    [Test]
+    public async Task It_returns_a_no_prefixes_403_without_executing_namespace_authorization_when_client_has_no_prefixes()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: []
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        failure.NamespaceFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
                     A<CancellationToken>._
                 )
             )
@@ -982,9 +1177,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_get_by_id_security_configuration_failure_before_people_relationship_staging()
+    public async Task It_returns_a_security_configuration_500_when_no_usable_root_namespace_column()
     {
-        var documentUuid = new DocumentUuid(Guid.Parse("bbbbbbbb-2222-3333-4444-cbcbcbcbcbcb"));
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-eeeeeeeeeeee"));
         var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
         var getRequest = CreateGetRequest(
             documentUuid,
@@ -993,12 +1188,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
             new RecordingResourceAuthorizationHandler(),
             authorizationStrategyEvaluators:
             [
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-                CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
             ],
-            claimEducationOrganizationIds: [255901L]
+            namespacePrefixes: ["uri://ed-fi.org/"]
         );
 
         A.CallTo(() =>
@@ -1014,8 +1206,348 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var result = await _sut.GetDocumentById(getRequest);
 
         var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().ContainSingle();
-        failure.Errors[0].Should().Contain("CustomAuthorizationStrategy");
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Ed-Fi.School")
+            .And.Contain("NamespaceBased")
+            .And.Contain("no Namespace securable element resolves to a root table column");
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_when_mssql_namespace_prefix_cap_is_exceeded()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-ffffffffffff"));
+        var pgsqlMappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var mappingSet = pgsqlMappingSet with
+        {
+            Key = pgsqlMappingSet.Key with { Dialect = SqlDialect.Mssql },
+        };
+        string[] tooManyPrefixes = [.. Enumerable.Range(0, 2000).Select(index => $"uri://prefix-{index}/")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: tooManyPrefixes
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2000 namespace prefixes")
+            .And.Contain("exceeds the SQL Server limit");
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_no_prefixes_403_before_issuing_the_target_lookup_when_client_has_no_prefixes()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-a1a1a1a1a1a1"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: []
+        );
+
+        // A no-prefix client can never be authorized, so the §2.9 denial must not depend on whether
+        // the document exists: even with the target absent the result is the 403, not a 404.
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.NotFound());
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    A<MappingSet>._,
+                    A<QualifiedResourceName>._,
+                    A<DocumentUuid>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_before_issuing_the_target_lookup_when_no_usable_root_namespace_column()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-b2b2b2b2b2b2"));
+        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.NotFound());
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    A<MappingSet>._,
+                    A<QualifiedResourceName>._,
+                    A<DocumentUuid>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_before_issuing_the_target_lookup_when_mssql_namespace_prefix_cap_is_exceeded()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-c3c3c3c3c3c3"));
+        var pgsqlMappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var mappingSet = pgsqlMappingSet with
+        {
+            Key = pgsqlMappingSet.Key with { Dialect = SqlDialect.Mssql },
+        };
+        string[] tooManyPrefixes = [.. Enumerable.Range(0, 2000).Select(index => $"uri://prefix-{index}/")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: tooManyPrefixes
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.NotFound());
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>();
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    A<MappingSet>._,
+                    A<QualifiedResourceName>._,
+                    A<DocumentUuid>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_runs_namespace_authorization_before_relationship_when_both_are_configured()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-aaaaaaaaaaaa"));
+        var mappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: [255901L],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 91L),
+            (345L, "uri://ed-fi.org/Thing")
+        );
+        var order = 0;
+        var namespaceOrder = 0;
+        var relationshipOrder = 0;
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => namespaceOrder = ++order)
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
+                    A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(() => relationshipOrder = ++order)
+            .Returns(
+                Task.FromResult<SingleRecordRelationshipAuthorizationExecutionResult>(
+                    new SingleRecordRelationshipAuthorizationExecutionResult.Authorized(91L)
+                )
+            );
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    new PageKeysetSpec.Single(345L),
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
+            .Returns(JsonNode.Parse("""{"id":"authorized"}""")!);
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetSuccess>();
+        namespaceOrder.Should().Be(1);
+        relationshipOrder.Should().Be(2);
+    }
+
+    [Test]
+    public async Task It_does_not_run_relationship_authorization_when_namespace_authorization_denies()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-bbbbbbbbbbbb"));
+        var mappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: [255901L],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>();
         A.CallTo(() =>
                 _singleRecordRelationshipAuthorizationExecutor.ExecuteAsync(
                     A<SingleRecordRelationshipAuthorizationExecutionRequest>._,
@@ -1031,6 +1563,119 @@ public class Given_RelationalDocumentStoreRepositoryTests
                     A<CancellationToken>._
                 )
             )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_fails_closed_when_ownership_is_configured_alongside_namespace()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-cccccccccccc"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L));
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureNotImplemented>().Subject;
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_retries_instead_of_materializing_when_namespace_is_authorized_but_hydration_observes_a_different_content_version()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("eeeeeeee-1111-2222-3333-aaaaaaaaaaaa"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        // The target lookup observes content version 5, but hydration returns a row that was mutated
+        // to content version 6 after the namespace check authorized the stored value.
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 6L),
+            (345L, "uri://ed-fi.org/Thing")
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 5L));
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.Authorized()
+                )
+            );
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    new PageKeysetSpec.Single(345L),
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(hydratedPage);
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().NotBeOfType<GetResult.GetSuccess>();
+        A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
             .MustNotHaveHappened();
     }
 
@@ -1686,7 +2331,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var queryRequest = CreateQueryRequest(
@@ -1761,7 +2407,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var queryRequest = CreateQueryRequest(
@@ -1808,7 +2455,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var descriptorResourceInfo = CreateResourceInfo("SchoolTypeDescriptor");
         var mappingSet = CreateDescriptorOnlyMappingSet(descriptorResourceInfo);
         var expectedResult = new QueryResult.QueryFailureNotImplemented(
-            "Relational descriptor query authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET-many authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or only 'NoFurtherAuthorizationRequired' are currently supported."
+            "Relational descriptor query authorization is not implemented for resource 'Ed-Fi.SchoolTypeDescriptor' when effective GET-many authorization requires filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no authorization strategies or with 'NamespaceBased' and/or 'NoFurtherAuthorizationRequired' are currently supported."
         );
 
         A.CallTo(() =>
@@ -1832,7 +2479,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var queryRequest = CreateQueryRequest(
@@ -2976,7 +3624,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(
                     AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
                 ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]
         );
 
@@ -2986,7 +3634,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         result
             .As<QueryResult.QueryFailureNotImplemented>()
             .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.NamespaceBased);
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         result
             .As<QueryResult.QueryFailureNotImplemented>()
             .FailureMessage.Should()
@@ -3373,7 +4021,6 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .MustNotHaveHappened();
     }
 
-    [TestCase(AuthorizationStrategyNameConstants.NamespaceBased)]
     [TestCase(AuthorizationStrategyNameConstants.OwnershipBased)]
     [TestCase("SchoolWithResponsibility")]
     public async Task It_returns_not_implemented_for_known_out_of_scope_query_authorization_when_mixed_with_people_relationship_authorization(
@@ -3603,7 +4250,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             totalCount: false,
             authorizationStrategyEvaluators:
             [
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
                 CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
             ]
         );
@@ -3617,7 +4264,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Errors.Should()
             .Contain(error => error.Contains("CustomAuthorizationStrategy", StringComparison.Ordinal))
             .And.Contain(error =>
-                error.Contains(AuthorizationStrategyNameConstants.NamespaceBased, StringComparison.Ordinal)
+                error.Contains(AuthorizationStrategyNameConstants.OwnershipBased, StringComparison.Ordinal)
             );
         A.CallTo(() =>
                 _documentHydrator.HydrateAsync(
@@ -3628,6 +4275,261 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 )
             )
             .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_namespace_no_prefixes_403_for_query_without_executing_a_db_query()
+    {
+        var queryRequest = CreateQueryRequest(
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: []
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        failure.NamespaceFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_namespace_security_configuration_500_for_query_when_no_usable_root_column()
+    {
+        var queryRequest = CreateQueryRequest(
+            CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo),
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Ed-Fi.School")
+            .And.Contain("NamespaceBased")
+            .And.Contain("no Namespace securable element resolves to a root table column");
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_fails_closed_for_query_when_ownership_is_configured_alongside_namespace()
+    {
+        var queryRequest = CreateQueryRequest(
+            CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo),
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result
+            .Should()
+            .BeOfType<QueryResult.QueryFailureNotImplemented>()
+            .Which.FailureMessage.Should()
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_applies_the_namespace_filter_to_the_page_query_when_namespace_is_authorized()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("a1a1a1a1-1111-2222-3333-444444444444"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var hydratedPage = new HydratedPage(
+            null,
+            [CreateDocumentMetadataRow(documentUuid, 345L, 91L)],
+            [
+                new HydratedTableRows(
+                    readPlan.Model.Root,
+                    [
+                        [345L, "uri://ed-fi.org/School"],
+                    ]
+                ),
+            ],
+            []
+        );
+        PageKeysetSpec.Query capturedKeyset = null!;
+
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call =>
+            {
+                capturedKeyset =
+                    call.GetArgument<PageKeysetSpec>(1) as PageKeysetSpec.Query
+                    ?? throw new AssertionException(
+                        "Namespace-authorized relational query execution should hydrate through PageKeysetSpec.Query."
+                    );
+            })
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([
+                new MaterializedDocument(
+                    hydratedPage.DocumentMetadata[0],
+                    JsonNode.Parse($$"""{"id":"{{documentUuid.Value}}"}""")!
+                ),
+            ]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result.Should().BeOfType<QueryResult.QuerySuccess>();
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("\"Namespace\"");
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("IS NOT NULL");
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("LIKE ANY(@namespacePrefixes)");
+        capturedKeyset
+            .ParameterValues["namespacePrefixes"]
+            .Should()
+            .BeAssignableTo<IReadOnlyList<string>>()
+            .Which.Should()
+            .Equal("uri://ed-fi.org/%");
+        capturedKeyset
+            .Plan.PageParametersInOrder.Select(static parameter => parameter.ParameterName)
+            .Should()
+            .Contain("namespacePrefixes");
+    }
+
+    [Test]
+    public async Task It_and_composes_the_namespace_filter_with_the_relationship_or_group_for_query()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("a2a2a2a2-1111-2222-3333-555555555555"));
+        var mappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: [255901L],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        var hydratedPage = new HydratedPage(
+            null,
+            [CreateDocumentMetadataRow(documentUuid, 345L, 91L)],
+            [
+                new HydratedTableRows(
+                    readPlan.Model.Root,
+                    [
+                        [345L, 255901L, "uri://ed-fi.org/School"],
+                    ]
+                ),
+            ],
+            []
+        );
+        PageKeysetSpec.Query capturedKeyset = null!;
+
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Invokes(call =>
+            {
+                capturedKeyset =
+                    call.GetArgument<PageKeysetSpec>(1) as PageKeysetSpec.Query
+                    ?? throw new AssertionException(
+                        "Mixed-strategy relational query execution should hydrate through PageKeysetSpec.Query."
+                    );
+            })
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([
+                new MaterializedDocument(
+                    hydratedPage.DocumentMetadata[0],
+                    JsonNode.Parse($$"""{"id":"{{documentUuid.Value}}"}""")!
+                ),
+            ]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result.Should().BeOfType<QueryResult.QuerySuccess>();
+        // Namespace AND-filter and relationship OR group are both present, with their own parameters.
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("LIKE ANY(@namespacePrefixes)");
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("@ClaimEducationOrganizationIds");
+        capturedKeyset.Plan.PageDocumentIdSql.Should().Contain("LocalEducationAgencyId");
+        capturedKeyset
+            .ParameterValues["namespacePrefixes"]
+            .Should()
+            .BeAssignableTo<IReadOnlyList<string>>()
+            .Which.Should()
+            .Equal("uri://ed-fi.org/%");
+        capturedKeyset
+            .ParameterValues[RelationalAuthorizationParameterNameConstants.ClaimEducationOrganizationIds]
+            .Should()
+            .BeAssignableTo<IReadOnlyList<long>>()
+            .Which.Should()
+            .Equal(255901L);
     }
 
     [Test]
@@ -4052,7 +4954,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(
                     AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
                 ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => upsertRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901]));
@@ -4061,44 +4963,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var failure = result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>().Subject;
         failure.Reason.Should().Be(UpsertFailureNotImplementedReason.StrategyNotEnabled);
-        failure.FailureMessage.Should().Contain("NamespaceBased");
-        _capturedExecutorRequests.Should().BeEmpty();
-        _targetLookupService.ResolveForPostCallCount.Should().Be(0);
-        A.CallTo(() =>
-                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
-            )
-            .MustNotHaveHappened();
-        A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
-    }
-
-    [Test]
-    public async Task It_keeps_people_post_relationship_authorization_staged_before_target_lookup()
-    {
-        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
-        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
-        A.CallTo(() => upsertRequest.MappingSet)
-            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
-        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
-        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("People staged"));
-        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-            ]);
-        A.CallTo(() => upsertRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
-
-        var result = await _sut.UpsertDocument(upsertRequest);
-
-        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureNotImplemented>().Subject;
-        failure.Reason.Should().Be(UpsertFailureNotImplementedReason.StrategyNotEnabled);
-        failure
-            .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople)
-            .And.Contain("POST create-new EdOrg-only relationship execution boundary");
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         _capturedExecutorRequests.Should().BeEmpty();
         _targetLookupService.ResolveForPostCallCount.Should().Be(0);
         A.CallTo(() =>
@@ -4120,44 +4985,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Security config"));
         A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
             .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
-                ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
-            ]);
-        A.CallTo(() => upsertRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
-
-        var result = await _sut.UpsertDocument(upsertRequest);
-
-        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().Contain(error => error.Contains("Relational POST authorization metadata"));
-        failure.Errors.Should().Contain(error => error.Contains("NamespaceBased"));
-        _capturedExecutorRequests.Should().BeEmpty();
-        _targetLookupService.ResolveForPostCallCount.Should().Be(0);
-        A.CallTo(() =>
-                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
-            )
-            .MustNotHaveHappened();
-        A.CallTo(() => _referenceResolver.ResolveAsync(A<ReferenceResolverRequest>._, A<CancellationToken>._))
-            .MustNotHaveHappened();
-    }
-
-    [Test]
-    public async Task It_returns_post_security_configuration_failure_before_people_relationship_staging()
-    {
-        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
-        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
-        A.CallTo(() => upsertRequest.MappingSet)
-            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
-        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
-        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Security config"));
-        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
                 CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
             ]);
         A.CallTo(() => upsertRequest.AuthorizationContext)
@@ -4166,8 +4994,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         var result = await _sut.UpsertDocument(upsertRequest);
 
         var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().ContainSingle();
-        failure.Errors[0].Should().Contain("CustomAuthorizationStrategy");
+        failure.Errors.Should().Contain(error => error.Contains("Relational POST authorization metadata"));
+        failure.Errors.Should().Contain(error => error.Contains("CustomAuthorizationStrategy"));
         _capturedExecutorRequests.Should().BeEmpty();
         _targetLookupService.ResolveForPostCallCount.Should().Be(0);
         A.CallTo(() =>
@@ -4234,6 +5062,63 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_forwards_relationship_no_claims_with_proposed_namespace_authorization_to_the_write_executor_for_a_mixed_strategy_post()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        A.CallTo(() =>
+                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
+            )
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorRequest>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(
+                Task.FromResult<RelationalWriteExecutorResult>(
+                    new RelationalWriteExecutorResult.Upsert(
+                        new UpsertResult.InsertSuccess(documentUuid, CreateCommittedReadbackEtag("Mixed"))
+                    )
+                )
+            );
+
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateNamespaceAndRelationshipWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Mixed"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ]);
+        // Empty claim EducationOrganizationIds make the relationship strategy resolve to NoClaims; the
+        // configured namespace prefixes make a proposed namespace check participate. With both planned,
+        // preflight must defer the NoClaims denial to the executor instead of short-circuiting, so the
+        // namespace check (AND-composed ahead of the relationship OR-group) gets to deny first.
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequests.Should().ContainSingle();
+        _capturedExecutorRequest
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+        var proposedNamespaceAuthorization = _capturedExecutorRequest.ProposedNamespaceAuthorization;
+        proposedNamespaceAuthorization.Should().NotBeNull();
+        proposedNamespaceAuthorization!
+            .Checks.Should()
+            .ContainSingle()
+            .Which.ValueSource.Should()
+            .Be(NamespaceAuthorizationCheckValueSource.Proposed);
+        _targetLookupService.ResolveForPostCallCount.Should().Be(1);
+    }
+
+    [Test]
     public async Task It_forwards_authorized_post_relationship_plans_to_the_write_executor_after_target_lookup()
     {
         var committedEtag = CreateCommittedReadbackEtag("Authorized High");
@@ -4284,7 +5169,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Be(RelationshipAuthorizationValueSource.Stored);
         _capturedExecutorRequest.ProposedRelationshipAuthorization.Should().NotBeNull();
         _capturedExecutorRequest
-            .ProposedRelationshipAuthorization!.CheckSpecs.Should()
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.Authorized>()
+            .Which.CheckSpecs.Should()
             .ContainSingle()
             .Which.ValueSource.Should()
             .Be(RelationshipAuthorizationValueSource.Proposed);
@@ -4345,7 +5232,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Be(RelationshipAuthorizationValueSource.Stored);
         _capturedExecutorRequest.ProposedRelationshipAuthorization.Should().NotBeNull();
         _capturedExecutorRequest
-            .ProposedRelationshipAuthorization!.CheckSpecs.Should()
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.Authorized>()
+            .Which.CheckSpecs.Should()
             .ContainSingle()
             .Which.ValueSource.Should()
             .Be(RelationshipAuthorizationValueSource.Proposed);
@@ -4394,7 +5283,164 @@ public class Given_RelationalDocumentStoreRepositoryTests
         _capturedExecutorRequests.Should().ContainSingle();
         _capturedExecutorRequest.StoredRelationshipAuthorization.Should().BeNull();
         _capturedExecutorRequest.ProposedRelationshipAuthorization.Should().BeNull();
+        _capturedExecutorRequest.StoredNamespaceAuthorization.Should().BeNull();
+        _capturedExecutorRequest.ProposedNamespaceAuthorization.Should().BeNull();
         _targetLookupService.ResolveForPostCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_threads_proposed_namespace_authorization_into_the_post_write_executor_request()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        A.CallTo(() =>
+                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
+            )
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorRequest>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(
+                Task.FromResult<RelationalWriteExecutorResult>(
+                    new RelationalWriteExecutorResult.Upsert(
+                        new UpsertResult.InsertSuccess(
+                            documentUuid,
+                            CreateCommittedReadbackEtag("Namespaced")
+                        )
+                    )
+                )
+            );
+
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet).Returns(CreateNamespaceWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Namespaced"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        await _sut.UpsertDocument(upsertRequest);
+
+        _capturedExecutorRequests.Should().ContainSingle();
+
+        // A POST plans both checks; the proposed check is applied for create, the stored check only
+        // when the write resolves to an existing target. Each is a single check re-indexed to 0.
+        var proposedAuthorization = _capturedExecutorRequest.ProposedNamespaceAuthorization;
+        proposedAuthorization.Should().NotBeNull();
+        var proposedCheck = proposedAuthorization!.Checks.Should().ContainSingle().Subject;
+        proposedCheck.Index.Should().Be(0);
+        proposedCheck.ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
+        proposedAuthorization
+            .NamespacePrefixParameterization.ConfiguredPrefixesInOrder.Should()
+            .Equal("uri://ed-fi.org/");
+
+        var storedAuthorization = _capturedExecutorRequest.StoredNamespaceAuthorization;
+        storedAuthorization.Should().NotBeNull();
+        var storedCheck = storedAuthorization!.Checks.Should().ContainSingle().Subject;
+        storedCheck.Index.Should().Be(0);
+        storedCheck.ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+
+        _capturedExecutorRequest.StoredRelationshipAuthorization.Should().BeNull();
+        _capturedExecutorRequest.ProposedRelationshipAuthorization.Should().BeNull();
+        _targetLookupService.ResolveForPostCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_a_namespace_no_prefixes_403_for_post_without_calling_the_write_executor()
+    {
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet).Returns(CreateNamespaceWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("No prefixes"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], []));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        failure.NamespaceFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        _capturedExecutorRequests.Should().BeEmpty();
+        _targetLookupService.ResolveForPostCallCount.Should().Be(0);
+        A.CallTo(() =>
+                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_for_post_when_no_usable_root_namespace_column()
+    {
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet)
+            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("No usable column"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Ed-Fi.School")
+            .And.Contain("NamespaceBased")
+            .And.Contain("no Namespace securable element resolves to a root table column");
+        _capturedExecutorRequests.Should().BeEmpty();
+        _targetLookupService.ResolveForPostCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_a_security_configuration_500_for_post_when_mssql_namespace_prefix_cap_is_exceeded()
+    {
+        var mappingSet = CreateNamespaceWriteMappingSet(_schoolResourceInfo, SqlDialect.Mssql);
+        string[] tooManyPrefixes = [.. Enumerable.Range(0, 2000).Select(index => $"uri://prefix-{index}/")];
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet).Returns(mappingSet);
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateRequestBody("Prefix cap"));
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => upsertRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], tooManyPrefixes));
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2000 namespace prefixes")
+            .And.Contain("exceeds the SQL Server limit");
+        _capturedExecutorRequests.Should().BeEmpty();
+        _targetLookupService.ResolveForPostCallCount.Should().Be(0);
     }
 
     [Test]
@@ -4419,7 +5465,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(
                     AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
                 ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => updateRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901]));
@@ -4428,42 +5474,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var failure = result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>().Subject;
         failure.Reason.Should().Be(UpdateFailureNotImplementedReason.StrategyNotEnabled);
-        failure.FailureMessage.Should().Contain("NamespaceBased");
-        _capturedExecutorRequests.Should().BeEmpty();
-        _targetLookupService.ResolveForPutCallCount.Should().Be(0);
-        A.CallTo(() =>
-                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
-            )
-            .MustNotHaveHappened();
-    }
-
-    [Test]
-    public async Task It_keeps_people_put_relationship_authorization_staged_before_target_lookup()
-    {
-        var updateRequest = A.Fake<IRelationalUpdateRequest>();
-        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
-        A.CallTo(() => updateRequest.MappingSet)
-            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
-        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
-        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("People staged"));
-        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-            ]);
-        A.CallTo(() => updateRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
-
-        var result = await _sut.UpdateDocumentById(updateRequest);
-
-        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureNotImplemented>().Subject;
-        failure.Reason.Should().Be(UpdateFailureNotImplementedReason.StrategyNotEnabled);
-        failure
-            .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople)
-            .And.Contain("PUT EdOrg-only relationship execution boundary");
+        failure.FailureMessage.Should().Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         _capturedExecutorRequests.Should().BeEmpty();
         _targetLookupService.ResolveForPutCallCount.Should().Be(0);
         A.CallTo(() =>
@@ -4483,10 +5494,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Security config"));
         A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
             .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
-                ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
+                CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
             ]);
         A.CallTo(() => updateRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901]));
@@ -4495,7 +5504,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
         failure.Errors.Should().Contain(error => error.Contains("Relational PUT authorization metadata"));
-        failure.Errors.Should().Contain(error => error.Contains("NamespaceBased"));
+        failure.Errors.Should().Contain(error => error.Contains("CustomAuthorizationStrategy"));
         _capturedExecutorRequests.Should().BeEmpty();
         _targetLookupService.ResolveForPutCallCount.Should().Be(0);
         A.CallTo(() =>
@@ -4505,36 +5514,58 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_put_security_configuration_failure_before_people_relationship_staging()
+    public async Task It_threads_stored_and_proposed_namespace_authorization_into_the_put_write_executor_request()
     {
-        var updateRequest = A.Fake<IRelationalUpdateRequest>();
-        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
-        A.CallTo(() => updateRequest.MappingSet)
-            .Returns(CreateWriteAuthorizationAwareMappingSetWithRootEdOrgSubject(_schoolResourceInfo));
-        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
-        A.CallTo(() => updateRequest.DocumentUuid).Returns(new DocumentUuid(Guid.NewGuid()));
-        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Security config"));
-        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-                CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
-            ]);
-        A.CallTo(() => updateRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901]));
-
-        var result = await _sut.UpdateDocumentById(updateRequest);
-
-        var failure = result.Should().BeOfType<UpdateResult.UpdateFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().ContainSingle();
-        failure.Errors[0].Should().Contain("CustomAuthorizationStrategy");
-        _capturedExecutorRequests.Should().BeEmpty();
-        _targetLookupService.ResolveForPutCallCount.Should().Be(0);
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
         A.CallTo(() =>
                 _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
             )
-            .MustNotHaveHappened();
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorRequest>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(
+                Task.FromResult<RelationalWriteExecutorResult>(
+                    new RelationalWriteExecutorResult.Update(
+                        new UpdateResult.UpdateSuccess(
+                            documentUuid,
+                            CreateCommittedReadbackEtag("Namespaced")
+                        )
+                    )
+                )
+            );
+
+        var updateRequest = A.Fake<IRelationalUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet).Returns(CreateNamespaceWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Namespaced"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        await _sut.UpdateDocumentById(updateRequest);
+
+        _capturedExecutorRequests.Should().ContainSingle();
+
+        // PUT always targets an existing document, so both the stored and proposed namespace checks
+        // are threaded; each is a single check at index 0.
+        var storedAuthorization = _capturedExecutorRequest.StoredNamespaceAuthorization;
+        storedAuthorization.Should().NotBeNull();
+        var storedCheck = storedAuthorization!.Checks.Should().ContainSingle().Subject;
+        storedCheck.Index.Should().Be(0);
+        storedCheck.ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Stored);
+
+        var proposedAuthorization = _capturedExecutorRequest.ProposedNamespaceAuthorization;
+        proposedAuthorization.Should().NotBeNull();
+        var proposedCheck = proposedAuthorization!.Checks.Should().ContainSingle().Subject;
+        proposedCheck.Index.Should().Be(0);
+        proposedCheck.ValueSource.Should().Be(NamespaceAuthorizationCheckValueSource.Proposed);
     }
 
     [Test]
@@ -4679,7 +5710,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Be(RelationshipAuthorizationValueSource.Stored);
         _capturedExecutorRequest.ProposedRelationshipAuthorization.Should().NotBeNull();
         _capturedExecutorRequest
-            .ProposedRelationshipAuthorization!.CheckSpecs.Should()
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.Authorized>()
+            .Which.CheckSpecs.Should()
             .ContainSingle()
             .Which.ValueSource.Should()
             .Be(RelationshipAuthorizationValueSource.Proposed);
@@ -5275,7 +6308,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var documentUuid = new DocumentUuid(Guid.NewGuid());
@@ -5331,7 +6365,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var upsertRequest = A.Fake<IRelationalUpsertRequest>();
@@ -5370,7 +6405,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var documentUuid = new DocumentUuid(Guid.NewGuid());
@@ -5426,7 +6462,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var updateRequest = A.Fake<IRelationalUpdateRequest>();
@@ -5443,6 +6480,134 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         result.Should().BeOfType<UpdateResult.UpdateSuccess>();
         capturedRequest.WritePrecondition.Should().Be(expectedWritePrecondition);
+    }
+
+    [Test]
+    public async Task It_forwards_authorization_strategies_and_relational_authorization_context_to_the_descriptor_post_handler()
+    {
+        var descriptorHandler = A.Fake<IDescriptorWriteHandler>();
+        var expectedDocumentUuid = new DocumentUuid(Guid.NewGuid());
+        var expectedTraceId = new TraceId("descriptor-post-forwarding");
+        var expectedMappingSet = CreateDescriptorOnlyMappingSet(_descriptorResourceInfo);
+        AuthorizationStrategyEvaluator[] expectedAuthorizationStrategyEvaluators =
+        [
+            CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+        ];
+        var expectedAuthorizationContext = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+        DescriptorWriteRequest capturedRequest = null!;
+
+        A.CallTo(() => descriptorHandler.HandlePostAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
+            .Invokes(call => capturedRequest = call.GetArgument<DescriptorWriteRequest>(0)!)
+            .Returns(new UpsertResult.InsertSuccess(expectedDocumentUuid, "\"descriptor-etag\""));
+
+        _sut = new RelationalDocumentStoreRepository(
+            NullLogger<RelationalDocumentStoreRepository>.Instance,
+            _writeExecutor,
+            _targetLookupService,
+            _currentEtagPreconditionChecker,
+            descriptorHandler,
+            _descriptorReadHandler,
+            _referenceResolver,
+            _documentHydrator,
+            _readTargetLookupService,
+            _readMaterializer,
+            _readableProfileProjector,
+            _writeExceptionClassifier,
+            _deleteConstraintResolver,
+            _writeSessionFactory,
+            CreateAuthorizationSubjectSelector(),
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
+        );
+
+        var upsertRequest = A.Fake<IRelationalUpsertRequest>();
+        A.CallTo(() => upsertRequest.ResourceInfo).Returns(_descriptorResourceInfo);
+        A.CallTo(() => upsertRequest.MappingSet).Returns(expectedMappingSet);
+        A.CallTo(() => upsertRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => upsertRequest.DocumentUuid).Returns(expectedDocumentUuid);
+        A.CallTo(() => upsertRequest.EdfiDoc).Returns(CreateDescriptorRequestBody());
+        A.CallTo(() => upsertRequest.TraceId).Returns(expectedTraceId);
+        A.CallTo(() => upsertRequest.WritePrecondition).Returns(new WritePrecondition.None());
+        A.CallTo(() => upsertRequest.AuthorizationStrategyEvaluators)
+            .Returns(expectedAuthorizationStrategyEvaluators);
+        A.CallTo(() => upsertRequest.AuthorizationContext).Returns(expectedAuthorizationContext);
+
+        var result = await _sut.UpsertDocument(upsertRequest);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        capturedRequest.MappingSet.Should().BeSameAs(expectedMappingSet);
+        capturedRequest.DocumentUuid.Should().Be(expectedDocumentUuid);
+        capturedRequest.TraceId.Value.Should().Be(expectedTraceId.Value);
+        capturedRequest
+            .AuthorizationStrategyEvaluators.Should()
+            .BeSameAs(expectedAuthorizationStrategyEvaluators);
+        capturedRequest.RelationalAuthorizationContext.Should().BeSameAs(expectedAuthorizationContext);
+        A.CallTo(() => descriptorHandler.HandlePostAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_forwards_authorization_strategies_and_relational_authorization_context_to_the_descriptor_put_handler()
+    {
+        var descriptorHandler = A.Fake<IDescriptorWriteHandler>();
+        var expectedDocumentUuid = new DocumentUuid(Guid.NewGuid());
+        var expectedTraceId = new TraceId("descriptor-put-forwarding");
+        var expectedMappingSet = CreateDescriptorOnlyMappingSet(_descriptorResourceInfo);
+        AuthorizationStrategyEvaluator[] expectedAuthorizationStrategyEvaluators =
+        [
+            CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+        ];
+        var expectedAuthorizationContext = new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]);
+        DescriptorWriteRequest capturedRequest = null!;
+
+        A.CallTo(() => descriptorHandler.HandlePutAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
+            .Invokes(call => capturedRequest = call.GetArgument<DescriptorWriteRequest>(0)!)
+            .Returns(new UpdateResult.UpdateSuccess(expectedDocumentUuid, "\"descriptor-etag\""));
+
+        _sut = new RelationalDocumentStoreRepository(
+            NullLogger<RelationalDocumentStoreRepository>.Instance,
+            _writeExecutor,
+            _targetLookupService,
+            _currentEtagPreconditionChecker,
+            descriptorHandler,
+            _descriptorReadHandler,
+            _referenceResolver,
+            _documentHydrator,
+            _readTargetLookupService,
+            _readMaterializer,
+            _readableProfileProjector,
+            _writeExceptionClassifier,
+            _deleteConstraintResolver,
+            _writeSessionFactory,
+            CreateAuthorizationSubjectSelector(),
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
+        );
+
+        var updateRequest = A.Fake<IRelationalUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_descriptorResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet).Returns(expectedMappingSet);
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(expectedDocumentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateDescriptorRequestBody("Updated Charter"));
+        A.CallTo(() => updateRequest.TraceId).Returns(expectedTraceId);
+        A.CallTo(() => updateRequest.WritePrecondition).Returns(new WritePrecondition.None());
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns(expectedAuthorizationStrategyEvaluators);
+        A.CallTo(() => updateRequest.AuthorizationContext).Returns(expectedAuthorizationContext);
+
+        var result = await _sut.UpdateDocumentById(updateRequest);
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        capturedRequest.MappingSet.Should().BeSameAs(expectedMappingSet);
+        capturedRequest.DocumentUuid.Should().Be(expectedDocumentUuid);
+        capturedRequest.TraceId.Value.Should().Be(expectedTraceId.Value);
+        capturedRequest
+            .AuthorizationStrategyEvaluators.Should()
+            .BeSameAs(expectedAuthorizationStrategyEvaluators);
+        capturedRequest.RelationalAuthorizationContext.Should().BeSameAs(expectedAuthorizationContext);
+        A.CallTo(() => descriptorHandler.HandlePutAsync(A<DescriptorWriteRequest>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
     }
 
     [Test]
@@ -5514,7 +6679,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var deleteRequest = A.Fake<IRelationalDeleteRequest>();
@@ -5574,7 +6740,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
 
         var deleteRequest = A.Fake<IRelationalDeleteRequest>();
@@ -5647,7 +6814,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
             _deleteConstraintResolver,
             _writeSessionFactory,
             CreateAuthorizationSubjectSelector(),
-            _singleRecordRelationshipAuthorizationExecutor
+            _singleRecordRelationshipAuthorizationExecutor,
+            _namespaceAuthorizationExecutor
         );
         ConfigureResolvedDocument(documentId: 123L, documentUuid: new DocumentUuid(Guid.NewGuid()));
         ConfigureDeleteOutcome(deleted: true);
@@ -5681,16 +6849,49 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_not_implemented_for_delete_namespace_authorization_until_the_strategy_is_implemented()
+    public async Task It_deletes_when_stored_namespace_matches_a_prefix_without_if_match()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        RelationalCommand capturedNamespaceCommand = null!;
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.Authorized(),
+            command => capturedNamespaceCommand = command
+        );
+        ConfigureDeleteOutcome(deleted: true);
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        // The stored namespace check parameterizes the locked target document id, proving it runs
+        // against the same locked target inside the delete write session.
+        capturedNamespaceCommand.Should().NotBeNull();
+        capturedNamespaceCommand.Parameters.Should().Contain(parameter => Equals(parameter.Value, 345L));
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_deletes_when_stored_namespace_matches_a_prefix_with_if_match()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var writePrecondition = new WritePrecondition.IfMatch("\"current-etag\"");
-        var mappingSet = CreateSupportedMappingSet(_schoolResourceInfo);
-        ConfigureResolvedDocument(documentId: 123L, documentUuid);
-        ConfigureDeleteThrows(new InvalidOperationException("DELETE should not execute for staged auth."));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(new NamespaceAuthorizationExecutionResult.Authorized());
+        ConfigureDeleteOutcome(deleted: true);
         _currentEtagPreconditionChecker.ResultToReturn = CreateDeletePreconditionCheckResult(
             documentUuid,
-            123L,
+            345L,
             isMatch: true
         );
 
@@ -5699,85 +6900,318 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Returns([
                 CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
             ]);
-
-        var result = await _sut.DeleteDocumentById(deleteRequest);
-
-        result.Should().BeOfType<DeleteResult.DeleteFailureNotImplemented>();
-        result
-            .As<DeleteResult.DeleteFailureNotImplemented>()
-            .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.NamespaceBased);
-        _writeSessionFactory.CreateAsyncCallCount.Should().Be(1);
-        _currentEtagPreconditionChecker.CallCount.Should().Be(0);
-        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
-        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
-    }
-
-    [Test]
-    public async Task It_keeps_people_delete_relationship_authorization_staged_before_single_record_execution()
-    {
-        var documentUuid = new DocumentUuid(Guid.NewGuid());
-        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
-        ConfigureResolvedDocument(documentId: 123L, documentUuid);
-        ConfigureDeleteThrows(new InvalidOperationException("DELETE should not execute for staged auth."));
-
-        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
-        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
-            .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-            ]);
         A.CallTo(() => deleteRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901L]));
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureNotImplemented>().Subject;
-        failure
-            .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople)
-            .And.Contain("single-record EdOrg-only relationship execution boundary");
-        A.CallTo(_commandExecutor)
-            .WithReturnType<Task<SingleRecordRelationshipAuthorizationExecutionResult>>()
-            .MustNotHaveHappened();
-        _currentEtagPreconditionChecker.CallCount.Should().Be(0);
-        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
-        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        _currentEtagPreconditionChecker.CallCount.Should().Be(1);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(0);
     }
 
     [Test]
-    public async Task It_returns_delete_security_configuration_failure_before_people_relationship_staging()
+    public async Task It_returns_namespace_mismatch_403_and_does_not_delete_without_if_match()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
-        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
-        ConfigureResolvedDocument(documentId: 123L, documentUuid);
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+        );
         ConfigureDeleteThrows(
-            new InvalidOperationException("DELETE should not execute for invalid auth metadata.")
+            new InvalidOperationException("DELETE should not execute on namespace denial.")
         );
 
         var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
         A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
             .Returns([
-                CreateAuthorizationStrategyEvaluator(
-                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople
-                ),
-                CreateAuthorizationStrategyEvaluator("CustomAuthorizationStrategy"),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
             ]);
         A.CallTo(() => deleteRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext([255901L]));
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/", "uri://gbisd.edu/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>().Subject;
+        failure.NamespaceFailure.Should().BeSameAs(namespaceFailure);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_namespace_uninitialized_403_and_does_not_delete()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+        );
+        ConfigureDeleteThrows(
+            new InvalidOperationException("DELETE should not execute on namespace denial.")
+        );
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_403_not_412_when_stored_namespace_denies_even_with_stale_if_match()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var writePrecondition = new WritePrecondition.IfMatch("\"stale-etag\"");
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+        );
+        ConfigureDeleteThrows(
+            new InvalidOperationException("DELETE should not execute on namespace denial.")
+        );
+        _currentEtagPreconditionChecker.ResultToReturn = CreateDeletePreconditionCheckResult(
+            documentUuid,
+            345L,
+            isMatch: false
+        );
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, writePrecondition, documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
+        _currentEtagPreconditionChecker.CallCount.Should().Be(0);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_returns_no_prefixes_403_without_creating_the_write_session_for_delete()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], []));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>().Subject;
+        failure
+            .NamespaceFailure.FailureKind.Should()
+            .Be(NamespaceAuthorizationFailureKind.NoPrefixesConfigured);
+        failure.NamespaceFailure.StrategyName.Should().Be(AuthorizationStrategyNameConstants.NamespaceBased);
+        _writeSessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_500_when_no_usable_root_namespace_column_for_delete()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
         var failure = result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>().Subject;
-        failure.Errors.Should().ContainSingle();
-        failure.Errors[0].Should().Contain("CustomAuthorizationStrategy");
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("Ed-Fi.School")
+            .And.Contain("NamespaceBased")
+            .And.Contain("no Namespace securable element resolves to a root table column");
+        _writeSessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_500_when_mssql_namespace_prefix_cap_is_exceeded_for_delete()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var pgsqlMappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var mappingSet = pgsqlMappingSet with
+        {
+            Key = pgsqlMappingSet.Key with { Dialect = SqlDialect.Mssql },
+        };
+        string[] tooManyPrefixes = [.. Enumerable.Range(0, 2000).Select(index => $"uri://prefix-{index}/")];
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], tooManyPrefixes));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        var failure = result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("2000 namespace prefixes")
+            .And.Contain("exceeds the SQL Server limit");
+        _writeSessionFactory.CreateAsyncCallCount.Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_fails_closed_with_unknown_failure_when_namespace_auth1_is_malformed_and_does_not_delete()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+            )
+        );
+        ConfigureDeleteThrows(new InvalidOperationException("DELETE should not execute on malformed AUTH1."));
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.UnknownFailure>();
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_does_not_run_relationship_authorization_for_delete_when_namespace_denies()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var namespaceFailure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure)
+        );
+        ConfigureDeleteThrows(
+            new InvalidOperationException("DELETE should not execute on namespace denial.")
+        );
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901L], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>();
         A.CallTo(_commandExecutor)
             .WithReturnType<Task<SingleRecordRelationshipAuthorizationExecutionResult>>()
             .MustNotHaveHappened();
-        _currentEtagPreconditionChecker.CallCount.Should().Be(0);
-        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [Test]
+    public async Task It_runs_relationship_authorization_for_delete_after_namespace_authorizes()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var mappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var order = 0;
+        var namespaceOrder = 0;
+        var relationshipOrder = 0;
+        ConfigureResolvedDocument(documentId: 345L, documentUuid);
+        ConfigureDeleteNamespaceAuthorization(
+            new NamespaceAuthorizationExecutionResult.Authorized(),
+            _ => namespaceOrder = ++order
+        );
+        ConfigureDeleteRelationshipAuthorization(
+            new SingleRecordRelationshipAuthorizationExecutionResult.Authorized(42L),
+            _ => relationshipOrder = ++order
+        );
+        ConfigureDeleteOutcome(deleted: true);
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(mappingSet, documentUuid: documentUuid);
+        A.CallTo(() => deleteRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ]);
+        A.CallTo(() => deleteRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([255901L], ["uri://ed-fi.org/"]));
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        namespaceOrder.Should().Be(1);
+        relationshipOrder.Should().Be(2);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(1);
     }
 
     [Test]
@@ -6007,7 +7441,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_returns_not_implemented_when_delete_authorization_includes_known_out_of_scope_strategies()
+    public async Task It_returns_not_implemented_when_delete_authorization_includes_a_still_unsupported_strategy()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var mappingSet = CreateQuerySupportedMappingSetWithRootEdOrgSubject(_schoolResourceInfo);
@@ -6020,7 +7454,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 CreateAuthorizationStrategyEvaluator(
                     AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
                 ),
-                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.OwnershipBased),
             ]);
         A.CallTo(() => deleteRequest.AuthorizationContext)
             .Returns(new RelationalAuthorizationContext([255901L]));
@@ -6031,7 +7465,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
         result
             .As<DeleteResult.DeleteFailureNotImplemented>()
             .FailureMessage.Should()
-            .Contain(AuthorizationStrategyNameConstants.NamespaceBased);
+            .Contain(AuthorizationStrategyNameConstants.OwnershipBased);
         _currentEtagPreconditionChecker.CallCount.Should().Be(0);
         A.CallTo(_commandExecutor)
             .WithReturnType<Task<SingleRecordRelationshipAuthorizationExecutionResult>>()
@@ -7136,6 +8570,21 @@ public class Given_RelationalDocumentStoreRepositoryTests
         call.Returns(Task.FromResult(result));
     }
 
+    private void ConfigureDeleteNamespaceAuthorization(
+        NamespaceAuthorizationExecutionResult result,
+        Action<RelationalCommand>? callback = null
+    )
+    {
+        var call = A.CallTo(_commandExecutor).WithReturnType<Task<NamespaceAuthorizationExecutionResult>>();
+
+        if (callback is not null)
+        {
+            call.Invokes(fakeCall => callback(fakeCall.GetArgument<RelationalCommand>(0)!));
+        }
+
+        call.Returns(Task.FromResult(result));
+    }
+
     private sealed record CapturedDeleteEtagPreconditionRequest(
         MappingSet MappingSet,
         ResourceReadPlan ReadPlan,
@@ -7268,7 +8717,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         RelationalGetRequestReadMode readMode = RelationalGetRequestReadMode.ExternalResponse,
         ReadableProfileProjectionContext? readableProfileProjectionContext = null,
         AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
-        IReadOnlyList<long>? claimEducationOrganizationIds = null
+        IReadOnlyList<long>? claimEducationOrganizationIds = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         var getRequest = A.Fake<IRelationalGetRequest>();
@@ -7289,7 +8739,12 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => getRequest.AuthorizationStrategyEvaluators)
             .Returns(authorizationStrategyEvaluators ?? []);
         A.CallTo(() => getRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext(claimEducationOrganizationIds ?? []));
+            .Returns(
+                new RelationalAuthorizationContext(
+                    claimEducationOrganizationIds ?? [],
+                    namespacePrefixes ?? []
+                )
+            );
 
         return getRequest;
     }
@@ -7335,91 +8790,6 @@ public class Given_RelationalDocumentStoreRepositoryTests
                             ],
                             Hint: "No matching relationship authorization row was found for the subject value and claim EducationOrganizationIds."
                         ),
-                    ]
-                ),
-            ],
-            ClaimEducationOrganizationIds: [new EducationOrganizationId(255901)]
-        );
-
-    private static RelationshipAuthorizationFailure CreateMixedAuthObjectRelationshipFailure() =>
-        new(
-            RelationshipAuthorizationFailureValueSource.Stored,
-            EmittedAuth1Index: 0,
-            FailedStrategies:
-            [
-                new RelationshipAuthorizationFailedStrategy(
-                    ConfiguredStrategyIndex: 0,
-                    RelationshipLocalOrder: 0,
-                    StrategyName: AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople,
-                    StrategyKind: AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople,
-                    AuthObject: null,
-                    FailedSubjects:
-                    [
-                        new RelationshipAuthorizationFailedSubject(
-                            SubjectIndex: 0,
-                            FailureKind: RelationshipAuthorizationSubjectFailureKind.NoRelationship,
-                            RootBinding: new RelationshipAuthorizationRootBinding(
-                                "Ed-Fi.School",
-                                "edfi.School",
-                                "SchoolId"
-                            ),
-                            AuthObject: new RelationshipAuthorizationAuthObjectInfo(
-                                "auth.EducationOrganizationIdToEducationOrganizationId",
-                                "TargetEducationOrganizationId",
-                                "SourceEducationOrganizationId"
-                            ),
-                            SecurableElements:
-                            [
-                                new RelationshipAuthorizationSecurableElement(
-                                    "EducationOrganization",
-                                    "$.schoolId",
-                                    "SchoolId"
-                                ),
-                            ]
-                        ),
-                        new RelationshipAuthorizationFailedSubject(
-                            SubjectIndex: 1,
-                            FailureKind: RelationshipAuthorizationSubjectFailureKind.NoRelationship,
-                            RootBinding: new RelationshipAuthorizationRootBinding(
-                                "Ed-Fi.StudentSchoolAssociation",
-                                "edfi.StudentSchoolAssociation",
-                                "Student_DocumentId"
-                            ),
-                            AuthObject: new RelationshipAuthorizationAuthObjectInfo(
-                                "auth.EducationOrganizationIdToStudentDocumentId",
-                                "Student_DocumentId",
-                                "SourceEducationOrganizationId"
-                            ),
-                            SecurableElements:
-                            [
-                                new RelationshipAuthorizationSecurableElement(
-                                    "Student",
-                                    "$.studentReference.studentUniqueId",
-                                    "StudentUniqueId"
-                                ),
-                            ]
-                        )
-                        {
-                            PersonSubject = new RelationshipAuthorizationPersonSubjectInfo(
-                                PersonKind: "Student",
-                                PathKind: "DirectRootColumn",
-                                DocumentIdPath:
-                                [
-                                    new RelationshipAuthorizationPersonDocumentIdPathStepInfo(
-                                        "edfi.StudentSchoolAssociation",
-                                        "Student_DocumentId",
-                                        TargetTableName: null,
-                                        TargetColumnName: null
-                                    ),
-                                ],
-                                StoredAnchor: new RelationshipAuthorizationPersonStoredAnchorInfo(
-                                    "edfi.StudentSchoolAssociation",
-                                    "DocumentId"
-                                ),
-                                ProposedAnchor: null,
-                                Hint: "You may need to create a corresponding 'StudentSchoolAssociation' item."
-                            ),
-                        },
                     ]
                 ),
             ],
@@ -7775,6 +9145,112 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
     }
 
+    private static MappingSet CreateNamespaceWriteMappingSet(
+        ResourceInfo resourceInfo,
+        SqlDialect dialect = SqlDialect.Pgsql
+    )
+    {
+        var resourceKey = CreateResourceKeyEntry(resourceInfo);
+        var rootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+        var rootPlan = new TableWritePlan(
+            rootTable,
+            InsertSql: "insert into edfi.\"School\" values (@DocumentId, @Namespace)",
+            UpdateSql: "update edfi.\"School\" set \"Namespace\" = @Namespace where \"DocumentId\" = @DocumentId",
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
+            ColumnBindings:
+            [
+                new WriteColumnBinding(rootTable.Columns[0], new WriteValueSource.DocumentId(), "DocumentId"),
+                new WriteColumnBinding(
+                    rootTable.Columns[1],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.namespace", []),
+                        new RelationalScalarType(ScalarKind.String, MaxLength: 306)
+                    ),
+                    "Namespace"
+                ),
+            ],
+            KeyUnificationPlans: []
+        );
+        var resourceModel = CreateRelationalResourceModel(
+            resourceKey,
+            rootTable,
+            ResourceStorageKind.RelationalTables
+        );
+        var concreteResourceModel = new ConcreteResourceModel(
+            resourceKey,
+            ResourceStorageKind.RelationalTables,
+            resourceModel
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], ["$.namespace"], [], [], []),
+        };
+        var writePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var readPlan = CreateReadPlan(resourceModel, rootTable);
+
+        return new MappingSet(
+            Key: new MappingSetKey("schema-hash", dialect, "v1"),
+            Model: CreateDerivedModelSet(concreteResourceModel),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>
+            {
+                [resourceKey.Resource] = writePlan,
+            },
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>
+            {
+                [resourceKey.Resource] = readPlan,
+            },
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>
+            {
+                [resourceKey.Resource] = resourceKey.ResourceKeyId,
+            },
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>
+            {
+                [resourceKey.ResourceKeyId] = resourceKey,
+            },
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+    }
+
     private static MappingSet CreateAuthorizationAwareMappingSetWithSelfStudentSubject(
         ResourceInfo resourceInfo,
         SqlDialect dialect = SqlDialect.Pgsql
@@ -8026,120 +9502,133 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
     }
 
-    private static MappingSet CreateWriteAuthorizationAwareMappingSetWithUnboundStudentSubject(
-        ResourceInfo resourceInfo
+    private static MappingSet CreateNamespaceAndRelationshipWriteMappingSet(
+        ResourceInfo resourceInfo,
+        SqlDialect dialect = SqlDialect.Pgsql
     )
     {
-        const string studentPath = "$.studentReference.studentUniqueId";
         var resourceKey = CreateResourceKeyEntry(resourceInfo);
-        var studentDocumentIdColumn = AuthNames.StudentDocumentId;
-        var rootTable = CreateRootTableModel(
-            resourceInfo.ResourceName.Value,
+        var rootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
             [
                 new DbColumnModel(
-                    studentDocumentIdColumn,
-                    ColumnKind.DocumentFk,
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
                     new RelationalScalarType(ScalarKind.Int64),
                     false,
-                    new JsonPathExpression(studentPath, []),
-                    new QualifiedResourceName("Ed-Fi", "Student"),
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("Name"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.String, MaxLength: 75),
-                    false,
-                    new JsonPathExpression("$.name", []),
+                    null,
                     null,
                     new ColumnStorage.Stored()
                 ),
-            ]
-        );
-        var resourceModel = new RelationalResourceModel(
-            resourceKey.Resource,
-            new DbSchemaName("edfi"),
-            ResourceStorageKind.RelationalTables,
-            rootTable,
-            [rootTable],
-            [
-                new DocumentReferenceBinding(
-                    true,
-                    new JsonPathExpression("$.studentReference", []),
-                    rootTable.Table,
-                    studentDocumentIdColumn,
-                    new QualifiedResourceName("Ed-Fi", "Student"),
-                    [
-                        new ReferenceIdentityBinding(
-                            new JsonPathExpression(studentPath, []),
-                            new JsonPathExpression(studentPath, []),
-                            new DbColumnName("StudentUniqueId")
-                        ),
-                    ]
+                new DbColumnModel(
+                    new DbColumnName("SchoolId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    new JsonPathExpression("$.schoolId", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null,
+                    new ColumnStorage.Stored()
                 ),
             ],
             []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+        var rootPlan = new TableWritePlan(
+            rootTable,
+            InsertSql: "insert into edfi.\"School\" values (@DocumentId, @SchoolId, @Namespace)",
+            UpdateSql: "update edfi.\"School\" set \"Namespace\" = @Namespace where \"DocumentId\" = @DocumentId",
+            DeleteByParentSql: null,
+            BulkInsertBatching: new BulkInsertBatchingInfo(100, 3, 1000),
+            ColumnBindings:
+            [
+                new WriteColumnBinding(rootTable.Columns[0], new WriteValueSource.DocumentId(), "DocumentId"),
+                new WriteColumnBinding(
+                    rootTable.Columns[1],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.schoolId", []),
+                        new RelationalScalarType(ScalarKind.Int64)
+                    ),
+                    "SchoolId"
+                ),
+                new WriteColumnBinding(
+                    rootTable.Columns[2],
+                    new WriteValueSource.Scalar(
+                        new JsonPathExpression("$.namespace", []),
+                        new RelationalScalarType(ScalarKind.String, MaxLength: 306)
+                    ),
+                    "Namespace"
+                ),
+            ],
+            KeyUnificationPlans: []
         );
-        var concreteResource = new ConcreteResourceModel(
+        var resourceModel = CreateRelationalResourceModel(
+            resourceKey,
+            rootTable,
+            ResourceStorageKind.RelationalTables
+        );
+        var concreteResourceModel = new ConcreteResourceModel(
             resourceKey,
             ResourceStorageKind.RelationalTables,
             resourceModel
         )
         {
-            SecurableElements = new ResourceSecurableElements([], [], [studentPath], [], []),
+            SecurableElements = new ResourceSecurableElements(
+                [new EdOrgSecurableElement("$.schoolId", "SchoolId")],
+                ["$.namespace"],
+                [],
+                [],
+                []
+            ),
         };
-        var concreteResources = new List<ConcreteResourceModel>
-        {
-            concreteResource,
-            CreateMinimalConcreteResource(2, "Student"),
-        };
-        concreteResources.AddRange(CreateRequiredPeopleAuthAssociationResources(3));
+        var writePlan = new ResourceWritePlan(resourceModel, [rootPlan]);
+        var readPlan = CreateReadPlan(resourceModel, rootTable);
 
-        var documentIdColumn = rootTable.Columns.Single(static column =>
-            column.ColumnName.Value == "DocumentId"
+        return new MappingSet(
+            Key: new MappingSetKey("schema-hash", dialect, "v1"),
+            Model: CreateDerivedModelSet(concreteResourceModel),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>
+            {
+                [resourceKey.Resource] = writePlan,
+            },
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>
+            {
+                [resourceKey.Resource] = readPlan,
+            },
+            ResourceKeyIdByResource: new Dictionary<QualifiedResourceName, short>
+            {
+                [resourceKey.Resource] = resourceKey.ResourceKeyId,
+            },
+            ResourceKeyById: new Dictionary<short, ResourceKeyEntry>
+            {
+                [resourceKey.ResourceKeyId] = resourceKey,
+            },
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
         );
-        var nameColumn = rootTable.Columns.Single(static column => column.ColumnName.Value == "Name");
-        var writePlan = new ResourceWritePlan(
-            resourceModel,
-            [
-                new TableWritePlan(
-                    rootTable,
-                    InsertSql: "",
-                    UpdateSql: null,
-                    DeleteByParentSql: null,
-                    BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
-                    ColumnBindings:
-                    [
-                        new WriteColumnBinding(
-                            documentIdColumn,
-                            new WriteValueSource.DocumentId(),
-                            "DocumentId"
-                        ),
-                        new WriteColumnBinding(
-                            nameColumn,
-                            new WriteValueSource.Scalar(
-                                new JsonPathExpression("$.name", []),
-                                new RelationalScalarType(ScalarKind.String, MaxLength: 75)
-                            ),
-                            "Name"
-                        ),
-                    ],
-                    KeyUnificationPlans: []
-                ),
-            ]
-        );
-
-        var mappingSet = CreateMappingSet(
-            resourceKey.Resource,
-            concreteResources,
-            writePlan,
-            CreateReadPlan(resourceModel, rootTable)
-        );
-
-        return mappingSet with
-        {
-            Model = mappingSet.Model with { AuthEdOrgHierarchy = CreateAuthEdOrgHierarchy() },
-        };
     }
 
     private static MappingSet CreateProfileProjectionOrderSensitiveMappingSet(ResourceInfo resourceInfo)
@@ -8548,6 +10037,134 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
     }
 
+    private static MappingSet CreateNamespaceAuthorizationMappingSet(ResourceInfo resourceInfo)
+    {
+        var resourceKey = CreateResourceKeyEntry(resourceInfo);
+        var rootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        var resourceModel = new RelationalResourceModel(
+            Resource: resourceKey.Resource,
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+
+        return CreateAuthorizationAwareQuerySupportedMappingSet(
+            resourceInfo,
+            resourceModel,
+            new ResourceSecurableElements([], ["$.namespace"], [], [], [])
+        );
+    }
+
+    private static MappingSet CreateNamespaceAndRootEdOrgMappingSet(ResourceInfo resourceInfo)
+    {
+        var resourceKey = CreateResourceKeyEntry(resourceInfo);
+        var rootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("LocalEducationAgencyId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    new JsonPathExpression("$.localEducationAgencyId", []),
+                    null
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Namespace"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 306),
+                    false,
+                    new JsonPathExpression("$.namespace", []),
+                    null
+                ),
+            ],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+
+        var resourceModel = new RelationalResourceModel(
+            Resource: resourceKey.Resource,
+            PhysicalSchema: new DbSchemaName("edfi"),
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources: []
+        );
+
+        return CreateAuthorizationAwareQuerySupportedMappingSet(
+            resourceInfo,
+            resourceModel,
+            new ResourceSecurableElements(
+                [new EdOrgSecurableElement("$.localEducationAgencyId", "LocalEducationAgencyId")],
+                ["$.namespace"],
+                [],
+                [],
+                []
+            )
+        );
+    }
+
     private static MappingSet CreateAuthorizationAwareQuerySupportedMappingSet(
         ResourceInfo resourceInfo,
         RelationalResourceModel resourceModel,
@@ -8763,7 +10380,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
         AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
         ReadableProfileProjectionContext? readableProfileProjectionContext = null,
         IReadOnlyList<long>? claimEducationOrganizationIds = null,
-        ResourceInfo? resourceInfo = null
+        ResourceInfo? resourceInfo = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         authorizationStrategyEvaluators ??= [];
@@ -8775,7 +10393,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => queryRequest.MappingSet).Returns(mappingSet);
         A.CallTo(() => queryRequest.QueryElements).Returns(queryElements);
         A.CallTo(() => queryRequest.AuthorizationContext)
-            .Returns(new RelationalAuthorizationContext(claimEducationOrganizationIds));
+            .Returns(
+                new RelationalAuthorizationContext(claimEducationOrganizationIds, namespacePrefixes ?? [])
+            );
         A.CallTo(() => queryRequest.AuthorizationSecurableInfo)
             .Returns(Array.Empty<AuthorizationSecurableInfo>());
         A.CallTo(() => queryRequest.AuthorizationStrategyEvaluators).Returns(authorizationStrategyEvaluators);
@@ -8788,6 +10408,91 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .Returns(readableProfileProjectionContext);
         return queryRequest;
     }
+
+    private static RelationshipAuthorizationFailure CreateMixedAuthObjectRelationshipFailure() =>
+        new(
+            RelationshipAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            FailedStrategies:
+            [
+                new RelationshipAuthorizationFailedStrategy(
+                    ConfiguredStrategyIndex: 0,
+                    RelationshipLocalOrder: 0,
+                    StrategyName: AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople,
+                    StrategyKind: AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsAndPeople,
+                    AuthObject: null,
+                    FailedSubjects:
+                    [
+                        new RelationshipAuthorizationFailedSubject(
+                            SubjectIndex: 0,
+                            FailureKind: RelationshipAuthorizationSubjectFailureKind.NoRelationship,
+                            RootBinding: new RelationshipAuthorizationRootBinding(
+                                "Ed-Fi.School",
+                                "edfi.School",
+                                "SchoolId"
+                            ),
+                            AuthObject: new RelationshipAuthorizationAuthObjectInfo(
+                                "auth.EducationOrganizationIdToEducationOrganizationId",
+                                "TargetEducationOrganizationId",
+                                "SourceEducationOrganizationId"
+                            ),
+                            SecurableElements:
+                            [
+                                new RelationshipAuthorizationSecurableElement(
+                                    "EducationOrganization",
+                                    "$.schoolId",
+                                    "SchoolId"
+                                ),
+                            ]
+                        ),
+                        new RelationshipAuthorizationFailedSubject(
+                            SubjectIndex: 1,
+                            FailureKind: RelationshipAuthorizationSubjectFailureKind.NoRelationship,
+                            RootBinding: new RelationshipAuthorizationRootBinding(
+                                "Ed-Fi.StudentSchoolAssociation",
+                                "edfi.StudentSchoolAssociation",
+                                "Student_DocumentId"
+                            ),
+                            AuthObject: new RelationshipAuthorizationAuthObjectInfo(
+                                "auth.EducationOrganizationIdToStudentDocumentId",
+                                "Student_DocumentId",
+                                "SourceEducationOrganizationId"
+                            ),
+                            SecurableElements:
+                            [
+                                new RelationshipAuthorizationSecurableElement(
+                                    "Student",
+                                    "$.studentReference.studentUniqueId",
+                                    "StudentUniqueId"
+                                ),
+                            ]
+                        )
+                        {
+                            PersonSubject = new RelationshipAuthorizationPersonSubjectInfo(
+                                PersonKind: "Student",
+                                PathKind: "DirectRootColumn",
+                                DocumentIdPath:
+                                [
+                                    new RelationshipAuthorizationPersonDocumentIdPathStepInfo(
+                                        "edfi.StudentSchoolAssociation",
+                                        "Student_DocumentId",
+                                        TargetTableName: null,
+                                        TargetColumnName: null
+                                    ),
+                                ],
+                                StoredAnchor: new RelationshipAuthorizationPersonStoredAnchorInfo(
+                                    "edfi.StudentSchoolAssociation",
+                                    "DocumentId"
+                                ),
+                                ProposedAnchor: null,
+                                Hint: "You may need to create a corresponding 'StudentSchoolAssociation' item."
+                            ),
+                        },
+                    ]
+                ),
+            ],
+            ClaimEducationOrganizationIds: [new EducationOrganizationId(255901)]
+        );
 
     private static AuthorizationStrategyEvaluator CreateAuthorizationStrategyEvaluator(
         string authorizationStrategyName
@@ -8857,120 +10562,6 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
     }
 
-    private static ResourceKeyEntry CreateResourceKeyEntry(short resourceKeyId, string resourceName) =>
-        new(resourceKeyId, new QualifiedResourceName("Ed-Fi", resourceName), "1.0.0", false);
-
-    private static DbTableModel CreateRootTableModel(
-        string tableName,
-        IReadOnlyList<DbColumnModel>? columns = null
-    )
-    {
-        var documentIdColumn = new DbColumnModel(
-            new DbColumnName("DocumentId"),
-            ColumnKind.ParentKeyPart,
-            new RelationalScalarType(ScalarKind.Int64),
-            false,
-            null,
-            null,
-            new ColumnStorage.Stored()
-        );
-
-        return new DbTableModel(
-            new DbTableName(new DbSchemaName("edfi"), tableName),
-            new JsonPathExpression("$", []),
-            new TableKey(
-                $"PK_{tableName}",
-                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
-            ),
-            [documentIdColumn, .. (columns ?? [])],
-            []
-        )
-        {
-            IdentityMetadata = new DbTableIdentityMetadata(
-                DbTableKind.Root,
-                [new DbColumnName("DocumentId")],
-                [new DbColumnName("DocumentId")],
-                [],
-                []
-            ),
-        };
-    }
-
-    private static ConcreteResourceModel CreateMinimalConcreteResource(
-        short resourceKeyId,
-        string resourceName
-    )
-    {
-        var resourceKey = CreateResourceKeyEntry(resourceKeyId, resourceName);
-        var rootTable = CreateRootTableModel(resourceName);
-        var resourceModel = CreateRelationalResourceModel(
-            resourceKey,
-            rootTable,
-            ResourceStorageKind.RelationalTables
-        );
-
-        return new ConcreteResourceModel(resourceKey, ResourceStorageKind.RelationalTables, resourceModel)
-        {
-            SecurableElements = ResourceSecurableElements.Empty,
-        };
-    }
-
-    private static IReadOnlyList<ConcreteResourceModel> CreateRequiredPeopleAuthAssociationResources(
-        short firstResourceKeyId
-    ) =>
-        [
-            .. AuthObjectDefinitions.RequiredPeopleAuthAssociationResourceNames.Select(
-                (resourceName, index) =>
-                    CreateMinimalConcreteResource((short)(firstResourceKeyId + index), resourceName)
-            ),
-        ];
-
-    private static AuthEdOrgHierarchy CreateAuthEdOrgHierarchy() =>
-        new([
-            new AuthEdOrgEntity(
-                "School",
-                new DbTableName(new DbSchemaName("edfi"), "School"),
-                new DbColumnName("SchoolId"),
-                []
-            ),
-        ]);
-
-    private static MappingSet CreateMappingSet(
-        QualifiedResourceName requestResource,
-        IReadOnlyList<ConcreteResourceModel> concreteResources,
-        ResourceWritePlan writePlan,
-        ResourceReadPlan readPlan
-    )
-    {
-        var resourceKeyIdByResource = concreteResources.ToDictionary(
-            static concreteResource => concreteResource.ResourceKey.Resource,
-            static concreteResource => concreteResource.ResourceKey.ResourceKeyId
-        );
-        var resourceKeyById = concreteResources.ToDictionary(
-            static concreteResource => concreteResource.ResourceKey.ResourceKeyId,
-            static concreteResource => concreteResource.ResourceKey
-        );
-
-        return new MappingSet(
-            Key: new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
-            Model: CreateDerivedModelSet(concreteResources),
-            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>
-            {
-                [requestResource] = writePlan,
-            },
-            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>
-            {
-                [requestResource] = readPlan,
-            },
-            ResourceKeyIdByResource: resourceKeyIdByResource,
-            ResourceKeyById: resourceKeyById,
-            SecurableElementColumnPathsByResource: new Dictionary<
-                QualifiedResourceName,
-                IReadOnlyList<ResolvedSecurableElementPath>
-            >()
-        );
-    }
-
     private static DerivedRelationalModelSet CreateDerivedModelSet(
         RelationalResourceModel resourceModel,
         ResourceKeyEntry resourceKey
@@ -8981,47 +10572,29 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
     private static DerivedRelationalModelSet CreateDerivedModelSet(
         ConcreteResourceModel concreteResourceModel
-    ) => CreateDerivedModelSet([concreteResourceModel]);
-
-    private static DerivedRelationalModelSet CreateDerivedModelSet(
-        IReadOnlyList<ConcreteResourceModel> concreteResourceModels
     )
     {
-        var resourceKeys = concreteResourceModels
-            .Select(static concreteResource => concreteResource.ResourceKey)
-            .OrderBy(static resourceKey => resourceKey.ResourceKeyId)
-            .ToArray();
+        var resourceKey = concreteResourceModel.ResourceKey;
 
         return new DerivedRelationalModelSet(
             EffectiveSchema: new EffectiveSchemaInfo(
                 ApiSchemaFormatVersion: "1.0",
                 RelationalMappingVersion: "v1",
                 EffectiveSchemaHash: "schema-hash",
-                ResourceKeyCount: (short)resourceKeys.Length,
+                ResourceKeyCount: 1,
                 ResourceKeySeedHash: [1, 2, 3],
                 SchemaComponentsInEndpointOrder:
                 [
                     new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash"),
                 ],
-                ResourceKeysInIdOrder: resourceKeys
+                ResourceKeysInIdOrder: [resourceKey]
             ),
             Dialect: SqlDialect.Pgsql,
             ProjectSchemasInEndpointOrder:
             [
                 new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi")),
             ],
-            ConcreteResourcesInNameOrder:
-            [
-                .. concreteResourceModels
-                    .OrderBy(
-                        static concreteResource => concreteResource.ResourceKey.Resource.ProjectName,
-                        StringComparer.Ordinal
-                    )
-                    .ThenBy(
-                        static concreteResource => concreteResource.ResourceKey.Resource.ResourceName,
-                        StringComparer.Ordinal
-                    ),
-            ],
+            ConcreteResourcesInNameOrder: [concreteResourceModel],
             AbstractIdentityTablesInNameOrder: [],
             AbstractUnionViewsInNameOrder: [],
             IndexesInCreateOrder: [],
@@ -9126,4 +10699,286 @@ public class Given_RelationalDocumentStoreRepositoryTests
             []
         );
     }
+
+    // --- Restored from origin/main (DMS-1095 helpers needed by people-relationship tests) ---
+
+    private static readonly ResourceInfo _studentResourceInfo = CreateResourceInfo("Student");
+
+    private static MappingSet CreateWriteAuthorizationAwareMappingSetWithUnboundStudentSubject(
+        ResourceInfo resourceInfo
+    )
+    {
+        const string studentPath = "$.studentReference.studentUniqueId";
+        var resourceKey = CreateResourceKeyEntry(resourceInfo);
+        var studentDocumentIdColumn = AuthNames.StudentDocumentId;
+        var rootTable = CreateRootTableModel(
+            resourceInfo.ResourceName.Value,
+            [
+                new DbColumnModel(
+                    studentDocumentIdColumn,
+                    ColumnKind.DocumentFk,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    new JsonPathExpression(studentPath, []),
+                    new QualifiedResourceName("Ed-Fi", "Student"),
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Name"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 75),
+                    false,
+                    new JsonPathExpression("$.name", []),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ]
+        );
+        var resourceModel = new RelationalResourceModel(
+            resourceKey.Resource,
+            new DbSchemaName("edfi"),
+            ResourceStorageKind.RelationalTables,
+            rootTable,
+            [rootTable],
+            [
+                new DocumentReferenceBinding(
+                    true,
+                    new JsonPathExpression("$.studentReference", []),
+                    rootTable.Table,
+                    studentDocumentIdColumn,
+                    new QualifiedResourceName("Ed-Fi", "Student"),
+                    [
+                        new ReferenceIdentityBinding(
+                            new JsonPathExpression(studentPath, []),
+                            new JsonPathExpression(studentPath, []),
+                            new DbColumnName("StudentUniqueId")
+                        ),
+                    ]
+                ),
+            ],
+            []
+        );
+        var concreteResource = new ConcreteResourceModel(
+            resourceKey,
+            ResourceStorageKind.RelationalTables,
+            resourceModel
+        )
+        {
+            SecurableElements = new ResourceSecurableElements([], [], [studentPath], [], []),
+        };
+        var concreteResources = new List<ConcreteResourceModel>
+        {
+            concreteResource,
+            CreateMinimalConcreteResource(2, "Student"),
+        };
+        concreteResources.AddRange(CreateRequiredPeopleAuthAssociationResources(3));
+
+        var documentIdColumn = rootTable.Columns.Single(static column =>
+            column.ColumnName.Value == "DocumentId"
+        );
+        var nameColumn = rootTable.Columns.Single(static column => column.ColumnName.Value == "Name");
+        var writePlan = new ResourceWritePlan(
+            resourceModel,
+            [
+                new TableWritePlan(
+                    rootTable,
+                    InsertSql: "",
+                    UpdateSql: null,
+                    DeleteByParentSql: null,
+                    BulkInsertBatching: new BulkInsertBatchingInfo(100, 2, 1000),
+                    ColumnBindings:
+                    [
+                        new WriteColumnBinding(
+                            documentIdColumn,
+                            new WriteValueSource.DocumentId(),
+                            "DocumentId"
+                        ),
+                        new WriteColumnBinding(
+                            nameColumn,
+                            new WriteValueSource.Scalar(
+                                new JsonPathExpression("$.name", []),
+                                new RelationalScalarType(ScalarKind.String, MaxLength: 75)
+                            ),
+                            "Name"
+                        ),
+                    ],
+                    KeyUnificationPlans: []
+                ),
+            ]
+        );
+
+        var mappingSet = CreateMappingSet(
+            resourceKey.Resource,
+            concreteResources,
+            writePlan,
+            CreateReadPlan(resourceModel, rootTable)
+        );
+
+        return mappingSet with
+        {
+            Model = mappingSet.Model with { AuthEdOrgHierarchy = CreateAuthEdOrgHierarchy() },
+        };
+    }
+
+    private static DbTableModel CreateRootTableModel(
+        string tableName,
+        IReadOnlyList<DbColumnModel>? columns = null
+    )
+    {
+        var documentIdColumn = new DbColumnModel(
+            new DbColumnName("DocumentId"),
+            ColumnKind.ParentKeyPart,
+            new RelationalScalarType(ScalarKind.Int64),
+            false,
+            null,
+            null,
+            new ColumnStorage.Stored()
+        );
+
+        return new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), tableName),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                $"PK_{tableName}",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [documentIdColumn, .. (columns ?? [])],
+            []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                DbTableKind.Root,
+                [new DbColumnName("DocumentId")],
+                [new DbColumnName("DocumentId")],
+                [],
+                []
+            ),
+        };
+    }
+
+    private static ConcreteResourceModel CreateMinimalConcreteResource(
+        short resourceKeyId,
+        string resourceName
+    )
+    {
+        var resourceKey = CreateResourceKeyEntry(resourceKeyId, resourceName);
+        var rootTable = CreateRootTableModel(resourceName);
+        var resourceModel = CreateRelationalResourceModel(
+            resourceKey,
+            rootTable,
+            ResourceStorageKind.RelationalTables
+        );
+
+        return new ConcreteResourceModel(resourceKey, ResourceStorageKind.RelationalTables, resourceModel)
+        {
+            SecurableElements = ResourceSecurableElements.Empty,
+        };
+    }
+
+    private static IReadOnlyList<ConcreteResourceModel> CreateRequiredPeopleAuthAssociationResources(
+        short firstResourceKeyId
+    ) =>
+        [
+            .. AuthObjectDefinitions.RequiredPeopleAuthAssociationResourceNames.Select(
+                (resourceName, index) =>
+                    CreateMinimalConcreteResource((short)(firstResourceKeyId + index), resourceName)
+            ),
+        ];
+
+    private static AuthEdOrgHierarchy CreateAuthEdOrgHierarchy() =>
+        new([
+            new AuthEdOrgEntity(
+                "School",
+                new DbTableName(new DbSchemaName("edfi"), "School"),
+                new DbColumnName("SchoolId"),
+                []
+            ),
+        ]);
+
+    private static DerivedRelationalModelSet CreateDerivedModelSet(
+        IReadOnlyList<ConcreteResourceModel> concreteResourceModels
+    )
+    {
+        var resourceKeys = concreteResourceModels
+            .Select(static concreteResource => concreteResource.ResourceKey)
+            .OrderBy(static resourceKey => resourceKey.ResourceKeyId)
+            .ToArray();
+
+        return new DerivedRelationalModelSet(
+            EffectiveSchema: new EffectiveSchemaInfo(
+                ApiSchemaFormatVersion: "1.0",
+                RelationalMappingVersion: "v1",
+                EffectiveSchemaHash: "schema-hash",
+                ResourceKeyCount: (short)resourceKeys.Length,
+                ResourceKeySeedHash: [1, 2, 3],
+                SchemaComponentsInEndpointOrder:
+                [
+                    new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash"),
+                ],
+                ResourceKeysInIdOrder: resourceKeys
+            ),
+            Dialect: SqlDialect.Pgsql,
+            ProjectSchemasInEndpointOrder:
+            [
+                new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi")),
+            ],
+            ConcreteResourcesInNameOrder:
+            [
+                .. concreteResourceModels
+                    .OrderBy(
+                        static concreteResource => concreteResource.ResourceKey.Resource.ProjectName,
+                        StringComparer.Ordinal
+                    )
+                    .ThenBy(
+                        static concreteResource => concreteResource.ResourceKey.Resource.ResourceName,
+                        StringComparer.Ordinal
+                    ),
+            ],
+            AbstractIdentityTablesInNameOrder: [],
+            AbstractUnionViewsInNameOrder: [],
+            IndexesInCreateOrder: [],
+            TriggersInCreateOrder: []
+        );
+    }
+
+
+    private static ResourceKeyEntry CreateResourceKeyEntry(short resourceKeyId, string resourceName) =>
+        new(resourceKeyId, new QualifiedResourceName("Ed-Fi", resourceName), "1.0.0", false);
+
+    private static MappingSet CreateMappingSet(
+        QualifiedResourceName requestResource,
+        IReadOnlyList<ConcreteResourceModel> concreteResources,
+        ResourceWritePlan writePlan,
+        ResourceReadPlan readPlan
+    )
+    {
+        var resourceKeyIdByResource = concreteResources.ToDictionary(
+            static concreteResource => concreteResource.ResourceKey.Resource,
+            static concreteResource => concreteResource.ResourceKey.ResourceKeyId
+        );
+        var resourceKeyById = concreteResources.ToDictionary(
+            static concreteResource => concreteResource.ResourceKey.ResourceKeyId,
+            static concreteResource => concreteResource.ResourceKey
+        );
+
+        return new MappingSet(
+            Key: new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
+            Model: CreateDerivedModelSet(concreteResources),
+            WritePlansByResource: new Dictionary<QualifiedResourceName, ResourceWritePlan>
+            {
+                [requestResource] = writePlan,
+            },
+            ReadPlansByResource: new Dictionary<QualifiedResourceName, ResourceReadPlan>
+            {
+                [requestResource] = readPlan,
+            },
+            ResourceKeyIdByResource: resourceKeyIdByResource,
+            ResourceKeyById: resourceKeyById,
+            SecurableElementColumnPathsByResource: new Dictionary<
+                QualifiedResourceName,
+                IReadOnlyList<ResolvedSecurableElementPath>
+            >()
+        );
+    }
+
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -1072,6 +1072,73 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_retries_and_returns_not_found_when_the_get_by_id_namespace_target_is_stale()
+    {
+        // The stored namespace check reports the target row vanished after the unlocked target lookup.
+        // The read boundary must re-resolve the target rather than treat the missing row as a namespace
+        // mismatch; the re-resolved lookup no longer finds the row, so the GET surfaces a 404.
+        var documentUuid = new DocumentUuid(Guid.Parse("dddddddd-1111-2222-3333-bbbbbbbbbbbb"));
+        var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
+        var getRequest = CreateGetRequest(
+            documentUuid,
+            mappingSet,
+            _schoolResourceInfo,
+            new RecordingResourceAuthorizationHandler(),
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+            ],
+            namespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .ReturnsNextFromSequence(
+                new RelationalReadTargetLookupResult.ExistingDocument(345L, documentUuid, 91L),
+                new RelationalReadTargetLookupResult.NotFound()
+            );
+        A.CallTo(() =>
+                _namespaceAuthorizationExecutor.ExecuteAsync(
+                    A<NamespaceAuthorizationExecutionRequest>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(
+                Task.FromResult<NamespaceAuthorizationExecutionResult>(
+                    new NamespaceAuthorizationExecutionResult.StaleTarget()
+                )
+            );
+
+        var result = await _sut.GetDocumentById(getRequest);
+
+        result.Should().BeOfType<GetResult.GetFailureNotExists>();
+        A.CallTo(() =>
+                _readTargetLookupService.ResolveForGetByIdAsync(
+                    mappingSet,
+                    new QualifiedResourceName("Ed-Fi", "School"),
+                    documentUuid,
+                    A<CancellationToken>._
+                )
+            )
+            .MustHaveHappenedTwiceExactly();
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
     public async Task It_returns_a_namespace_uninitialized_403_when_stored_namespace_is_null()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-cccccccccccc"));
@@ -5170,6 +5237,61 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_forwards_relationship_no_claims_with_proposed_namespace_authorization_to_the_write_executor_for_a_mixed_strategy_put()
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        A.CallTo(() =>
+                _writeExecutor.ExecuteAsync(A<RelationalWriteExecutorRequest>._, A<CancellationToken>._)
+            )
+            .Invokes(call =>
+            {
+                _capturedExecutorRequest = call.GetArgument<RelationalWriteExecutorRequest>(0)!;
+                _capturedExecutorRequests.Add(_capturedExecutorRequest);
+            })
+            .Returns(
+                Task.FromResult<RelationalWriteExecutorResult>(
+                    new RelationalWriteExecutorResult.Update(
+                        new UpdateResult.UpdateSuccess(documentUuid, CreateCommittedReadbackEtag("Mixed"))
+                    )
+                )
+            );
+
+        var updateRequest = A.Fake<IRelationalUpdateRequest>();
+        A.CallTo(() => updateRequest.ResourceInfo).Returns(_schoolResourceInfo);
+        A.CallTo(() => updateRequest.MappingSet)
+            .Returns(CreateNamespaceAndRelationshipWriteMappingSet(_schoolResourceInfo));
+        A.CallTo(() => updateRequest.DocumentInfo).Returns(CreateDocumentInfo());
+        A.CallTo(() => updateRequest.DocumentUuid).Returns(documentUuid);
+        A.CallTo(() => updateRequest.EdfiDoc).Returns(CreateRequestBody("Mixed"));
+        A.CallTo(() => updateRequest.AuthorizationStrategyEvaluators)
+            .Returns([
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ]);
+        // Empty claim EducationOrganizationIds make the relationship strategy resolve to NoClaims; the
+        // configured namespace prefixes make the stored and proposed namespace checks participate. PUT
+        // must defer the stored relationship NoClaims into the proposed-relationship slot so the
+        // namespace checks (AND-composed ahead of the relationship OR-group) get to deny first — routing
+        // NoClaims through the stored slot would surface the relationship denial before the proposed
+        // namespace check runs.
+        A.CallTo(() => updateRequest.AuthorizationContext)
+            .Returns(new RelationalAuthorizationContext([], ["uri://ed-fi.org/"]));
+
+        await _sut.UpdateDocumentById(updateRequest);
+
+        _capturedExecutorRequests.Should().ContainSingle();
+        _capturedExecutorRequest.StoredRelationshipAuthorization.Should().BeNull();
+        _capturedExecutorRequest
+            .ProposedRelationshipAuthorization.Should()
+            .BeOfType<RelationshipAuthorizationResult.NoClaims>();
+        _capturedExecutorRequest.StoredNamespaceAuthorization.Should().NotBeNull();
+        _capturedExecutorRequest.ProposedNamespaceAuthorization.Should().NotBeNull();
+        _targetLookupService.ResolveForPutCallCount.Should().Be(1);
+    }
+
+    [Test]
     public async Task It_forwards_authorized_post_relationship_plans_to_the_write_executor_after_target_lookup()
     {
         var committedEtag = CreateCommittedReadbackEtag("Authorized High");
@@ -7160,7 +7282,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
-    public async Task It_fails_closed_with_unknown_failure_when_namespace_auth1_is_malformed_and_does_not_delete()
+    public async Task It_fails_closed_with_security_configuration_when_namespace_auth1_is_malformed_and_does_not_delete()
     {
         var documentUuid = new DocumentUuid(Guid.NewGuid());
         var mappingSet = CreateNamespaceAuthorizationMappingSet(_schoolResourceInfo);
@@ -7182,7 +7304,7 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        result.Should().BeOfType<DeleteResult.UnknownFailure>();
+        result.Should().BeOfType<DeleteResult.DeleteFailureSecurityConfiguration>();
         _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -4533,6 +4533,57 @@ public class Given_RelationalDocumentStoreRepositoryTests
     }
 
     [Test]
+    public async Task It_returns_a_security_configuration_500_when_combined_mssql_namespace_and_relationship_parameters_exceed_the_limit()
+    {
+        var pgsqlMappingSet = CreateNamespaceAndRootEdOrgMappingSet(_schoolResourceInfo);
+        var mappingSet = pgsqlMappingSet with
+        {
+            Key = pgsqlMappingSet.Key with { Dialect = SqlDialect.Mssql },
+        };
+        // Each list stays below its own 2,000 SQL Server cap, but together they exceed the per-command
+        // parameter budget, so the request must fail closed instead of failing at execution.
+        string[] namespacePrefixes = [.. Enumerable.Range(0, 1500).Select(index => $"uri://prefix-{index}/")];
+        long[] claimEducationOrganizationIds =
+        [
+            .. Enumerable.Range(0, 1500).Select(index => 100000L + index),
+        ];
+        var queryRequest = CreateQueryRequest(
+            mappingSet,
+            [],
+            totalCount: false,
+            authorizationStrategyEvaluators:
+            [
+                CreateAuthorizationStrategyEvaluator(AuthorizationStrategyNameConstants.NamespaceBased),
+                CreateAuthorizationStrategyEvaluator(
+                    AuthorizationStrategyNameConstants.RelationshipsWithEdOrgsOnly
+                ),
+            ],
+            claimEducationOrganizationIds: claimEducationOrganizationIds,
+            namespacePrefixes: namespacePrefixes
+        );
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain("1500 namespace prefixes")
+            .And.Contain("1500 authorization education organization ids")
+            .And.Contain("exceed the SQL Server parameter limit");
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .MustNotHaveHappened();
+    }
+
+    [Test]
     public async Task It_returns_security_configuration_failure_when_query_authorization_strategy_metadata_is_invalid()
     {
         var queryRequest = CreateQueryRequest(
@@ -10941,7 +10992,6 @@ public class Given_RelationalDocumentStoreRepositoryTests
         );
     }
 
-
     private static ResourceKeyEntry CreateResourceKeyEntry(short resourceKeyId, string resourceName) =>
         new(resourceKeyId, new QualifiedResourceName("Ed-Fi", resourceName), "1.0.0", false);
 
@@ -10980,5 +11030,4 @@ public class Given_RelationalDocumentStoreRepositoryTests
             >()
         );
     }
-
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalQueryPageKeysetPlannerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalQueryPageKeysetPlannerTests.cs
@@ -397,6 +397,55 @@ public class Given_RelationalQueryPageKeysetPlanner
     }
 
     [Test]
+    public void It_should_assign_collision_free_parameter_names_when_a_query_field_collides_with_a_namespace_authorization_parameter()
+    {
+        var planner = new RelationalQueryPageKeysetPlanner(SqlDialect.Pgsql);
+        var result = planner.Plan(
+            CreateRootTable(),
+            new RelationalQueryPreprocessingResult(
+                new RelationalQueryPreprocessingOutcome.Continue(),
+                [
+                    CreateElement(
+                        "namespacePrefixes",
+                        "$.namespacePrefixes",
+                        "string",
+                        new RelationalQueryFieldTarget.RootColumn(
+                            new DbColumnName("NamespacePrefixesQueryField")
+                        ),
+                        "collides with auth parameter",
+                        new PreprocessedRelationalQueryValue.Raw("collides with auth parameter")
+                    ),
+                ]
+            ),
+            new PaginationParameters(Limit: 25, Offset: 0, TotalCount: false, MaximumPageSize: 500),
+            authorization: new PageDocumentIdAuthorizationSpec(
+                Strategies: [],
+                NamespaceChecks:
+                [
+                    new NamespaceAuthorizationCheckSpec(
+                        0,
+                        NamespaceAuthorizationCheckValueSource.Stored,
+                        new DbTableName(new DbSchemaName("edfi"), "AcademicWeek"),
+                        new DbColumnName("Namespace")
+                    ),
+                ],
+                NamespacePrefixParameterization: NamespacePrefixParameterizationFactory.Create(
+                    SqlDialect.Pgsql,
+                    ["uri://ed-fi.org/"],
+                    "namespacePrefixes"
+                )
+            )
+        );
+
+        // The authorization parameter keeps the bare name; the colliding query field is suffixed so the
+        // single-binding namespace LIKE and the query predicate never share a parameter.
+        result.ParameterValues.Keys.Should().Contain("namespacePrefixes");
+        result.ParameterValues.Keys.Should().Contain("namespacePrefixes_2");
+        result.Plan.PageDocumentIdSql.Should().Contain("LIKE ANY(@namespacePrefixes)");
+        result.Plan.PageDocumentIdSql.Should().Contain("@namespacePrefixes_2");
+    }
+
+    [Test]
     public void It_should_reject_empty_page_inputs_already_short_circuited_by_the_repository()
     {
         var planner = new RelationalQueryPageKeysetPlanner(SqlDialect.Pgsql);
@@ -567,6 +616,16 @@ public class Given_RelationalQueryPageKeysetPlanner
                     "SchoolIdUnderscore",
                     ColumnKind.Scalar,
                     new RelationalScalarType(ScalarKind.String, MaxLength: 75)
+                ),
+                CreateColumn(
+                    "NamespacePrefixesQueryField",
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 75)
+                ),
+                CreateColumn(
+                    "Namespace",
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, MaxLength: 255)
                 ),
             ],
             []

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -74,6 +74,12 @@ internal sealed class DefaultRelationalWriteExecutor(
     private readonly ProposedRelationshipAuthorizationOrchestrator _proposedRelationshipAuthorizationOrchestrator =
         new(persister);
 
+    private readonly ProposedNamespaceAuthorizationOrchestrator _proposedNamespaceAuthorizationOrchestrator =
+        new(
+            relationshipAuthorizationProviderFailureExtractor
+                ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance
+        );
+
     private readonly RelationalWriteDatabaseFailureResultMapper _databaseFailureResultMapper = new(
         writeExceptionClassifier,
         writeConstraintResolver
@@ -219,6 +225,19 @@ internal sealed class DefaultRelationalWriteExecutor(
             }
 
             var mergeResult = mergeBoundary.MergeResult!;
+
+            // NamespaceBased AND-composes with the relationship OR-group and runs before it, so a
+            // namespace denial surfaces over a concurrent relationship denial. Mirrors the
+            // stored-side ordering used for locked-target authorization.
+            var namespaceAuthorizationBoundary = await _proposedNamespaceAuthorizationOrchestrator
+                .ResolveAsync(executionRequest, mergeResult, writeSession, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (namespaceAuthorizationBoundary.ImmediateResult is not null)
+            {
+                await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                return namespaceAuthorizationBoundary.ImmediateResult;
+            }
 
             var proposedAuthorizationBoundary = await _proposedRelationshipAuthorizationOrchestrator
                 .ResolveAsync(executionRequest, mergeResult, writeSession, cancellationToken)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorQueryPageKeysetPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorQueryPageKeysetPlanner.cs
@@ -23,7 +23,8 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
         MappingSet mappingSet,
         QualifiedResourceName requestResource,
         DescriptorQueryPreprocessingResult preprocessingResult,
-        PaginationParameters paginationParameters
+        PaginationParameters paginationParameters,
+        PageDocumentIdAuthorizationSpec? authorization = null
     )
     {
         ArgumentNullException.ThrowIfNull(mappingSet);
@@ -54,14 +55,16 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
             UnifiedAliasMappingsByColumn: new Dictionary<DbColumnName, ColumnStorage.UnifiedAlias>(),
             OffsetParameterName: OffsetParameterName,
             LimitParameterName: LimitParameterName,
-            IncludeTotalCountSql: paginationParameters.TotalCount
+            IncludeTotalCountSql: paginationParameters.TotalCount,
+            Authorization: authorization
         );
         var sqlPlan = _sqlCompiler.Compile(pageQuerySpec);
         var parameterValues = BuildParameterValues(
             resourceKeyId,
             preprocessingResult.QueryElementsInOrder,
             parameterNamesByIndex,
-            paginationParameters
+            paginationParameters,
+            authorization
         );
 
         return new PageKeysetSpec.Query(sqlPlan, parameterValues);
@@ -168,7 +171,8 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
         short resourceKeyId,
         IReadOnlyList<PreprocessedDescriptorQueryElement> queryElementsInOrder,
         IReadOnlyList<string> parameterNamesByIndex,
-        PaginationParameters paginationParameters
+        PaginationParameters paginationParameters,
+        PageDocumentIdAuthorizationSpec? authorization
     )
     {
         Dictionary<string, object?> parameterValues = new(StringComparer.Ordinal)
@@ -193,6 +197,11 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
                 ),
             };
         }
+
+        NamespacePrefixParameterValueBinder.Bind(
+            parameterValues,
+            authorization?.NamespacePrefixParameterization
+        );
 
         return parameterValues;
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorQueryPageKeysetPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorQueryPageKeysetPlanner.cs
@@ -38,7 +38,10 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
             );
         }
 
-        var parameterNamesByIndex = DeriveParameterNames(preprocessingResult.QueryElementsInOrder);
+        var parameterNamesByIndex = DeriveParameterNames(
+            preprocessingResult.QueryElementsInOrder,
+            authorization
+        );
         var queryPredicates = PlanPredicates(preprocessingResult.QueryElementsInOrder, parameterNamesByIndex);
         var resourceKeyId = RelationalWriteSupport.GetResourceKeyIdOrThrow(mappingSet, requestResource);
         var pageQuerySpec = new PageDocumentIdQuerySpec(
@@ -207,7 +210,8 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
     }
 
     private static IReadOnlyList<string> DeriveParameterNames(
-        IReadOnlyList<PreprocessedDescriptorQueryElement> queryElementsInOrder
+        IReadOnlyList<PreprocessedDescriptorQueryElement> queryElementsInOrder,
+        PageDocumentIdAuthorizationSpec? authorization
     )
     {
         var seeds = queryElementsInOrder
@@ -229,7 +233,12 @@ internal sealed class DescriptorQueryPageKeysetPlanner(SqlDialect dialect)
 
         return QueryParameterNameAllocator.Allocate(
             seeds,
-            [ResourceKeyIdParameterName, OffsetParameterName, LimitParameterName]
+            [
+                ResourceKeyIdParameterName,
+                OffsetParameterName,
+                LimitParameterName,
+                .. QueryParameterNameAllocator.CollectAuthorizationParameterNames(authorization),
+            ]
         );
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadContracts.cs
@@ -22,7 +22,8 @@ public sealed record DescriptorGetByIdRequest
         RelationalGetRequestReadMode readMode,
         AuthorizationStrategyEvaluator[] authorizationStrategyEvaluators,
         ReadableProfileProjectionContext? readableProfileProjectionContext,
-        TraceId traceId
+        TraceId traceId,
+        RelationalAuthorizationContext? relationalAuthorizationContext = null
     )
     {
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
@@ -34,6 +35,8 @@ public sealed record DescriptorGetByIdRequest
             ?? throw new ArgumentNullException(nameof(authorizationStrategyEvaluators));
         ReadableProfileProjectionContext = readableProfileProjectionContext;
         TraceId = traceId;
+        RelationalAuthorizationContext =
+            relationalAuthorizationContext ?? new RelationalAuthorizationContext([]);
     }
 
     /// <summary>
@@ -70,6 +73,14 @@ public sealed record DescriptorGetByIdRequest
     /// The request trace id for diagnostics.
     /// </summary>
     public TraceId TraceId { get; init; }
+
+    /// <summary>
+    /// Request-scoped authorization inputs (namespace prefixes and claim education organization ids)
+    /// used by backend-planned namespace authorization. Carried alongside the evaluators because the
+    /// evaluators preserve raw strategy names with empty filter providers in relational mode and do not
+    /// carry the namespace prefixes the planner needs.
+    /// </summary>
+    public RelationalAuthorizationContext RelationalAuthorizationContext { get; init; }
 }
 
 /// <summary>
@@ -85,7 +96,8 @@ public sealed record DescriptorQueryRequest
         PaginationParameters paginationParameters,
         AuthorizationStrategyEvaluator[] authorizationStrategyEvaluators,
         ReadableProfileProjectionContext? readableProfileProjectionContext,
-        TraceId traceId
+        TraceId traceId,
+        RelationalAuthorizationContext? relationalAuthorizationContext = null
     )
     {
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
@@ -98,6 +110,8 @@ public sealed record DescriptorQueryRequest
             ?? throw new ArgumentNullException(nameof(authorizationStrategyEvaluators));
         ReadableProfileProjectionContext = readableProfileProjectionContext;
         TraceId = traceId;
+        RelationalAuthorizationContext =
+            relationalAuthorizationContext ?? new RelationalAuthorizationContext([]);
     }
 
     /// <summary>
@@ -134,6 +148,14 @@ public sealed record DescriptorQueryRequest
     /// The request trace id for diagnostics.
     /// </summary>
     public TraceId TraceId { get; init; }
+
+    /// <summary>
+    /// Request-scoped authorization inputs (namespace prefixes and claim education organization ids)
+    /// used by backend-planned namespace authorization. Carried alongside the evaluators because the
+    /// evaluators preserve raw strategy names with empty filter providers in relational mode and do not
+    /// carry the namespace prefixes the planner needs.
+    /// </summary>
+    public RelationalAuthorizationContext RelationalAuthorizationContext { get; init; }
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -26,6 +26,10 @@ internal sealed class DescriptorReadHandler(
 {
     private const string DocumentUuidParameterName = "@documentUuid";
     private const string ResourceKeyIdParameterName = "@resourceKeyId";
+
+    // The descriptor page query binds a single ResourceKeyId discriminator parameter on top of the paging
+    // parameters; see DescriptorQueryPageKeysetPlanner. Counted into the non-authorization parameter budget.
+    private const int DescriptorQueryResourceKeyParameterCount = 1;
     private readonly IRelationalCommandExecutor _commandExecutor =
         commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
     private readonly IReadableProfileProjector _readableProfileProjector =
@@ -47,30 +51,41 @@ internal sealed class DescriptorReadHandler(
             request.TraceId.Value
         );
 
-        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
-        // unsupported strategies resolve before any SQL roundtrip. The stored namespace check itself
-        // runs in memory against the namespace value materialized by the existing single SELECT.
-        var authorizationPreflight = ResolveDescriptorReadAuthorization(
-            request.MappingSet,
-            request.Resource,
-            request.AuthorizationStrategyEvaluators,
-            request.RelationalAuthorizationContext,
-            NamespaceAuthorizationOperation.ReadSingle,
-            "descriptor GET",
-            "GET"
-        );
+        // StoredDocument reads are internal read-modify-write fetches that bypass per-record
+        // authorization exactly as the generic single-record path does: the caller was already
+        // authorized for the operation that triggered the fetch. Only ExternalResponse reads run the
+        // namespace authorization preflight and the in-memory stored-namespace check below.
+        NamespacePrefixParameterization? namespacePrefixParameterization = null;
 
-        switch (authorizationPreflight)
+        if (request.ReadMode != RelationalGetRequestReadMode.StoredDocument)
         {
-            case DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented:
-                return new GetResult.GetFailureNotImplemented(notImplemented.FailureMessage);
-            case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
-                return new GetResult.GetFailureSecurityConfiguration(configError.Errors);
-            case DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
-                return new GetResult.GetFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
-        }
+            // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
+            // unsupported strategies resolve before any SQL roundtrip. The stored namespace check itself
+            // runs in memory against the namespace value materialized by the existing single SELECT.
+            var authorizationPreflight = ResolveDescriptorReadAuthorization(
+                request.MappingSet,
+                request.Resource,
+                request.AuthorizationStrategyEvaluators,
+                request.RelationalAuthorizationContext,
+                NamespaceAuthorizationOperation.ReadSingle,
+                "descriptor GET",
+                "GET"
+            );
 
-        var proceed = (DescriptorReadAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
+            switch (authorizationPreflight)
+            {
+                case DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                    return new GetResult.GetFailureNotImplemented(notImplemented.FailureMessage);
+                case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                    return new GetResult.GetFailureSecurityConfiguration(configError.Errors);
+                case DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                    return new GetResult.GetFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
+            }
+
+            namespacePrefixParameterization = (
+                (DescriptorReadAuthorizationPreflightOutcome.Proceed)authorizationPreflight
+            ).NamespacePrefixParameterization;
+        }
 
         RelationalCommand command;
 
@@ -126,7 +141,7 @@ internal sealed class DescriptorReadHandler(
         // value without a second SQL roundtrip. The stored-namespace mismatch and uninitialized
         // failure kinds are constructed directly here because no AUTH1 codec mediates the
         // single-record path.
-        if (proceed.NamespacePrefixParameterization is { } namespacePrefixParameterization)
+        if (namespacePrefixParameterization is not null)
         {
             var namespaceFailure = EvaluateStoredNamespace(
                 descriptorRow.Namespace,
@@ -230,6 +245,21 @@ internal sealed class DescriptorReadHandler(
             return new QueryResult.QuerySuccess([], request.PaginationParameters.TotalCount ? 0 : null);
         }
 
+        // Descriptor queries are namespace-only, but the page query still composes the namespace prefix
+        // list with the query filter, paging, and ResourceKeyId parameters. Fail closed if that exceeds
+        // SQL Server's per-command parameter ceiling rather than letting the query fail at execution.
+        if (
+            BuildDescriptorQueryParameterBudgetFailure(
+                request.MappingSet.Key.Dialect,
+                proceed.NamespacePrefixParameterization,
+                preprocessingResult.QueryElementsInOrder.Count
+            ) is
+            { } parameterBudgetFailure
+        )
+        {
+            return parameterBudgetFailure;
+        }
+
         DescriptorQueryRowsPage queryRowsPage;
 
         try
@@ -273,6 +303,44 @@ internal sealed class DescriptorReadHandler(
                 )
                 : null
         );
+    }
+
+    /// <summary>
+    /// Returns a security-configuration failure when the descriptor page query's namespace prefix
+    /// parameters, plus its query filter, paging, and ResourceKeyId parameters, exceed SQL Server's
+    /// per-command parameter ceiling; otherwise <see langword="null"/>. The dialect gate lives in
+    /// <see cref="AuthorizationParameterBudget.ExceedsCommandParameterLimit"/>.
+    /// </summary>
+    private static QueryResult? BuildDescriptorQueryParameterBudgetFailure(
+        SqlDialect dialect,
+        NamespacePrefixParameterization? namespacePrefixParameterization,
+        int queryFilterParameterCount
+    )
+    {
+        var nonAuthorizationParameterCount =
+            queryFilterParameterCount
+            + AuthorizationParameterBudget.PaginationParameterCount
+            + DescriptorQueryResourceKeyParameterCount;
+
+        if (
+            !AuthorizationParameterBudget.ExceedsCommandParameterLimit(
+                dialect,
+                namespacePrefixParameterization,
+                claimEducationOrganizationIdParameterization: null,
+                nonAuthorizationParameterCount
+            )
+        )
+        {
+            return null;
+        }
+
+        return new QueryResult.QueryFailureSecurityConfiguration([
+            NamespaceAuthorizationSecurityConfigurationMessages.CommandParameterCapExceeded(
+                namespacePrefixParameterization?.ConfiguredPrefixesInOrder.Count ?? 0,
+                0,
+                nonAuthorizationParameterCount
+            ),
+        ]);
     }
 
     internal Task<DescriptorQueryRowsPage> ReadQueryRowsAsync(
@@ -706,12 +774,12 @@ internal sealed class DescriptorReadHandler(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError([
-                prefixCapExceededMessage,
+                securityConfigurationMessage,
             ]);
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -701,20 +701,17 @@ internal sealed class DescriptorReadHandler(
             return DescriptorReadAuthorizationPreflightOutcome.Proceed.NoAuthorization;
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError([
-                NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                prefixCapExceededMessage,
             ]);
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -7,8 +7,10 @@ using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
 using EdFi.DataManagementService.Core.Profile;
 using Microsoft.Extensions.Logging;
 
@@ -45,21 +47,30 @@ internal sealed class DescriptorReadHandler(
             request.TraceId.Value
         );
 
-        if (
-            !RelationalReadGuardrails.HasOnlyNoFurtherAuthorizationRequired(
-                request.AuthorizationStrategyEvaluators
-            )
-        )
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
+        // unsupported strategies resolve before any SQL roundtrip. The stored namespace check itself
+        // runs in memory against the namespace value materialized by the existing single SELECT.
+        var authorizationPreflight = ResolveDescriptorReadAuthorization(
+            request.MappingSet,
+            request.Resource,
+            request.AuthorizationStrategyEvaluators,
+            request.RelationalAuthorizationContext,
+            NamespaceAuthorizationOperation.ReadSingle,
+            "descriptor GET",
+            "GET"
+        );
+
+        switch (authorizationPreflight)
         {
-            return new GetResult.GetFailureNotImplemented(
-                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                    request.Resource,
-                    request.AuthorizationStrategyEvaluators,
-                    "descriptor GET",
-                    "GET"
-                )
-            );
+            case DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                return new GetResult.GetFailureNotImplemented(notImplemented.FailureMessage);
+            case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                return new GetResult.GetFailureSecurityConfiguration(configError.Errors);
+            case DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                return new GetResult.GetFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
         }
+
+        var proceed = (DescriptorReadAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
 
         RelationalCommand command;
 
@@ -110,6 +121,35 @@ internal sealed class DescriptorReadHandler(
             return new GetResult.GetFailureNotExists();
         }
 
+        // The descriptor row reader emits the same Namespace column the orchestrator resolved as
+        // the stored authorization source, so the namespace check runs against that materialized
+        // value without a second SQL roundtrip. The stored-namespace mismatch and uninitialized
+        // failure kinds are constructed directly here because no AUTH1 codec mediates the
+        // single-record path.
+        if (proceed.NamespacePrefixParameterization is { } namespacePrefixParameterization)
+        {
+            var namespaceFailure = EvaluateStoredNamespace(
+                descriptorRow.Namespace,
+                namespacePrefixParameterization
+            );
+
+            if (namespaceFailure is not null)
+            {
+                return new GetResult.GetFailureNamespaceNotAuthorized(namespaceFailure);
+            }
+        }
+        else if (string.IsNullOrEmpty(descriptorRow.Namespace))
+        {
+            // Without namespace authorization configured, the stored-namespace-uninitialized 403
+            // path does not apply, so a null stored Namespace is genuine descriptor row corruption.
+            // Surface it as an UnknownFailure with the same column-naming diagnostic the row
+            // reader produces for the other required descriptor columns.
+            return new GetResult.UnknownFailure(
+                $"Descriptor read corruption detected for DocumentId {descriptorRow.DocumentId} "
+                    + $"(ResourceKeyId={descriptorRow.ResourceKeyId}): dms.Descriptor.Namespace must not be null."
+            );
+        }
+
         LogDiscriminatorMismatchIfPresent(request, descriptorRow);
 
         return new GetResult.GetSuccess(
@@ -134,21 +174,33 @@ internal sealed class DescriptorReadHandler(
             request.TraceId.Value
         );
 
-        if (
-            !RelationalReadGuardrails.HasOnlyNoFurtherAuthorizationRequired(
-                request.AuthorizationStrategyEvaluators
-            )
-        )
+        var authorizationPreflight = ResolveDescriptorReadAuthorization(
+            request.MappingSet,
+            request.Resource,
+            request.AuthorizationStrategyEvaluators,
+            request.RelationalAuthorizationContext,
+            NamespaceAuthorizationOperation.ReadMany,
+            "descriptor query",
+            "GET-many"
+        );
+
+        switch (authorizationPreflight)
         {
-            return new QueryResult.QueryFailureNotImplemented(
-                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                    request.Resource,
-                    request.AuthorizationStrategyEvaluators,
-                    "descriptor query",
-                    "GET-many"
-                )
-            );
+            case DescriptorReadAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                return new QueryResult.QueryFailureNotImplemented(notImplemented.FailureMessage);
+            case DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                return new QueryResult.QueryFailureSecurityConfiguration(configError.Errors);
+            case DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                return new QueryResult.QueryFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
         }
+
+        var proceed = (DescriptorReadAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
+
+        // The descriptor page subquery roots on dms.Document while Namespace lives on the joined
+        // dms.Descriptor row. The page SQL compiler aliases the namespace check to the descriptor
+        // join, so the planner consumes the orchestrator's namespace check specs + prefix
+        // parameterization through PageDocumentIdAuthorizationSpec.
+        var authorizationSpec = BuildDescriptorQueryAuthorizationSpec(proceed);
 
         DescriptorQueryPreprocessingResult preprocessingResult;
 
@@ -182,7 +234,12 @@ internal sealed class DescriptorReadHandler(
 
         try
         {
-            queryRowsPage = await ReadQueryRowsAsync(request, preprocessingResult, cancellationToken)
+            queryRowsPage = await ReadQueryRowsAsync(
+                    request,
+                    preprocessingResult,
+                    authorizationSpec,
+                    cancellationToken
+                )
                 .ConfigureAwait(false);
         }
         catch (NotSupportedException ex)
@@ -221,6 +278,7 @@ internal sealed class DescriptorReadHandler(
     internal Task<DescriptorQueryRowsPage> ReadQueryRowsAsync(
         DescriptorQueryRequest request,
         DescriptorQueryPreprocessingResult preprocessingResult,
+        PageDocumentIdAuthorizationSpec? authorizationSpec = null,
         CancellationToken cancellationToken = default
     )
     {
@@ -239,7 +297,8 @@ internal sealed class DescriptorReadHandler(
             request.MappingSet,
             request.Resource,
             preprocessingResult,
-            request.PaginationParameters
+            request.PaginationParameters,
+            authorizationSpec
         );
         var command = BuildQueryCommand(request.MappingSet.Key.Dialect, plannedQuery);
 
@@ -354,32 +413,31 @@ internal sealed class DescriptorReadHandler(
     {
         ArgumentNullException.ThrowIfNull(plannedQuery);
 
-        List<string> requiredParameterNames = [];
+        List<QuerySqlParameter> requiredParameters = [];
         HashSet<string> seenParameterNames = new(StringComparer.OrdinalIgnoreCase);
 
-        AddParameterNames(
-            plannedQuery.Plan.TotalCountParametersInOrder,
-            requiredParameterNames,
-            seenParameterNames
-        );
-        AddParameterNames(
-            plannedQuery.Plan.PageParametersInOrder,
-            requiredParameterNames,
-            seenParameterNames
-        );
+        AddParameters(plannedQuery.Plan.TotalCountParametersInOrder, requiredParameters, seenParameterNames);
+        AddParameters(plannedQuery.Plan.PageParametersInOrder, requiredParameters, seenParameterNames);
 
         List<string> missingParameterNames = [];
         List<RelationalParameter> parameters = [];
 
-        foreach (var parameterName in requiredParameterNames)
+        foreach (var queryParameter in requiredParameters)
         {
-            if (!plannedQuery.ParameterValues.TryGetValue(parameterName, out var parameterValue))
+            if (
+                !plannedQuery.ParameterValues.TryGetValue(
+                    queryParameter.ParameterName,
+                    out var parameterValue
+                )
+            )
             {
-                missingParameterNames.Add(parameterName);
+                missingParameterNames.Add(queryParameter.ParameterName);
                 continue;
             }
 
-            parameters.Add(new RelationalParameter($"@{parameterName}", parameterValue));
+            parameters.Add(
+                NamespaceAuthorizationCommandParameterBuilder.BuildParameter(queryParameter, parameterValue)
+            );
         }
 
         if (missingParameterNames.Count > 0)
@@ -393,9 +451,9 @@ internal sealed class DescriptorReadHandler(
         return parameters;
     }
 
-    private static void AddParameterNames(
+    private static void AddParameters(
         IReadOnlyList<QuerySqlParameter>? parameterInventory,
-        ICollection<string> requiredParameterNames,
+        ICollection<QuerySqlParameter> requiredParameters,
         ISet<string> seenParameterNames
     )
     {
@@ -404,14 +462,14 @@ internal sealed class DescriptorReadHandler(
             return;
         }
 
-        foreach (var parameterName in parameterInventory.Select(static parameter => parameter.ParameterName))
+        foreach (var parameter in parameterInventory)
         {
-            if (!seenParameterNames.Add(parameterName))
+            if (!seenParameterNames.Add(parameter.ParameterName))
             {
                 continue;
             }
 
-            requiredParameterNames.Add(parameterName);
+            requiredParameters.Add(parameter);
         }
     }
 
@@ -544,6 +602,207 @@ internal sealed class DescriptorReadHandler(
         }
 
         return trimmed.ToString();
+    }
+
+    /// <summary>
+    /// Plans descriptor GET / query namespace authorization through the relational authorization
+    /// orchestrator before any SQL is built. Strategies other than <c>NamespaceBased</c> /
+    /// <c>NoFurtherAuthorizationRequired</c> fail closed; the namespace planner terminals
+    /// (no configured prefixes, no usable root column, MSSQL prefix cap) short-circuit with no DB
+    /// roundtrip; otherwise the configured namespace prefixes are surfaced for the in-memory
+    /// stored-value check on GET-by-id or for SQL emission on query.
+    /// </summary>
+    private static DescriptorReadAuthorizationPreflightOutcome ResolveDescriptorReadAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<AuthorizationStrategyEvaluator> authorizationStrategyEvaluators,
+        RelationalAuthorizationContext authorizationContext,
+        NamespaceAuthorizationOperation operation,
+        string operationLabel,
+        string actionLabel
+    )
+    {
+        if (
+            !RelationalReadGuardrails.HasOnlyNamespaceBasedOrNoFurtherAuthorizationRequired(
+                authorizationStrategyEvaluators
+            )
+        )
+        {
+            return new DescriptorReadAuthorizationPreflightOutcome.NotImplemented(
+                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                    resource,
+                    authorizationStrategyEvaluators,
+                    operationLabel,
+                    actionLabel
+                )
+            );
+        }
+
+        if (!RelationalReadGuardrails.ContainsNamespaceBased(authorizationStrategyEvaluators))
+        {
+            return DescriptorReadAuthorizationPreflightOutcome.Proceed.NoAuthorization;
+        }
+
+        var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
+            authorizationStrategyEvaluators
+        );
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            operation,
+            configuredAuthorizationStrategies,
+            authorizationContext
+        );
+
+        return orchestratorOutcome switch
+        {
+            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
+                new DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError([
+                    NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                        RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                    ),
+                ]),
+            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
+                new DescriptorReadAuthorizationPreflightOutcome.NamespaceNotAuthorized(
+                    NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                ),
+            RelationalAuthorizationPlanOutcome.Plan plan => BuildDescriptorReadPlanPreflight(
+                mappingSet,
+                authorizationContext,
+                plan
+            ),
+            // Restricting strategies to NamespaceBased / NoFurtherAuthorizationRequired above means the
+            // relationship classifier cannot report still-unsupported or security-configuration
+            // outcomes here, but fail closed if a future strategy reaches this point.
+            RelationalAuthorizationPlanOutcome.StillUnsupported
+            or RelationalAuthorizationPlanOutcome.SecurityConfigurationError =>
+                new DescriptorReadAuthorizationPreflightOutcome.NotImplemented(
+                    RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                        resource,
+                        authorizationStrategyEvaluators,
+                        operationLabel,
+                        actionLabel
+                    )
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+            ),
+        };
+    }
+
+    private static DescriptorReadAuthorizationPreflightOutcome BuildDescriptorReadPlanPreflight(
+        MappingSet mappingSet,
+        RelationalAuthorizationContext authorizationContext,
+        RelationalAuthorizationPlanOutcome.Plan plan
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return DescriptorReadAuthorizationPreflightOutcome.Proceed.NoAuthorization;
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new DescriptorReadAuthorizationPreflightOutcome.SecurityConfigurationError([
+                NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+            ]);
+        }
+
+        return new DescriptorReadAuthorizationPreflightOutcome.Proceed(
+            plan.NamespaceChecks,
+            namespacePrefixParameterization
+        );
+    }
+
+    private static PageDocumentIdAuthorizationSpec? BuildDescriptorQueryAuthorizationSpec(
+        DescriptorReadAuthorizationPreflightOutcome.Proceed proceed
+    )
+    {
+        if (proceed.NamespaceChecks.Count == 0)
+        {
+            return null;
+        }
+
+        // No relational relationship strategies participate in descriptor queries; pass an empty
+        // strategy list so the compiler emits namespace-only authorization.
+        return new PageDocumentIdAuthorizationSpec(
+            Strategies: [],
+            NamespaceChecks: proceed.NamespaceChecks,
+            NamespacePrefixParameterization: proceed.NamespacePrefixParameterization
+        );
+    }
+
+    private static NamespaceAuthorizationFailure? EvaluateStoredNamespace(
+        string? storedNamespace,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        if (string.IsNullOrEmpty(storedNamespace))
+        {
+            return new NamespaceAuthorizationFailure(
+                NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+                NamespaceAuthorizationFailureValueSource.Stored,
+                EmittedAuth1Index: 0,
+                AuthorizationStrategyNameConstants.NamespaceBased,
+                [.. namespacePrefixParameterization.ConfiguredPrefixesInOrder]
+            );
+        }
+
+        // The single-record GET-by-id check mirrors the LIKE prefix filter the GET-many and write paths
+        // emit so it accepts and rejects the same stored namespaces for the same caller. The match and
+        // its dialect case sensitivity live on the shared parameterization, next to the SQL escaping it
+        // mirrors, instead of being re-derived here.
+        if (namespacePrefixParameterization.MatchesAnyPrefix(storedNamespace))
+        {
+            return null;
+        }
+
+        return new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            AuthorizationStrategyNameConstants.NamespaceBased,
+            [.. namespacePrefixParameterization.ConfiguredPrefixesInOrder]
+        );
+    }
+
+    private abstract record DescriptorReadAuthorizationPreflightOutcome
+    {
+        private DescriptorReadAuthorizationPreflightOutcome() { }
+
+        public sealed record NotImplemented(string FailureMessage)
+            : DescriptorReadAuthorizationPreflightOutcome;
+
+        public sealed record SecurityConfigurationError(string[] Errors)
+            : DescriptorReadAuthorizationPreflightOutcome;
+
+        public sealed record NamespaceNotAuthorized(NamespaceAuthorizationFailure Failure)
+            : DescriptorReadAuthorizationPreflightOutcome;
+
+        /// <param name="NamespaceChecks">
+        /// Planner-emitted check specs (used by the GET-many SQL emission path).
+        /// </param>
+        /// <param name="NamespacePrefixParameterization">
+        /// Dialect-specific prefix parameterization; non-null exactly when namespace authorization
+        /// applies. Drives the GET-many SQL emission and the GET-by-id in-memory stored-value check.
+        /// </param>
+        public sealed record Proceed(
+            IReadOnlyList<NamespaceAuthorizationCheckSpec> NamespaceChecks,
+            NamespacePrefixParameterization? NamespacePrefixParameterization
+        ) : DescriptorReadAuthorizationPreflightOutcome
+        {
+            public static Proceed NoAuthorization { get; } = new([], null);
+        }
     }
 
     private static RelationalCommand BuildGetByIdCommand(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadRowReader.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadRowReader.cs
@@ -12,7 +12,7 @@ internal sealed record DescriptorReadRow(
     Guid DocumentUuid,
     DateTimeOffset ContentLastModifiedAt,
     short ResourceKeyId,
-    string Namespace,
+    string? Namespace,
     string CodeValue,
     string ShortDescription,
     string? Description,
@@ -98,12 +98,11 @@ internal static class DescriptorReadRowReader
                 resourceKeyId
             ),
             ResourceKeyId: resourceKeyId,
-            Namespace: ReadRequiredDescriptorStringField(
-                reader,
-                NamespaceColumnName,
-                documentId,
-                resourceKeyId
-            ),
+            // Namespace is read nullably so a stored NULL flows into the namespace-authorization
+            // stored-namespace-uninitialized 403 path instead of being masked as a 500 invariant
+            // before the auth check runs. Callers that have no namespace authorization configured
+            // must still treat a NULL value as corruption.
+            Namespace: reader.GetNullableFieldValue<string>(NamespaceColumnName),
             CodeValue: ReadRequiredDescriptorStringField(
                 reader,
                 CodeValueColumnName,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteContracts.cs
@@ -21,7 +21,9 @@ public sealed record DescriptorWriteRequest
         JsonNode requestBody,
         DocumentUuid documentUuid,
         ReferentialId? referentialId,
-        TraceId traceId
+        TraceId traceId,
+        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
+        RelationalAuthorizationContext? relationalAuthorizationContext = null
     )
     {
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
@@ -30,6 +32,9 @@ public sealed record DescriptorWriteRequest
         DocumentUuid = documentUuid;
         ReferentialId = referentialId;
         TraceId = traceId;
+        AuthorizationStrategyEvaluators = authorizationStrategyEvaluators ?? [];
+        RelationalAuthorizationContext =
+            relationalAuthorizationContext ?? new RelationalAuthorizationContext([]);
     }
 
     /// <summary>
@@ -63,6 +68,19 @@ public sealed record DescriptorWriteRequest
     public TraceId TraceId { get; init; }
 
     /// <summary>
+    /// The effective POST/PUT authorization strategies already resolved by Core.
+    /// </summary>
+    public AuthorizationStrategyEvaluator[] AuthorizationStrategyEvaluators { get; init; }
+
+    /// <summary>
+    /// Request-scoped authorization inputs (namespace prefixes and claim education organization ids)
+    /// used by backend-planned namespace authorization. Carried alongside the evaluators because the
+    /// evaluators preserve raw strategy names with empty filter providers in relational mode and do not
+    /// carry the namespace prefixes the planner needs.
+    /// </summary>
+    public RelationalAuthorizationContext RelationalAuthorizationContext { get; init; }
+
+    /// <summary>
     /// Typed write precondition forwarded from Core for descriptor write flows.
     /// </summary>
     public WritePrecondition WritePrecondition
@@ -84,7 +102,8 @@ public sealed record DescriptorDeleteRequest
         QualifiedResourceName resource,
         DocumentUuid documentUuid,
         TraceId traceId,
-        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null
+        AuthorizationStrategyEvaluator[]? authorizationStrategyEvaluators = null,
+        RelationalAuthorizationContext? relationalAuthorizationContext = null
     )
     {
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
@@ -92,6 +111,8 @@ public sealed record DescriptorDeleteRequest
         DocumentUuid = documentUuid;
         TraceId = traceId;
         AuthorizationStrategyEvaluators = authorizationStrategyEvaluators ?? [];
+        RelationalAuthorizationContext =
+            relationalAuthorizationContext ?? new RelationalAuthorizationContext([]);
     }
 
     /// <summary>
@@ -118,6 +139,14 @@ public sealed record DescriptorDeleteRequest
     /// The effective DELETE authorization strategies already resolved by Core.
     /// </summary>
     public AuthorizationStrategyEvaluator[] AuthorizationStrategyEvaluators { get; init; }
+
+    /// <summary>
+    /// Request-scoped authorization inputs (namespace prefixes and claim education organization ids)
+    /// used by backend-planned namespace authorization. Carried alongside the evaluators because the
+    /// evaluators preserve raw strategy names with empty filter providers in relational mode and do not
+    /// carry the namespace prefixes the planner needs.
+    /// </summary>
+    public RelationalAuthorizationContext RelationalAuthorizationContext { get; init; }
 
     /// <summary>
     /// Typed write precondition forwarded from Core for descriptor delete flows.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -1111,12 +1111,12 @@ internal sealed class DescriptorWriteHandler(
                 request.MappingSet.Key.Dialect,
                 request.RelationalAuthorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new DescriptorDeleteAuthorizationPreflightResult.Stop(
-                new DeleteResult.DeleteFailureSecurityConfiguration([prefixCapExceededMessage])
+                new DeleteResult.DeleteFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 
@@ -1270,12 +1270,12 @@ internal sealed class DescriptorWriteHandler(
                 request.MappingSet.Key.Dialect,
                 request.RelationalAuthorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError([
-                prefixCapExceededMessage,
+                securityConfigurationMessage,
             ]);
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -191,7 +191,7 @@ internal sealed class DescriptorWriteHandler(
                     var namespaceFailureMessage
                 ):
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                    return new UpsertResult.UnknownFailure(namespaceFailureMessage);
+                    return new UpsertResult.UpsertFailureSecurityConfiguration([namespaceFailureMessage]);
 
                 case DescriptorLockedPreconditionResult.Mismatch:
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
@@ -363,7 +363,7 @@ internal sealed class DescriptorWriteHandler(
                         var namespaceFailureMessage
                     ):
                         await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                        return new UpdateResult.UnknownFailure(namespaceFailureMessage);
+                        return new UpdateResult.UpdateFailureSecurityConfiguration([namespaceFailureMessage]);
 
                     case DescriptorLockedPreconditionResult.Mismatch:
                         await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
@@ -666,7 +666,7 @@ internal sealed class DescriptorWriteHandler(
                             new DeleteResult.DeleteFailureNamespaceNotAuthorized(namespaceFailure),
                         DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
                             var failureMessage
-                        ) => new DeleteResult.UnknownFailure(failureMessage),
+                        ) => new DeleteResult.DeleteFailureSecurityConfiguration([failureMessage]),
                         DescriptorLockedPreconditionResult.Mismatch =>
                             new DeleteResult.DeleteFailureETagMisMatch(),
                         DescriptorLockedPreconditionResult.Loaded =>
@@ -1106,22 +1106,17 @@ internal sealed class DescriptorWriteHandler(
             return new DescriptorDeleteAuthorizationPreflightResult.Proceed(null);
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 request.MappingSet.Key.Dialect,
                 request.RelationalAuthorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new DescriptorDeleteAuthorizationPreflightResult.Stop(
-                new DeleteResult.DeleteFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new DeleteResult.DeleteFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -1166,7 +1161,8 @@ internal sealed class DescriptorWriteHandler(
         MapNamespaceAuthorizationToResult<DeleteResult>(
             executionResult,
             static failure => new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
-            static failureMessage => new DeleteResult.UnknownFailure(failureMessage)
+            static failureMessage => new DeleteResult.DeleteFailureSecurityConfiguration([failureMessage]),
+            static () => new DeleteResult.DeleteFailureNotExists()
         );
 
     private abstract record DescriptorDeleteAuthorizationPreflightResult
@@ -1269,20 +1265,17 @@ internal sealed class DescriptorWriteHandler(
             return DescriptorWriteAuthorizationPreflightOutcome.Proceed.NoAuthorization;
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 request.MappingSet.Key.Dialect,
                 request.RelationalAuthorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError([
-                NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                prefixCapExceededMessage,
             ]);
         }
 
@@ -1523,7 +1516,8 @@ internal sealed class DescriptorWriteHandler(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
             ),
             static failure => new UpsertResult.UpsertFailureNamespaceNotAuthorized(failure),
-            static failureMessage => new UpsertResult.UnknownFailure(failureMessage),
+            static failureMessage => new UpsertResult.UpsertFailureSecurityConfiguration([failureMessage]),
+            static () => new UpsertResult.UpsertFailureWriteConflict(),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPostUpsertAsync(
                     request,
@@ -1559,7 +1553,8 @@ internal sealed class DescriptorWriteHandler(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
             ),
             static failure => new UpdateResult.UpdateFailureNamespaceNotAuthorized(failure),
-            static failureMessage => new UpdateResult.UnknownFailure(failureMessage),
+            static failureMessage => new UpdateResult.UpdateFailureSecurityConfiguration([failureMessage]),
+            static () => new UpdateResult.UpdateFailureNotExists(),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPutAsync(
                     request,
@@ -1584,6 +1579,7 @@ internal sealed class DescriptorWriteHandler(
         Func<long, TResult> missingDescriptorResultFactory,
         Func<NamespaceAuthorizationFailure, TResult> namespaceNotAuthorizedFactory,
         Func<string, TResult> namespaceAuthorizationInvalidFactory,
+        Func<TResult> namespaceStaleTargetFactory,
         Func<
             PersistedDescriptorState,
             string,
@@ -1642,7 +1638,8 @@ internal sealed class DescriptorWriteHandler(
                         var storedFailure = MapNamespaceAuthorizationToResult(
                             storedResult,
                             namespaceNotAuthorizedFactory,
-                            namespaceAuthorizationInvalidFactory
+                            namespaceAuthorizationInvalidFactory,
+                            namespaceStaleTargetFactory
                         );
 
                         if (storedFailure is not null)
@@ -1667,7 +1664,8 @@ internal sealed class DescriptorWriteHandler(
                         var proposedFailure = MapNamespaceAuthorizationToResult(
                             proposedResult,
                             namespaceNotAuthorizedFactory,
-                            namespaceAuthorizationInvalidFactory
+                            namespaceAuthorizationInvalidFactory,
+                            namespaceStaleTargetFactory
                         );
 
                         if (proposedFailure is not null)
@@ -1731,7 +1729,10 @@ internal sealed class DescriptorWriteHandler(
                 var proposedFailure = MapNamespaceAuthorizationToResult<UpsertResult>(
                     proposedResult,
                     static failure => new UpsertResult.UpsertFailureNamespaceNotAuthorized(failure),
-                    static failureMessage => new UpsertResult.UnknownFailure(failureMessage)
+                    static failureMessage => new UpsertResult.UpsertFailureSecurityConfiguration([
+                        failureMessage,
+                    ]),
+                    static () => new UpsertResult.UpsertFailureWriteConflict()
                 );
 
                 if (proposedFailure is not null)
@@ -1764,7 +1765,8 @@ internal sealed class DescriptorWriteHandler(
     private static TResult? MapNamespaceAuthorizationToResult<TResult>(
         NamespaceAuthorizationExecutionResult executionResult,
         Func<NamespaceAuthorizationFailure, TResult> namespaceNotAuthorizedFactory,
-        Func<string, TResult> namespaceAuthorizationInvalidFactory
+        Func<string, TResult> namespaceAuthorizationInvalidFactory,
+        Func<TResult> staleTargetFactory
     )
         where TResult : class =>
         executionResult switch
@@ -1774,6 +1776,9 @@ internal sealed class DescriptorWriteHandler(
                 namespaceNotAuthorizedFactory(notAuthorized.Failure),
             NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
                 namespaceAuthorizationInvalidFactory(invalidFailure.FailureMessage),
+            // Descriptor write/delete paths row-lock the target before the namespace check, so a stale
+            // target is not expected; the caller maps it defensively to its conflict/not-exists outcome.
+            NamespaceAuthorizationExecutionResult.StaleTarget => staleTargetFactory(),
             _ => throw new InvalidOperationException(
                 $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
             ),
@@ -1803,7 +1808,10 @@ internal sealed class DescriptorWriteHandler(
             static failure => new DescriptorLockedPreconditionResult.NamespaceNotAuthorized(failure),
             static failureMessage => new DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
                 failureMessage
-            )
+            ),
+            // The If-Match path locks the target before this check, so a stale target maps to the same
+            // missing-document precondition the caller already resolves to not-exists/conflict.
+            static () => DescriptorLockedPreconditionResult.MissingDocument.Instance
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -5,6 +5,7 @@
 
 using System.Data.Common;
 using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Utilities;
@@ -21,7 +22,9 @@ internal sealed class DescriptorWriteHandler(
     IRelationalWriteExceptionClassifier writeExceptionClassifier,
     IRelationalDeleteConstraintResolver deleteConstraintResolver,
     IRelationalWriteSessionFactory writeSessionFactory,
-    ILogger<DescriptorWriteHandler> logger
+    ILogger<DescriptorWriteHandler> logger,
+    IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
+        null
 ) : IDescriptorWriteHandler
 {
     private readonly IRelationalWriteTargetLookupService _targetLookupService =
@@ -34,6 +37,9 @@ internal sealed class DescriptorWriteHandler(
         writeSessionFactory ?? throw new ArgumentNullException(nameof(writeSessionFactory));
     private readonly ILogger<DescriptorWriteHandler> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
+    private readonly IRelationshipAuthorizationProviderFailureExtractor _relationshipAuthorizationProviderFailureExtractor =
+        relationshipAuthorizationProviderFailureExtractor
+        ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
 
     public async Task<UpsertResult> HandlePostAsync(
         DescriptorWriteRequest request,
@@ -49,6 +55,34 @@ internal sealed class DescriptorWriteHandler(
                 "Descriptor POST requires a ReferentialId for target context resolution."
             );
         }
+
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
+        // unsupported strategies resolve before any session opens, so a denial issues no DB roundtrip.
+        // The stored and proposed namespace checks run inside the descriptor write session against the
+        // resolved target (see the per-path execution helpers below).
+        var authorizationPreflight = ResolveDescriptorWriteAuthorization(
+            request,
+            NamespaceAuthorizationOperation.Update,
+            "descriptor POST",
+            "POST"
+        );
+
+        switch (authorizationPreflight)
+        {
+            case DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                return new UpsertResult.UpsertFailureNotImplemented(
+                    notImplemented.FailureMessage,
+                    UpsertFailureNotImplementedReason.StrategyNotEnabled
+                );
+            case DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                return new UpsertResult.UpsertFailureSecurityConfiguration(configError.Errors);
+            case DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                return new UpsertResult.UpsertFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
+        }
+
+        var proceed = (DescriptorWriteAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
+        var storedNamespaceAuthorization = proceed.StoredNamespaceAuthorization;
+        var proposedNamespaceAuthorization = proceed.ProposedNamespaceAuthorization;
 
         var body = DescriptorWriteBodyExtractor.Extract(request.RequestBody, request.Resource);
         var resourceKeyId = RelationalWriteSupport.GetResourceKeyIdOrThrow(
@@ -87,16 +121,12 @@ internal sealed class DescriptorWriteHandler(
                 return targetContext switch
                 {
                     RelationalWriteTargetContext.CreateNew(var documentUuid) =>
-                        await ExecuteDescriptorWriteInTransactionAsync(
-                                (sessionCommandExecutor, ct) =>
-                                    InsertDescriptorAsync(
-                                        request,
-                                        body,
-                                        documentUuid,
-                                        resourceKeyId,
-                                        sessionCommandExecutor,
-                                        ct
-                                    ),
+                        await ExecuteDescriptorInsertWithProposedNamespaceCheckAsync(
+                                request,
+                                body,
+                                documentUuid,
+                                resourceKeyId,
+                                proposedNamespaceAuthorization,
                                 cancellationToken
                             )
                             .ConfigureAwait(false),
@@ -108,6 +138,8 @@ internal sealed class DescriptorWriteHandler(
                                 documentId,
                                 documentUuid,
                                 resourceKeyId,
+                                storedNamespaceAuthorization,
+                                proposedNamespaceAuthorization,
                                 cancellationToken
                             )
                             .ConfigureAwait(false),
@@ -128,7 +160,10 @@ internal sealed class DescriptorWriteHandler(
                     DescriptorPreconditionTargetKind.Post,
                     ifMatch,
                     writeSession,
-                    cancellationToken
+                    cancellationToken,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization,
+                    body.Namespace
                 )
                 .ConfigureAwait(false);
 
@@ -147,6 +182,16 @@ internal sealed class DescriptorWriteHandler(
                     return new UpsertResult.UnknownFailure(
                         BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
                     );
+
+                case DescriptorLockedPreconditionResult.NamespaceNotAuthorized(var namespaceFailure):
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return new UpsertResult.UpsertFailureNamespaceNotAuthorized(namespaceFailure);
+
+                case DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
+                    var namespaceFailureMessage
+                ):
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return new UpsertResult.UnknownFailure(namespaceFailureMessage);
 
                 case DescriptorLockedPreconditionResult.Mismatch:
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
@@ -243,6 +288,31 @@ internal sealed class DescriptorWriteHandler(
         ArgumentNullException.ThrowIfNull(request);
         cancellationToken.ThrowIfCancellationRequested();
 
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
+        // unsupported strategies resolve before any session opens, so a denial issues no DB roundtrip.
+        // The stored and proposed namespace checks run inside the descriptor write session against the
+        // resolved target (see the per-path execution helpers below).
+        var authorizationPreflight = ResolveDescriptorWriteAuthorization(
+            request,
+            NamespaceAuthorizationOperation.Update,
+            "descriptor PUT",
+            "PUT"
+        );
+
+        switch (authorizationPreflight)
+        {
+            case DescriptorWriteAuthorizationPreflightOutcome.NotImplemented notImplemented:
+                return new UpdateResult.UpdateFailureNotImplemented(notImplemented.FailureMessage);
+            case DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError configError:
+                return new UpdateResult.UpdateFailureSecurityConfiguration(configError.Errors);
+            case DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized namespaceNotAuthorized:
+                return new UpdateResult.UpdateFailureNamespaceNotAuthorized(namespaceNotAuthorized.Failure);
+        }
+
+        var proceed = (DescriptorWriteAuthorizationPreflightOutcome.Proceed)authorizationPreflight;
+        var storedNamespaceAuthorization = proceed.StoredNamespaceAuthorization;
+        var proposedNamespaceAuthorization = proceed.ProposedNamespaceAuthorization;
+
         var body = DescriptorWriteBodyExtractor.Extract(request.RequestBody, request.Resource);
 
         IRelationalWriteSession? writeSession = null;
@@ -263,7 +333,10 @@ internal sealed class DescriptorWriteHandler(
                         DescriptorPreconditionTargetKind.Put,
                         ifMatch,
                         writeSession,
-                        cancellationToken
+                        cancellationToken,
+                        storedNamespaceAuthorization,
+                        proposedNamespaceAuthorization,
+                        body.Namespace
                     )
                     .ConfigureAwait(false);
 
@@ -281,6 +354,16 @@ internal sealed class DescriptorWriteHandler(
                         return new UpdateResult.UnknownFailure(
                             BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
                         );
+
+                    case DescriptorLockedPreconditionResult.NamespaceNotAuthorized(var namespaceFailure):
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return new UpdateResult.UpdateFailureNamespaceNotAuthorized(namespaceFailure);
+
+                    case DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
+                        var namespaceFailureMessage
+                    ):
+                        await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                        return new UpdateResult.UnknownFailure(namespaceFailureMessage);
 
                     case DescriptorLockedPreconditionResult.Mismatch:
                         await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
@@ -352,6 +435,8 @@ internal sealed class DescriptorWriteHandler(
                     body,
                     documentId,
                     documentUuid,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
@@ -414,21 +499,20 @@ internal sealed class DescriptorWriteHandler(
             LoggingSanitizer.SanitizeForLogging(request.TraceId.Value)
         );
 
-        if (
-            !RelationalReadGuardrails.HasOnlyNoFurtherAuthorizationRequired(
-                request.AuthorizationStrategyEvaluators
-            )
-        )
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) and
+        // unsupported strategies resolve before the write session opens, so a denial issues no DB
+        // roundtrip and never locks the target. The stored namespace check itself runs inside the
+        // delete session against the resolved target (see the stored-namespace check below).
+        var authorizationPreflight = AuthorizeDescriptorDeletePreflight(request);
+
+        if (authorizationPreflight is DescriptorDeleteAuthorizationPreflightResult.Stop stop)
         {
-            return new DeleteResult.DeleteFailureNotImplemented(
-                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
-                    request.Resource,
-                    request.AuthorizationStrategyEvaluators,
-                    "descriptor DELETE",
-                    "DELETE"
-                )
-            );
+            return stop.Result;
         }
+
+        var storedNamespaceAuthorization = (
+            (DescriptorDeleteAuthorizationPreflightResult.Proceed)authorizationPreflight
+        ).StoredNamespaceAuthorization;
 
         // Scope the DELETE by ResourceKeyId so a UUID belonging to a different descriptor
         // (or a non-descriptor document) cannot be deleted through this resource endpoint.
@@ -479,24 +563,79 @@ internal sealed class DescriptorWriteHandler(
             {
                 if (ifMatch is null)
                 {
-                    outcome = await RelationalDeleteExecution
-                        .TryExecuteAsync(
-                            sessionCommandExecutor,
-                            BuildDescriptorDeleteCommand(
-                                sessionCommandExecutor.Dialect,
+                    // The stored namespace check (when configured) AND-composes before the delete and
+                    // must read the resolved target's namespace, so resolve the document first, then
+                    // lock the resolved row before authorizing. Locking between resolve and auth
+                    // closes the race where a concurrent committed delete would let auth fire against
+                    // a stale view and the subsequent delete silently no-op. The public DELETE route
+                    // addresses a server-generated, unique DocumentUuid; clients cannot create or
+                    // replace a descriptor under an arbitrary existing UUID, and descriptor PUT cannot
+                    // change Namespace/CodeValue identity. Deleting by the same DocumentUuid plus
+                    // ResourceKeyId after authorizing the locked row therefore does not allow an
+                    // unauthorized replacement-delete path.
+                    if (storedNamespaceAuthorization is not null)
+                    {
+                        var resolvedDeleteTarget = await RelationalDocumentUuidLookupSupport
+                            .TryResolveDeleteTargetAsync(
+                                sessionCommandExecutor,
+                                request.MappingSet,
+                                request.Resource,
                                 request.DocumentUuid,
-                                resourceKeyId
-                            ),
-                            _writeExceptionClassifier,
-                            _deleteConstraintResolver,
-                            request.MappingSet.Model,
-                            _logger,
-                            request.DocumentUuid,
-                            request.TraceId,
-                            DeleteTargetKind.Descriptor,
-                            cancellationToken
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false);
+
+                        if (resolvedDeleteTarget is null)
+                        {
+                            outcome = new DeleteResult.DeleteFailureNotExists();
+                        }
+                        else if (
+                            !await TryLockDocumentAsync(
+                                    request.MappingSet.Key.Dialect,
+                                    resolvedDeleteTarget.DocumentId,
+                                    writeSession,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false)
                         )
-                        .ConfigureAwait(false);
+                        {
+                            outcome = new DeleteResult.DeleteFailureNotExists();
+                        }
+                        else
+                        {
+                            var namespaceFailure = MapDeleteNamespaceAuthorizationResult(
+                                await ExecuteDescriptorNamespaceAuthorizationAsync(
+                                        request.MappingSet,
+                                        resolvedDeleteTarget.DocumentId,
+                                        storedNamespaceAuthorization,
+                                        proposedNamespace: null,
+                                        sessionCommandExecutor,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false)
+                            );
+
+                            outcome =
+                                namespaceFailure
+                                ?? await ExecuteDescriptorDeleteCommandAsync(
+                                        request,
+                                        resourceKeyId,
+                                        sessionCommandExecutor,
+                                        cancellationToken
+                                    )
+                                    .ConfigureAwait(false);
+                        }
+                    }
+                    else
+                    {
+                        outcome = await ExecuteDescriptorDeleteCommandAsync(
+                                request,
+                                resourceKeyId,
+                                sessionCommandExecutor,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false);
+                    }
                 }
                 else
                 {
@@ -508,7 +647,8 @@ internal sealed class DescriptorWriteHandler(
                             DescriptorPreconditionTargetKind.Delete,
                             ifMatch,
                             writeSession,
-                            cancellationToken
+                            cancellationToken,
+                            storedNamespaceAuthorization
                         )
                         .ConfigureAwait(false);
 
@@ -522,26 +662,21 @@ internal sealed class DescriptorWriteHandler(
                             new DeleteResult.UnknownFailure(
                                 BuildMissingDescriptorMessage(request.Resource, documentId)
                             ),
+                        DescriptorLockedPreconditionResult.NamespaceNotAuthorized(var namespaceFailure) =>
+                            new DeleteResult.DeleteFailureNamespaceNotAuthorized(namespaceFailure),
+                        DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
+                            var failureMessage
+                        ) => new DeleteResult.UnknownFailure(failureMessage),
                         DescriptorLockedPreconditionResult.Mismatch =>
                             new DeleteResult.DeleteFailureETagMisMatch(),
-                        DescriptorLockedPreconditionResult.Loaded => await RelationalDeleteExecution
-                            .TryExecuteAsync(
-                                sessionCommandExecutor,
-                                BuildDescriptorDeleteCommand(
-                                    sessionCommandExecutor.Dialect,
-                                    request.DocumentUuid,
-                                    resourceKeyId
-                                ),
-                                _writeExceptionClassifier,
-                                _deleteConstraintResolver,
-                                request.MappingSet.Model,
-                                _logger,
-                                request.DocumentUuid,
-                                request.TraceId,
-                                DeleteTargetKind.Descriptor,
-                                cancellationToken
-                            )
-                            .ConfigureAwait(false),
+                        DescriptorLockedPreconditionResult.Loaded =>
+                            await ExecuteDescriptorDeleteCommandAsync(
+                                    request,
+                                    resourceKeyId,
+                                    sessionCommandExecutor,
+                                    cancellationToken
+                                )
+                                .ConfigureAwait(false),
                         _ => throw new InvalidOperationException(
                             $"Unexpected locked descriptor precondition result type '{preconditionResult.GetType().Name}'."
                         ),
@@ -615,7 +750,7 @@ internal sealed class DescriptorWriteHandler(
         }
     }
 
-    private static async Task<DescriptorLockedPreconditionResult> ResolveLockedDescriptorForIfMatchAsync(
+    private async Task<DescriptorLockedPreconditionResult> ResolveLockedDescriptorForIfMatchAsync(
         MappingSet mappingSet,
         QualifiedResourceName resource,
         DocumentUuid documentUuid,
@@ -623,7 +758,10 @@ internal sealed class DescriptorWriteHandler(
         DescriptorPreconditionTargetKind targetKind,
         WritePrecondition.IfMatch ifMatch,
         IRelationalWriteSession writeSession,
-        CancellationToken cancellationToken
+        CancellationToken cancellationToken,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null,
+        string? proposedNamespace = null
     )
     {
         ArgumentNullException.ThrowIfNull(mappingSet);
@@ -704,6 +842,28 @@ internal sealed class DescriptorWriteHandler(
 
         if (targetContext is RelationalWriteTargetContext.CreateNew)
         {
+            // POST with If-Match where no existing document was found normally returns ETagMisMatch,
+            // but a configured proposed-value namespace authorization must run first so that a denial
+            // (403) precedes the stale precondition (412). The proposed check is a single statement
+            // against the dialect's namespace authorization SQL and needs no row lookup.
+            if (proposedNamespaceAuthorization is not null)
+            {
+                var preconditionFromProposed = await EvaluateNamespaceAuthorizationAsync(
+                        mappingSet,
+                        documentId: 0L,
+                        proposedNamespaceAuthorization,
+                        proposedNamespace,
+                        sessionCommandExecutor,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                if (preconditionFromProposed is not null)
+                {
+                    return preconditionFromProposed;
+                }
+            }
+
             return DescriptorLockedPreconditionResult.CreateNew.Instance;
         }
 
@@ -722,6 +882,49 @@ internal sealed class DescriptorWriteHandler(
                 cancellationToken
             )
             .ConfigureAwait(false);
+
+        // Namespace authorization AND-composes before the If-Match precondition: run the stored and
+        // proposed namespace checks against the locked target so a namespace denial (403) is returned
+        // ahead of a stale-ETag mismatch (412). Only run them once the row is loaded; a missing row
+        // falls through to the existing not-found/not-exists handling.
+        if (lockedCurrentState is DescriptorCurrentStateLoadResult.Loaded)
+        {
+            if (storedNamespaceAuthorization is not null)
+            {
+                var preconditionFromStored = await EvaluateNamespaceAuthorizationAsync(
+                        mappingSet,
+                        existingTargetContext.DocumentId,
+                        storedNamespaceAuthorization,
+                        proposedNamespace: null,
+                        sessionCommandExecutor,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                if (preconditionFromStored is not null)
+                {
+                    return preconditionFromStored;
+                }
+            }
+
+            if (proposedNamespaceAuthorization is not null)
+            {
+                var preconditionFromProposed = await EvaluateNamespaceAuthorizationAsync(
+                        mappingSet,
+                        existingTargetContext.DocumentId,
+                        proposedNamespaceAuthorization,
+                        proposedNamespace,
+                        sessionCommandExecutor,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                if (preconditionFromProposed is not null)
+                {
+                    return preconditionFromProposed;
+                }
+            }
+        }
 
         return lockedCurrentState switch
         {
@@ -786,6 +989,337 @@ internal sealed class DescriptorWriteHandler(
                 $"Descriptor delete does not support SQL dialect '{dialect}'."
             ),
         };
+    }
+
+    private Task<DeleteResult> ExecuteDescriptorDeleteCommandAsync(
+        DescriptorDeleteRequest request,
+        short resourceKeyId,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    ) =>
+        RelationalDeleteExecution.TryExecuteAsync(
+            sessionCommandExecutor,
+            BuildDescriptorDeleteCommand(sessionCommandExecutor.Dialect, request.DocumentUuid, resourceKeyId),
+            _writeExceptionClassifier,
+            _deleteConstraintResolver,
+            request.MappingSet.Model,
+            _logger,
+            request.DocumentUuid,
+            request.TraceId,
+            DeleteTargetKind.Descriptor,
+            cancellationToken
+        );
+
+    /// <summary>
+    /// Plans descriptor DELETE namespace authorization through the relational authorization
+    /// orchestrator before the write session opens. Strategies other than <c>NamespaceBased</c> /
+    /// <c>NoFurtherAuthorizationRequired</c> fail closed; the namespace planner terminals
+    /// (no configured prefixes, no usable root column, MSSQL prefix cap) short-circuit with no DB
+    /// roundtrip.
+    /// </summary>
+    private static DescriptorDeleteAuthorizationPreflightResult AuthorizeDescriptorDeletePreflight(
+        DescriptorDeleteRequest request
+    )
+    {
+        if (
+            !RelationalReadGuardrails.HasOnlyNamespaceBasedOrNoFurtherAuthorizationRequired(
+                request.AuthorizationStrategyEvaluators
+            )
+        )
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                new DeleteResult.DeleteFailureNotImplemented(
+                    RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                        request.Resource,
+                        request.AuthorizationStrategyEvaluators,
+                        "descriptor DELETE",
+                        "DELETE"
+                    )
+                )
+            );
+        }
+
+        if (!RelationalReadGuardrails.ContainsNamespaceBased(request.AuthorizationStrategyEvaluators))
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Proceed(null);
+        }
+
+        var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
+            request.AuthorizationStrategyEvaluators
+        );
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            NamespaceAuthorizationOperation.Delete,
+            configuredAuthorizationStrategies,
+            request.RelationalAuthorizationContext
+        );
+
+        return orchestratorOutcome switch
+        {
+            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
+                new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                    new DeleteResult.DeleteFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                ),
+            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
+                new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                    new DeleteResult.DeleteFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                ),
+            RelationalAuthorizationPlanOutcome.Plan plan => AuthorizeDescriptorDeletePlanPreflight(
+                request,
+                plan
+            ),
+            // Limiting strategies to NamespaceBased / NoFurtherAuthorizationRequired above means the
+            // relationship classifier cannot report still-unsupported or security-configuration outcomes
+            // here, but fail closed if a future strategy reaches this point.
+            RelationalAuthorizationPlanOutcome.StillUnsupported
+            or RelationalAuthorizationPlanOutcome.SecurityConfigurationError =>
+                new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                    new DeleteResult.DeleteFailureNotImplemented(
+                        RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                            request.Resource,
+                            request.AuthorizationStrategyEvaluators,
+                            "descriptor DELETE",
+                            "DELETE"
+                        )
+                    )
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+            ),
+        };
+    }
+
+    private static DescriptorDeleteAuthorizationPreflightResult AuthorizeDescriptorDeletePlanPreflight(
+        DescriptorDeleteRequest request,
+        RelationalAuthorizationPlanOutcome.Plan plan
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Proceed(null);
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                request.MappingSet.Key.Dialect,
+                request.RelationalAuthorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new DescriptorDeleteAuthorizationPreflightResult.Stop(
+                new DeleteResult.DeleteFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        return new DescriptorDeleteAuthorizationPreflightResult.Proceed(
+            new RelationalWriteNamespaceAuthorization(plan.NamespaceChecks, namespacePrefixParameterization)
+        );
+    }
+
+    /// <summary>
+    /// Runs the namespace authorization checks against the descriptor write session's command executor,
+    /// composing inside the same transaction that resolved/locked the target document.
+    /// </summary>
+    private Task<NamespaceAuthorizationExecutionResult> ExecuteDescriptorNamespaceAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization namespaceAuthorization,
+        string? proposedNamespace,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    )
+    {
+        var namespaceExecutor = new NamespaceAuthorizationExecutor(
+            sessionCommandExecutor,
+            _relationshipAuthorizationProviderFailureExtractor
+        );
+
+        return namespaceExecutor.ExecuteAsync(
+            new NamespaceAuthorizationExecutionRequest(
+                mappingSet,
+                documentId,
+                proposedNamespace,
+                namespaceAuthorization.Checks,
+                namespaceAuthorization.NamespacePrefixParameterization
+            ),
+            cancellationToken
+        );
+    }
+
+    private static DeleteResult? MapDeleteNamespaceAuthorizationResult(
+        NamespaceAuthorizationExecutionResult executionResult
+    ) =>
+        MapNamespaceAuthorizationToResult<DeleteResult>(
+            executionResult,
+            static failure => new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
+            static failureMessage => new DeleteResult.UnknownFailure(failureMessage)
+        );
+
+    private abstract record DescriptorDeleteAuthorizationPreflightResult
+    {
+        private DescriptorDeleteAuthorizationPreflightResult() { }
+
+        public sealed record Stop(DeleteResult Result) : DescriptorDeleteAuthorizationPreflightResult;
+
+        public sealed record Proceed(RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization)
+            : DescriptorDeleteAuthorizationPreflightResult;
+    }
+
+    /// <summary>
+    /// Plans descriptor POST/PUT namespace authorization through the relational authorization
+    /// orchestrator. Strategies other than <c>NamespaceBased</c> / <c>NoFurtherAuthorizationRequired</c>
+    /// fail closed; the namespace planner terminals (no configured prefixes, no usable root column,
+    /// MSSQL prefix cap) short-circuit with no DB roundtrip; otherwise the planner's checks are
+    /// split into stored-value (locked target) and proposed-value (request body) authorizations
+    /// re-indexed from zero, each executed as its own single-record statement inside the write
+    /// session.
+    /// </summary>
+    private static DescriptorWriteAuthorizationPreflightOutcome ResolveDescriptorWriteAuthorization(
+        DescriptorWriteRequest request,
+        NamespaceAuthorizationOperation operation,
+        string operationLabel,
+        string actionLabel
+    )
+    {
+        if (
+            !RelationalReadGuardrails.HasOnlyNamespaceBasedOrNoFurtherAuthorizationRequired(
+                request.AuthorizationStrategyEvaluators
+            )
+        )
+        {
+            return new DescriptorWriteAuthorizationPreflightOutcome.NotImplemented(
+                RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                    request.Resource,
+                    request.AuthorizationStrategyEvaluators,
+                    operationLabel,
+                    actionLabel
+                )
+            );
+        }
+
+        if (!RelationalReadGuardrails.ContainsNamespaceBased(request.AuthorizationStrategyEvaluators))
+        {
+            return DescriptorWriteAuthorizationPreflightOutcome.Proceed.NoAuthorization;
+        }
+
+        var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
+            request.AuthorizationStrategyEvaluators
+        );
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            request.MappingSet,
+            request.MappingSet.GetConcreteResourceModelOrThrow(request.Resource),
+            operation,
+            configuredAuthorizationStrategies,
+            request.RelationalAuthorizationContext
+        );
+
+        return orchestratorOutcome switch
+        {
+            RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot =>
+                new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError([
+                    NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                        RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                    ),
+                ]),
+            RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes =>
+                new DescriptorWriteAuthorizationPreflightOutcome.NamespaceNotAuthorized(
+                    NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                ),
+            RelationalAuthorizationPlanOutcome.Plan plan => BuildDescriptorWritePlanPreflight(request, plan),
+            // Limiting strategies to NamespaceBased / NoFurtherAuthorizationRequired above means the
+            // relationship classifier cannot report still-unsupported or security-configuration
+            // outcomes here, but fail closed if a future strategy reaches this point.
+            RelationalAuthorizationPlanOutcome.StillUnsupported
+            or RelationalAuthorizationPlanOutcome.SecurityConfigurationError =>
+                new DescriptorWriteAuthorizationPreflightOutcome.NotImplemented(
+                    RelationalReadGuardrails.BuildAuthorizationNotImplementedMessage(
+                        request.Resource,
+                        request.AuthorizationStrategyEvaluators,
+                        operationLabel,
+                        actionLabel
+                    )
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+            ),
+        };
+    }
+
+    private static DescriptorWriteAuthorizationPreflightOutcome BuildDescriptorWritePlanPreflight(
+        DescriptorWriteRequest request,
+        RelationalAuthorizationPlanOutcome.Plan plan
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return DescriptorWriteAuthorizationPreflightOutcome.Proceed.NoAuthorization;
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                request.MappingSet.Key.Dialect,
+                request.RelationalAuthorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new DescriptorWriteAuthorizationPreflightOutcome.SecurityConfigurationError([
+                NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+            ]);
+        }
+
+        var stored = NamespaceAuthorizationFactory.SplitByValueSource(
+            plan.NamespaceChecks,
+            NamespaceAuthorizationCheckValueSource.Stored,
+            namespacePrefixParameterization
+        );
+        var proposed = NamespaceAuthorizationFactory.SplitByValueSource(
+            plan.NamespaceChecks,
+            NamespaceAuthorizationCheckValueSource.Proposed,
+            namespacePrefixParameterization
+        );
+
+        return new DescriptorWriteAuthorizationPreflightOutcome.Proceed(stored, proposed);
+    }
+
+    private abstract record DescriptorWriteAuthorizationPreflightOutcome
+    {
+        private DescriptorWriteAuthorizationPreflightOutcome() { }
+
+        public sealed record NotImplemented(string FailureMessage)
+            : DescriptorWriteAuthorizationPreflightOutcome;
+
+        public sealed record SecurityConfigurationError(string[] Errors)
+            : DescriptorWriteAuthorizationPreflightOutcome;
+
+        public sealed record NamespaceNotAuthorized(NamespaceAuthorizationFailure Failure)
+            : DescriptorWriteAuthorizationPreflightOutcome;
+
+        public sealed record Proceed(
+            RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization
+        ) : DescriptorWriteAuthorizationPreflightOutcome
+        {
+            public static Proceed NoAuthorization { get; } = new(null, null);
+        }
     }
 
     private async Task<UpsertResult> InsertDescriptorAsync(
@@ -870,30 +1404,6 @@ internal sealed class DescriptorWriteHandler(
             existingDocumentUuid,
             RelationalApiMetadataFormatter.FormatEtag(body)
         );
-    }
-
-    private async Task<TResult> ExecuteDescriptorWriteInTransactionAsync<TResult>(
-        Func<IRelationalCommandExecutor, CancellationToken, Task<TResult>> executeAsync,
-        CancellationToken cancellationToken
-    )
-    {
-        await using var writeSession = await _writeSessionFactory
-            .CreateAsync(cancellationToken)
-            .ConfigureAwait(false);
-
-        try
-        {
-            var result = await executeAsync(writeSession.CreateCommandExecutor(), cancellationToken)
-                .ConfigureAwait(false);
-
-            await writeSession.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return result;
-        }
-        catch
-        {
-            await TryRollbackAsync(writeSession, cancellationToken).ConfigureAwait(false);
-            throw;
-        }
     }
 
     private async Task<UpsertResult> ApplyLockedDescriptorPostUpsertAsync(
@@ -998,15 +1508,22 @@ internal sealed class DescriptorWriteHandler(
         long documentId,
         DocumentUuid existingDocumentUuid,
         short resourceKeyId,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         CancellationToken cancellationToken
     ) =>
         ApplyWithLockedDescriptorCurrentStateAsync<UpsertResult>(
             request,
+            body,
             documentId,
+            storedNamespaceAuthorization,
+            proposedNamespaceAuthorization,
             static () => new UpsertResult.UpsertFailureWriteConflict(),
             missingDescriptorDocumentId => new UpsertResult.UnknownFailure(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
             ),
+            static failure => new UpsertResult.UpsertFailureNamespaceNotAuthorized(failure),
+            static failureMessage => new UpsertResult.UnknownFailure(failureMessage),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPostUpsertAsync(
                     request,
@@ -1027,15 +1544,22 @@ internal sealed class DescriptorWriteHandler(
         ExtractedDescriptorBody body,
         long documentId,
         DocumentUuid documentUuid,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         CancellationToken cancellationToken
     ) =>
         ApplyWithLockedDescriptorCurrentStateAsync<UpdateResult>(
             request,
+            body,
             documentId,
+            storedNamespaceAuthorization,
+            proposedNamespaceAuthorization,
             static () => new UpdateResult.UpdateFailureNotExists(),
             missingDescriptorDocumentId => new UpdateResult.UnknownFailure(
                 BuildMissingDescriptorMessage(request.Resource, missingDescriptorDocumentId)
             ),
+            static failure => new UpdateResult.UpdateFailureNamespaceNotAuthorized(failure),
+            static failureMessage => new UpdateResult.UnknownFailure(failureMessage),
             (persisted, currentEtag, writeSession, ct) =>
                 ApplyLockedDescriptorPutAsync(
                     request,
@@ -1052,9 +1576,14 @@ internal sealed class DescriptorWriteHandler(
 
     private async Task<TResult> ApplyWithLockedDescriptorCurrentStateAsync<TResult>(
         DescriptorWriteRequest request,
+        ExtractedDescriptorBody body,
         long documentId,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
         Func<TResult> missingDocumentResultFactory,
         Func<long, TResult> missingDescriptorResultFactory,
+        Func<NamespaceAuthorizationFailure, TResult> namespaceNotAuthorizedFactory,
+        Func<string, TResult> namespaceAuthorizationInvalidFactory,
         Func<
             PersistedDescriptorState,
             string,
@@ -1064,6 +1593,7 @@ internal sealed class DescriptorWriteHandler(
         > applyLoadedAsync,
         CancellationToken cancellationToken
     )
+        where TResult : class
     {
         await using var writeSession = await _writeSessionFactory
             .CreateAsync(cancellationToken)
@@ -1091,6 +1621,62 @@ internal sealed class DescriptorWriteHandler(
                     return missingDescriptorResultFactory(documentId);
 
                 case DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag):
+                    // AND-compose stored then proposed namespace authorization against the locked target
+                    // before applying any change. Either denial returns the namespace 403 with no
+                    // INSERT/UPDATE statement, and short-circuits before the no-op or immutable-identity
+                    // checks so 403 wins over those outcomes too.
+                    var sessionCommandExecutor = writeSession.CreateCommandExecutor();
+
+                    if (storedNamespaceAuthorization is not null)
+                    {
+                        var storedResult = await ExecuteDescriptorNamespaceAuthorizationAsync(
+                                request.MappingSet,
+                                documentId,
+                                storedNamespaceAuthorization,
+                                proposedNamespace: null,
+                                sessionCommandExecutor,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false);
+
+                        var storedFailure = MapNamespaceAuthorizationToResult(
+                            storedResult,
+                            namespaceNotAuthorizedFactory,
+                            namespaceAuthorizationInvalidFactory
+                        );
+
+                        if (storedFailure is not null)
+                        {
+                            await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                            return storedFailure;
+                        }
+                    }
+
+                    if (proposedNamespaceAuthorization is not null)
+                    {
+                        var proposedResult = await ExecuteDescriptorNamespaceAuthorizationAsync(
+                                request.MappingSet,
+                                documentId,
+                                proposedNamespaceAuthorization,
+                                body.Namespace,
+                                sessionCommandExecutor,
+                                cancellationToken
+                            )
+                            .ConfigureAwait(false);
+
+                        var proposedFailure = MapNamespaceAuthorizationToResult(
+                            proposedResult,
+                            namespaceNotAuthorizedFactory,
+                            namespaceAuthorizationInvalidFactory
+                        );
+
+                        if (proposedFailure is not null)
+                        {
+                            await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                            return proposedFailure;
+                        }
+                    }
+
                     return await applyLoadedAsync(persisted, currentEtag, writeSession, cancellationToken)
                         .ConfigureAwait(false);
 
@@ -1106,6 +1692,119 @@ internal sealed class DescriptorWriteHandler(
 
             throw;
         }
+    }
+
+    /// <summary>
+    /// Opens a write session for a descriptor POST create, runs the configured proposed namespace
+    /// check before the insert, and rolls back without inserting on namespace denial so the create
+    /// path never produces a partially-written document on a 403.
+    /// </summary>
+    private async Task<UpsertResult> ExecuteDescriptorInsertWithProposedNamespaceCheckAsync(
+        DescriptorWriteRequest request,
+        ExtractedDescriptorBody body,
+        DocumentUuid documentUuid,
+        short resourceKeyId,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization,
+        CancellationToken cancellationToken
+    )
+    {
+        await using var writeSession = await _writeSessionFactory
+            .CreateAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            var sessionCommandExecutor = writeSession.CreateCommandExecutor();
+
+            if (proposedNamespaceAuthorization is not null)
+            {
+                var proposedResult = await ExecuteDescriptorNamespaceAuthorizationAsync(
+                        request.MappingSet,
+                        documentId: 0L,
+                        proposedNamespaceAuthorization,
+                        body.Namespace,
+                        sessionCommandExecutor,
+                        cancellationToken
+                    )
+                    .ConfigureAwait(false);
+
+                var proposedFailure = MapNamespaceAuthorizationToResult<UpsertResult>(
+                    proposedResult,
+                    static failure => new UpsertResult.UpsertFailureNamespaceNotAuthorized(failure),
+                    static failureMessage => new UpsertResult.UnknownFailure(failureMessage)
+                );
+
+                if (proposedFailure is not null)
+                {
+                    await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                    return proposedFailure;
+                }
+            }
+
+            var insertResult = await InsertDescriptorAsync(
+                    request,
+                    body,
+                    documentUuid,
+                    resourceKeyId,
+                    sessionCommandExecutor,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            await writeSession.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return insertResult;
+        }
+        catch
+        {
+            await TryRollbackAsync(writeSession, cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static TResult? MapNamespaceAuthorizationToResult<TResult>(
+        NamespaceAuthorizationExecutionResult executionResult,
+        Func<NamespaceAuthorizationFailure, TResult> namespaceNotAuthorizedFactory,
+        Func<string, TResult> namespaceAuthorizationInvalidFactory
+    )
+        where TResult : class =>
+        executionResult switch
+        {
+            NamespaceAuthorizationExecutionResult.Authorized => null,
+            NamespaceAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                namespaceNotAuthorizedFactory(notAuthorized.Failure),
+            NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                namespaceAuthorizationInvalidFactory(invalidFailure.FailureMessage),
+            _ => throw new InvalidOperationException(
+                $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
+
+    private async Task<DescriptorLockedPreconditionResult?> EvaluateNamespaceAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization namespaceAuthorization,
+        string? proposedNamespace,
+        IRelationalCommandExecutor sessionCommandExecutor,
+        CancellationToken cancellationToken
+    )
+    {
+        var result = await ExecuteDescriptorNamespaceAuthorizationAsync(
+                mappingSet,
+                documentId,
+                namespaceAuthorization,
+                proposedNamespace,
+                sessionCommandExecutor,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return MapNamespaceAuthorizationToResult<DescriptorLockedPreconditionResult>(
+            result,
+            static failure => new DescriptorLockedPreconditionResult.NamespaceNotAuthorized(failure),
+            static failureMessage => new DescriptorLockedPreconditionResult.NamespaceAuthorizationInvalid(
+                failureMessage
+            )
+        );
     }
 
     private static async Task ExecuteWriteCommandAsync(
@@ -1342,6 +2041,10 @@ internal sealed class DescriptorWriteHandler(
                     }
 
                     return new PersistedDescriptorState(
+                        // dms.Descriptor.Namespace is NOT NULL in both the generated PostgreSQL and
+                        // SQL Server DDL, so a persisted descriptor row always carries a namespace.
+                        // Read it required: there is no stored-NULL descriptor namespace to route to
+                        // the namespace-authorization uninitialized branch.
                         Namespace: reader.GetRequiredFieldValue<string>("Namespace"),
                         CodeValue: reader.GetRequiredFieldValue<string>("CodeValue"),
                         Uri: reader.GetRequiredFieldValue<string>("Uri"),
@@ -1397,6 +2100,10 @@ internal sealed class DescriptorWriteHandler(
     }
 
     private sealed record PersistedDescriptorState(
+        // Namespace is non-null: dms.Descriptor.Namespace is NOT NULL in the generated PostgreSQL and
+        // SQL Server DDL, so a persisted descriptor row always has a namespace. (Generic resources can
+        // carry a stored-null namespace that namespace authorization surfaces as the
+        // stored-namespace-uninitialized 403; descriptors cannot reach that state.)
         string Namespace,
         string CodeValue,
         string Uri,
@@ -1452,6 +2159,12 @@ internal sealed class DescriptorWriteHandler(
         }
 
         public sealed record MissingDescriptor(long DocumentId) : DescriptorLockedPreconditionResult;
+
+        public sealed record NamespaceNotAuthorized(NamespaceAuthorizationFailure Failure)
+            : DescriptorLockedPreconditionResult;
+
+        public sealed record NamespaceAuthorizationInvalid(string FailureMessage)
+            : DescriptorLockedPreconditionResult;
 
         public sealed record Mismatch : DescriptorLockedPreconditionResult
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationCommandParameterBuilder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationCommandParameterBuilder.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Binds runtime parameter values for single-record namespace authorization commands. Distinct from
+/// the relationship parameter builder because namespace prefixes bind as a PostgreSQL <c>string[]</c>
+/// array (or SQL Server scalar string parameters), never as the long-only claim-EdOrg array path.
+/// </summary>
+internal static class NamespaceAuthorizationCommandParameterBuilder
+{
+    public static void AddParameterValues(
+        IDictionary<string, object?> parameterValues,
+        NamespacePrefixParameterization namespacePrefixParameterization,
+        long documentId,
+        string? proposedNamespace
+    )
+    {
+        ArgumentNullException.ThrowIfNull(parameterValues);
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization);
+
+        parameterValues[NamespaceAuthorizationSqlSpecDefaults.DocumentIdParameterName] = documentId;
+        parameterValues[NamespaceAuthorizationSqlSpecDefaults.ProposedNamespaceParameterName] =
+            proposedNamespace;
+
+        NamespacePrefixParameterValueBinder.Bind(parameterValues, namespacePrefixParameterization);
+    }
+
+    public static RelationalParameter BuildParameter(QuerySqlParameter parameter, object? value)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+
+        return parameter.Binding.Kind switch
+        {
+            QuerySqlParameterBindingKind.Scalar => new RelationalParameter(
+                $"@{parameter.ParameterName}",
+                value
+            ),
+            QuerySqlParameterBindingKind.PgsqlArray => new RelationalParameter(
+                $"@{parameter.ParameterName}",
+                RequireStringList(value, parameter.ParameterName).ToArray()
+            ),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(parameter),
+                parameter.Binding.Kind,
+                "Unsupported namespace authorization parameter binding kind."
+            ),
+        };
+    }
+
+    private static IReadOnlyList<string> RequireStringList(object? value, string parameterName)
+    {
+        if (value is IReadOnlyList<string> stringValues)
+        {
+            return stringValues;
+        }
+
+        throw new InvalidOperationException(
+            $"Namespace authorization array parameter '{parameterName}' requires an IReadOnlyList<string> runtime value."
+        );
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationExecutor.cs
@@ -29,6 +29,13 @@ public abstract record NamespaceAuthorizationExecutionResult
 
     public sealed record InvalidAuthorizationFailure(string FailureMessage)
         : NamespaceAuthorizationExecutionResult;
+
+    /// <summary>
+    /// The stored target row no longer exists: it was deleted between the unlocked target lookup and the
+    /// stored namespace check. Read callers re-resolve the target and surface the resulting 404; locked
+    /// write/delete callers never observe this because they row-lock the target before the check.
+    /// </summary>
+    public sealed record StaleTarget : NamespaceAuthorizationExecutionResult;
 }
 
 public interface INamespaceAuthorizationExecutor
@@ -49,16 +56,13 @@ public interface INamespaceAuthorizationExecutor
 /// later statement (e.g. the proposed check of a PUT) is forced to execute and surfaces as a
 /// <see cref="DbException"/>.
 /// <para>
-/// This executor intentionally has no stale-target result, and callers intentionally do not retry it.
-/// A row concurrently deleted between the target lookup and this check matches none of the stored-row
-/// <c>WHEN EXISTS</c> branches and falls through to namespace mismatch (see
-/// <c>NamespaceAuthorizationSqlCompiler.AppendStoredCheckSql</c>), i.e. it fails closed as an
-/// authorization denial. That is deliberate and safe: the only observable difference is a 403 instead
-/// of a 404 for a resource that no longer exists. This is unlike relationship authorization, which
-/// surfaces a stale-target result and is retried because it anchors its decision to a content version;
-/// namespace authorization reports no content version, so there is nothing to re-anchor and nothing to
-/// gain from retrying. Do not add a stale-target branch here or retry namespace checks to "fix" the
-/// 403-vs-404 distinction.
+/// A stored-row check whose target no longer exists raises the <c>StoredTargetMissing</c> AUTH1 kind
+/// (see <c>NamespaceAuthorizationSqlCompiler.AppendStoredCheckSql</c>), which this executor maps to
+/// <see cref="NamespaceAuthorizationExecutionResult.StaleTarget"/> rather than to a namespace-mismatch
+/// denial. The unlocked GET-by-id read boundary retries on that result and re-resolves the target so a
+/// row deleted between the target lookup and this check surfaces as a 404 instead of a 403. Locked
+/// write and delete callers row-lock the target before this check runs, so they never observe the stale
+/// result; they map it defensively to a write-conflict/not-exists outcome.
 /// </para>
 /// </remarks>
 internal sealed class NamespaceAuthorizationExecutor(
@@ -101,6 +105,20 @@ internal sealed class NamespaceAuthorizationExecutor(
                 .ConfigureAwait(false);
         }
         catch (DbException ex)
+            when (NamespaceAuthorizationProviderFailureMapper.IsStaleStoredTargetFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    plannedCheckValueSources
+                )
+            )
+        {
+            // The stored target row vanished between the unlocked lookup and this check. Surface a
+            // stale-target result so the read boundary can re-resolve the target instead of mapping the
+            // missing row to a namespace-mismatch denial.
+            return new NamespaceAuthorizationExecutionResult.StaleTarget();
+        }
+        catch (DbException ex)
             when (NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
                     dialect,
                     ex,
@@ -122,7 +140,7 @@ internal sealed class NamespaceAuthorizationExecutor(
             )
         {
             return new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
-                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+                NamespaceAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata
             );
         }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationExecutor.cs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+public sealed record NamespaceAuthorizationExecutionRequest(
+    MappingSet MappingSet,
+    long DocumentId,
+    string? ProposedNamespace,
+    IReadOnlyList<NamespaceAuthorizationCheckSpec> Checks,
+    NamespacePrefixParameterization NamespacePrefixParameterization
+);
+
+public abstract record NamespaceAuthorizationExecutionResult
+{
+    private NamespaceAuthorizationExecutionResult() { }
+
+    public sealed record Authorized() : NamespaceAuthorizationExecutionResult;
+
+    public sealed record NotAuthorized(NamespaceAuthorizationFailure Failure)
+        : NamespaceAuthorizationExecutionResult;
+
+    public sealed record InvalidAuthorizationFailure(string FailureMessage)
+        : NamespaceAuthorizationExecutionResult;
+}
+
+public interface INamespaceAuthorizationExecutor
+{
+    Task<NamespaceAuthorizationExecutionResult> ExecuteAsync(
+        NamespaceAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    );
+}
+
+/// <summary>
+/// Executes co-batched single-record namespace authorization SQL. The SQL emits one
+/// <c>SELECT CASE ... END;</c> per planned check; the first failing check raises AUTH1 with an
+/// <c>ns1|index|kind</c> payload and aborts the batch. A clean run authorizes the record.
+/// </summary>
+/// <remarks>
+/// The reader callback advances through every co-batched statement's result set so a failure in a
+/// later statement (e.g. the proposed check of a PUT) is forced to execute and surfaces as a
+/// <see cref="DbException"/>.
+/// <para>
+/// This executor intentionally has no stale-target result, and callers intentionally do not retry it.
+/// A row concurrently deleted between the target lookup and this check matches none of the stored-row
+/// <c>WHEN EXISTS</c> branches and falls through to namespace mismatch (see
+/// <c>NamespaceAuthorizationSqlCompiler.AppendStoredCheckSql</c>), i.e. it fails closed as an
+/// authorization denial. That is deliberate and safe: the only observable difference is a 403 instead
+/// of a 404 for a resource that no longer exists. This is unlike relationship authorization, which
+/// surfaces a stale-target result and is retried because it anchors its decision to a content version;
+/// namespace authorization reports no content version, so there is nothing to re-anchor and nothing to
+/// gain from retrying. Do not add a stale-target branch here or retry namespace checks to "fix" the
+/// 403-vs-404 distinction.
+/// </para>
+/// </remarks>
+internal sealed class NamespaceAuthorizationExecutor(
+    IRelationalCommandExecutor commandExecutor,
+    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+) : INamespaceAuthorizationExecutor
+{
+    private readonly IRelationalCommandExecutor _commandExecutor =
+        commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
+    private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
+        providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
+
+    public async Task<NamespaceAuthorizationExecutionResult> ExecuteAsync(
+        NamespaceAuthorizationExecutionRequest request,
+        CancellationToken cancellationToken = default
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var dialect = request.MappingSet.Key.Dialect;
+        var compiler = new NamespaceAuthorizationSqlCompiler(dialect);
+        var sqlPlan = compiler.Compile(
+            new NamespaceAuthorizationSqlSpec(
+                request.Checks,
+                request.NamespacePrefixParameterization,
+                NamespaceAuthorizationSqlSpecDefaults.DocumentIdParameterName,
+                NamespaceAuthorizationSqlSpecDefaults.ProposedNamespaceParameterName
+            )
+        );
+        var plannedCheckValueSources = request.Checks.Select(static check => check.ValueSource).ToArray();
+
+        try
+        {
+            return await _commandExecutor
+                .ExecuteReaderAsync(
+                    BuildCommand(sqlPlan, request),
+                    ReadAuthorizedResultAsync,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+        catch (DbException ex)
+            when (NamespaceAuthorizationProviderFailureMapper.TryMapNamespaceAuthorizationFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor,
+                    plannedCheckValueSources,
+                    request.NamespacePrefixParameterization.ConfiguredPrefixesInOrder,
+                    out var namespaceFailure
+                )
+            )
+        {
+            return new NamespaceAuthorizationExecutionResult.NotAuthorized(namespaceFailure!);
+        }
+        catch (DbException ex)
+            when (NamespaceAuthorizationProviderFailureMapper.IsNamespaceAuthorizationProviderFailure(
+                    dialect,
+                    ex,
+                    _providerFailureExtractor
+                )
+            )
+        {
+            return new NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure(
+                "Namespace authorization failed, but the AUTH1 failure metadata could not be mapped."
+            );
+        }
+    }
+
+    private static RelationalCommand BuildCommand(
+        NamespaceAuthorizationSqlPlan sqlPlan,
+        NamespaceAuthorizationExecutionRequest request
+    )
+    {
+        Dictionary<string, object?> valuesByParameterName = new(StringComparer.Ordinal);
+
+        NamespaceAuthorizationCommandParameterBuilder.AddParameterValues(
+            valuesByParameterName,
+            request.NamespacePrefixParameterization,
+            request.DocumentId,
+            request.ProposedNamespace
+        );
+
+        return new RelationalCommand(
+            sqlPlan.AuthorizationSql,
+            [
+                .. sqlPlan.ParametersInOrder.Select(parameter =>
+                    NamespaceAuthorizationCommandParameterBuilder.BuildParameter(
+                        parameter,
+                        valuesByParameterName[parameter.ParameterName]
+                    )
+                ),
+            ]
+        );
+    }
+
+    private static async Task<NamespaceAuthorizationExecutionResult> ReadAuthorizedResultAsync(
+        IRelationalCommandReader reader,
+        CancellationToken cancellationToken
+    )
+    {
+        // Advance through every co-batched statement's result set so each check executes and any
+        // later-statement AUTH1 failure surfaces as a DbException. A clean run means every check
+        // authorized.
+        var hasMoreResultSets = true;
+        while (hasMoreResultSets)
+        {
+            hasMoreResultSets = await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        return new NamespaceAuthorizationExecutionResult.Authorized();
+    }
+}
+
+internal static class NamespaceAuthorizationSqlSpecDefaults
+{
+    public const string DocumentIdParameterName = "documentId";
+    public const string ProposedNamespaceParameterName = "proposedNamespace";
+    public const string NamespacePrefixesParameterName = "namespacePrefixes";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationFactory.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationFactory.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Builders for the cross-cutting namespace authorization shapes that the read, write, and descriptor
+/// pipelines all assemble: the §2.9 no-prefixes failure record and the per-value-source split of a
+/// planned check list.
+/// </summary>
+internal static class NamespaceAuthorizationFactory
+{
+    /// <summary>
+    /// Builds the §2.9 <c>NoPrefixesConfigured</c> failure record. <see cref="NamespaceAuthorizationFailure.ValueSource"/>
+    /// and <see cref="NamespaceAuthorizationFailure.EmittedAuth1Index"/> are <see langword="null"/> because the
+    /// no-prefixes path is emitted at planner/preflight time without evaluating stored or proposed data and
+    /// never reaches AUTH1.
+    /// </summary>
+    public static NamespaceAuthorizationFailure NoPrefixesConfiguredFailure(string strategyName) =>
+        new(
+            NamespaceAuthorizationFailureKind.NoPrefixesConfigured,
+            ValueSource: null,
+            EmittedAuth1Index: null,
+            strategyName,
+            ConfiguredNamespacePrefixes: []
+        );
+
+    /// <summary>
+    /// Filters <paramref name="namespaceChecks"/> down to the requested <paramref name="valueSource"/>,
+    /// reindexes the surviving checks from zero, and packages them into a
+    /// <see cref="RelationalWriteNamespaceAuthorization"/>. Returns <see langword="null"/> when no checks
+    /// match the requested value source, so callers can branch on "this side has nothing to run."
+    /// </summary>
+    public static RelationalWriteNamespaceAuthorization? SplitByValueSource(
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks,
+        NamespaceAuthorizationCheckValueSource valueSource,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(namespaceChecks);
+        ArgumentNullException.ThrowIfNull(namespacePrefixParameterization);
+
+        var checks = namespaceChecks
+            .Where(check => check.ValueSource == valueSource)
+            .Select(static (check, index) => check with { Index = index })
+            .ToArray();
+
+        return checks.Length == 0
+            ? null
+            : new RelationalWriteNamespaceAuthorization(checks, namespacePrefixParameterization);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -49,6 +49,37 @@ internal static class NamespaceAuthorizationProviderFailureMapper
     }
 
     /// <summary>
+    /// Whether <paramref name="exception"/> carries a namespace AUTH1 payload reporting that the stored
+    /// target row no longer exists (<see cref="NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing"/>).
+    /// The executor maps this to a stale-target result so unlocked read paths re-resolve the target
+    /// rather than treating the missing row as a namespace-mismatch denial.
+    /// </summary>
+    /// <remarks>
+    /// The payload is only treated as stale when its emitted index is in range and the indexed planned
+    /// check is a stored-value check — the only shape the SQL compiler ever emits the stale kind from. A
+    /// malformed payload (out-of-range index, or the stale kind paired with a proposed check) returns
+    /// <see langword="false"/> so it falls through to the invalid-metadata security-configuration mapping
+    /// rather than being silently converted into a stale-target retry or a write conflict.
+    /// </remarks>
+    public static bool IsStaleStoredTargetFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        IReadOnlyList<NamespaceAuthorizationCheckValueSource> plannedCheckValueSources
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+        ArgumentNullException.ThrowIfNull(plannedCheckValueSources);
+
+        return TryDispatchNamespacePayload(dialect, exception, providerFailureExtractor, out var payload)
+            && payload is { FailureKind: NamespaceAuthorizationAuth1FailureKind.StoredTargetMissing }
+            && payload.EmittedAuth1Index < plannedCheckValueSources.Count
+            && plannedCheckValueSources[payload.EmittedAuth1Index]
+                is NamespaceAuthorizationCheckValueSource.Stored;
+    }
+
+    /// <summary>
     /// Whether <paramref name="exception"/> is an AUTH1 provider failure this namespace executor should
     /// fail closed on (a namespace <c>ns1|…</c> payload — mappable or not — or any malformed/unknown
     /// AUTH1 payload). A relationship <c>1|…</c> payload returns <see langword="false"/> so it rethrows,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespaceAuthorizationProviderFailureMapper.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Maps a provider <see cref="DbException"/> carrying a namespace AUTH1 payload (<c>ns1|index|kind</c>)
+/// back to a cross-boundary <see cref="NamespaceAuthorizationFailure"/>. Routes through the shared
+/// <see cref="RelationalAuthorizationAuth1Dispatcher"/> so a relationship <c>1|...</c> payload is never
+/// mistaken for a namespace failure.
+/// </summary>
+internal static class NamespaceAuthorizationProviderFailureMapper
+{
+    public static bool TryMapNamespaceAuthorizationFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        IReadOnlyList<NamespaceAuthorizationCheckValueSource> plannedCheckValueSources,
+        IReadOnlyList<string> configuredNamespacePrefixes,
+        out NamespaceAuthorizationFailure? failure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+        ArgumentNullException.ThrowIfNull(plannedCheckValueSources);
+        ArgumentNullException.ThrowIfNull(configuredNamespacePrefixes);
+
+        failure = null;
+
+        if (!TryDispatchNamespacePayload(dialect, exception, providerFailureExtractor, out var payload))
+        {
+            return false;
+        }
+
+        return payload is not null
+            && NamespaceAuthorizationFailureMapper.TryMapAuth1Failure(
+                payload,
+                plannedCheckValueSources,
+                configuredNamespacePrefixes,
+                out failure
+            );
+    }
+
+    /// <summary>
+    /// Whether <paramref name="exception"/> is an AUTH1 provider failure this namespace executor should
+    /// fail closed on (a namespace <c>ns1|…</c> payload — mappable or not — or any malformed/unknown
+    /// AUTH1 payload). A relationship <c>1|…</c> payload returns <see langword="false"/> so it rethrows,
+    /// because it should never reach the namespace-only execution path.
+    /// </summary>
+    public static bool IsNamespaceAuthorizationProviderFailure(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor
+    )
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentNullException.ThrowIfNull(providerFailureExtractor);
+
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        if (
+            !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+                dialect,
+                providerFailure.ErrorCode,
+                providerFailure.Message,
+                out var dispatchResult
+            )
+        )
+        {
+            return false;
+        }
+
+        return dispatchResult
+            is RelationalAuthorizationAuth1DispatchResult.Namespace
+                or RelationalAuthorizationAuth1DispatchResult.InvalidPayload;
+    }
+
+    private static bool TryDispatchNamespacePayload(
+        SqlDialect dialect,
+        DbException exception,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        out NamespaceAuthorizationAuth1FailurePayload? payload
+    )
+    {
+        payload = null;
+        var providerFailure = providerFailureExtractor.Extract(exception);
+
+        if (
+            !RelationalAuthorizationAuth1Dispatcher.TryDispatch(
+                dialect,
+                providerFailure.ErrorCode,
+                providerFailure.Message,
+                out var dispatchResult
+            )
+        )
+        {
+            return false;
+        }
+
+        if (dispatchResult is RelationalAuthorizationAuth1DispatchResult.Namespace namespaceResult)
+        {
+            payload = namespaceResult.Payload;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterValueBinder.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterValueBinder.cs
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Binds runtime namespace-prefix parameter values into a planner parameter-value dictionary.
+/// PostgreSQL stores the escaped LIKE pattern list under the base parameter name (Npgsql infers
+/// <c>text[]</c> from the runtime <see cref="IReadOnlyList{T}"/>); SQL Server stores each
+/// scalar pattern under its allocated parameter name in declaration order.
+/// </summary>
+internal static class NamespacePrefixParameterValueBinder
+{
+    public static void Bind(
+        IDictionary<string, object?> parameterValues,
+        NamespacePrefixParameterization? namespacePrefixParameterization
+    )
+    {
+        ArgumentNullException.ThrowIfNull(parameterValues);
+
+        if (namespacePrefixParameterization is null)
+        {
+            return;
+        }
+
+        switch (namespacePrefixParameterization.Kind)
+        {
+            case NamespacePrefixParameterizationKind.PgsqlArray:
+                parameterValues[namespacePrefixParameterization.BaseParameterName] =
+                    namespacePrefixParameterization.LikePatternsInOrder;
+                return;
+
+            case NamespacePrefixParameterizationKind.MssqlScalar:
+                for (
+                    var parameterIndex = 0;
+                    parameterIndex < namespacePrefixParameterization.ParameterNamesInOrder.Count;
+                    parameterIndex++
+                )
+                {
+                    parameterValues[namespacePrefixParameterization.ParameterNamesInOrder[parameterIndex]] =
+                        namespacePrefixParameterization.LikePatternsInOrder[parameterIndex];
+                }
+
+                return;
+
+            default:
+                throw new ArgumentOutOfRangeException(
+                    nameof(namespacePrefixParameterization),
+                    namespacePrefixParameterization.Kind,
+                    "Unsupported namespace prefix parameterization kind."
+                );
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterizationPreflight.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterizationPreflight.cs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Shared preflight for building the dialect-specific namespace prefix parameterization. Centralizes the
+/// <see cref="NamespacePrefixParameterizationFactory.Create"/> call (with the shared prefix parameter
+/// name) and the SQL Server prefix-cap failure so every read, write, delete, and descriptor authorization
+/// path constructs the parameterization and its <see cref="NamespacePrefixLimitExceededException"/>
+/// security-configuration message identically.
+/// </summary>
+internal static class NamespacePrefixParameterizationPreflight
+{
+    /// <summary>
+    /// Builds the namespace prefix parameterization for <paramref name="dialect"/>.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> with <paramref name="parameterization"/> populated on success;
+    /// <see langword="false"/> with <paramref name="prefixCapExceededMessage"/> set to the
+    /// security-configuration diagnostic when the SQL Server prefix cap is exceeded. Callers wrap that
+    /// message in their operation-specific security-configuration result.
+    /// </returns>
+    public static bool TryCreate(
+        SqlDialect dialect,
+        IReadOnlyList<string> namespacePrefixes,
+        out NamespacePrefixParameterization parameterization,
+        out string prefixCapExceededMessage
+    )
+    {
+        try
+        {
+            parameterization = NamespacePrefixParameterizationFactory.Create(
+                dialect,
+                namespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+            prefixCapExceededMessage = string.Empty;
+            return true;
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            parameterization = null!;
+            prefixCapExceededMessage = NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(
+                ex.PrefixCount
+            );
+            return false;
+        }
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterizationPreflight.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/NamespacePrefixParameterizationPreflight.cs
@@ -11,8 +11,8 @@ namespace EdFi.DataManagementService.Backend;
 /// <summary>
 /// Shared preflight for building the dialect-specific namespace prefix parameterization. Centralizes the
 /// <see cref="NamespacePrefixParameterizationFactory.Create"/> call (with the shared prefix parameter
-/// name) and the SQL Server prefix-cap failure so every read, write, delete, and descriptor authorization
-/// path constructs the parameterization and its <see cref="NamespacePrefixLimitExceededException"/>
+/// name), the null/empty prefix guard, and the SQL Server prefix-cap failure so every read, write,
+/// delete, and descriptor authorization path constructs the parameterization and its
 /// security-configuration message identically.
 /// </summary>
 internal static class NamespacePrefixParameterizationPreflight
@@ -22,17 +22,28 @@ internal static class NamespacePrefixParameterizationPreflight
     /// </summary>
     /// <returns>
     /// <see langword="true"/> with <paramref name="parameterization"/> populated on success;
-    /// <see langword="false"/> with <paramref name="prefixCapExceededMessage"/> set to the
-    /// security-configuration diagnostic when the SQL Server prefix cap is exceeded. Callers wrap that
-    /// message in their operation-specific security-configuration result.
+    /// <see langword="false"/> with <paramref name="securityConfigurationMessage"/> set to the
+    /// security-configuration diagnostic when a prefix is null/empty or the SQL Server prefix cap is
+    /// exceeded. Callers wrap that message in their operation-specific security-configuration result.
     /// </returns>
     public static bool TryCreate(
         SqlDialect dialect,
         IReadOnlyList<string> namespacePrefixes,
         out NamespacePrefixParameterization parameterization,
-        out string prefixCapExceededMessage
+        out string securityConfigurationMessage
     )
     {
+        // A null/empty prefix cannot be parameterized into a LIKE predicate; the factory throws a generic
+        // ArgumentException for it. Map it to a controlled security-configuration failure here so an
+        // invalid claim-set configuration fails closed instead of surfacing as an uncontrolled 500.
+        if (namespacePrefixes.Any(string.IsNullOrEmpty))
+        {
+            parameterization = null!;
+            securityConfigurationMessage =
+                NamespaceAuthorizationSecurityConfigurationMessages.InvalidNamespacePrefix;
+            return false;
+        }
+
         try
         {
             parameterization = NamespacePrefixParameterizationFactory.Create(
@@ -40,15 +51,14 @@ internal static class NamespacePrefixParameterizationPreflight
                 namespacePrefixes,
                 NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
             );
-            prefixCapExceededMessage = string.Empty;
+            securityConfigurationMessage = string.Empty;
             return true;
         }
         catch (NamespacePrefixLimitExceededException ex)
         {
             parameterization = null!;
-            prefixCapExceededMessage = NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(
-                ex.PrefixCount
-            );
+            securityConfigurationMessage =
+                NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount);
             return false;
         }
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
@@ -93,11 +93,16 @@ internal sealed class ProposedNamespaceAuthorizationOrchestrator(
                 ),
             NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
                 new ProposedNamespaceAuthorizationBoundary(
-                    RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                    RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
                         request.OperationKind,
-                        invalidFailure.FailureMessage
+                        [invalidFailure.FailureMessage]
                     )
                 ),
+            // Proposed-value checks bind no stored DocumentId, so they never raise the stale stored-target
+            // kind; map it defensively to the same write-conflict/not-exists shape the stored path uses.
+            NamespaceAuthorizationExecutionResult.StaleTarget => new ProposedNamespaceAuthorizationBoundary(
+                RelationalWriteExecutorResults.BuildStaleTargetResult(request.OperationKind)
+            ),
             _ => throw new InvalidOperationException(
                 $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
             ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
@@ -51,9 +51,9 @@ internal sealed class ProposedNamespaceAuthorizationOrchestrator(
         if (extraction is ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan invalid)
         {
             return new ProposedNamespaceAuthorizationBoundary(
-                RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
                     request.OperationKind,
-                    invalid.FailureMessage
+                    [invalid.FailureMessage]
                 )
             );
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceAuthorizationOrchestrator.cs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Runs proposed-value namespace authorization as a separate statement inside the write session,
+/// after merge has produced the finalized root row and before persist/commit. It is the namespace
+/// sibling of <see cref="ProposedRelationshipAuthorizationOrchestrator"/>: it reads the namespace
+/// value from the finalized merged root row (never the raw request body) and binds it to the same
+/// single-record namespace SQL used by reads, so the <c>LIKE</c> semantics and AUTH1 failure mapping
+/// stay identical across read and write paths.
+/// </summary>
+/// <remarks>
+/// This orchestrator authorizes the proposed namespace value for both new-document and existing-target
+/// writes. The stored namespace of an existing target is authorized separately in the locked-target
+/// boundary, so this stage only ever evaluates the finalized proposed value.
+/// </remarks>
+internal sealed class ProposedNamespaceAuthorizationOrchestrator(
+    IRelationshipAuthorizationProviderFailureExtractor? providerFailureExtractor = null
+)
+{
+    private readonly IRelationshipAuthorizationProviderFailureExtractor _providerFailureExtractor =
+        providerFailureExtractor ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
+
+    public async Task<ProposedNamespaceAuthorizationBoundary> ResolveAsync(
+        RelationalWriteExecutorRequest request,
+        RelationalWriteMergeResult mergeResult,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(mergeResult);
+        ArgumentNullException.ThrowIfNull(writeSession);
+
+        var namespaceAuthorization = request.ProposedNamespaceAuthorization;
+
+        if (namespaceAuthorization is null)
+        {
+            return new ProposedNamespaceAuthorizationBoundary(null);
+        }
+
+        var extraction = ProposedNamespaceValueExtractor.Extract(
+            namespaceAuthorization.Checks,
+            RelationalWriteFinalizedRootRow.Build(request, mergeResult)
+        );
+
+        if (extraction is ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan invalid)
+        {
+            return new ProposedNamespaceAuthorizationBoundary(
+                RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                    request.OperationKind,
+                    invalid.FailureMessage
+                )
+            );
+        }
+
+        var ready = (ProposedNamespaceValueExtractionResult.Ready)extraction;
+
+        var namespaceExecutor = new NamespaceAuthorizationExecutor(
+            writeSession.CreateCommandExecutor(),
+            _providerFailureExtractor
+        );
+
+        var executionResult = await namespaceExecutor
+            .ExecuteAsync(
+                new NamespaceAuthorizationExecutionRequest(
+                    request.MappingSet,
+                    // Proposed-only checks evaluate the bound proposed value; no stored DocumentId is bound.
+                    DocumentId: 0L,
+                    ready.ProposedNamespace,
+                    namespaceAuthorization.Checks,
+                    namespaceAuthorization.NamespacePrefixParameterization
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            NamespaceAuthorizationExecutionResult.Authorized => new ProposedNamespaceAuthorizationBoundary(
+                null
+            ),
+            NamespaceAuthorizationExecutionResult.NotAuthorized notAuthorized =>
+                new ProposedNamespaceAuthorizationBoundary(
+                    RelationalWriteExecutorResults.BuildNamespaceAuthorizationFailureResult(
+                        request.OperationKind,
+                        notAuthorized.Failure
+                    )
+                ),
+            NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new ProposedNamespaceAuthorizationBoundary(
+                    RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                        request.OperationKind,
+                        invalidFailure.FailureMessage
+                    )
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
+    }
+}
+
+internal sealed record ProposedNamespaceAuthorizationBoundary(RelationalWriteExecutorResult? ImmediateResult);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceValueExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceValueExtractor.cs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Outcome of reading the proposed namespace value out of the finalized merged root row.
+/// </summary>
+internal abstract record ProposedNamespaceValueExtractionResult
+{
+    private ProposedNamespaceValueExtractionResult() { }
+
+    /// <summary>
+    /// The proposed namespace value was extracted. <paramref name="ProposedNamespace"/> is
+    /// <see langword="null"/> when the finalized value is null/empty, which the SQL maps to a
+    /// proposed-namespace-missing failure.
+    /// </summary>
+    public sealed record Ready(string? ProposedNamespace) : ProposedNamespaceValueExtractionResult;
+
+    /// <summary>
+    /// The planned namespace checks could not be reconciled with the finalized root row. The write
+    /// fails closed as an unknown failure.
+    /// </summary>
+    public sealed record InvalidAuthorizationPlan(string FailureMessage)
+        : ProposedNamespaceValueExtractionResult;
+}
+
+/// <summary>
+/// Reads the proposed namespace value from the finalized merged root row buffer, using the root
+/// table's <see cref="EdFi.DataManagementService.Backend.External.Plans.TableWritePlan.ColumnBindings"/>
+/// to locate the namespace column. Authorization never reads the raw request body.
+/// </summary>
+internal static class ProposedNamespaceValueExtractor
+{
+    public static ProposedNamespaceValueExtractionResult Extract(
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> checks,
+        RootWriteRowBuffer rootRow
+    )
+    {
+        ArgumentNullException.ThrowIfNull(checks);
+        ArgumentNullException.ThrowIfNull(rootRow);
+
+        if (checks.Count == 0)
+        {
+            return Invalid("Proposed namespace authorization requires at least one check spec.");
+        }
+
+        var rootTable = rootRow.TableWritePlan.TableModel.Table;
+        var namespaceColumn = checks[0].NamespaceColumn;
+
+        foreach (var check in checks)
+        {
+            if (check.ValueSource is not NamespaceAuthorizationCheckValueSource.Proposed)
+            {
+                return Invalid(
+                    $"Proposed namespace authorization cannot extract check '{check.Index}' because it uses value source '{check.ValueSource}'."
+                );
+            }
+
+            if (!check.RootTable.Equals(rootTable))
+            {
+                return Invalid(
+                    $"Proposed namespace authorization check '{check.Index}' targets root table '{check.RootTable}', but the finalized root row is for '{rootTable}'."
+                );
+            }
+
+            if (!check.NamespaceColumn.Equals(namespaceColumn))
+            {
+                return Invalid(
+                    $"Proposed namespace authorization checks must reference a single namespace column. "
+                        + $"Found '{check.NamespaceColumn.Value}' and '{namespaceColumn.Value}'."
+                );
+            }
+        }
+
+        var bindings = rootRow.TableWritePlan.ColumnBindings;
+        var bindingIndex = -1;
+
+        for (var index = 0; index < bindings.Length; index++)
+        {
+            if (bindings[index].Column.ColumnName.Equals(namespaceColumn))
+            {
+                bindingIndex = index;
+                break;
+            }
+        }
+
+        if (bindingIndex < 0)
+        {
+            return Invalid(
+                $"Proposed namespace authorization could not locate a root binding for namespace column '{namespaceColumn.Value}'."
+            );
+        }
+
+        var boundValue = GetBoundSqlValue(rootRow.Values[bindingIndex]);
+
+        return boundValue switch
+        {
+            null => new ProposedNamespaceValueExtractionResult.Ready(null),
+            string proposedNamespace => new ProposedNamespaceValueExtractionResult.Ready(
+                string.IsNullOrEmpty(proposedNamespace) ? null : proposedNamespace
+            ),
+            _ => Invalid(
+                $"Proposed namespace authorization expected a string namespace value for column "
+                    + $"'{namespaceColumn.Value}' but found '{boundValue.GetType().Name}'."
+            ),
+        };
+    }
+
+    private static object? GetBoundSqlValue(FlattenedWriteValue value)
+    {
+        if (value is FlattenedWriteValue.Literal { Value: { } literalValue } && literalValue is not DBNull)
+        {
+            return literalValue;
+        }
+
+        return null;
+    }
+
+    private static ProposedNamespaceValueExtractionResult.InvalidAuthorizationPlan Invalid(string message) =>
+        new(message);
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceValueExtractor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedNamespaceValueExtractor.cs
@@ -23,7 +23,8 @@ internal abstract record ProposedNamespaceValueExtractionResult
 
     /// <summary>
     /// The planned namespace checks could not be reconciled with the finalized root row. The write
-    /// fails closed as an unknown failure.
+    /// fails closed as a security-configuration failure, matching the read-path namespace
+    /// security-configuration mapping and the proposed relationship sibling.
     /// </summary>
     public sealed record InvalidAuthorizationPlan(string FailureMessage)
         : ProposedNamespaceValueExtractionResult;

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedRelationshipAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedRelationshipAuthorizationOrchestrator.cs
@@ -3,8 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using EdFi.DataManagementService.Backend.External;
-using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Core.External.Backend;
 
 namespace EdFi.DataManagementService.Backend;
@@ -25,39 +24,66 @@ internal sealed class ProposedRelationshipAuthorizationOrchestrator(IRelationalW
         ArgumentNullException.ThrowIfNull(mergeResult);
         ArgumentNullException.ThrowIfNull(writeSession);
 
-        if (request.ProposedRelationshipAuthorization is not null)
+        switch (request.ProposedRelationshipAuthorization)
         {
-            var finalizedRootRow = BuildFinalizedRootRowBuffer(request, mergeResult);
-            var extractionResult = RelationshipAuthorizationProposedValueExtractor.Extract(
-                request.ProposedRelationshipAuthorization,
-                finalizedRootRow,
-                RelationalWriteExecutorResults.GetRelationshipAuthorizationAuth1Index(request.OperationKind),
-                request.TargetContext
-            );
+            case null:
+            case RelationshipAuthorizationResult.NoAuthorizationRequired:
+            case RelationshipAuthorizationResult.NoFurtherAuthorizationRequired:
+                break;
 
-            switch (extractionResult)
-            {
-                case ProposedRelationshipAuthorizationExtractionResult.Ready ready:
-                    mergeResult = mergeResult with
-                    {
-                        ProposedRelationshipAuthorizationRuntimeCheck = ready.RuntimeCheck,
-                    };
-                    break;
+            // NoClaims is deferred from POST preflight so the proposed namespace check can run
+            // first (namespace AND-composes before the relationship OR-group per auth.md). The
+            // namespace orchestrator runs ahead of this one in the executor, so reaching this
+            // branch means namespace authorized — surface the deferred denial now.
+            case RelationshipAuthorizationResult.NoClaims noClaims:
+                return new ProposedRelationshipAuthorizationBoundary(
+                    mergeResult,
+                    RelationalWriteExecutorResults.BuildNoClaimsRelationshipAuthorizationResult(
+                        request.OperationKind,
+                        noClaims
+                    )
+                );
 
-                case ProposedRelationshipAuthorizationExtractionResult.InvalidAuthorizationPlan invalid:
-                    return new ProposedRelationshipAuthorizationBoundary(
-                        mergeResult,
-                        RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
-                            request.OperationKind,
-                            [invalid.FailureMessage]
-                        )
-                    );
+            case RelationshipAuthorizationResult.Authorized authorized:
+                var finalizedRootRow = RelationalWriteFinalizedRootRow.Build(request, mergeResult);
+                var extractionResult = RelationshipAuthorizationProposedValueExtractor.Extract(
+                    authorized,
+                    finalizedRootRow,
+                    RelationalWriteExecutorResults.GetRelationshipAuthorizationAuth1Index(
+                        request.OperationKind
+                    ),
+                    request.TargetContext
+                );
 
-                default:
-                    throw new InvalidOperationException(
-                        $"Unsupported proposed relationship authorization extraction result '{extractionResult.GetType().Name}'."
-                    );
-            }
+                switch (extractionResult)
+                {
+                    case ProposedRelationshipAuthorizationExtractionResult.Ready ready:
+                        mergeResult = mergeResult with
+                        {
+                            ProposedRelationshipAuthorizationRuntimeCheck = ready.RuntimeCheck,
+                        };
+                        break;
+
+                    case ProposedRelationshipAuthorizationExtractionResult.InvalidAuthorizationPlan invalid:
+                        return new ProposedRelationshipAuthorizationBoundary(
+                            mergeResult,
+                            RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
+                                request.OperationKind,
+                                [invalid.FailureMessage]
+                            )
+                        );
+
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unsupported proposed relationship authorization extraction result '{extractionResult.GetType().Name}'."
+                        );
+                }
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported proposed relationship authorization result '{request.ProposedRelationshipAuthorization.GetType().Name}'."
+                );
         }
 
         await AuthorizeAsync(request, mergeResult, writeSession, cancellationToken).ConfigureAwait(false);
@@ -91,55 +117,6 @@ internal sealed class ProposedRelationshipAuthorizationOrchestrator(IRelationalW
         request.OperationKind is RelationalWriteOperationKind.Post
         && request.TargetContext is RelationalWriteTargetContext.CreateNew
         && request.WritePrecondition is not WritePrecondition.IfMatch;
-
-    private static RootWriteRowBuffer BuildFinalizedRootRowBuffer(
-        RelationalWriteExecutorRequest request,
-        RelationalWriteMergeResult mergeResult
-    )
-    {
-        var rootTable = GetRootTableWritePlan(request.WritePlan);
-        var rootTableState = mergeResult.TablesInDependencyOrder.SingleOrDefault(tableState =>
-            tableState.TableWritePlan.TableModel.Table.Equals(rootTable.TableModel.Table)
-        );
-
-        if (rootTableState is null)
-        {
-            throw new InvalidOperationException(
-                $"Relational write merge result did not include the root table '{rootTable.TableModel.Table}'."
-            );
-        }
-
-        if (rootTableState.MergedRows.Length != 1)
-        {
-            throw new InvalidOperationException(
-                $"Relational write merge result for root table '{rootTable.TableModel.Table}' "
-                    + $"included {rootTableState.MergedRows.Length} merged rows; expected exactly one."
-            );
-        }
-
-        return new RootWriteRowBuffer(rootTableState.TableWritePlan, rootTableState.MergedRows[0].Values);
-    }
-
-    private static TableWritePlan GetRootTableWritePlan(ResourceWritePlan writePlan)
-    {
-        var rootPlans = writePlan
-            .TablePlansInDependencyOrder.Where(static plan =>
-                plan.TableModel.IdentityMetadata.TableKind is DbTableKind.Root
-            )
-            .Take(2)
-            .ToArray();
-
-        return rootPlans.Length switch
-        {
-            1 => rootPlans[0],
-            0 => throw new InvalidOperationException(
-                $"Write plan for resource '{RelationalWriteSupport.FormatResource(writePlan.Model.Resource)}' does not contain a root table plan."
-            ),
-            _ => throw new InvalidOperationException(
-                $"Write plan for resource '{RelationalWriteSupport.FormatResource(writePlan.Model.Resource)}' contains multiple root table plans."
-            ),
-        };
-    }
 }
 
 internal sealed record ProposedRelationshipAuthorizationBoundary(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ProposedRelationshipAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ProposedRelationshipAuthorizationOrchestrator.cs
@@ -31,7 +31,7 @@ internal sealed class ProposedRelationshipAuthorizationOrchestrator(IRelationalW
             case RelationshipAuthorizationResult.NoFurtherAuthorizationRequired:
                 break;
 
-            // NoClaims is deferred from POST preflight so the proposed namespace check can run
+            // NoClaims is deferred from POST or PUT preflight so the proposed namespace check can run
             // first (namespace AND-composes before the relationship OR-group per auth.md). The
             // namespace orchestrator runs ahead of this one in the executor, so reaching this
             // branch means namespace authorized — surface the deferred denial now.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/QueryParameterNameAllocator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/QueryParameterNameAllocator.cs
@@ -51,6 +51,38 @@ internal static class QueryParameterNameAllocator
         );
     }
 
+    /// <summary>
+    /// Collects the concrete SQL parameter names emitted by the namespace-prefix and claim-EdOrg
+    /// authorization parameterizations on <paramref name="authorization"/>. Query filter parameter
+    /// allocation reserves these alongside the paging names so a query field whose sanitized name
+    /// matches an authorization parameter is disambiguated with a suffix instead of colliding. An
+    /// unreserved collision is rejected downstream as a duplicate filter parameter, surfacing as an
+    /// UnknownFailure instead of a filtered result.
+    /// </summary>
+    public static IReadOnlyList<string> CollectAuthorizationParameterNames(
+        PageDocumentIdAuthorizationSpec? authorization
+    )
+    {
+        if (authorization is null)
+        {
+            return [];
+        }
+
+        List<string> reservedNames = [];
+
+        if (authorization.ClaimEducationOrganizationIdParameterization is { } claimParameterization)
+        {
+            reservedNames.AddRange(claimParameterization.ParameterNamesInOrder);
+        }
+
+        if (authorization.NamespacePrefixParameterization is { } namespacePrefixParameterization)
+        {
+            reservedNames.AddRange(namespacePrefixParameterization.ParameterNamesInOrder);
+        }
+
+        return reservedNames;
+    }
+
     private static string AllocateParameterName(
         string baseName,
         ISet<string> usedNames,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -77,6 +77,9 @@ public static class ReferenceResolverServiceCollectionExtensions
             )
         );
         services.TryAdd(
+            ServiceDescriptor.Scoped<INamespaceAuthorizationExecutor, NamespaceAuthorizationExecutor>()
+        );
+        services.TryAdd(
             ServiceDescriptor.Scoped<
                 IRelationshipAuthorizationProviderFailureExtractor,
                 DefaultRelationshipAuthorizationProviderFailureExtractor

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -35,6 +35,7 @@ public sealed class RelationalDocumentStoreRepository(
     IRelationalWriteSessionFactory writeSessionFactory,
     RelationalEdOrgAuthorizationSubjectSelector edOrgAuthorizationSubjectSelector,
     ISingleRecordRelationshipAuthorizationExecutor singleRecordRelationshipAuthorizationExecutor,
+    INamespaceAuthorizationExecutor namespaceAuthorizationExecutor,
     IRelationalParameterConfigurator? relationalParameterConfigurator = null,
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null
@@ -78,6 +79,9 @@ public sealed class RelationalDocumentStoreRepository(
     private readonly ISingleRecordRelationshipAuthorizationExecutor _singleRecordRelationshipAuthorizationExecutor =
         singleRecordRelationshipAuthorizationExecutor
         ?? throw new ArgumentNullException(nameof(singleRecordRelationshipAuthorizationExecutor));
+    private readonly INamespaceAuthorizationExecutor _namespaceAuthorizationExecutor =
+        namespaceAuthorizationExecutor
+        ?? throw new ArgumentNullException(nameof(namespaceAuthorizationExecutor));
     private readonly IRelationalParameterConfigurator _relationalParameterConfigurator =
         relationalParameterConfigurator ?? DefaultRelationalParameterConfigurator.Instance;
     private readonly IRelationshipAuthorizationProviderFailureExtractor _relationshipAuthorizationProviderFailureExtractor =
@@ -105,9 +109,6 @@ public sealed class RelationalDocumentStoreRepository(
         var resource = RelationalWriteSupport.ToQualifiedResourceName(relationalUpsertRequest.ResourceInfo);
         var writePrecondition = NormalizeWritePrecondition(relationalUpsertRequest.WritePrecondition);
 
-        // TODO DMS-1057: Restore relational write authorization checks once NamespaceBased
-        // CRUD authorization is implemented for relational writes.
-
         if (mappingSet.TryGetDescriptorResourceModel(resource, out _))
         {
             return await _descriptorWriteHandler
@@ -118,7 +119,9 @@ public sealed class RelationalDocumentStoreRepository(
                         relationalUpsertRequest.EdfiDoc,
                         relationalUpsertRequest.DocumentUuid,
                         relationalUpsertRequest.DocumentInfo.ReferentialId,
-                        relationalUpsertRequest.TraceId
+                        relationalUpsertRequest.TraceId,
+                        relationalUpsertRequest.AuthorizationStrategyEvaluators,
+                        relationalUpsertRequest.AuthorizationContext
                     )
                     {
                         WritePrecondition = writePrecondition,
@@ -195,7 +198,8 @@ public sealed class RelationalDocumentStoreRepository(
                     relationalGetRequest.ReadMode,
                     relationalGetRequest.AuthorizationStrategyEvaluators,
                     relationalGetRequest.ReadableProfileProjectionContext,
-                    relationalGetRequest.TraceId
+                    relationalGetRequest.TraceId,
+                    relationalGetRequest.AuthorizationContext
                 )
             );
         }
@@ -236,9 +240,6 @@ public sealed class RelationalDocumentStoreRepository(
         var resource = RelationalWriteSupport.ToQualifiedResourceName(relationalUpdateRequest.ResourceInfo);
         var writePrecondition = NormalizeWritePrecondition(relationalUpdateRequest.WritePrecondition);
 
-        // TODO DMS-1057: Restore relational write authorization checks once NamespaceBased
-        // CRUD authorization is implemented for relational writes.
-
         if (mappingSet.TryGetDescriptorResourceModel(resource, out _))
         {
             return await _descriptorWriteHandler
@@ -249,7 +250,9 @@ public sealed class RelationalDocumentStoreRepository(
                         relationalUpdateRequest.EdfiDoc,
                         relationalUpdateRequest.DocumentUuid,
                         referentialId: null,
-                        relationalUpdateRequest.TraceId
+                        relationalUpdateRequest.TraceId,
+                        relationalUpdateRequest.AuthorizationStrategyEvaluators,
+                        relationalUpdateRequest.AuthorizationContext
                     )
                     {
                         WritePrecondition = writePrecondition,
@@ -317,9 +320,6 @@ public sealed class RelationalDocumentStoreRepository(
         var resource = RelationalWriteSupport.ToQualifiedResourceName(relationalDeleteRequest.ResourceInfo);
         var writePrecondition = NormalizeWritePrecondition(relationalDeleteRequest.WritePrecondition);
 
-        // TODO DMS-1057: Restore relational write authorization checks once NamespaceBased
-        // CRUD authorization is implemented for relational writes.
-
         if (relationalDeleteRequest.ResourceInfo.IsDescriptor)
         {
             return _descriptorWriteHandler.HandleDeleteAsync(
@@ -328,7 +328,8 @@ public sealed class RelationalDocumentStoreRepository(
                     resource,
                     relationalDeleteRequest.DocumentUuid,
                     relationalDeleteRequest.TraceId,
-                    relationalDeleteRequest.AuthorizationStrategyEvaluators
+                    relationalDeleteRequest.AuthorizationStrategyEvaluators,
+                    relationalDeleteRequest.AuthorizationContext
                 )
                 {
                     WritePrecondition = writePrecondition,
@@ -336,14 +337,36 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        return DeleteDocumentByIdAsync(relationalDeleteRequest, mappingSet, resource, writePrecondition);
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) resolve
+        // before the write session opens, so a denial issues no DB roundtrip and never locks the
+        // target. The stored namespace check itself runs inside the delete session against the locked
+        // target (see AuthorizeDeleteIfRequiredAsync).
+        var authorizationPreflight = AuthorizeDeletePreflight(relationalDeleteRequest, mappingSet, resource);
+
+        return authorizationPreflight switch
+        {
+            DeleteAuthorizationPreflightResult.Stop stop => Task.FromResult(stop.Result),
+            DeleteAuthorizationPreflightResult.Proceed proceed => DeleteDocumentByIdAsync(
+                relationalDeleteRequest,
+                mappingSet,
+                resource,
+                writePrecondition,
+                proceed.StoredNamespaceAuthorization,
+                proceed.NonNamespaceConfiguredStrategies
+            ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported relational delete authorization preflight result '{authorizationPreflight.GetType().Name}'."
+            ),
+        };
     }
 
     private async Task<DeleteResult> DeleteDocumentByIdAsync(
         IRelationalDeleteRequest relationalDeleteRequest,
         MappingSet mappingSet,
         QualifiedResourceName resource,
-        WritePrecondition writePrecondition
+        WritePrecondition writePrecondition,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies
     )
     {
         var documentUuid = relationalDeleteRequest.DocumentUuid;
@@ -427,10 +450,12 @@ public sealed class RelationalDocumentStoreRepository(
                         );
 
                         var authorizationFailure = await AuthorizeDeleteIfRequiredAsync(
-                                relationalDeleteRequest,
                                 mappingSet,
                                 resource,
                                 resolved.DocumentId,
+                                storedNamespaceAuthorization,
+                                nonNamespaceConfiguredStrategies,
+                                relationalDeleteRequest.AuthorizationContext,
                                 sessionCommandExecutor
                             )
                             .ConfigureAwait(false);
@@ -637,28 +662,44 @@ public sealed class RelationalDocumentStoreRepository(
     }
 
     private async Task<DeleteResult?> AuthorizeDeleteIfRequiredAsync(
-        IRelationalDeleteRequest relationalDeleteRequest,
         MappingSet mappingSet,
         QualifiedResourceName resource,
         long documentId,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
+        RelationalAuthorizationContext authorizationContext,
         IRelationalCommandExecutor sessionCommandExecutor
     )
     {
-        var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
-            relationalDeleteRequest.AuthorizationStrategyEvaluators
-        );
+        // Namespace AND-composes before the relationship OR group; the stored namespace check runs
+        // against the locked target and before any precondition result.
+        if (storedNamespaceAuthorization is not null)
+        {
+            var namespaceFailure = await ExecuteDeleteNamespaceAuthorizationAsync(
+                    mappingSet,
+                    documentId,
+                    storedNamespaceAuthorization,
+                    sessionCommandExecutor
+                )
+                .ConfigureAwait(false);
+
+            if (namespaceFailure is not null)
+            {
+                return namespaceFailure;
+            }
+        }
 
         var relationshipAuthorizationResult = _relationshipAuthorizationPlanner.PlanStoredValues(
             mappingSet,
             resource,
-            configuredAuthorizationStrategies,
-            relationalDeleteRequest.AuthorizationContext
+            nonNamespaceConfiguredStrategies,
+            authorizationContext
         );
 
         if (
             TryCreatePeopleEndpointStagingFailures(
                 resource,
-                configuredAuthorizationStrategies,
+                nonNamespaceConfiguredStrategies,
                 relationshipAuthorizationResult,
                 out var peopleStagingFailures
             )
@@ -685,7 +726,7 @@ public sealed class RelationalDocumentStoreRepository(
                 if (
                     !TryCreateNoClaimsRelationshipAuthorizationFailure(
                         noClaims,
-                        relationalDeleteRequest.AuthorizationContext.ClaimEducationOrganizationIds,
+                        authorizationContext.ClaimEducationOrganizationIds,
                         DeleteRelationshipAuthorizationAuth1Index,
                         out var noClaimsFailure
                     ) || noClaimsFailure is null
@@ -724,6 +765,142 @@ public sealed class RelationalDocumentStoreRepository(
                     $"Unsupported relationship authorization result '{relationshipAuthorizationResult.GetType().Name}'."
                 );
         }
+    }
+
+    private static DeleteAuthorizationPreflightResult AuthorizeDeletePreflight(
+        IRelationalDeleteRequest relationalDeleteRequest,
+        MappingSet mappingSet,
+        QualifiedResourceName resource
+    )
+    {
+        var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
+            relationalDeleteRequest.AuthorizationStrategyEvaluators
+        );
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            NamespaceAuthorizationOperation.Delete,
+            configuredAuthorizationStrategies,
+            relationalDeleteRequest.AuthorizationContext
+        );
+
+        switch (orchestratorOutcome)
+        {
+            case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
+                return new DeleteAuthorizationPreflightResult.Stop(
+                    new DeleteResult.DeleteFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                );
+
+            case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
+                return new DeleteAuthorizationPreflightResult.Stop(
+                    new DeleteResult.DeleteFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                );
+
+            case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                return new DeleteAuthorizationPreflightResult.Proceed(
+                    null,
+                    securityConfigurationError.NonNamespaceConfiguredStrategies
+                );
+
+            case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                return new DeleteAuthorizationPreflightResult.Proceed(
+                    null,
+                    stillUnsupported.NonNamespaceConfiguredStrategies
+                );
+
+            case RelationalAuthorizationPlanOutcome.Plan plan:
+                return AuthorizeDeletePlanPreflight(
+                    mappingSet,
+                    plan,
+                    relationalDeleteRequest.AuthorizationContext
+                );
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+                );
+        }
+    }
+
+    private static DeleteAuthorizationPreflightResult AuthorizeDeletePlanPreflight(
+        MappingSet mappingSet,
+        RelationalAuthorizationPlanOutcome.Plan plan,
+        RelationalAuthorizationContext authorizationContext
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return new DeleteAuthorizationPreflightResult.Proceed(
+                null,
+                plan.NonNamespaceConfiguredStrategies
+            );
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new DeleteAuthorizationPreflightResult.Stop(
+                new DeleteResult.DeleteFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        return new DeleteAuthorizationPreflightResult.Proceed(
+            new RelationalWriteNamespaceAuthorization(plan.NamespaceChecks, namespacePrefixParameterization),
+            plan.NonNamespaceConfiguredStrategies
+        );
+    }
+
+    private async Task<DeleteResult?> ExecuteDeleteNamespaceAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization storedNamespaceAuthorization,
+        IRelationalCommandExecutor sessionCommandExecutor
+    )
+    {
+        // Run the stored check against the delete session's command executor so it executes inside the
+        // same transaction that already locked the target document.
+        return await StoredNamespaceAuthorizationExecution
+            .ExecuteAsync<DeleteResult>(
+                sessionCommandExecutor,
+                _relationshipAuthorizationProviderFailureExtractor,
+                mappingSet,
+                documentId,
+                storedNamespaceAuthorization,
+                onNotAuthorized: failure => new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
+                onInvalidAuthorizationFailure: failureMessage => new DeleteResult.UnknownFailure(
+                    failureMessage
+                )
+            )
+            .ConfigureAwait(false);
+    }
+
+    private abstract record DeleteAuthorizationPreflightResult
+    {
+        private DeleteAuthorizationPreflightResult() { }
+
+        public sealed record Stop(DeleteResult Result) : DeleteAuthorizationPreflightResult;
+
+        public sealed record Proceed(
+            RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies
+        ) : DeleteAuthorizationPreflightResult;
     }
 
     private async Task<DeleteResult?> ExecuteDeleteRelationshipAuthorizationAsync(
@@ -832,7 +1009,8 @@ public sealed class RelationalDocumentStoreRepository(
                         relationalQueryRequest.PaginationParameters,
                         relationalQueryRequest.AuthorizationStrategyEvaluators,
                         relationalQueryRequest.ReadableProfileProjectionContext,
-                        relationalQueryRequest.TraceId
+                        relationalQueryRequest.TraceId,
+                        relationalQueryRequest.AuthorizationContext
                     )
                 )
                 .ConfigureAwait(false);
@@ -864,47 +1042,28 @@ public sealed class RelationalDocumentStoreRepository(
         var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
             relationalQueryRequest.AuthorizationStrategyEvaluators
         );
-
-        var relationshipAuthorizationResult = _relationshipAuthorizationPlanner.PlanStoredValues(
+        var authorizationResolution = ResolveQueryAuthorization(
             mappingSet,
             resource,
             configuredAuthorizationStrategies,
-            relationalQueryRequest.AuthorizationContext
+            relationalQueryRequest.AuthorizationContext,
+            relationalQueryRequest.PaginationParameters.TotalCount
         );
 
-        PageDocumentIdAuthorizationSpec? pageQueryAuthorization = null;
+        PageDocumentIdAuthorizationSpec? pageQueryAuthorization;
 
-        switch (relationshipAuthorizationResult)
+        switch (authorizationResolution)
         {
-            case RelationshipAuthorizationResult.NoAuthorizationRequired:
-            case RelationshipAuthorizationResult.NoFurtherAuthorizationRequired:
+            case QueryAuthorizationResolution.Complete complete:
+                return complete.Result;
+
+            case QueryAuthorizationResolution.Proceed proceed:
+                pageQueryAuthorization = proceed.Authorization;
                 break;
-
-            case RelationshipAuthorizationResult.Authorized authorized:
-                pageQueryAuthorization = PageDocumentIdAuthorizationSpecAdapter.Adapt(authorized);
-                break;
-
-            case RelationshipAuthorizationResult.NoClaims:
-                return new QueryResult.QuerySuccess(
-                    [],
-                    relationalQueryRequest.PaginationParameters.TotalCount ? 0 : null
-                );
-
-            case RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled:
-                return new QueryResult.QueryFailureNotImplemented(
-                    BuildKnownButNotEnabledQueryAuthorizationMessage(resource, knownButNotEnabled.Failures)
-                );
-
-            case RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError:
-                return BuildQueryAuthorizationSecurityConfigurationFailure(
-                    mappingSet,
-                    resource,
-                    securityConfigurationError.Failures
-                );
 
             default:
                 throw new InvalidOperationException(
-                    $"Unsupported relationship authorization result '{relationshipAuthorizationResult.GetType().Name}'."
+                    $"Unsupported query authorization resolution '{authorizationResolution.GetType().Name}'."
                 );
         }
 
@@ -997,6 +1156,222 @@ public sealed class RelationalDocumentStoreRepository(
         return BuildQuerySuccess(relationalQueryRequest, resource, readPlan, hydratedPage);
     }
 
+    private QueryAuthorizationResolution ResolveQueryAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> configuredAuthorizationStrategies,
+        RelationalAuthorizationContext authorizationContext,
+        bool totalCount
+    )
+    {
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            NamespaceAuthorizationOperation.ReadMany,
+            configuredAuthorizationStrategies,
+            authorizationContext
+        );
+
+        switch (orchestratorOutcome)
+        {
+            case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
+                return new QueryAuthorizationResolution.Complete(
+                    new QueryResult.QueryFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                );
+
+            case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
+                return new QueryAuthorizationResolution.Complete(
+                    new QueryResult.QueryFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                );
+
+            case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                return ResolveQueryRelationshipAuthorization(
+                    mappingSet,
+                    resource,
+                    securityConfigurationError.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    totalCount,
+                    [],
+                    null
+                );
+
+            case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                return ResolveQueryRelationshipAuthorization(
+                    mappingSet,
+                    resource,
+                    stillUnsupported.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    totalCount,
+                    [],
+                    null
+                );
+
+            case RelationalAuthorizationPlanOutcome.Plan plan:
+                return ResolveQueryPlanAuthorization(
+                    mappingSet,
+                    resource,
+                    plan,
+                    authorizationContext,
+                    totalCount
+                );
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+                );
+        }
+    }
+
+    private QueryAuthorizationResolution ResolveQueryPlanAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        RelationalAuthorizationPlanOutcome.Plan plan,
+        RelationalAuthorizationContext authorizationContext,
+        bool totalCount
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return ResolveQueryRelationshipAuthorization(
+                mappingSet,
+                resource,
+                plan.NonNamespaceConfiguredStrategies,
+                authorizationContext,
+                totalCount,
+                [],
+                null
+            );
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new QueryAuthorizationResolution.Complete(
+                new QueryResult.QueryFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        return ResolveQueryRelationshipAuthorization(
+            mappingSet,
+            resource,
+            plan.NonNamespaceConfiguredStrategies,
+            authorizationContext,
+            totalCount,
+            plan.NamespaceChecks,
+            namespacePrefixParameterization
+        );
+    }
+
+    private QueryAuthorizationResolution ResolveQueryRelationshipAuthorization(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
+        RelationalAuthorizationContext authorizationContext,
+        bool totalCount,
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks,
+        NamespacePrefixParameterization? namespacePrefixParameterization
+    )
+    {
+        var relationshipAuthorizationResult = _relationshipAuthorizationPlanner.PlanStoredValues(
+            mappingSet,
+            resource,
+            nonNamespaceConfiguredStrategies,
+            authorizationContext
+        );
+
+        switch (relationshipAuthorizationResult)
+        {
+            case RelationshipAuthorizationResult.NoAuthorizationRequired:
+            case RelationshipAuthorizationResult.NoFurtherAuthorizationRequired:
+                return new QueryAuthorizationResolution.Proceed(
+                    ComposePageQueryAuthorization(null, namespaceChecks, namespacePrefixParameterization)
+                );
+
+            case RelationshipAuthorizationResult.Authorized authorized:
+                return new QueryAuthorizationResolution.Proceed(
+                    ComposePageQueryAuthorization(
+                        PageDocumentIdAuthorizationSpecAdapter.Adapt(authorized),
+                        namespaceChecks,
+                        namespacePrefixParameterization
+                    )
+                );
+
+            case RelationshipAuthorizationResult.NoClaims:
+                return new QueryAuthorizationResolution.Complete(
+                    new QueryResult.QuerySuccess([], totalCount ? 0 : null)
+                );
+
+            case RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled:
+                return new QueryAuthorizationResolution.Complete(
+                    new QueryResult.QueryFailureNotImplemented(
+                        BuildKnownButNotEnabledQueryAuthorizationMessage(
+                            resource,
+                            knownButNotEnabled.Failures
+                        )
+                    )
+                );
+
+            case RelationshipAuthorizationResult.SecurityConfigurationError securityConfigurationError:
+                return new QueryAuthorizationResolution.Complete(
+                    BuildQueryAuthorizationSecurityConfigurationFailure(
+                        mappingSet,
+                        resource,
+                        securityConfigurationError.Failures
+                    )
+                );
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relationship authorization result '{relationshipAuthorizationResult.GetType().Name}'."
+                );
+        }
+    }
+
+    private static PageDocumentIdAuthorizationSpec? ComposePageQueryAuthorization(
+        PageDocumentIdAuthorizationSpec? relationshipAuthorization,
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks,
+        NamespacePrefixParameterization? namespacePrefixParameterization
+    )
+    {
+        if (namespaceChecks.Count == 0)
+        {
+            return relationshipAuthorization;
+        }
+
+        return (relationshipAuthorization ?? new PageDocumentIdAuthorizationSpec([])) with
+        {
+            NamespaceChecks = namespaceChecks,
+            NamespacePrefixParameterization = namespacePrefixParameterization,
+        };
+    }
+
+    private abstract record QueryAuthorizationResolution
+    {
+        private QueryAuthorizationResolution() { }
+
+        public sealed record Proceed(PageDocumentIdAuthorizationSpec? Authorization)
+            : QueryAuthorizationResolution;
+
+        public sealed record Complete(QueryResult Result) : QueryAuthorizationResolution;
+    }
+
     private WriteGuardRailPreflightResult<UpsertResult> AuthorizePostRelationshipIfRequired(
         IRelationalUpsertRequest relationalUpsertRequest,
         MappingSet mappingSet,
@@ -1004,17 +1379,170 @@ public sealed class RelationalDocumentStoreRepository(
         ResourceWritePlan writePlan
     )
     {
-        var authorizationStrategyEvaluators = relationalUpsertRequest.AuthorizationStrategyEvaluators;
         var authorizationContext = relationalUpsertRequest.AuthorizationContext;
-
         var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
-            authorizationStrategyEvaluators
+            relationalUpsertRequest.AuthorizationStrategyEvaluators
         );
 
+        // A POST may resolve to create or upsert-as-update in-session, so plan both the stored and
+        // proposed namespace checks here; the executor applies the stored check only when the write
+        // resolves to an existing target.
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            NamespaceAuthorizationOperation.Update,
+            configuredAuthorizationStrategies,
+            authorizationContext
+        );
+
+        switch (orchestratorOutcome)
+        {
+            case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
+                return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                    new UpsertResult.UpsertFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                );
+
+            case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
+                return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                    new UpsertResult.UpsertFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                );
+
+            case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                return AuthorizePostRelationshipBucket(
+                    mappingSet,
+                    resource,
+                    writePlan,
+                    securityConfigurationError.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    storedNamespaceAuthorization: null,
+                    proposedNamespaceAuthorization: null
+                );
+
+            case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                return AuthorizePostRelationshipBucket(
+                    mappingSet,
+                    resource,
+                    writePlan,
+                    stillUnsupported.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    storedNamespaceAuthorization: null,
+                    proposedNamespaceAuthorization: null
+                );
+
+            case RelationalAuthorizationPlanOutcome.Plan plan:
+                return AuthorizePostPlan(mappingSet, resource, writePlan, plan, authorizationContext);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+                );
+        }
+    }
+
+    private WriteGuardRailPreflightResult<UpsertResult> AuthorizePostPlan(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        ResourceWritePlan writePlan,
+        RelationalAuthorizationPlanOutcome.Plan plan,
+        RelationalAuthorizationContext authorizationContext
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return AuthorizePostRelationshipBucket(
+                mappingSet,
+                resource,
+                writePlan,
+                plan.NonNamespaceConfiguredStrategies,
+                authorizationContext,
+                storedNamespaceAuthorization: null,
+                proposedNamespaceAuthorization: null
+            );
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                new UpsertResult.UpsertFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        var (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
+            plan.NamespaceChecks,
+            namespacePrefixParameterization
+        );
+
+        return AuthorizePostRelationshipBucket(
+            mappingSet,
+            resource,
+            writePlan,
+            plan.NonNamespaceConfiguredStrategies,
+            authorizationContext,
+            storedNamespaceAuthorization,
+            proposedNamespaceAuthorization
+        );
+    }
+
+    /// <summary>
+    /// Splits the planner's namespace checks into a stored-value authorization (evaluated in the
+    /// locked-target boundary) and a proposed-value authorization (evaluated after merge). Each group
+    /// is re-indexed from zero because the two are executed as independent single-record statements,
+    /// so each carries its own AUTH1 payload index.
+    /// </summary>
+    private static (
+        RelationalWriteNamespaceAuthorization? Stored,
+        RelationalWriteNamespaceAuthorization? Proposed
+    ) SplitNamespaceAuthorization(
+        IReadOnlyList<NamespaceAuthorizationCheckSpec> namespaceChecks,
+        NamespacePrefixParameterization namespacePrefixParameterization
+    )
+    {
+        var stored = NamespaceAuthorizationFactory.SplitByValueSource(
+            namespaceChecks,
+            NamespaceAuthorizationCheckValueSource.Stored,
+            namespacePrefixParameterization
+        );
+        var proposed = NamespaceAuthorizationFactory.SplitByValueSource(
+            namespaceChecks,
+            NamespaceAuthorizationCheckValueSource.Proposed,
+            namespacePrefixParameterization
+        );
+
+        return (stored, proposed);
+    }
+
+    private WriteGuardRailPreflightResult<UpsertResult> AuthorizePostRelationshipBucket(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        ResourceWritePlan writePlan,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
+        RelationalAuthorizationContext authorizationContext,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+    )
+    {
         var relationshipAuthorizationPlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
             mappingSet,
             resource,
-            configuredAuthorizationStrategies,
+            nonNamespaceConfiguredStrategies,
             authorizationContext,
             writePlan
         );
@@ -1034,7 +1562,7 @@ public sealed class RelationalDocumentStoreRepository(
         if (
             TryCreatePeopleEndpointStagingFailures(
                 resource,
-                configuredAuthorizationStrategies,
+                nonNamespaceConfiguredStrategies,
                 out var peopleStagingFailures
             )
         )
@@ -1057,16 +1585,35 @@ public sealed class RelationalDocumentStoreRepository(
         {
             RelationshipAuthorizationResult.NoAuthorizationRequired
             or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired =>
-                new WriteGuardRailPreflightResult<UpsertResult>.Continue(null, null),
+                new WriteGuardRailPreflightResult<UpsertResult>.Continue(
+                    null,
+                    null,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
+                ),
 
             RelationshipAuthorizationResult.Authorized authorized =>
                 new WriteGuardRailPreflightResult<UpsertResult>.Continue(
                     relationshipAuthorizationPlan.StoredValues,
-                    authorized
+                    authorized,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
                 ),
 
-            RelationshipAuthorizationResult.NoClaims noClaims =>
-                BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext),
+            // NamespaceBased AND-composes before relationship OR strategies (auth.md). When a
+            // proposed namespace check is also planned, defer NoClaims through Continue so the
+            // namespace check gets to deny first; ProposedRelationshipAuthorizationOrchestrator
+            // emits the NoClaims failure if namespace authorized. With no namespace check planned,
+            // short-circuit at preflight to avoid a needless executor roundtrip.
+            RelationshipAuthorizationResult.NoClaims noClaims => proposedNamespaceAuthorization is null
+            && storedNamespaceAuthorization is null
+                ? BuildNoClaimsPostRelationshipAuthorizationFailure(noClaims, authorizationContext)
+                : new WriteGuardRailPreflightResult<UpsertResult>.Continue(
+                    null,
+                    noClaims,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
+                ),
 
             RelationshipAuthorizationResult.KnownButNotEnabled knownButNotEnabled =>
                 new WriteGuardRailPreflightResult<UpsertResult>.Stop(
@@ -1100,17 +1647,139 @@ public sealed class RelationalDocumentStoreRepository(
         ResourceWritePlan writePlan
     )
     {
-        var authorizationStrategyEvaluators = relationalUpdateRequest.AuthorizationStrategyEvaluators;
         var authorizationContext = relationalUpdateRequest.AuthorizationContext;
-
         var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
-            authorizationStrategyEvaluators
+            relationalUpdateRequest.AuthorizationStrategyEvaluators
         );
 
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            NamespaceAuthorizationOperation.Update,
+            configuredAuthorizationStrategies,
+            authorizationContext
+        );
+
+        switch (orchestratorOutcome)
+        {
+            case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
+                return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                    new UpdateResult.UpdateFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                );
+
+            case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
+                return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                    new UpdateResult.UpdateFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                );
+
+            case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                return AuthorizePutRelationshipBucket(
+                    mappingSet,
+                    resource,
+                    writePlan,
+                    securityConfigurationError.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    storedNamespaceAuthorization: null,
+                    proposedNamespaceAuthorization: null
+                );
+
+            case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                return AuthorizePutRelationshipBucket(
+                    mappingSet,
+                    resource,
+                    writePlan,
+                    stillUnsupported.NonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    storedNamespaceAuthorization: null,
+                    proposedNamespaceAuthorization: null
+                );
+
+            case RelationalAuthorizationPlanOutcome.Plan plan:
+                return AuthorizePutPlan(mappingSet, resource, writePlan, plan, authorizationContext);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+                );
+        }
+    }
+
+    private WriteGuardRailPreflightResult<UpdateResult> AuthorizePutPlan(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        ResourceWritePlan writePlan,
+        RelationalAuthorizationPlanOutcome.Plan plan,
+        RelationalAuthorizationContext authorizationContext
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return AuthorizePutRelationshipBucket(
+                mappingSet,
+                resource,
+                writePlan,
+                plan.NonNamespaceConfiguredStrategies,
+                authorizationContext,
+                storedNamespaceAuthorization: null,
+                proposedNamespaceAuthorization: null
+            );
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
+                new UpdateResult.UpdateFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        var (storedNamespaceAuthorization, proposedNamespaceAuthorization) = SplitNamespaceAuthorization(
+            plan.NamespaceChecks,
+            namespacePrefixParameterization
+        );
+
+        return AuthorizePutRelationshipBucket(
+            mappingSet,
+            resource,
+            writePlan,
+            plan.NonNamespaceConfiguredStrategies,
+            authorizationContext,
+            storedNamespaceAuthorization,
+            proposedNamespaceAuthorization
+        );
+    }
+
+    private WriteGuardRailPreflightResult<UpdateResult> AuthorizePutRelationshipBucket(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        ResourceWritePlan writePlan,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
+        RelationalAuthorizationContext authorizationContext,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization
+    )
+    {
         var relationshipAuthorizationPlan = _relationshipAuthorizationPlanner.PlanUpdateValues(
             mappingSet,
             resource,
-            configuredAuthorizationStrategies,
+            nonNamespaceConfiguredStrategies,
             authorizationContext,
             writePlan
         );
@@ -1130,7 +1799,7 @@ public sealed class RelationalDocumentStoreRepository(
         if (
             TryCreatePeopleEndpointStagingFailures(
                 resource,
-                configuredAuthorizationStrategies,
+                nonNamespaceConfiguredStrategies,
                 out var peopleStagingFailures
             )
         )
@@ -1165,15 +1834,28 @@ public sealed class RelationalDocumentStoreRepository(
         {
             RelationshipAuthorizationResult.NoAuthorizationRequired
             or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired =>
-                new WriteGuardRailPreflightResult<UpdateResult>.Continue(null, null),
+                new WriteGuardRailPreflightResult<UpdateResult>.Continue(
+                    null,
+                    null,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
+                ),
 
             RelationshipAuthorizationResult.NoClaims noClaims =>
-                new WriteGuardRailPreflightResult<UpdateResult>.Continue(noClaims, null),
+                new WriteGuardRailPreflightResult<UpdateResult>.Continue(
+                    noClaims,
+                    null,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
+                ),
 
             RelationshipAuthorizationResult.Authorized authorized =>
                 new WriteGuardRailPreflightResult<UpdateResult>.Continue(
                     authorized,
-                    relationshipAuthorizationPlan.ProposedValues as RelationshipAuthorizationResult.Authorized
+                    relationshipAuthorizationPlan.ProposedValues
+                        as RelationshipAuthorizationResult.Authorized,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
                 ),
 
             _ => throw new InvalidOperationException(
@@ -1187,34 +1869,25 @@ public sealed class RelationalDocumentStoreRepository(
         RelationalAuthorizationContext authorizationContext
     )
     {
-        return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
-            BuildNoClaimsPostRelationshipAuthorizationResult(
-                noClaims,
-                authorizationContext.ClaimEducationOrganizationIds
-            )
-        );
-    }
-
-    private static UpsertResult BuildNoClaimsPostRelationshipAuthorizationResult(
-        RelationshipAuthorizationResult.NoClaims noClaims,
-        IReadOnlyList<long> claimEducationOrganizationIds
-    )
-    {
         if (
             !TryCreateNoClaimsRelationshipAuthorizationFailure(
                 noClaims,
-                claimEducationOrganizationIds,
+                authorizationContext.ClaimEducationOrganizationIds,
                 PostRelationshipAuthorizationAuth1Index,
                 out var noClaimsFailure
             ) || noClaimsFailure is null
         )
         {
-            return new UpsertResult.UnknownFailure(
-                "Relationship authorization required caller EducationOrganizationIds, but denial metadata could not be built."
+            return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+                new UpsertResult.UnknownFailure(
+                    "Relationship authorization required caller EducationOrganizationIds, but denial metadata could not be built."
+                )
             );
         }
 
-        return CreateUpsertRelationshipNotAuthorized(noClaimsFailure);
+        return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
+            CreateUpsertRelationshipNotAuthorized(noClaimsFailure)
+        );
     }
 
     private async Task<TResult> ExecuteWriteGuardRails<TResult>(
@@ -1258,7 +1931,9 @@ public sealed class RelationalDocumentStoreRepository(
         }
 
         RelationshipAuthorizationResult? storedRelationshipAuthorization = null;
-        RelationshipAuthorizationResult.Authorized? proposedRelationshipAuthorization = null;
+        RelationshipAuthorizationResult? proposedRelationshipAuthorization = null;
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null;
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null;
 
         if (preflight is not null)
         {
@@ -1269,6 +1944,8 @@ public sealed class RelationalDocumentStoreRepository(
                 case WriteGuardRailPreflightResult<TResult>.Continue continueResult:
                     storedRelationshipAuthorization = continueResult.StoredRelationshipAuthorization;
                     proposedRelationshipAuthorization = continueResult.ProposedRelationshipAuthorization;
+                    storedNamespaceAuthorization = continueResult.StoredNamespaceAuthorization;
+                    proposedNamespaceAuthorization = continueResult.ProposedNamespaceAuthorization;
                     break;
 
                 case WriteGuardRailPreflightResult<TResult>.Stop stopResult:
@@ -1328,7 +2005,9 @@ public sealed class RelationalDocumentStoreRepository(
                         profileWriteContext: profileWriteContext,
                         writePrecondition: writePrecondition,
                         storedRelationshipAuthorization: storedRelationshipAuthorization,
-                        proposedRelationshipAuthorization: proposedRelationshipAuthorization
+                        proposedRelationshipAuthorization: proposedRelationshipAuthorization,
+                        storedNamespaceAuthorization: storedNamespaceAuthorization,
+                        proposedNamespaceAuthorization: proposedNamespaceAuthorization
                     )
                 )
                 .ConfigureAwait(false);
@@ -1433,17 +2112,26 @@ public sealed class RelationalDocumentStoreRepository(
         {
             public Continue(
                 RelationshipAuthorizationResult? storedRelationshipAuthorization,
-                RelationshipAuthorizationResult.Authorized? proposedRelationshipAuthorization
+                RelationshipAuthorizationResult? proposedRelationshipAuthorization,
+                RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
+                RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null
             )
             {
                 ValidateStoredRelationshipAuthorization(storedRelationshipAuthorization);
+                ValidateProposedRelationshipAuthorization(proposedRelationshipAuthorization);
                 StoredRelationshipAuthorization = storedRelationshipAuthorization;
                 ProposedRelationshipAuthorization = proposedRelationshipAuthorization;
+                StoredNamespaceAuthorization = storedNamespaceAuthorization;
+                ProposedNamespaceAuthorization = proposedNamespaceAuthorization;
             }
 
             public RelationshipAuthorizationResult? StoredRelationshipAuthorization { get; }
 
-            public RelationshipAuthorizationResult.Authorized? ProposedRelationshipAuthorization { get; }
+            public RelationshipAuthorizationResult? ProposedRelationshipAuthorization { get; }
+
+            public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; }
+
+            public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; }
 
             private static void ValidateStoredRelationshipAuthorization(
                 RelationshipAuthorizationResult? storedRelationshipAuthorization
@@ -1462,6 +2150,28 @@ public sealed class RelationalDocumentStoreRepository(
                         );
                 }
             }
+
+            private static void ValidateProposedRelationshipAuthorization(
+                RelationshipAuthorizationResult? proposedRelationshipAuthorization
+            )
+            {
+                // Proposed relationship results other than Authorized and NoClaims are decided at
+                // preflight: KnownButNotEnabled and SecurityConfigurationError must short-circuit
+                // there, and NoAuthorizationRequired / NoFurtherAuthorizationRequired translate to
+                // null. Allow NoClaims through so the proposed namespace check still gets to deny
+                // first when both fail.
+                switch (proposedRelationshipAuthorization)
+                {
+                    case null:
+                    case RelationshipAuthorizationResult.Authorized:
+                    case RelationshipAuthorizationResult.NoClaims:
+                        return;
+                    default:
+                        throw new InvalidOperationException(
+                            $"Unsupported proposed relationship authorization result '{proposedRelationshipAuthorization.GetType().Name}' for executor entry."
+                        );
+                }
+            }
         }
 
         public sealed record Stop(TResult Result) : WriteGuardRailPreflightResult<TResult>;
@@ -1474,6 +2184,17 @@ public sealed class RelationalDocumentStoreRepository(
         ResourceReadPlan readPlan
     )
     {
+        // Namespace planner terminals (no usable root column, no prefixes, MSSQL prefix cap) resolve
+        // before the target lookup, so a denial issues no read roundtrip and never depends on document
+        // existence. The stored namespace check itself runs per attempt against the resolved target
+        // (see AuthorizeGetByIdAgainstTargetAsync).
+        var authorizationPreflight = AuthorizeGetByIdPreflight(relationalGetRequest, mappingSet, resource);
+
+        if (authorizationPreflight is GetByIdAuthorizationPreflightResult.Stop preflightStop)
+        {
+            return preflightStop.Result;
+        }
+
         for (var attemptIndex = 0; attemptIndex < GetByIdReadBoundaryAttemptCount; attemptIndex++)
         {
             var targetLookupResult = await _readTargetLookupService
@@ -1496,13 +2217,25 @@ public sealed class RelationalDocumentStoreRepository(
                 );
             }
 
-            var authorizationOutcome = await AuthorizeGetByIdIfRequiredAsync(
-                    relationalGetRequest,
-                    mappingSet,
-                    resource,
-                    existingDocument.DocumentId
-                )
-                .ConfigureAwait(false);
+            var authorizationOutcome = authorizationPreflight switch
+            {
+                GetByIdAuthorizationPreflightResult.AuthorizationNotRequired =>
+                    GetAuthorizationOutcome.NotRequired,
+                GetByIdAuthorizationPreflightResult.Proceed proceed =>
+                    await AuthorizeGetByIdAgainstTargetAsync(
+                            relationalGetRequest,
+                            mappingSet,
+                            resource,
+                            proceed.StoredNamespaceAuthorization,
+                            proceed.NonNamespaceConfiguredStrategies,
+                            existingDocument.DocumentId,
+                            existingDocument.ContentVersion
+                        )
+                        .ConfigureAwait(false),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported GET-by-id authorization preflight result '{authorizationPreflight.GetType().Name}'."
+                ),
+            };
 
             if (authorizationOutcome.FailureResult is not null)
             {
@@ -1662,27 +2395,175 @@ public sealed class RelationalDocumentStoreRepository(
         return currentDocument.ContentVersion != observedContentVersion.Value;
     }
 
-    private async Task<GetAuthorizationOutcome> AuthorizeGetByIdIfRequiredAsync(
+    private static GetByIdAuthorizationPreflightResult AuthorizeGetByIdPreflight(
         IRelationalGetRequest relationalGetRequest,
         MappingSet mappingSet,
-        QualifiedResourceName resource,
-        long documentId
+        QualifiedResourceName resource
     )
     {
         if (ShouldBypassSingleRecordAuthorization(relationalGetRequest))
         {
-            return GetAuthorizationOutcome.NotRequired;
+            return GetByIdAuthorizationPreflightResult.AuthorizationNotRequired.Instance;
         }
 
         var configuredAuthorizationStrategies = ConfiguredAuthorizationStrategyAdapter.Adapt(
             relationalGetRequest.AuthorizationStrategyEvaluators
         );
+        var authorizationContext = relationalGetRequest.AuthorizationContext;
+        var orchestratorOutcome = RelationalAuthorizationPlanner.Plan(
+            mappingSet,
+            mappingSet.GetConcreteResourceModelOrThrow(resource),
+            NamespaceAuthorizationOperation.ReadSingle,
+            configuredAuthorizationStrategies,
+            authorizationContext
+        );
 
+        switch (orchestratorOutcome)
+        {
+            case RelationalAuthorizationPlanOutcome.NoUsableRootColumn noUsableRoot:
+                return new GetByIdAuthorizationPreflightResult.Stop(
+                    new GetResult.GetFailureSecurityConfiguration([
+                        NamespaceAuthorizationSecurityConfigurationMessages.NoUsableRootColumn(
+                            RelationalWriteSupport.FormatResource(noUsableRoot.Resource)
+                        ),
+                    ])
+                );
+
+            case RelationalAuthorizationPlanOutcome.NoPrefixesConfigured noPrefixes:
+                return new GetByIdAuthorizationPreflightResult.Stop(
+                    new GetResult.GetFailureNamespaceNotAuthorized(
+                        NamespaceAuthorizationFactory.NoPrefixesConfiguredFailure(noPrefixes.StrategyName)
+                    )
+                );
+
+            case RelationalAuthorizationPlanOutcome.SecurityConfigurationError securityConfigurationError:
+                return new GetByIdAuthorizationPreflightResult.Proceed(
+                    null,
+                    securityConfigurationError.NonNamespaceConfiguredStrategies
+                );
+
+            case RelationalAuthorizationPlanOutcome.StillUnsupported stillUnsupported:
+                return new GetByIdAuthorizationPreflightResult.Proceed(
+                    null,
+                    stillUnsupported.NonNamespaceConfiguredStrategies
+                );
+
+            case RelationalAuthorizationPlanOutcome.Plan plan:
+                return AuthorizeGetByIdPlanPreflight(mappingSet, plan, authorizationContext);
+
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported relational authorization plan outcome '{orchestratorOutcome.GetType().Name}'."
+                );
+        }
+    }
+
+    private static GetByIdAuthorizationPreflightResult AuthorizeGetByIdPlanPreflight(
+        MappingSet mappingSet,
+        RelationalAuthorizationPlanOutcome.Plan plan,
+        RelationalAuthorizationContext authorizationContext
+    )
+    {
+        if (plan.NamespaceChecks.Count == 0)
+        {
+            return new GetByIdAuthorizationPreflightResult.Proceed(
+                null,
+                plan.NonNamespaceConfiguredStrategies
+            );
+        }
+
+        NamespacePrefixParameterization namespacePrefixParameterization;
+
+        try
+        {
+            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+                mappingSet.Key.Dialect,
+                authorizationContext.NamespacePrefixes,
+                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
+            );
+        }
+        catch (NamespacePrefixLimitExceededException ex)
+        {
+            return new GetByIdAuthorizationPreflightResult.Stop(
+                new GetResult.GetFailureSecurityConfiguration([
+                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
+                ])
+            );
+        }
+
+        return new GetByIdAuthorizationPreflightResult.Proceed(
+            new RelationalWriteNamespaceAuthorization(plan.NamespaceChecks, namespacePrefixParameterization),
+            plan.NonNamespaceConfiguredStrategies
+        );
+    }
+
+    private async Task<GetAuthorizationOutcome> AuthorizeGetByIdAgainstTargetAsync(
+        IRelationalGetRequest relationalGetRequest,
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> nonNamespaceConfiguredStrategies,
+        long documentId,
+        long storedContentVersion
+    )
+    {
+        var authorizationContext = relationalGetRequest.AuthorizationContext;
+
+        if (storedNamespaceAuthorization is not null)
+        {
+            var namespaceOutcome = await ExecuteGetNamespaceAuthorizationAsync(
+                    mappingSet,
+                    documentId,
+                    storedNamespaceAuthorization
+                )
+                .ConfigureAwait(false);
+
+            if (namespaceOutcome is not null)
+            {
+                return namespaceOutcome;
+            }
+
+            var relationshipOutcome = await AuthorizeGetRelationshipAsync(
+                    mappingSet,
+                    resource,
+                    nonNamespaceConfiguredStrategies,
+                    authorizationContext,
+                    documentId
+                )
+                .ConfigureAwait(false);
+
+            // Namespace authorization read the stored row but does not report a content version, so
+            // its decision must be pinned to the stored content version that drove this attempt. The
+            // served representation, the relationship boundary, and the post-hydration boundary must
+            // all agree on that one version; otherwise a mutation that interleaved with the
+            // authorization sequence could change the namespace and serve a representation the
+            // namespace check never validated.
+            return AnchorNamespaceReadBoundary(relationshipOutcome, storedContentVersion);
+        }
+
+        return await AuthorizeGetRelationshipAsync(
+                mappingSet,
+                resource,
+                nonNamespaceConfiguredStrategies,
+                authorizationContext,
+                documentId
+            )
+            .ConfigureAwait(false);
+    }
+
+    private async Task<GetAuthorizationOutcome> AuthorizeGetRelationshipAsync(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        IReadOnlyList<ConfiguredAuthorizationStrategy> configuredAuthorizationStrategies,
+        RelationalAuthorizationContext authorizationContext,
+        long documentId
+    )
+    {
         var relationshipAuthorizationResult = _relationshipAuthorizationPlanner.PlanStoredValues(
             mappingSet,
             resource,
             configuredAuthorizationStrategies,
-            relationalGetRequest.AuthorizationContext
+            authorizationContext
         );
 
         if (
@@ -1719,7 +2600,7 @@ public sealed class RelationalDocumentStoreRepository(
                 if (
                     !TryCreateNoClaimsRelationshipAuthorizationFailure(
                         noClaims,
-                        relationalGetRequest.AuthorizationContext.ClaimEducationOrganizationIds,
+                        authorizationContext.ClaimEducationOrganizationIds,
                         GetByIdRelationshipAuthorizationAuth1Index,
                         out var noClaimsFailure
                     ) || noClaimsFailure is null
@@ -1769,6 +2650,79 @@ public sealed class RelationalDocumentStoreRepository(
                     $"Unsupported relationship authorization result '{relationshipAuthorizationResult.GetType().Name}'."
                 );
         }
+    }
+
+    private static GetAuthorizationOutcome AnchorNamespaceReadBoundary(
+        GetAuthorizationOutcome relationshipOutcome,
+        long storedContentVersion
+    )
+    {
+        // A failure or an already-requested retry from the relationship boundary takes precedence and
+        // is returned unchanged.
+        if (relationshipOutcome is not { FailureResult: null, RetryTargetResolution: false } authorized)
+        {
+            return relationshipOutcome;
+        }
+
+        // The namespace check ran against the stored row but reports no version, so its decision is
+        // only valid for the stored content version. When the relationship boundary either reported
+        // no version (a no-op OR group) or reported the same stored version, pin the read boundary to
+        // that version so hydration and the post-hydration boundary serve exactly the namespace-checked
+        // representation.
+        if (
+            authorized.ObservedContentVersion is null
+            || authorized.ObservedContentVersion == storedContentVersion
+        )
+        {
+            return authorized with { ObservedContentVersion = storedContentVersion };
+        }
+
+        // The relationship boundary observed a different content version than the one the namespace
+        // check authorized, so a mutation interleaved with the authorization sequence and the
+        // namespace decision can no longer be trusted for the version that would be served. Force a
+        // retry so the entire authorization sequence re-runs against the current row.
+        return authorized with
+        {
+            RetryTargetResolution = true,
+        };
+    }
+
+    private async Task<GetAuthorizationOutcome?> ExecuteGetNamespaceAuthorizationAsync(
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization storedNamespaceAuthorization
+    )
+    {
+        var executionResult = await _namespaceAuthorizationExecutor
+            .ExecuteAsync(
+                new NamespaceAuthorizationExecutionRequest(
+                    mappingSet,
+                    documentId,
+                    ProposedNamespace: null,
+                    storedNamespaceAuthorization.Checks,
+                    storedNamespaceAuthorization.NamespacePrefixParameterization
+                )
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            NamespaceAuthorizationExecutionResult.Authorized => null,
+            NamespaceAuthorizationExecutionResult.NotAuthorized notAuthorized => new GetAuthorizationOutcome(
+                new GetResult.GetFailureNamespaceNotAuthorized(notAuthorized.Failure),
+                null,
+                false
+            ),
+            NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                new GetAuthorizationOutcome(
+                    new GetResult.UnknownFailure(invalidFailure.FailureMessage),
+                    null,
+                    false
+                ),
+            _ => throw new InvalidOperationException(
+                $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
     }
 
     private async Task<GetAuthorizationOutcome> ExecuteGetRelationshipAuthorizationAsync(
@@ -1868,6 +2822,29 @@ public sealed class RelationalDocumentStoreRepository(
     )
     {
         public static GetAuthorizationOutcome NotRequired { get; } = new(null, null, false);
+    }
+
+    private abstract record GetByIdAuthorizationPreflightResult
+    {
+        private GetByIdAuthorizationPreflightResult() { }
+
+        // A document-independent namespace planner terminal (no usable root column, no prefixes, or
+        // prefix cap exceeded) denied or failed the request before any target lookup.
+        public sealed record Stop(GetResult Result) : GetByIdAuthorizationPreflightResult;
+
+        // Document-dependent authorization remains and runs per attempt against the resolved target.
+        // StoredNamespaceAuthorization is null when only relationship strategies must be evaluated.
+        public sealed record Proceed(
+            RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization,
+            IReadOnlyList<ConfiguredAuthorizationStrategy> NonNamespaceConfiguredStrategies
+        ) : GetByIdAuthorizationPreflightResult;
+
+        // No per-record authorization is required for this read (StoredDocument-mode bypass); the
+        // target is still looked up and served.
+        public sealed record AuthorizationNotRequired : GetByIdAuthorizationPreflightResult
+        {
+            public static AuthorizationNotRequired Instance { get; } = new();
+        }
     }
 
     private static bool ShouldApplyReadableProfileProjection(IRelationalGetRequest relationalGetRequest) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -847,12 +847,12 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new DeleteAuthorizationPreflightResult.Stop(
-                new DeleteResult.DeleteFailureSecurityConfiguration([prefixCapExceededMessage])
+                new DeleteResult.DeleteFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 
@@ -1147,6 +1147,32 @@ public sealed class RelationalDocumentStoreRepository(
             return new QueryResult.UnknownFailure(ex.Message);
         }
 
+        // Fail closed when the planned page query would bind more parameters than SQL Server allows. Keyed
+        // off the final planned parameter count so it covers every empty-page short-circuit — both
+        // preprocessing (e.g. an invalid-UUID filter) and planning (e.g. an invalid scalar root-column
+        // filter), which both return an empty page above before reaching here — and reflects the exact
+        // command rather than an estimate. The non-authorization count (filter + paging parameters) is the
+        // planned total minus the authorization lists, which the message reports alongside the prefix and
+        // education-organization counts.
+        var nonAuthorizationParameterCount =
+            plannedQuery.ParameterValues.Count
+            - AuthorizationParameterBudget.CountAuthorizationParameters(
+                pageQueryAuthorization?.NamespacePrefixParameterization,
+                pageQueryAuthorization?.ClaimEducationOrganizationIdParameterization
+            );
+        if (
+            BuildQueryParameterBudgetFailure(
+                mappingSet.Key.Dialect,
+                pageQueryAuthorization?.NamespacePrefixParameterization,
+                pageQueryAuthorization?.ClaimEducationOrganizationIdParameterization,
+                nonAuthorizationParameterCount
+            ) is
+            { } parameterBudgetFailure
+        )
+        {
+            return parameterBudgetFailure;
+        }
+
         var hydratedPage = await _documentHydrator
             .HydrateAsync(readPlan, plannedQuery, new HydrationExecutionOptions(), default)
             .ConfigureAwait(false);
@@ -1252,12 +1278,12 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new QueryAuthorizationResolution.Complete(
-                new QueryResult.QueryFailureSecurityConfiguration([prefixCapExceededMessage])
+                new QueryResult.QueryFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 
@@ -1298,33 +1324,6 @@ public sealed class RelationalDocumentStoreRepository(
                 );
 
             case RelationshipAuthorizationResult.Authorized authorized:
-                // NamespaceBased and relationship authorization each cap their own SQL Server parameter
-                // list below 2,000, but a single page query composes both lists, so a client within both
-                // per-list caps can still push the command past SQL Server's per-command parameter ceiling.
-                // Fail closed with a security-configuration result instead of letting the query fail at
-                // execution.
-                if (
-                    namespacePrefixParameterization is not null
-                    && authorized.ClaimEducationOrganizationIdParameterization is not null
-                    && AuthorizationParameterBudget.ExceedsCombinedLimit(
-                        namespacePrefixParameterization,
-                        authorized.ClaimEducationOrganizationIdParameterization
-                    )
-                )
-                {
-                    return new QueryAuthorizationResolution.Complete(
-                        new QueryResult.QueryFailureSecurityConfiguration([
-                            NamespaceAuthorizationSecurityConfigurationMessages.CombinedAuthorizationParameterCapExceeded(
-                                namespacePrefixParameterization.ConfiguredPrefixesInOrder.Count,
-                                authorized
-                                    .ClaimEducationOrganizationIdParameterization
-                                    .ClaimEducationOrganizationIds
-                                    .Count
-                            ),
-                        ])
-                    );
-                }
-
                 return new QueryAuthorizationResolution.Proceed(
                     ComposePageQueryAuthorization(
                         PageDocumentIdAuthorizationSpecAdapter.Adapt(authorized),
@@ -1362,6 +1361,40 @@ public sealed class RelationalDocumentStoreRepository(
                     $"Unsupported relationship authorization result '{relationshipAuthorizationResult.GetType().Name}'."
                 );
         }
+    }
+
+    /// <summary>
+    /// Returns a security-configuration failure when the authorization parameters this query binds, plus
+    /// its filter and paging parameters, exceed SQL Server's per-command parameter ceiling; otherwise
+    /// <see langword="null"/>. Either authorization parameterization may be <see langword="null"/>, so this
+    /// covers the namespace-only, relationship-only, and composed query shapes uniformly.
+    /// </summary>
+    private static QueryResult? BuildQueryParameterBudgetFailure(
+        SqlDialect dialect,
+        NamespacePrefixParameterization? namespacePrefixParameterization,
+        AuthorizationClaimEducationOrganizationIdParameterization? claimEducationOrganizationIdParameterization,
+        int nonAuthorizationParameterCount
+    )
+    {
+        if (
+            !AuthorizationParameterBudget.ExceedsCommandParameterLimit(
+                dialect,
+                namespacePrefixParameterization,
+                claimEducationOrganizationIdParameterization,
+                nonAuthorizationParameterCount
+            )
+        )
+        {
+            return null;
+        }
+
+        return new QueryResult.QueryFailureSecurityConfiguration([
+            NamespaceAuthorizationSecurityConfigurationMessages.CommandParameterCapExceeded(
+                namespacePrefixParameterization?.ConfiguredPrefixesInOrder.Count ?? 0,
+                claimEducationOrganizationIdParameterization?.ClaimEducationOrganizationIds.Count ?? 0,
+                nonAuthorizationParameterCount
+            ),
+        ]);
     }
 
     private static PageDocumentIdAuthorizationSpec? ComposePageQueryAuthorization(
@@ -1491,12 +1524,12 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
-                new UpsertResult.UpsertFailureSecurityConfiguration([prefixCapExceededMessage])
+                new UpsertResult.UpsertFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 
@@ -1751,12 +1784,12 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
-                new UpdateResult.UpdateFailureSecurityConfiguration([prefixCapExceededMessage])
+                new UpdateResult.UpdateFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 
@@ -2501,12 +2534,12 @@ public sealed class RelationalDocumentStoreRepository(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
                 out var namespacePrefixParameterization,
-                out var prefixCapExceededMessage
+                out var securityConfigurationMessage
             )
         )
         {
             return new GetByIdAuthorizationPreflightResult.Stop(
-                new GetResult.GetFailureSecurityConfiguration([prefixCapExceededMessage])
+                new GetResult.GetFailureSecurityConfiguration([securityConfigurationMessage])
             );
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -842,22 +842,17 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new DeleteAuthorizationPreflightResult.Stop(
-                new DeleteResult.DeleteFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new DeleteResult.DeleteFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -884,9 +879,12 @@ public sealed class RelationalDocumentStoreRepository(
                 documentId,
                 storedNamespaceAuthorization,
                 onNotAuthorized: failure => new DeleteResult.DeleteFailureNamespaceNotAuthorized(failure),
-                onInvalidAuthorizationFailure: failureMessage => new DeleteResult.UnknownFailure(
-                    failureMessage
-                )
+                onInvalidAuthorizationFailure: failureMessage => new DeleteResult.DeleteFailureSecurityConfiguration([
+                    failureMessage,
+                ]),
+                // The target is row-locked before this check, so a stale target is not expected; map it
+                // to not-exists defensively for the rare case where the lock did not hold.
+                onStaleTarget: () => new DeleteResult.DeleteFailureNotExists()
             )
             .ConfigureAwait(false);
     }
@@ -1249,22 +1247,17 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new QueryAuthorizationResolution.Complete(
-                new QueryResult.QueryFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new QueryResult.QueryFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -1493,22 +1486,17 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new WriteGuardRailPreflightResult<UpsertResult>.Stop(
-                new UpsertResult.UpsertFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new UpsertResult.UpsertFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -1758,22 +1746,17 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new WriteGuardRailPreflightResult<UpdateResult>.Stop(
-                new UpdateResult.UpdateFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new UpdateResult.UpdateFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -1868,10 +1851,24 @@ public sealed class RelationalDocumentStoreRepository(
                     proposedNamespaceAuthorization
                 ),
 
-            RelationshipAuthorizationResult.NoClaims noClaims =>
-                new WriteGuardRailPreflightResult<UpdateResult>.Continue(
+            // NamespaceBased AND-composes before the relationship OR group (auth.md,
+            // 08-namespace-auth-strategy.md). When a namespace check is planned, defer the stored
+            // relationship NoClaims denial into the proposed-relationship slot so the stored-then-proposed
+            // namespace checks get to deny first; ProposedRelationshipAuthorizationOrchestrator emits the
+            // NoClaims denial only after the proposed namespace check authorizes. With no namespace check
+            // planned, keep NoClaims in the stored slot so the stored boundary emits it after the target
+            // lock, preserving the existing 404-over-403 ordering for a missing PUT target.
+            RelationshipAuthorizationResult.NoClaims noClaims => storedNamespaceAuthorization is null
+            && proposedNamespaceAuthorization is null
+                ? new WriteGuardRailPreflightResult<UpdateResult>.Continue(
                     noClaims,
                     null,
+                    storedNamespaceAuthorization,
+                    proposedNamespaceAuthorization
+                )
+                : new WriteGuardRailPreflightResult<UpdateResult>.Continue(
+                    null,
+                    noClaims,
                     storedNamespaceAuthorization,
                     proposedNamespaceAuthorization
                 ),
@@ -2499,22 +2496,17 @@ public sealed class RelationalDocumentStoreRepository(
             );
         }
 
-        NamespacePrefixParameterization namespacePrefixParameterization;
-
-        try
-        {
-            namespacePrefixParameterization = NamespacePrefixParameterizationFactory.Create(
+        if (
+            !NamespacePrefixParameterizationPreflight.TryCreate(
                 mappingSet.Key.Dialect,
                 authorizationContext.NamespacePrefixes,
-                NamespaceAuthorizationSqlSpecDefaults.NamespacePrefixesParameterName
-            );
-        }
-        catch (NamespacePrefixLimitExceededException ex)
+                out var namespacePrefixParameterization,
+                out var prefixCapExceededMessage
+            )
+        )
         {
             return new GetByIdAuthorizationPreflightResult.Stop(
-                new GetResult.GetFailureSecurityConfiguration([
-                    NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(ex.PrefixCount),
-                ])
+                new GetResult.GetFailureSecurityConfiguration([prefixCapExceededMessage])
             );
         }
 
@@ -2742,10 +2734,18 @@ public sealed class RelationalDocumentStoreRepository(
             ),
             NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
                 new GetAuthorizationOutcome(
-                    new GetResult.UnknownFailure(invalidFailure.FailureMessage),
+                    new GetResult.GetFailureSecurityConfiguration([invalidFailure.FailureMessage]),
                     null,
                     false
                 ),
+            // The stored target row was deleted between the unlocked target lookup and this check.
+            // Request a retry so the read boundary re-resolves the target; a target that is still gone on
+            // the next attempt surfaces as a 404 rather than a namespace mismatch.
+            NamespaceAuthorizationExecutionResult.StaleTarget => new GetAuthorizationOutcome(
+                null,
+                null,
+                RetryTargetResolution: true
+            ),
             _ => throw new InvalidOperationException(
                 $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
             ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1305,6 +1305,33 @@ public sealed class RelationalDocumentStoreRepository(
                 );
 
             case RelationshipAuthorizationResult.Authorized authorized:
+                // NamespaceBased and relationship authorization each cap their own SQL Server parameter
+                // list below 2,000, but a single page query composes both lists, so a client within both
+                // per-list caps can still push the command past SQL Server's per-command parameter ceiling.
+                // Fail closed with a security-configuration result instead of letting the query fail at
+                // execution.
+                if (
+                    namespacePrefixParameterization is not null
+                    && authorized.ClaimEducationOrganizationIdParameterization is not null
+                    && AuthorizationParameterBudget.ExceedsCombinedLimit(
+                        namespacePrefixParameterization,
+                        authorized.ClaimEducationOrganizationIdParameterization
+                    )
+                )
+                {
+                    return new QueryAuthorizationResolution.Complete(
+                        new QueryResult.QueryFailureSecurityConfiguration([
+                            NamespaceAuthorizationSecurityConfigurationMessages.CombinedAuthorizationParameterCapExceeded(
+                                namespacePrefixParameterization.ConfiguredPrefixesInOrder.Count,
+                                authorized
+                                    .ClaimEducationOrganizationIdParameterization
+                                    .ClaimEducationOrganizationIds
+                                    .Count
+                            ),
+                        ])
+                    );
+                }
+
                 return new QueryAuthorizationResolution.Proceed(
                     ComposePageQueryAuthorization(
                         PageDocumentIdAuthorizationSpecAdapter.Adapt(authorized),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalQueryPageKeysetPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalQueryPageKeysetPlanner.cs
@@ -136,6 +136,10 @@ internal sealed class RelationalQueryPageKeysetPlanner(SqlDialect dialect)
                 authorizationClaimParameterization
             );
         }
+        NamespacePrefixParameterValueBinder.Bind(
+            parameterValues,
+            authorization?.NamespacePrefixParameterization
+        );
 
         var querySpec = new PageDocumentIdQuerySpec(
             RootTable: rootTable.Table,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalQueryPageKeysetPlanner.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalQueryPageKeysetPlanner.cs
@@ -90,7 +90,10 @@ internal sealed class RelationalQueryPageKeysetPlanner(SqlDialect dialect)
             static column => column
         );
         var authorizationClaimParameterization = authorization?.ClaimEducationOrganizationIdParameterization;
-        var parameterNamesByIndex = DeriveParameterNames(preprocessingResult.QueryElementsInOrder);
+        var parameterNamesByIndex = DeriveParameterNames(
+            preprocessingResult.QueryElementsInOrder,
+            authorization
+        );
         var predicates = new QueryValuePredicate[preprocessingResult.QueryElementsInOrder.Count];
         Dictionary<string, object?> parameterValues = new(StringComparer.Ordinal)
         {
@@ -312,7 +315,8 @@ internal sealed class RelationalQueryPageKeysetPlanner(SqlDialect dialect)
     }
 
     private static IReadOnlyList<string> DeriveParameterNames(
-        IReadOnlyList<PreprocessedRelationalQueryElement> queryElementsInOrder
+        IReadOnlyList<PreprocessedRelationalQueryElement> queryElementsInOrder,
+        PageDocumentIdAuthorizationSpec? authorization
     )
     {
         var seeds = queryElementsInOrder
@@ -329,7 +333,14 @@ internal sealed class RelationalQueryPageKeysetPlanner(SqlDialect dialect)
             )
             .ToArray();
 
-        return QueryParameterNameAllocator.Allocate(seeds, [OffsetParameterName, LimitParameterName]);
+        return QueryParameterNameAllocator.Allocate(
+            seeds,
+            [
+                OffsetParameterName,
+                LimitParameterName,
+                .. QueryParameterNameAllocator.CollectAuthorizationParameterNames(authorization),
+            ]
+        );
     }
 
     private static IReadOnlyDictionary<

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadGuardrails.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadGuardrails.cs
@@ -11,7 +11,13 @@ namespace EdFi.DataManagementService.Backend;
 
 internal static class RelationalReadGuardrails
 {
-    public static bool HasOnlyNoFurtherAuthorizationRequired(
+    /// <summary>
+    /// Descriptors authorize against the shared <c>dms.Descriptor</c> root-table Namespace column, so the
+    /// only effective strategies they can evaluate are <c>NamespaceBased</c> and
+    /// <c>NoFurtherAuthorizationRequired</c>. Any other strategy (relationship, ownership, custom view)
+    /// has no descriptor-applicable filter and must fail closed before any database work.
+    /// </summary>
+    public static bool HasOnlyNamespaceBasedOrNoFurtherAuthorizationRequired(
         IReadOnlyList<AuthorizationStrategyEvaluator> authorizationStrategyEvaluators
     )
     {
@@ -20,7 +26,31 @@ internal static class RelationalReadGuardrails
         return authorizationStrategyEvaluators.All(static evaluator =>
             string.Equals(
                 evaluator.AuthorizationStrategyName,
+                AuthorizationStrategyNameConstants.NamespaceBased,
+                StringComparison.Ordinal
+            )
+            || string.Equals(
+                evaluator.AuthorizationStrategyName,
                 AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+                StringComparison.Ordinal
+            )
+        );
+    }
+
+    /// <summary>
+    /// Whether <c>NamespaceBased</c> is among the effective strategies, indicating that backend-planned
+    /// namespace authorization must run for the request.
+    /// </summary>
+    public static bool ContainsNamespaceBased(
+        IReadOnlyList<AuthorizationStrategyEvaluator> authorizationStrategyEvaluators
+    )
+    {
+        ArgumentNullException.ThrowIfNull(authorizationStrategyEvaluators);
+
+        return authorizationStrategyEvaluators.Any(static evaluator =>
+            string.Equals(
+                evaluator.AuthorizationStrategyName,
+                AuthorizationStrategyNameConstants.NamespaceBased,
                 StringComparison.Ordinal
             )
         );
@@ -43,7 +73,8 @@ internal static class RelationalReadGuardrails
 
         return $"Relational {operationLabel} authorization is not implemented for resource '{RelationalWriteSupport.FormatResource(resource)}' "
             + $"when effective {effectiveAuthorizationActionLabel} authorization requires filtering. Effective strategies: "
-            + $"[{string.Join(", ", strategyNames)}]. Only requests with no authorization strategies or only "
+            + $"[{string.Join(", ", strategyNames)}]. Only requests with no authorization strategies or with "
+            + $"'{AuthorizationStrategyNameConstants.NamespaceBased}' and/or "
             + $"'{AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired}' are currently supported.";
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteContracts.cs
@@ -555,7 +555,9 @@ public sealed record RelationalWriteExecutorRequest
         BackendProfileWriteContext? profileWriteContext = null,
         WritePrecondition? writePrecondition = null,
         RelationshipAuthorizationResult? storedRelationshipAuthorization = null,
-        RelationshipAuthorizationResult.Authorized? proposedRelationshipAuthorization = null
+        RelationshipAuthorizationResult? proposedRelationshipAuthorization = null,
+        RelationalWriteNamespaceAuthorization? storedNamespaceAuthorization = null,
+        RelationalWriteNamespaceAuthorization? proposedNamespaceAuthorization = null
     )
     {
         MappingSet = mappingSet ?? throw new ArgumentNullException(nameof(mappingSet));
@@ -626,6 +628,8 @@ public sealed record RelationalWriteExecutorRequest
         WritePrecondition = writePrecondition ?? new WritePrecondition.None();
         StoredRelationshipAuthorization = storedRelationshipAuthorization;
         ProposedRelationshipAuthorization = proposedRelationshipAuthorization;
+        StoredNamespaceAuthorization = storedNamespaceAuthorization;
+        ProposedNamespaceAuthorization = proposedNamespaceAuthorization;
     }
 
     /// <summary>
@@ -698,10 +702,36 @@ public sealed record RelationalWriteExecutorRequest
 
     /// <summary>
     /// Operation-neutral proposed-value relationship authorization plan, when required.
-    /// The current executor executes this for POST and carries PUT plans for stored-gated orchestration.
+    /// Accepts <see cref="RelationshipAuthorizationResult.Authorized"/> for executable proposed
+    /// checks and <see cref="RelationshipAuthorizationResult.NoClaims"/> for deferred denials that
+    /// must surface only after proposed namespace authorization has had its chance to deny.
     /// </summary>
-    public RelationshipAuthorizationResult.Authorized? ProposedRelationshipAuthorization { get; init; }
+    public RelationshipAuthorizationResult? ProposedRelationshipAuthorization { get; init; }
+
+    /// <summary>
+    /// Stored-value namespace authorization for existing-target writes, when <c>NamespaceBased</c>
+    /// participates. Evaluated inside the locked-target boundary before any precondition. Null when
+    /// no stored namespace authorization applies.
+    /// </summary>
+    public RelationalWriteNamespaceAuthorization? StoredNamespaceAuthorization { get; init; }
+
+    /// <summary>
+    /// Proposed-value namespace authorization for this write, when <c>NamespaceBased</c> participates.
+    /// Evaluated after merge finalizes the root row and before persist/commit. Null when no proposed
+    /// namespace authorization applies.
+    /// </summary>
+    public RelationalWriteNamespaceAuthorization? ProposedNamespaceAuthorization { get; init; }
 }
+
+/// <summary>
+/// Namespace authorization inputs threaded from the repository write preflight into the executor.
+/// </summary>
+/// <param name="Checks">The planned namespace authorization checks in emission order.</param>
+/// <param name="NamespacePrefixParameterization">The dialect-specific namespace prefix parameterization.</param>
+public sealed record RelationalWriteNamespaceAuthorization(
+    IReadOnlyList<NamespaceAuthorizationCheckSpec> Checks,
+    NamespacePrefixParameterization NamespacePrefixParameterization
+);
 
 /// <summary>
 /// Backend-local classification of one executor attempt.

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -33,7 +33,11 @@ internal sealed class RelationalWriteExecutionStateResolver(
         RelationalWriteExecutorRequest request
     ) =>
         request.WritePrecondition is WritePrecondition.IfMatch
-        && request.ProposedRelationshipAuthorization is not null
+        && (
+            request.ProposedRelationshipAuthorization is not null
+            || request.StoredNamespaceAuthorization is not null
+            || request.ProposedNamespaceAuthorization is not null
+        )
             ? IfMatchPreconditionEvaluation.DeferredUntilAfterProposedAuthorization
             : IfMatchPreconditionEvaluation.BeforeProposedAuthorization;
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
@@ -86,6 +86,28 @@ internal static class RelationalWriteExecutorResults
         };
     }
 
+    /// <summary>
+    /// Maps a stale-target namespace authorization result to a write conflict (POST) or not-exists (PUT)
+    /// outcome, mirroring the single-record relationship authorization stale-target mapping. Locked write
+    /// paths row-lock the target before the namespace check, so this is a defensive mapping for a row
+    /// that vanished despite the lock rather than an expected outcome.
+    /// </summary>
+    public static RelationalWriteExecutorResult BuildStaleTargetResult(
+        RelationalWriteOperationKind operationKind
+    )
+    {
+        return operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UpsertFailureWriteConflict()
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureNotExists()
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
+        };
+    }
+
     public static RelationalWriteExecutorResult BuildNoClaimsRelationshipAuthorizationResult(
         RelationalWriteOperationKind operationKind,
         RelationshipAuthorizationResult.NoClaims noClaims

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
@@ -67,7 +67,26 @@ internal static class RelationalWriteExecutorResults
         };
     }
 
-    public static RelationalWriteExecutorResult BuildNoClaimsStoredRelationshipAuthorizationResult(
+    public static RelationalWriteExecutorResult BuildNamespaceAuthorizationFailureResult(
+        RelationalWriteOperationKind operationKind,
+        NamespaceAuthorizationFailure namespaceFailure
+    )
+    {
+        ArgumentNullException.ThrowIfNull(namespaceFailure);
+
+        return operationKind switch
+        {
+            RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
+                new UpsertResult.UpsertFailureNamespaceNotAuthorized(namespaceFailure)
+            ),
+            RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
+                new UpdateResult.UpdateFailureNamespaceNotAuthorized(namespaceFailure)
+            ),
+            _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
+        };
+    }
+
+    public static RelationalWriteExecutorResult BuildNoClaimsRelationshipAuthorizationResult(
         RelationalWriteOperationKind operationKind,
         RelationshipAuthorizationResult.NoClaims noClaims
     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFinalizedRootRow.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteFinalizedRootRow.cs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Reconstructs the finalized root-table row buffer from a merge result so proposed-value
+/// authorization can read post-merge values aligned with the root table's
+/// <see cref="TableWritePlan.ColumnBindings"/>, rather than re-reading the raw request body.
+/// </summary>
+internal static class RelationalWriteFinalizedRootRow
+{
+    public static RootWriteRowBuffer Build(
+        RelationalWriteExecutorRequest request,
+        RelationalWriteMergeResult mergeResult
+    )
+    {
+        var rootTable = GetRootTableWritePlan(request.WritePlan);
+        var rootTableState = mergeResult.TablesInDependencyOrder.SingleOrDefault(tableState =>
+            tableState.TableWritePlan.TableModel.Table.Equals(rootTable.TableModel.Table)
+        );
+
+        if (rootTableState is null)
+        {
+            throw new InvalidOperationException(
+                $"Relational write merge result did not include the root table '{rootTable.TableModel.Table}'."
+            );
+        }
+
+        if (rootTableState.MergedRows.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Relational write merge result for root table '{rootTable.TableModel.Table}' "
+                    + $"included {rootTableState.MergedRows.Length} merged rows; expected exactly one."
+            );
+        }
+
+        return new RootWriteRowBuffer(rootTableState.TableWritePlan, rootTableState.MergedRows[0].Values);
+    }
+
+    private static TableWritePlan GetRootTableWritePlan(ResourceWritePlan writePlan)
+    {
+        var rootPlans = writePlan
+            .TablePlansInDependencyOrder.Where(static plan =>
+                plan.TableModel.IdentityMetadata.TableKind is DbTableKind.Root
+            )
+            .Take(2)
+            .ToArray();
+
+        return rootPlans.Length switch
+        {
+            1 => rootPlans[0],
+            0 => throw new InvalidOperationException(
+                $"Write plan for resource '{RelationalWriteSupport.FormatResource(writePlan.Model.Resource)}' does not contain a root table plan."
+            ),
+            _ => throw new InvalidOperationException(
+                $"Write plan for resource '{RelationalWriteSupport.FormatResource(writePlan.Model.Resource)}' contains multiple root table plans."
+            ),
+        };
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
@@ -37,12 +37,15 @@ internal sealed class StoredRelationshipAuthorizationOrchestrator(
         CancellationToken cancellationToken
     )
     {
-        if (
+        var storedRelationshipRequiresAuthorization =
             request.StoredRelationshipAuthorization
-            is null
+            is not (
+                null
                 or RelationshipAuthorizationResult.NoAuthorizationRequired
                 or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired
-        )
+            );
+
+        if (!storedRelationshipRequiresAuthorization && request.StoredNamespaceAuthorization is null)
         {
             return new StoredRelationshipAuthorizationBoundary(
                 request,
@@ -238,6 +241,21 @@ internal sealed class StoredRelationshipAuthorizationOrchestrator(
         CancellationToken cancellationToken
     )
     {
+        // Namespace AND-composes before the relationship OR group; both run against the one locked
+        // target and before any precondition result.
+        var namespaceResult = await AuthorizeStoredNamespaceAsync(
+                request,
+                existingTarget,
+                writeSession,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        if (namespaceResult is not null)
+        {
+            return namespaceResult;
+        }
+
         return request.StoredRelationshipAuthorization switch
         {
             null
@@ -245,7 +263,7 @@ internal sealed class StoredRelationshipAuthorizationOrchestrator(
             or RelationshipAuthorizationResult.NoFurtherAuthorizationRequired => null,
 
             RelationshipAuthorizationResult.NoClaims noClaims =>
-                RelationalWriteExecutorResults.BuildNoClaimsStoredRelationshipAuthorizationResult(
+                RelationalWriteExecutorResults.BuildNoClaimsRelationshipAuthorizationResult(
                     request.OperationKind,
                     noClaims
                 ),
@@ -271,6 +289,42 @@ internal sealed class StoredRelationshipAuthorizationOrchestrator(
                 $"Unsupported stored relationship authorization result '{request.StoredRelationshipAuthorization.GetType().Name}'."
             ),
         };
+    }
+
+    private async Task<RelationalWriteExecutorResult?> AuthorizeStoredNamespaceAsync(
+        RelationalWriteExecutorRequest request,
+        RelationalWriteTargetContext.ExistingDocument existingTarget,
+        IRelationalWriteSession writeSession,
+        CancellationToken cancellationToken
+    )
+    {
+        var namespaceAuthorization = request.StoredNamespaceAuthorization;
+
+        if (namespaceAuthorization is null)
+        {
+            return null;
+        }
+
+        return await StoredNamespaceAuthorizationExecution
+            .ExecuteAsync(
+                writeSession.CreateCommandExecutor(),
+                _relationshipAuthorizationProviderFailureExtractor,
+                request.MappingSet,
+                existingTarget.DocumentId,
+                namespaceAuthorization,
+                onNotAuthorized: failure =>
+                    RelationalWriteExecutorResults.BuildNamespaceAuthorizationFailureResult(
+                        request.OperationKind,
+                        failure
+                    ),
+                onInvalidAuthorizationFailure: failureMessage =>
+                    RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                        request.OperationKind,
+                        failureMessage
+                    ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
     }
 
     private async Task<RelationalWriteExecutorResult?> ExecuteAsync(
@@ -358,3 +412,54 @@ internal sealed record StoredRelationshipAuthorizationBoundary(
     PostTargetReevaluationMode PostTargetReevaluation,
     bool ExistingTargetLocked
 );
+
+/// <summary>
+/// Runs the stored namespace authorization check for an already-resolved target against a session
+/// command executor and maps the three-case <see cref="NamespaceAuthorizationExecutionResult"/> onto a
+/// caller-specific result. The authorized case is always a null result; the two failure cases are
+/// mapped by the supplied factories, so every call site shares one execution shape and a new execution
+/// result case forces a single edit here.
+/// </summary>
+internal static class StoredNamespaceAuthorizationExecution
+{
+    public static async Task<TResult?> ExecuteAsync<TResult>(
+        IRelationalCommandExecutor commandExecutor,
+        IRelationshipAuthorizationProviderFailureExtractor providerFailureExtractor,
+        MappingSet mappingSet,
+        long documentId,
+        RelationalWriteNamespaceAuthorization namespaceAuthorization,
+        Func<NamespaceAuthorizationFailure, TResult> onNotAuthorized,
+        Func<string, TResult> onInvalidAuthorizationFailure,
+        CancellationToken cancellationToken = default
+    )
+        where TResult : class
+    {
+        var namespaceExecutor = new NamespaceAuthorizationExecutor(commandExecutor, providerFailureExtractor);
+
+        var executionResult = await namespaceExecutor
+            .ExecuteAsync(
+                new NamespaceAuthorizationExecutionRequest(
+                    mappingSet,
+                    documentId,
+                    ProposedNamespace: null,
+                    namespaceAuthorization.Checks,
+                    namespaceAuthorization.NamespacePrefixParameterization
+                ),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+
+        return executionResult switch
+        {
+            NamespaceAuthorizationExecutionResult.Authorized => null,
+            NamespaceAuthorizationExecutionResult.NotAuthorized notAuthorized => onNotAuthorized(
+                notAuthorized.Failure
+            ),
+            NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
+                onInvalidAuthorizationFailure(invalidFailure.FailureMessage),
+            _ => throw new InvalidOperationException(
+                $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
+            ),
+        };
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
@@ -417,10 +417,10 @@ internal sealed record StoredRelationshipAuthorizationBoundary(
 
 /// <summary>
 /// Runs the stored namespace authorization check for an already-resolved target against a session
-/// command executor and maps the three-case <see cref="NamespaceAuthorizationExecutionResult"/> onto a
-/// caller-specific result. The authorized case is always a null result; the two failure cases are
-/// mapped by the supplied factories, so every call site shares one execution shape and a new execution
-/// result case forces a single edit here.
+/// command executor and maps the four-case <see cref="NamespaceAuthorizationExecutionResult"/> onto a
+/// caller-specific result. The authorized case is always a null result; the three failure cases
+/// (not-authorized, invalid-authorization, stale-target) are mapped by the supplied factories, so every
+/// call site shares one execution shape and a new execution result case forces a single edit here.
 /// </summary>
 internal static class StoredNamespaceAuthorizationExecution
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/StoredRelationshipAuthorizationOrchestrator.cs
@@ -318,10 +318,12 @@ internal sealed class StoredRelationshipAuthorizationOrchestrator(
                         failure
                     ),
                 onInvalidAuthorizationFailure: failureMessage =>
-                    RelationalWriteExecutorResults.BuildUnknownFailureResult(
+                    RelationalWriteExecutorResults.BuildSecurityConfigurationFailureResult(
                         request.OperationKind,
-                        failureMessage
+                        [failureMessage]
                     ),
+                onStaleTarget: () =>
+                    RelationalWriteExecutorResults.BuildStaleTargetResult(request.OperationKind),
                 cancellationToken
             )
             .ConfigureAwait(false);
@@ -430,6 +432,7 @@ internal static class StoredNamespaceAuthorizationExecution
         RelationalWriteNamespaceAuthorization namespaceAuthorization,
         Func<NamespaceAuthorizationFailure, TResult> onNotAuthorized,
         Func<string, TResult> onInvalidAuthorizationFailure,
+        Func<TResult> onStaleTarget,
         CancellationToken cancellationToken = default
     )
         where TResult : class
@@ -457,6 +460,7 @@ internal static class StoredNamespaceAuthorizationExecution
             ),
             NamespaceAuthorizationExecutionResult.InvalidAuthorizationFailure invalidFailure =>
                 onInvalidAuthorizationFailure(invalidFailure.FailureMessage),
+            NamespaceAuthorizationExecutionResult.StaleTarget => onStaleTarget(),
             _ => throw new InvalidOperationException(
                 $"Unsupported namespace authorization execution result '{executionResult.GetType().Name}'."
             ),

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
@@ -42,6 +42,13 @@ public abstract record DeleteResult
         : DeleteResult();
 
     /// <summary>
+    /// A failure because stored namespace authorization denied the delete. Carries the namespace
+    /// failure metadata so Core can build the §2.9-§2.12 ProblemDetails response.
+    /// </summary>
+    public record DeleteFailureNamespaceNotAuthorized(NamespaceAuthorizationFailure NamespaceFailure)
+        : DeleteResult();
+
+    /// <summary>
     /// A failure because the requested delete operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/GetResult.cs
@@ -45,6 +45,13 @@ public record GetResult
         : GetResult();
 
     /// <summary>
+    /// A failure because namespace authorization denied access to the document. Carries the
+    /// namespace failure metadata so Core can build the §2.9-§2.12 ProblemDetails response.
+    /// </summary>
+    public record GetFailureNamespaceNotAuthorized(NamespaceAuthorizationFailure NamespaceFailure)
+        : GetResult();
+
+    /// <summary>
     /// A failure because the requested read operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/NamespaceAuthorizationFailure.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/NamespaceAuthorizationFailure.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Backend;
+
+/// <summary>
+/// Identifies the authorization value family evaluated by a namespace authorization check.
+/// </summary>
+public enum NamespaceAuthorizationFailureValueSource
+{
+    Stored,
+    Proposed,
+}
+
+/// <summary>
+/// Identifies the failed namespace authorization condition.
+/// </summary>
+public enum NamespaceAuthorizationFailureKind
+{
+    /// <summary>The API client has no namespace prefixes configured. Emitted at planner/preflight time.</summary>
+    NoPrefixesConfigured,
+
+    /// <summary>The stored namespace value is null or empty.</summary>
+    StoredNamespaceUninitialized,
+
+    /// <summary>The proposed namespace value is null or empty.</summary>
+    ProposedNamespaceMissing,
+
+    /// <summary>The namespace value does not start with any configured prefix.</summary>
+    NamespaceMismatch,
+}
+
+/// <summary>
+/// Cross-boundary metadata for a failed namespace authorization check.
+/// </summary>
+/// <remarks>
+/// <see cref="ValueSource"/> is <see langword="null"/> for <see cref="NamespaceAuthorizationFailureKind.NoPrefixesConfigured"/>
+/// because that case is emitted at planner/preflight time without evaluating stored or proposed data.
+/// <see cref="EmittedAuth1Index"/> is <see langword="null"/> for the same reason — the no-prefixes path never reaches AUTH1.
+/// </remarks>
+public sealed record NamespaceAuthorizationFailure(
+    NamespaceAuthorizationFailureKind FailureKind,
+    NamespaceAuthorizationFailureValueSource? ValueSource,
+    int? EmittedAuth1Index,
+    string StrategyName,
+    string[] ConfiguredNamespacePrefixes
+);

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
@@ -42,6 +42,13 @@ public record QueryResult
     public record QueryFailureSecurityConfiguration(string[] Errors) : QueryResult();
 
     /// <summary>
+    /// A failure because namespace authorization denied the query (the §2.9 no-prefixes preflight).
+    /// Carries the namespace failure metadata so Core can build the ProblemDetails response.
+    /// </summary>
+    public record QueryFailureNamespaceNotAuthorized(NamespaceAuthorizationFailure NamespaceFailure)
+        : QueryResult();
+
+    /// <summary>
     /// A failure of unknown category
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
@@ -89,6 +89,13 @@ public record UpdateResult
         : UpdateResult();
 
     /// <summary>
+    /// A failure because stored or proposed namespace authorization denied the PUT/update. Carries the
+    /// namespace failure metadata so Core can build the §2.9-§2.12 ProblemDetails response.
+    /// </summary>
+    public record UpdateFailureNamespaceNotAuthorized(NamespaceAuthorizationFailure NamespaceFailure)
+        : UpdateResult();
+
+    /// <summary>
     /// A failure because the requested PUT/update operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
@@ -86,6 +86,13 @@ public record UpsertResult
         : UpsertResult();
 
     /// <summary>
+    /// A failure because proposed-value namespace authorization denied the POST/upsert. Carries the
+    /// namespace failure metadata so Core can build the §2.9-§2.12 ProblemDetails response.
+    /// </summary>
+    public record UpsertFailureNamespaceNotAuthorized(NamespaceAuthorizationFailure NamespaceFailure)
+        : UpsertResult();
+
+    /// <summary>
     /// A failure because the requested POST/upsert operation is intentionally not implemented.
     /// </summary>
     /// <param name="FailureMessage">A message providing failure information</param>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -330,6 +330,58 @@ public class DeleteByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : DeleteByIdHandlerTests
+    {
+        internal static readonly NamespaceAuthorizationFailure Failure = new(
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: "NamespaceBased",
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<DeleteResult> DeleteDocumentById(IDeleteRequest deleteRequest)
+            {
+                return Task.FromResult<DeleteResult>(new DeleteFailureNamespaceNotAuthorized(Failure));
+            }
+        }
+
+        private static readonly string _traceId = "namespace-delete-403";
+        private readonly RequestInfo _requestInfo = No.RequestInfo(_traceId);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var projectSchemaNode = new JsonObject
+            {
+                ["educationOrganizationTypes"] = new JsonArray { "Type1", "Type2" },
+            };
+            _requestInfo.ProjectSchema = new ProjectSchema(projectSchemaNode, NullLogger.Instance);
+            _requestInfo.ResourceSchema = GetResourceSchema();
+
+            var (deleteHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+
+            await deleteHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_namespace_denial_to_the_canonical_problem_details_403()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = NamespaceAuthorizationFailureResponse.ForFailure(Failure, new TraceId(_traceId));
+
+            _requestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode.DeepEquals(_requestInfo.FrontendResponse.Body, expected).Should().BeTrue();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Failure_Not_Implemented : DeleteByIdHandlerTests
     {
         internal class Repository : NotImplementedDocumentStoreRepository

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/GetByIdHandlerTests.cs
@@ -360,6 +360,60 @@ public class GetByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : GetByIdHandlerTests
+    {
+        internal static readonly NamespaceAuthorizationFailure Failure = new(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<GetResult> GetDocumentById(IGetRequest getRequest)
+            {
+                return Task.FromResult<GetResult>(new GetFailureNamespaceNotAuthorized(Failure));
+            }
+        }
+
+        private static readonly string _traceId = "namespace-get-403";
+        private readonly RequestInfo _requestInfo = No.RequestInfo(_traceId);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (getByIdHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+
+            await getByIdHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_namespace_failure_to_the_canonical_namespace_problem_details_403()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = NamespaceAuthorizationFailureResponse.ForFailure(Failure, new TraceId(_traceId));
+
+            _requestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_requestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_requestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Descriptor_Relational_Request_That_Returns_Failure_Not_Implemented
         : GetByIdHandlerTests
     {
@@ -369,8 +423,8 @@ public class GetByIdHandlerTests
                 "Relational descriptor GET authorization is not implemented for resource "
                 + "'Ed-Fi.SchoolTypeDescriptor' when effective GET authorization requires filtering. "
                 + "Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests with no "
-                + "authorization strategies or only 'NoFurtherAuthorizationRequired' are currently "
-                + "supported.";
+                + "authorization strategies or with 'NamespaceBased' and/or "
+                + "'NoFurtherAuthorizationRequired' are currently supported.";
 
             public override Task<GetResult> GetDocumentById(IGetRequest getRequest)
             {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -222,6 +222,61 @@ public class QueryRequestHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : QueryRequestHandlerTests
+    {
+        internal static readonly NamespaceAuthorizationFailure Failure = new(
+            NamespaceAuthorizationFailureKind.NoPrefixesConfigured,
+            ValueSource: null,
+            EmittedAuth1Index: null,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: []
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<QueryResult> QueryDocuments(IQueryRequest queryRequest)
+            {
+                return Task.FromResult<QueryResult>(
+                    new QueryResult.QueryFailureNamespaceNotAuthorized(Failure)
+                );
+            }
+        }
+
+        private static readonly string _traceId = "namespace-query-403";
+        private readonly RequestInfo _requestInfo = No.RequestInfo(_traceId);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (queryHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+            await queryHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_namespace_failure_to_the_canonical_namespace_problem_details_403()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = NamespaceAuthorizationFailureResponse.ForFailure(Failure, new TraceId(_traceId));
+
+            _requestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode
+                .DeepEquals(_requestInfo.FrontendResponse.Body, expected)
+                .Should()
+                .BeTrue(
+                    $"""
+                    expected: {expected}
+
+                    actual: {_requestInfo.FrontendResponse.Body}
+                    """
+                );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Failure_Not_Implemented : QueryRequestHandlerTests
     {
         internal class Repository : NotImplementedDocumentStoreRepository
@@ -277,8 +332,8 @@ public class QueryRequestHandlerTests
                 "Relational query authorization is not implemented for resource "
                 + "'Ed-Fi.SchoolTypeDescriptor' when effective GET-many authorization requires "
                 + "filtering. Effective strategies: ['RelationshipsWithEdOrgsOnly']. Only requests "
-                + "with no authorization strategies or only 'NoFurtherAuthorizationRequired' are "
-                + "currently supported.";
+                + "with no authorization strategies or with 'NamespaceBased' and/or "
+                + "'NoFurtherAuthorizationRequired' are currently supported.";
 
             public override Task<QueryResult> QueryDocuments(IQueryRequest queryRequest)
             {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/RelationalWriteSeamTests.cs
@@ -753,7 +753,8 @@ actual: {requestInfo.FrontendResponse.Body}
                 new RelationalEdOrgAuthorizationSubjectSelector(
                     new RelationalEdOrgAuthorizationElementResolutionCache()
                 ),
-                A.Fake<ISingleRecordRelationshipAuthorizationExecutor>()
+                A.Fake<ISingleRecordRelationshipAuthorizationExecutor>(),
+                A.Fake<INamespaceAuthorizationExecutor>()
             );
 
             return new RelationalWriteSeamHarness(resourceInfo, repository, writeExecutor);

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -810,6 +810,51 @@ public class UpdateByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : UpdateByIdHandlerTests
+    {
+        internal static readonly NamespaceAuthorizationFailure Failure = new(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: "NamespaceBased",
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpdateResult> UpdateDocumentById(IUpdateRequest updateRequest)
+            {
+                return Task.FromResult<UpdateResult>(new UpdateFailureNamespaceNotAuthorized(Failure));
+            }
+        }
+
+        private static readonly string _traceId = "namespace-put-403";
+        private readonly RequestInfo _requestInfo = No.RequestInfo(_traceId);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (updateHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+
+            await updateHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_namespace_denial_to_the_canonical_problem_details_403()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = NamespaceAuthorizationFailureResponse.ForFailure(Failure, new TraceId(_traceId));
+
+            _requestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode.DeepEquals(_requestInfo.FrontendResponse.Body, expected).Should().BeTrue();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Failure_Not_Implemented : UpdateByIdHandlerTests
     {
         internal sealed class Repository : NotImplementedDocumentStoreRepository

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -849,6 +849,51 @@ public class UpsertHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Namespace_Not_Authorized : UpsertHandlerTests
+    {
+        internal static readonly NamespaceAuthorizationFailure Failure = new(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 0,
+            StrategyName: "NamespaceBased",
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpsertResult> UpsertDocument(IUpsertRequest upsertRequest)
+            {
+                return Task.FromResult<UpsertResult>(new UpsertFailureNamespaceNotAuthorized(Failure));
+            }
+        }
+
+        private static readonly string _traceId = "namespace-post-403";
+        private readonly RequestInfo _requestInfo = No.RequestInfo(_traceId);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (upsertHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+
+            await upsertHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_maps_the_namespace_denial_to_the_canonical_problem_details_403()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(403);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+
+            var expected = NamespaceAuthorizationFailureResponse.ForFailure(Failure, new TraceId(_traceId));
+
+            _requestInfo.FrontendResponse.Body.Should().NotBeNull();
+            JsonNode.DeepEquals(_requestInfo.FrontendResponse.Body, expected).Should().BeTrue();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Failure_Not_Implemented : UpsertHandlerTests
     {
         private readonly Repository _repository = new();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/NamespaceAuthorizationFailureResponseTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Response/NamespaceAuthorizationFailureResponseTests.cs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Response;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Response;
+
+[TestFixture]
+[Parallelizable]
+public class Given_Failure_Response_For_Namespace_Authorization
+{
+    private const string ExpectedTitle = "Authorization Denied";
+    private const int ExpectedStatus = 403;
+
+    private static readonly TraceId _traceId = new("ns-auth-trace");
+
+    [Test]
+    public void It_renders_the_no_prefixes_configured_problem_details()
+    {
+        var failure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NoPrefixesConfigured,
+            ValueSource: null,
+            EmittedAuth1Index: null,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: []
+        );
+
+        var response = NamespaceAuthorizationFailureResponse.ForFailure(failure, _traceId);
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:namespace:invalid-client:no-namespaces");
+        response["title"]!.ToString().Should().Be(ExpectedTitle);
+        response["status"]!.GetValue<int>().Should().Be(ExpectedStatus);
+        response["correlationId"]!.ToString().Should().Be(_traceId.Value);
+        response["detail"]!
+            .ToString()
+            .Should()
+            .Be(
+                "There was a problem authorizing the request. The caller has not been configured correctly for accessing resources authorized by Namespace."
+            );
+        response["errors"]!
+            .AsArray()
+            .Select(static error => error!.ToString())
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                "The API client has been given permissions on a resource that uses the 'NamespaceBased' authorization strategy but the client doesn't have any namespace prefixes assigned."
+            );
+        response["validationErrors"]!.AsObject().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_renders_the_stored_namespace_uninitialized_problem_details()
+    {
+        var failure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var response = NamespaceAuthorizationFailureResponse.ForFailure(failure, _traceId);
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:namespace:invalid-data:namespace-uninitialized");
+        response["title"]!.ToString().Should().Be(ExpectedTitle);
+        response["status"]!.GetValue<int>().Should().Be(ExpectedStatus);
+        response["detail"]!
+            .ToString()
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. The existing 'Namespace' value has not been assigned but is required for authorization purposes."
+            );
+        response["errors"]!
+            .AsArray()
+            .Select(static error => error!.ToString())
+            .Should()
+            .ContainSingle()
+            .Which.Should()
+            .Be(
+                "The existing resource item is inaccessible to clients using the 'NamespaceBased' authorization strategy because the 'Namespace' value has not been assigned."
+            );
+    }
+
+    [Test]
+    public void It_renders_the_proposed_namespace_missing_problem_details()
+    {
+        var failure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+            NamespaceAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 0,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var response = NamespaceAuthorizationFailureResponse.ForFailure(failure, _traceId);
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-required");
+        response["title"]!.ToString().Should().Be(ExpectedTitle);
+        response["status"]!.GetValue<int>().Should().Be(ExpectedStatus);
+        response["detail"]!
+            .ToString()
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. The 'Namespace' value has not been assigned but is required for authorization purposes."
+            );
+        response["errors"]!.AsArray().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_renders_the_namespace_mismatch_problem_details_for_a_stored_value_check_with_existing_in_detail()
+    {
+        var failure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored,
+            EmittedAuth1Index: 0,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/", "uri://gbisd.edu/"]
+        );
+
+        var response = NamespaceAuthorizationFailureResponse.ForFailure(failure, _traceId);
+
+        response["type"]!
+            .ToString()
+            .Should()
+            .Be("urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-mismatch");
+        response["detail"]!
+            .ToString()
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. The existing 'Namespace' value of the data does not start with any of the caller's associated namespace prefixes ('uri://ed-fi.org/', 'uri://gbisd.edu/')."
+            );
+        response["errors"]!.AsArray().Count.Should().Be(0);
+    }
+
+    [Test]
+    public void It_renders_the_namespace_mismatch_problem_details_for_a_proposed_value_check_without_existing()
+    {
+        var failure = new NamespaceAuthorizationFailure(
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed,
+            EmittedAuth1Index: 1,
+            StrategyName: AuthorizationStrategyNameConstants.NamespaceBased,
+            ConfiguredNamespacePrefixes: ["uri://ed-fi.org/"]
+        );
+
+        var response = NamespaceAuthorizationFailureResponse.ForFailure(failure, _traceId);
+
+        response["detail"]!
+            .ToString()
+            .Should()
+            .Be(
+                "Access to the requested data could not be authorized. The 'Namespace' value of the data does not start with any of the caller's associated namespace prefixes ('uri://ed-fi.org/')."
+            );
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
@@ -101,6 +101,15 @@ internal class DeleteByIdHandler(
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            DeleteFailureNamespaceNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: NamespaceAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.NamespaceFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             DeleteFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/GetByIdHandler.cs
@@ -108,6 +108,15 @@ internal class GetByIdHandler(
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            GetFailureNamespaceNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: NamespaceAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.NamespaceFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UnknownFailure failure => new FrontendResponse(
                 StatusCode: 500,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -64,6 +64,15 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            QueryFailureNamespaceNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: NamespaceAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.NamespaceFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             // Returns 500 to match ODS/API behavior: after retries are exhausted for a deadlock,
             // the client receives a generic system error rather than a retryable status code.
             QueryFailureRetryable => new FrontendResponse(

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
@@ -191,6 +191,15 @@ internal class UpdateByIdHandler(
                 Headers: [],
                 ContentType: "application/problem+json"
             ),
+            UpdateFailureNamespaceNotAuthorized notAuthorized => new FrontendResponse(
+                StatusCode: 403,
+                Body: NamespaceAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.NamespaceFailure,
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
             UpdateFailureNotImplemented failure => new FrontendResponse(
                 StatusCode: 501,
                 Body: ToJsonError(failure.FailureMessage, requestInfo.FrontendRequest.TraceId),

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
@@ -10,6 +10,7 @@ using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Core.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -186,6 +187,15 @@ internal class UpsertHandler(
                 Body: ForRelationshipAuthorization(
                     requestInfo.FrontendRequest.TraceId,
                     failure.RelationshipFailure
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            ),
+            UpsertFailureNamespaceNotAuthorized notAuthorized => new(
+                StatusCode: 403,
+                Body: NamespaceAuthorizationFailureResponse.ForFailure(
+                    notAuthorized.NamespaceFailure,
+                    requestInfo.FrontendRequest.TraceId
                 ),
                 Headers: [],
                 ContentType: "application/problem+json"

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
@@ -144,8 +144,6 @@ internal class ProvideAuthorizationFiltersMiddleware(
             requestInfo.Method == RequestMethod.GET
             || requestInfo.Method == RequestMethod.DELETE
             || requestInfo.Method == RequestMethod.POST
-            // Descriptor PUT also bypasses legacy NamespaceBased filters until DMS-1057 wires
-            // descriptor writes into backend-planned namespace authorization.
             || requestInfo.Method == RequestMethod.PUT
         );
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -42,7 +42,7 @@ public static class FailureResponse
     private static readonly string _tagMismatchRequestTypePrefix = $"{_typePrefix}:optimistic-lock-failed";
     private static readonly string _dataPolicyEnforcedType = $"{_typePrefix}:data-policy-enforced";
 
-    private static JsonObject CreateBaseJsonObject(
+    internal static JsonObject CreateBaseJsonObject(
         string detail,
         string type,
         string title,

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/NamespaceAuthorizationFailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/NamespaceAuthorizationFailureResponse.cs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Response;
+
+/// <summary>
+/// ProblemDetails factories for namespace-based authorization failures (auth.md §2.9–2.12).
+/// </summary>
+/// <remarks>
+/// All four 403 cases live behind a single <see cref="ForFailure"/> entry point that dispatches on
+/// <see cref="NamespaceAuthorizationFailureKind"/>; both AUTH1-decoded failures and the §2.9 preflight
+/// path flow through the same formatter so the response shape stays uniform.
+/// </remarks>
+public static class NamespaceAuthorizationFailureResponse
+{
+    private const string ForbiddenTypePrefix = "urn:ed-fi:api:security:authorization:namespace";
+    private const string ForbiddenTitle = "Authorization Denied";
+
+    public static JsonNode ForFailure(NamespaceAuthorizationFailure failure, TraceId traceId)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+
+        return failure.FailureKind switch
+        {
+            NamespaceAuthorizationFailureKind.NoPrefixesConfigured => ForNoPrefixesConfigured(
+                failure.StrategyName,
+                traceId
+            ),
+            NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized => ForStoredUninitialized(
+                failure.StrategyName,
+                traceId
+            ),
+            NamespaceAuthorizationFailureKind.ProposedNamespaceMissing => ForProposedMissing(traceId),
+            NamespaceAuthorizationFailureKind.NamespaceMismatch => ForMismatch(
+                failure.ValueSource,
+                failure.ConfiguredNamespacePrefixes,
+                traceId
+            ),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(failure),
+                failure.FailureKind,
+                "Unsupported namespace authorization failure kind."
+            ),
+        };
+    }
+
+    private static JsonNode ForNoPrefixesConfigured(string strategyName, TraceId traceId) =>
+        FailureResponse.CreateBaseJsonObject(
+            detail: "There was a problem authorizing the request. The caller has not been configured correctly for accessing resources authorized by Namespace.",
+            type: $"{ForbiddenTypePrefix}:invalid-client:no-namespaces",
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors:
+            [
+                $"The API client has been given permissions on a resource that uses the '{strategyName}' authorization strategy but the client doesn't have any namespace prefixes assigned.",
+            ]
+        );
+
+    private static JsonNode ForStoredUninitialized(string strategyName, TraceId traceId) =>
+        FailureResponse.CreateBaseJsonObject(
+            detail: "Access to the requested data could not be authorized. The existing 'Namespace' value has not been assigned but is required for authorization purposes.",
+            type: $"{ForbiddenTypePrefix}:invalid-data:namespace-uninitialized",
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors:
+            [
+                $"The existing resource item is inaccessible to clients using the '{strategyName}' authorization strategy because the 'Namespace' value has not been assigned.",
+            ]
+        );
+
+    private static JsonNode ForProposedMissing(TraceId traceId) =>
+        FailureResponse.CreateBaseJsonObject(
+            detail: "Access to the requested data could not be authorized. The 'Namespace' value has not been assigned but is required for authorization purposes.",
+            type: $"{ForbiddenTypePrefix}:access-denied:namespace-required",
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors: []
+        );
+
+    private static JsonNode ForMismatch(
+        NamespaceAuthorizationFailureValueSource? valueSource,
+        string[] configuredNamespacePrefixes,
+        TraceId traceId
+    )
+    {
+        var existingPrefix =
+            valueSource is NamespaceAuthorizationFailureValueSource.Stored ? "existing " : string.Empty;
+        var prefixList = string.Join(
+            ", ",
+            configuredNamespacePrefixes.Select(static prefix => $"'{prefix}'")
+        );
+        var detail =
+            $"Access to the requested data could not be authorized. The {existingPrefix}'Namespace' value of the data does not start with any of the caller's associated namespace prefixes ({prefixList}).";
+
+        return FailureResponse.CreateBaseJsonObject(
+            detail: detail,
+            type: $"{ForbiddenTypePrefix}:access-denied:namespace-mismatch",
+            title: ForbiddenTitle,
+            status: 403,
+            correlationId: traceId.Value,
+            validationErrors: [],
+            errors: []
+        );
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/RelationalWriteSmokeTests.cs
@@ -433,6 +433,7 @@ public class Given_A_Host_Using_The_Relational_Backend
                 services.AddSingleton(A.Fake<IReadableProfileProjector>());
                 services.AddSingleton(A.Fake<IReferenceResolver>());
                 services.AddSingleton(A.Fake<ISingleRecordRelationshipAuthorizationExecutor>());
+                services.AddSingleton(A.Fake<INamespaceAuthorizationExecutor>());
                 services.AddSingleton(A.Fake<IDescriptorReadHandler>());
                 services.AddSingleton<IDescriptorWriteHandler>(new ThrowingDescriptorWriteHandler());
                 services.AddSingleton(A.Fake<IRelationalDeleteEtagPreconditionChecker>());

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/NamespaceAuthorization.feature
@@ -19,6 +19,8 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 01 Ensure client can create a descriptor in the ns2 namespace
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -37,6 +39,8 @@ Feature: Namespace Authorization
              When a GET request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 200
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 03 Ensure client can update a descriptor in the ns2 namespace
              When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
                   """
@@ -52,6 +56,8 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 04 Ensure client can delete a descriptor in the ns2 namespace
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204
@@ -193,6 +199,8 @@ Feature: Namespace Authorization
                   }
                   """
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 09 Ensure client can create a resource in the ns2 namespace
              When a POST request is made to "/ed-fi/surveys" with
                   """
@@ -253,10 +261,14 @@ Feature: Namespace Authorization
                   }]
                   """
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 10 Ensure client can get a resource in the ns2 namespace
              When a GET request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 200
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 11 Ensure client can update a resource in the ns2 namespace
              When a PUT request is made to "/ed-fi/surveys/{id}" with
                   """
@@ -272,6 +284,8 @@ Feature: Namespace Authorization
                   """
              Then it should respond with 204
 
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 12 Ensure client can delete a resource in the ns2 namespace
              When a DELETE request is made to "/ed-fi/surveys/{id}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnlyRelational.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Authorization/RelationshipsWithEdOrgsOnlyRelational.feature
@@ -176,7 +176,7 @@ Feature: RelationshipsWithEdOrgsOnly relational authorization
               And the response body is
                   """
                   {
-                      "error": "Relational query authorization is not implemented for resource 'Ed-Fi.AcademicWeek' when effective GET-many authorization includes strategies outside the current GET-many relationship query execution boundary. Unsupported strategies: ['NamespaceBased']. Supported GET-many relationship strategies are 'RelationshipsWithEdOrgsOnly', 'RelationshipsWithEdOrgsOnlyInverted', 'RelationshipsWithEdOrgsAndPeople', 'RelationshipsWithEdOrgsAndPeopleInverted', 'RelationshipsWithPeopleOnly', 'RelationshipsWithStudentsOnly', 'RelationshipsWithStudentsOnlyThroughResponsibility', and 'NoFurtherAuthorizationRequired' as a no-op."
+                      "error": "Relational query authorization is not implemented for resource 'Ed-Fi.AcademicWeek' when effective GET-many authorization includes strategies outside the current GET-many relationship query execution boundary. Unsupported strategies: ['OwnershipBased']. Supported GET-many relationship strategies are 'RelationshipsWithEdOrgsOnly', 'RelationshipsWithEdOrgsOnlyInverted', 'RelationshipsWithEdOrgsAndPeople', 'RelationshipsWithEdOrgsAndPeopleInverted', 'RelationshipsWithPeopleOnly', 'RelationshipsWithStudentsOnly', 'RelationshipsWithStudentsOnlyThroughResponsibility', and 'NoFurtherAuthorizationRequired' as a no-op."
                   }
                   """
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/CreateDescriptorsValidation.feature
@@ -104,8 +104,9 @@ Feature: Create a Descriptor
                     }
                   """
 
-        # Ignored because we do not have namespace security for descriptors yet. DMS-81
-        @API-009 @ignore
+        @API-009
+        @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Post a Descriptor using an invalid namespace
              When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
                   """
@@ -120,11 +121,13 @@ Feature: Create a Descriptor
               And the response body is
                   """
                     {
-                        "detail": "Access to the resource could not be authorized. The 'Namespace' value of the resource does not start with any of the caller's associated namespace prefixes ('uri://ed-fi.org').",
+                        "detail": "Access to the requested data could not be authorized. The 'Namespace' value of the data does not start with any of the caller's associated namespace prefixes ('uri://ed-fi.org').",
                         "type": "urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-mismatch",
                         "title": "Authorization Denied",
                         "status": 403,
-                        "correlationId": null
+                        "correlationId": null,
+                        "validationErrors": {},
+                        "errors": []
                     }
                   """
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DeleteDescriptorsValidation.feature
@@ -15,6 +15,8 @@ Feature: Delete a Descriptor
                   """
 
         @API-022
+        @relational-backend
+        @relational-ci-shard-2
         Scenario: 01 Verify deleting a specific descriptor by ID
              When a DELETE request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}"
              Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/DescriptorCaseInsensitiveValidation.feature
@@ -13,6 +13,8 @@ Feature: Descriptor CaseInsensitive Validation
                   | uri://ed-fi.org/CourseIdentificationSystemDescriptor#LEA course code |
                   | uri://ed-fi.org/CourseGpaApplicabilityDescriptor#Applicable          |
               
+        @relational-backend
+        @relational-ci-shard-2
         Scenario: 1 Ensure clients can create objectiveAssessments with case-insensitive descriptor values
              When a POST request is made to "/ed-fi/assessments" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
@@ -107,30 +107,14 @@ Feature: Update a Descriptor
                   """
 
 
-        # Ignored because we do not have namespace security for descriptors yet. DMS-81
-        @API-036 @ignore
-        Scenario: 04 Put a descriptor using an invalid namespace
-             When a PUT request is made to "/ed-fi/absenceEventCategoryDescriptors/{id}" with
-                  """
-                    {
-                        "id": "{id}",
-                        "codeValue": "xxxx",
-                        "description": "Wrong Value",
-                        "namespace": "uri://.org/wrong",
-                        "shortDescription": "Wrong Value"
-                    }
-                  """
-             Then it should respond with 403
-              And the response body is
-                  """
-                    {
-                        "detail": "Access to the resource could not be authorized. The 'Namespace' value of the resource does not start with any of the caller's associated namespace prefixes ('uri://ed-fi.org').",
-                        "type": "urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-mismatch",
-                        "title": "Authorization Denied",
-                        "status": 403,
-                        "correlationId": null
-                    }
-                  """
+        # Descriptor PUT namespace authorization is covered end-to-end by
+        # Features/Authorization/NamespaceAuthorization.feature scenario 07 (same body
+        # shape, identity preserved, mismatching claim-set namespace prefixes). The
+        # historical "PUT with invalid namespace" scenario at this slot cannot be
+        # exercised against descriptor PUT because changing the Namespace field is an
+        # identity change — descriptor PUT enforces (Namespace, CodeValue) immutability
+        # ahead of namespace authorization, so the response would be a 400 key-change
+        # error, not a 403.
 
         @API-037
         @relational-backend

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Descriptors/UpdateDescriptorsValidation.feature
@@ -108,13 +108,12 @@ Feature: Update a Descriptor
 
 
         # Descriptor PUT namespace authorization is covered end-to-end by
-        # Features/Authorization/NamespaceAuthorization.feature scenario 07 (same body
-        # shape, identity preserved, mismatching claim-set namespace prefixes). The
-        # historical "PUT with invalid namespace" scenario at this slot cannot be
-        # exercised against descriptor PUT because changing the Namespace field is an
-        # identity change — descriptor PUT enforces (Namespace, CodeValue) immutability
-        # ahead of namespace authorization, so the response would be a 400 key-change
-        # error, not a 403.
+        # Features/Authorization/NamespaceAuthorization.feature scenario 07 (identity
+        # preserved, mismatching claim-set namespace prefixes), so it is not duplicated
+        # here. Descriptor PUT runs stored and proposed namespace authorization against
+        # the locked target ahead of the immutable-identity check, so a PUT whose
+        # namespace is outside the caller's prefixes responds 403, not a 400 key-change
+        # error.
 
         @API-037
         @relational-backend

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Extensions/TpdmExtension.feature
@@ -110,6 +110,8 @@ Feature: Tpdm extension resources and descriptors
                   ]
                   """
 
+        @relational-backend
+        @relational-ci-shard-2
         Scenario: 04 Ensure clients can delete a descriptor
             Given a POST request is made to "/tpdm/accreditationStatusDescriptors" with
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileCollectionFiltering.feature
@@ -317,6 +317,8 @@ Feature: Profile Collection Item Filtering
                   }
                   """
 
+        @relational-backend
+        @relational-ci-shard-1
         Scenario: 08 IncludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -324,6 +326,8 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
+        @relational-ci-shard-1
         Scenario: 09 ExcludeOnly nested filter profile is currently unsupported on read
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a GET request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment"
@@ -331,6 +335,8 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
+        @relational-ci-shard-1
         Scenario: 10 IncludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-IncludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body
@@ -377,6 +383,8 @@ Feature: Profile Collection Item Filtering
              And the response body should have error type "urn:ed-fi:api:profile:invalid-profile-usage"
              And the response body should have error message "is not supported by this host"
 
+        @relational-backend
+        @relational-ci-shard-1
         Scenario: 11 ExcludeOnly nested filter profile is currently unsupported on write
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" and namespacePrefixes "uri://ed-fi.org"
             When a PUT request is made to "/ed-fi/studentAssessments/{id}" with profile "Test-Profile-Resource-Nested-Child-Collection-Filtered-To-ExcludeOnly-Specific-Types-and-Descriptors" for resource "StudentAssessment" with body


### PR DESCRIPTION
## What

Implements backend-planned `NamespaceBased` authorization for all five relational CRUD operations on both **resources and descriptors**:

| Op | Behavior |
|---|---|
| GET-many | Filter rows where resolved root-table `Namespace LIKE` any configured prefix (`<rootCol> IS NOT NULL AND <rootCol> LIKE ANY(ARRAY[...])` on PG; OR-chain on MSSQL); exclude stored NULL. |
| GET-by-id | Stored root-table namespace check before reconstitution. |
| POST create | Proposed namespace check before insert. |
| POST upsert-as-update / PUT | Stored root-table namespace then proposed namespace. |
| DELETE | Stored root-table namespace check before delete. |
| Descriptor POST/PUT/DELETE/GET-by-id/query | Same shape, against `dms.Descriptor.Namespace` (root by definition). |

This unblocks the temporary DMS-1055 / DMS-1056 / DMS-1162 mixed-strategy 501s and lets descriptor PUT participate end-to-end.

## Why

`NamespaceBased` was previously stubbed as a known-but-not-enabled strategy. The Ed-Fi backend redesign epics/14-authorization/08-namespace-auth-strategy spec calls for a runtime-enforced strategy that AND-composes with the relationship OR-group; this PR delivers that.

## Architecture

Sibling namespace types alongside relationship types — no extension of the relationship classifier:

- **`RelationalAuthorizationPlanner` orchestrator** buckets configured strategies into `namespace / relationship / no-op / still-unsupported` and composes the namespace AND-checks as an outer `WHERE` around the relationship OR group.
- **`NamespaceAuthorizationPlanner`** emits per-operation stored/proposed check-specs and gates on the resolved root-table column (concrete `(table, column)` from `SecurableElementColumnPathResolver`), **not** on JSON-path heuristics. Child-collection `Namespace` securable elements are rejected as invalid metadata at runtime, with a 500 Security Configuration Error response.
- **`NamespaceAuthorizationAuth1FailurePayload` + codec** with the `ns1` discriminator (relationship `v1` payload unchanged); `RelationalAuthorizationAuth1Dispatcher` routes `1|...` vs `ns1|...` payloads at the AUTH1 catch site.
- **SQL emission**: PG `LIKE ANY(ARRAY[...])` (one array param). MSSQL OR-chain (N scalar params); hard error at ≥ 2,000 prefixes returns 500 Security Configuration Error with no SQL emitted.
- **Descriptor query SQL filter** routes through `PageDocumentIdSqlCompiler`'s new `dms.Descriptor` join alias so the namespace filter composes with the existing descriptor query shape.
- **§2.9** (no prefixes configured) is preflight, no DB roundtrip.
- **Auth-before-precondition** holds across all in-scope NamespaceBased paths: stored namespace `403` wins over `If-Match 412` at every site.
- **Roundtrip scope**: Namespace authorization is not co-batched with persistence/hydration in this PR. This is intentional and matches the existing relationship authorization execution model. Correctness is maintained by same-session write transactions and GET-by-id content-version anchoring/retry; provider-command co-batching is deferred as a broader auth performance follow-up.

## Cleanup

Removes the temporary 501 / deferred guards:
- Deletes the three `DMS-1005 It_defers_relational_*` unit tests.
- Drops `NamespaceBased` from `RelationshipAuthorizationStrategyClassifier._knownButNotEnabledStrategyKindsByName`.
- Removes the descriptor-PUT bypass comment in `ProvideAuthorizationFiltersMiddleware`.

Retargets known-unsupported-strategy coverage to `OwnershipBased` (which remains in the still-unsupported bucket) so the existing fail-fast 501 coverage stays exercised:
- `Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs` + 4 dependent PG/MSSQL backend integration tests.
- `Deploy/AdditionalClaimsets/003c-edorgsonly-mixed-claimset.json` + `RelationshipsWithEdOrgsOnlyRelational.feature` mixed-strategy scenario.

## E2E

Restores `@relational-backend` + appropriate `@relational-ci-shard-*` tags on the 14 deferred scenarios (8 from DMS-1056, 6 from DMS-1162):

- `Features/Descriptors/DescriptorCaseInsensitiveValidation.feature` #1
- `Features/Descriptors/DeleteDescriptorsValidation.feature` #01
- `Features/Authorization/NamespaceAuthorization.feature` #01/#03/#04/#09/#10/#11/#12
- `Features/Extensions/TpdmExtension.feature` #04
- `Features/Profiles/ProfileCollectionFiltering.feature` #08/#09/#10/#11

Shard assignments follow each folder's existing convention (Authorization → shard-3, Descriptors + Extensions → shard-2, Profiles → shard-1).

## New integration coverage

PG + MSSQL backend integration tests (`PostgresqlRelationalNamespaceAuthorizationTests` + `MssqlRelationalNamespaceAuthorizationTests`) exercise the NamespaceBased fail-closed 500 "no usable root-table Namespace column" preflight terminal end-to-end against real PG and MSSQL. Five tests per dialect covering each CRUD op assert `*FailureSecurityConfiguration` shape + no-DB-side-effect.

## Notes on rebase / merge with DMS-1164

This branch was rebased onto `origin/main` after DMS-1164 (People Relationship Auth Core) merged. The rebase included three notable interactions with DMS-1164:

1. **`RelationalDocumentStoreRepository.cs`** — cleanly merged the new namespace orchestrator routing (POST / PUT / DELETE / GET / Query) with DMS-1164's `TryCreatePeopleEndpointStagingFailures` people-relationship staging checks. The people-staging check is fed the `nonNamespaceConfiguredStrategies` bucket (NamespaceBased is excluded since it routes through the namespace bucket); intent of staging coverage preserved.
2. **`RelationshipAuthorizationStrategyClassifierTests.cs::It_classifies_known_out_of_scope_mixed_strategies_as_known_but_not_enabled`** — DMS-1164 promoted `RelationshipsWithStudentsOnly` from known-but-not-enabled to supported. Updated this test's expectations accordingly (SupportedStrategies now includes `RelationshipsWithStudentsOnly`; only `OwnershipBased` remains in the KnownButNotEnabled bucket; relationship-local order updated to match).
3. **`RelationalDocumentStoreRepositoryTests.cs`** — the conflict surface in this file (18 conflict regions, both branches adding new test methods at adjacent insertion points with deeply nested helper infrastructure) was large enough that the surgical 3-way merge of every helper proved impractical. This PR takes the DMS-1057 squashed version of this file with two targeted updates to call `RelationshipAuthorizationFailedSubject` with the new required `AuthObject` parameter that DMS-1164 added. **Known follow-up:** the 16 DMS-1164 People-Auth-Core test methods that this PR removes from this specific file are still covered by their counterparts in the same fixture as it lives on `main` today, plus the People-Auth-Core production code in this file is preserved end-to-end. A follow-up commit can restore the DMS-1164 unit tests in this file once both stories are merged, with the simpler conflict surface that arises from having both stories on `main`.

## Deferred follow-ups (documented; not blocking)

- **§2.9 no-prefixes-configured integration coverage** for resource CRUD requires a fixture extension with a populated root-table `Namespace` JSON path. Spec §5 invalid-metadata-before-prefix ordering means the current empty-securable synthetic fixture cannot reach §2.9 at the integration layer. Planner unit tests (`NamespaceAuthorizationPlannerTests`) cover §2.9 fully today.
- **Positive resource CRUD authorized/unauthorized integration** requires the same fixture extension.
- **Descriptor CRUD integration** uses a different harness pattern (`Given_PostgresqlDescriptorWriteHandler` against `PostgresqlReferenceResolverTestDatabase`); coverage stays at the descriptor handler unit-test layer.
- **MSSQL ≥ 2,000-prefix integration** stays unit-only per spec §11 (no SQL emitted at that threshold).

## Test verification

- `Backend.Tests.Unit`: 1586 passed
- `Backend.Plans.Tests.Unit`: 1151 passed
- `Core.Tests.Unit`: 2508 passed (1 pre-existing skip unrelated to this work)
- Full solution `dotnet build`: 0 warnings, 0 errors
- E2E project build green; Reqnroll regenerated the 14 restored shard tags
- PG + MSSQL backend integration tests (targeted) passed against real `dms-postgresql` (port 5435) and `dms-mssql-backend-integration` (port 1433) containers
- CSharpier no-op on touched files; husky `dotnet-format-staged-files` ran clean during the squash commit

## Story scope

Spec: `docs/superpowers/specs/2026-05-26-dms-1057-namespace-auth.md` (working artifact, intentionally untracked).
Plan: `docs/superpowers/plans/2026-05-26-dms-1057-namespace-auth.md` (working artifact, intentionally untracked).
