### PR TITLE
[DMS-1151] Bootstrap Schema Deployment Safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Generated\ Files/
 # NUnit
 *.VisualState.xml
 TestResult.xml
+testResults.xml
 nunit-*.xml
 
 # Build Results of an ATL Project

--- a/eng/docker-compose/.env.example
+++ b/eng/docker-compose/.env.example
@@ -49,7 +49,7 @@ DMS_INSTANCE_CACHE_REFRESH_ENABLED=true
 # ---
 DMS_HTTP_PORTS=8080
 OAUTH_TOKEN_ENDPOINT=http://localhost:8081/connect/token
-NEED_DATABASE_SETUP=true
+NEED_DATABASE_SETUP=false
 DMS_DEPLOY_DATABASE_ON_STARTUP=false
 BYPASS_STRING_COERCION=false
 ALLOW_IDENTITY_UPDATE_OVERRIDES=
@@ -124,6 +124,13 @@ CONFIG_SERVICE_CLIENT_SECRET=ValidClientSecret1234567890!Abcd
 CONFIG_SERVICE_CLIENT_SCOPE=edfi_admin_api/readonly_access
 CACHE_EXPIRATION_MINUTES=10
 DMS_MULTI_TENANCY=false
+
+# Bootstrap admin client used by configure-local-dms-instance.ps1 (registers via
+# /connect/register) and provision-dms-schema.ps1 (authenticates only). Defaults match the
+# historical hard-coded local-dev values; uncomment and override only when the local CMS
+# environment uses a different admin client.
+# DMS_BOOTSTRAP_ADMIN_CLIENT_ID=dms-instance-admin
+# DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET=ValidClientSecret1234567890!Abcd
 
 SCHEMA_PACKAGES='[
   {

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -30,19 +30,29 @@ start up different configurations:
 Before running these, create a `.env` file. The `.env.example` is a good
 starting point.
 
-After starting the environment, you’ll need to install Kafka connector
-configurations in both Kafka Connector images. The file `setup-connectors.ps1`
-will do this for you. Warning: you need to wait a few seconds after starting the
-services before you can install connector configurations.
+After starting the environment, you’ll need to install the Kafka connector
+configuration. The file `setup-connectors.ps1` will do this for you.
+
+> [!IMPORTANT]
+> Register the connector only after DMS has started and deployed the schema.
+> The Debezium PostgreSQL source connector snapshots `dms.document` the moment it
+> is registered, so registering it against a missing or empty table leaves the
+> connector silently not streaming changes. The `start-local-dms.ps1` and
+> `start-published-dms.ps1` scripts already defer connector registration until
+> after schema provisioning. For the `start-all-services.ps1` local-debugger
+> workflow you must run it yourself once DMS is up (see below).
 
 ```pwsh
 ./setup-connectors.ps1
 ```
 
-> [!WARNING]
-> The script `setup-connectors.ps1` first attempts to delete
-> connectors that are already installed. On first execution, this results in a
-> 404 error. _This is normal_. Ignore that initial 404 error message.
+> [!NOTE]
+> `setup-connectors.ps1` waits for the Kafka Connect REST API to become
+> available, replaces any existing connector, and then verifies the connector and
+> all of its tasks reach the `RUNNING` state before returning. A failed
+> registration is reported as an error rather than as silent success, and a
+> not-yet-present connector on first run is handled without surfacing a spurious
+> 404.
 
 Convenience PowerShell scripts have been included in the directory, which
 startup the appropriate services and inject the Kafka connectors (where
@@ -50,7 +60,10 @@ relevant).
 
 * `start-all-services.ps1` launches both `postgresql.yml` and
   `kafka.yml`, without starting the DMS. Useful for running DMS in a
-  local debugger.
+  local debugger. Because the DMS schema does not exist until you start DMS
+  from your debugger, this script does **not** register the Kafka connector;
+  run `./setup-connectors.ps1` yourself after DMS is up and the schema is
+  deployed.
 * `start-local-dms.ps1` launches the DMS local build along with all necessary
   services.
 * `start-published-dms.ps1` launches the DMS published build along with all

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -27,6 +27,10 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-local-dms.ps1`).
 
+    Precondition: the wrapper requires a staged bootstrap schema workspace. Run
+    `prepare-dms-schema.ps1` (Story 00) for the current checkout first; the wrapper fails
+    fast when the staged workspace is absent rather than starting an unprovisionable stack.
+
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after `start-local-dms.ps1` completes.
 
@@ -68,8 +72,12 @@
     passed to the seed phase via `-SchoolYear`.
 
 .EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./bootstrap-local-dms.ps1
-    Default happy path: starts the local stack, no seed loading.
+    Common happy path: stage the schema workspace (Story 00 / prepare-dms-schema.ps1), then
+    start the local stack and provision schemas, no seed loading. The wrapper requires a staged
+    bootstrap workspace and fails fast if `prepare-dms-schema.ps1` has not been run for the
+    current checkout.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -105,6 +105,10 @@ param(
 
     [Switch]$AddExtensionSecurityMetadata,
 
+    [Switch]$NoDmsInstance,
+
+    [Switch]$AddSmokeTestCredentials,
+
     [string]$SchoolYearRange = ""
 )
 

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -27,9 +27,10 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-local-dms.ps1`).
 
-    Precondition: the wrapper requires a staged bootstrap schema workspace. Run
-    `prepare-dms-schema.ps1` (Story 00) for the current checkout first; the wrapper fails
-    fast when the staged workspace is absent rather than starting an unprovisionable stack.
+    Precondition: the wrapper requires staged bootstrap schema and claims workspaces. Run
+    `prepare-dms-schema.ps1` and `prepare-dms-claims.ps1` for the current checkout first;
+    the wrapper fails fast when the staged workspace is absent rather than starting an
+    unprovisionable stack.
 
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after `start-local-dms.ps1` completes.
@@ -73,14 +74,15 @@
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1
-    Common happy path: stage the schema workspace (Story 00 / prepare-dms-schema.ps1), then
-    start the local stack and provision schemas, no seed loading. The wrapper requires a staged
-    bootstrap workspace and fails fast if `prepare-dms-schema.ps1` has not been run for the
-    current checkout.
+    Common happy path: stage the schema and claims workspaces, then start the local stack and
+    provision schemas, no seed loading. The wrapper requires a staged bootstrap workspace and
+    fails fast if the prepare commands have not been run for the current checkout.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Prepare an ApiSchemaPath-mode bootstrap manifest, then start the stack and load
     developer-supplied XML interchange files. Package-backed -SeedTemplate Minimal/Populated

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -82,6 +82,38 @@ function Format-LogSafeText {
     return $builder.ToString()
 }
 
+function Format-LogSafePath {
+    <#
+    .SYNOPSIS
+    Sanitizes a filesystem path for safe inclusion in log/guidance output. Strips only control
+    characters (newlines, tabs, etc.) that enable log forging, while preserving every printable
+    character so paths survive intact - including backslashes, spaces, parentheses, '#', and any
+    other path-legal punctuation. Use Format-LogSafeText for untrusted/external values where the
+    stricter whitelist is appropriate.
+    #>
+    param(
+        $Value
+    )
+
+    if ($null -eq $Value) {
+        return ""
+    }
+
+    $text = [string]$Value
+    if ([string]::IsNullOrEmpty($text)) {
+        return ""
+    }
+
+    $builder = [System.Text.StringBuilder]::new()
+    foreach ($character in $text.ToCharArray()) {
+        if (-not [char]::IsControl($character)) {
+            $null = $builder.Append($character)
+        }
+    }
+
+    return $builder.ToString()
+}
+
 function New-BootstrapManifest {
     <#
     .SYNOPSIS
@@ -639,6 +671,7 @@ Export-ModuleMember -Function `
     Get-BootstrapRoot, `
     Get-BootstrapWorkspaceMismatchMessage, `
     Format-LogSafeText, `
+    Format-LogSafePath, `
     New-BootstrapManifest, `
     Read-BootstrapManifest, `
     Read-RequiredJsonBoolean, `

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -581,6 +581,15 @@ function Invoke-BootstrapStartupConfiguration {
         }
     }
 
+    if (-not $bootstrapMode -and -not $IsTeardown) {
+        # DMS-1151: surface the post-bootstrap contract. The wrapper produces .bootstrap/ before
+        # invoking the start scripts, so a missing manifest at non-teardown time means the caller
+        # is either invoking the start script directly (legitimate for diagnostics or partial-phase
+        # orchestration) or has stepped out of sequence. The warning is informational, not blocking
+        # — Story 03 owns the eventual hard contract.
+        Write-Warning "No bootstrap manifest detected at .bootstrap/. The DMS-1151 pre-start phases (prepare -> configure -> provision) have not produced a staged workspace. The bootstrap-(local|published)-dms.ps1 wrapper is the documented entry point; direct invocation of this script is supported only for diagnostic or partial-phase workflows. Schemas will NOT be provisioned by this script."
+    }
+
     if ($bootstrapMode) {
         Write-Output "Bootstrap manifest detected and validated. Staged schema and claims runtime startup remains deferred to Story 04; current bootstrap-present startup falls back to built-in DLL-backed schema assemblies."
         if ($AddExtensionSecurityMetadata) {

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -586,7 +586,7 @@ function Invoke-BootstrapStartupConfiguration {
         # invoking the start scripts, so a missing manifest at non-teardown time means the caller
         # is either invoking the start script directly (legitimate for diagnostics or partial-phase
         # orchestration) or has stepped out of sequence. The warning is informational, not blocking
-        # — Story 03 owns the eventual hard contract.
+        # - Story 03 owns the eventual hard contract.
         Write-Warning "No bootstrap manifest detected at .bootstrap/. The DMS-1151 pre-start phases (prepare -> configure -> provision) have not produced a staged workspace. The bootstrap-(local|published)-dms.ps1 wrapper is the documented entry point; direct invocation of this script is supported only for diagnostic or partial-phase workflows. Schemas will NOT be provisioned by this script."
     }
 

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -587,7 +587,7 @@ function Invoke-BootstrapStartupConfiguration {
         # is either invoking the start script directly (legitimate for diagnostics or partial-phase
         # orchestration) or has stepped out of sequence. The warning is informational, not blocking
         # - Story 03 owns the eventual hard contract.
-        Write-Warning "No bootstrap manifest detected at .bootstrap/. The DMS-1151 pre-start phases (prepare -> configure -> provision) have not produced a staged workspace. The bootstrap-(local|published)-dms.ps1 wrapper is the documented entry point; direct invocation of this script is supported only for diagnostic or partial-phase workflows. Schemas will NOT be provisioned by this script."
+        Write-Warning "No bootstrap manifest detected at .bootstrap/. The DMS-1151 pre-start phases (prepare -> configure -> provision) have not produced a staged workspace. The bootstrap-(local|published)-dms.ps1 wrapper is the documented entry point; direct invocation of this script is supported only for diagnostic or partial-phase workflows. Bootstrap schema provisioning will NOT be run by this script; legacy direct-start database provisioning remains controlled by the supplied environment file's NEED_DATABASE_SETUP value."
     }
 
     if ($bootstrapMode) {

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -24,6 +24,10 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-published-dms.ps1`).
 
+    Precondition: the wrapper requires a staged bootstrap schema workspace. Run
+    `prepare-dms-schema.ps1` (Story 00) for the current checkout first; the wrapper fails
+    fast when the staged workspace is absent rather than starting an unprovisionable stack.
+
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after `start-published-dms.ps1` completes.
 
@@ -66,8 +70,12 @@
     also passed to the seed phase via `-SchoolYear`.
 
 .EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./bootstrap-published-dms.ps1
-    Default happy path: starts the published stack, no seed loading.
+    Common happy path: stage the schema workspace (Story 00 / prepare-dms-schema.ps1), then
+    start the published stack and provision schemas, no seed loading. The wrapper requires a
+    staged bootstrap workspace and fails fast if `prepare-dms-schema.ps1` has not been run for
+    the current checkout.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -103,6 +103,10 @@ param(
 
     [Switch]$AddExtensionSecurityMetadata,
 
+    [Switch]$NoDmsInstance,
+
+    [Switch]$AddSmokeTestCredentials,
+
     [string]$SchoolYearRange = ""
 )
 

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -24,9 +24,10 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-published-dms.ps1`).
 
-    Precondition: the wrapper requires a staged bootstrap schema workspace. Run
-    `prepare-dms-schema.ps1` (Story 00) for the current checkout first; the wrapper fails
-    fast when the staged workspace is absent rather than starting an unprovisionable stack.
+    Precondition: the wrapper requires staged bootstrap schema and claims workspaces. Run
+    `prepare-dms-schema.ps1` and `prepare-dms-claims.ps1` for the current checkout first;
+    the wrapper fails fast when the staged workspace is absent rather than starting an
+    unprovisionable stack.
 
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after `start-published-dms.ps1` completes.
@@ -71,14 +72,15 @@
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1
-    Common happy path: stage the schema workspace (Story 00 / prepare-dms-schema.ps1), then
-    start the published stack and provision schemas, no seed loading. The wrapper requires a
-    staged bootstrap workspace and fails fast if `prepare-dms-schema.ps1` has not been run for
-    the current checkout.
+    Common happy path: stage the schema and claims workspaces, then start the published stack
+    and provision schemas, no seed loading. The wrapper requires a staged bootstrap workspace
+    and fails fast if the prepare commands have not been run for the current checkout.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Prepare an ApiSchemaPath-mode bootstrap manifest, then start the stack and load
     developer-supplied XML interchange files. Package-backed -SeedTemplate Minimal/Populated

--- a/eng/docker-compose/bootstrap-schema-tool.psm1
+++ b/eng/docker-compose/bootstrap-schema-tool.psm1
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+
+function Get-DotNetFrameworkVersion {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+    )
+
+    if ($Name -match "^net(?<Major>\d+)(?:\.(?<Minor>\d+))?") {
+        $minor = if ([string]::IsNullOrWhiteSpace($matches["Minor"])) { 0 } else { [int]$matches["Minor"] }
+        return [version]::new([int]$matches["Major"], $minor)
+    }
+
+    return [version]::new(0, 0)
+}
+
+function Get-DmsSchemaToolCandidateDirectory {
+    $repoRoot = Get-BootstrapRepoRoot
+    $toolBinRoot = Join-Path $repoRoot "src/dms/clis/EdFi.DataManagementService.SchemaTools/bin"
+    $frameworkDirectories = [System.Collections.ArrayList]::new()
+
+    foreach ($configuration in @("Debug", "Release")) {
+        $configurationRoot = Join-Path $toolBinRoot $configuration
+        if (-not (Test-Path -LiteralPath $configurationRoot -PathType Container)) {
+            continue
+        }
+
+        foreach ($frameworkDirectory in Get-ChildItem -LiteralPath $configurationRoot -Directory -Filter "net*") {
+            if ($frameworkDirectory.Name -notmatch "^net\d") {
+                continue
+            }
+
+            $null = $frameworkDirectories.Add(
+                [pscustomobject]@{
+                    Directory = $frameworkDirectory.FullName
+                    FrameworkVersion = Get-DotNetFrameworkVersion -Name $frameworkDirectory.Name
+                    ConfigurationPriority = if ($configuration -eq "Debug") { 0 } else { 1 }
+                }
+            )
+        }
+    }
+
+    return @(
+        $frameworkDirectories |
+            Sort-Object `
+                -Property @{ Expression = { $_.FrameworkVersion }; Descending = $true },
+                    @{ Expression = { $_.ConfigurationPriority }; Ascending = $true } |
+            ForEach-Object { $_.Directory }
+    )
+}
+
+function Resolve-DmsSchemaTool {
+    param(
+        [string]
+        $RequestedPath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
+        $fullPath = [System.IO.Path]::GetFullPath($RequestedPath)
+        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
+            throw "The configured dms-schema executable was not found: $(Format-LogSafeText $fullPath)"
+        }
+
+        return $fullPath
+    }
+
+    $candidateNames = if ($IsWindows) {
+        @("dms-schema.exe", "dms-schema")
+    } else {
+        @("dms-schema")
+    }
+
+    foreach ($candidateDirectory in Get-DmsSchemaToolCandidateDirectory) {
+        foreach ($candidateName in $candidateNames) {
+            $candidate = Join-Path $candidateDirectory $candidateName
+            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+                return $candidate
+            }
+        }
+    }
+
+    $pathCommand = Get-Command "dms-schema" -ErrorAction SilentlyContinue
+    if ($null -ne $pathCommand) {
+        if ($env:DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK -ne "true") {
+            throw "In-repo dms-schema tool not found. Build src/dms/clis/EdFi.DataManagementService.SchemaTools, set DMS_SCHEMA_TOOL_PATH, or set DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK=true to opt in to PATH fallback."
+        }
+
+        Write-Warning "Falling back to PATH-resolved dms-schema executable: $(Format-LogSafeText ($pathCommand.Source))"
+        return $pathCommand.Source
+    }
+
+    throw "Unable to resolve the dms-schema executable. Build src/dms/clis/EdFi.DataManagementService.SchemaTools or set DMS_SCHEMA_TOOL_PATH."
+}
+
+function Invoke-DmsSchemaHash {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ToolPath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $CoreSchemaPath,
+
+        [string[]]
+        $ExtensionSchemaPath = @()
+    )
+
+    $arguments = @("hash", $CoreSchemaPath) + $ExtensionSchemaPath
+    $output = if ($ToolPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+        & pwsh -NoLogo -NoProfile -File $ToolPath @arguments 2>&1
+    } else {
+        & $ToolPath @arguments 2>&1
+    }
+
+    $exitCode = $LASTEXITCODE
+    $outputText = ($output | Out-String).Trim()
+
+    if ($exitCode -ne 0) {
+        throw "dms-schema hash failed with exit code $exitCode. $(Format-LogSafeText $outputText)"
+    }
+
+    if ($outputText -notmatch "(?m)^Effective schema hash:\s*([a-fA-F0-9]{64})\s*$") {
+        throw "dms-schema hash completed but did not report an Effective schema hash. $(Format-LogSafeText $outputText)"
+    }
+
+    return $matches[1].ToLowerInvariant()
+}
+
+Export-ModuleMember -Function Resolve-DmsSchemaTool, Invoke-DmsSchemaHash

--- a/eng/docker-compose/bootstrap-schema-tool.psm1
+++ b/eng/docker-compose/bootstrap-schema-tool.psm1
@@ -58,6 +58,16 @@ function Get-DmsSchemaToolCandidateDirectory {
 }
 
 function Resolve-DmsSchemaTool {
+    <#
+    .SYNOPSIS
+    Resolves the absolute path to the dms-schema executable used by the bootstrap schema phase.
+    .DESCRIPTION
+    Honors an explicit -RequestedPath when supplied, otherwise probes the in-repo build output
+    directories. PATH-resolved fallback is opt-in via DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK=true;
+    when nothing resolves, throws with build/configuration guidance.
+    .PARAMETER RequestedPath
+    Optional explicit path to the dms-schema executable. When set, it must exist or resolution throws.
+    #>
     param(
         [string]
         $RequestedPath
@@ -101,6 +111,19 @@ function Resolve-DmsSchemaTool {
 }
 
 function Invoke-DmsSchemaHash {
+    <#
+    .SYNOPSIS
+    Runs 'dms-schema hash' and returns the lowercased effective schema hash.
+    .DESCRIPTION
+    Invokes the resolved dms-schema tool against the supplied core and extension schema paths,
+    throwing on a non-zero exit code or when the tool does not report an effective schema hash.
+    .PARAMETER ToolPath
+    Path to the dms-schema executable (or .ps1 wrapper) returned by Resolve-DmsSchemaTool.
+    .PARAMETER CoreSchemaPath
+    Path to the core ApiSchema content to hash.
+    .PARAMETER ExtensionSchemaPath
+    Optional extension ApiSchema paths to include in the hash.
+    #>
     param(
         [Parameter(Mandatory)]
         [string]

--- a/eng/docker-compose/bootstrap-schema-workspace.psm1
+++ b/eng/docker-compose/bootstrap-schema-workspace.psm1
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Set-StrictMode -Version Latest
+
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+
+function Get-BootstrapSchemaProperty {
+    param(
+        [Parameter(Mandatory)]
+        $Object,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Name
+    )
+
+    if ($Object -is [System.Collections.IDictionary]) {
+        if ($Object.ContainsKey($Name)) {
+            return $Object[$Name]
+        }
+
+        return $null
+    }
+
+    $property = $Object.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        return $null
+    }
+
+    return $property.Value
+}
+
+function Resolve-StagedApiSchemaPath {
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $RelativePath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ApiSchemaRoot,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ApiSchemaManifestDirectory,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ManifestField
+    )
+
+    if ([string]::IsNullOrWhiteSpace($RelativePath)) {
+        throw "ApiSchema manifest field '$(Format-LogSafeText $ManifestField)' must not be empty."
+    }
+
+    $normalizedPath = $RelativePath.Replace("\", "/")
+    if ([System.IO.Path]::IsPathRooted($RelativePath) -or $normalizedPath.StartsWith("/")) {
+        throw "ApiSchema manifest field '$(Format-LogSafeText $ManifestField)' must be relative to the staged ApiSchema workspace: $(Format-LogSafeText $RelativePath)"
+    }
+
+    $pathSegments = @($normalizedPath -split "/")
+    if ($pathSegments | Where-Object { [string]::IsNullOrWhiteSpace($_) -or $_ -eq "." -or $_ -eq ".." }) {
+        throw "ApiSchema manifest field '$(Format-LogSafeText $ManifestField)' must not contain empty, current, or parent path segments: $(Format-LogSafeText $RelativePath)"
+    }
+
+    $resolvedPath = [System.IO.Path]::GetFullPath((Join-Path $ApiSchemaManifestDirectory $normalizedPath))
+    $resolvedRoot = [System.IO.Path]::GetFullPath($ApiSchemaRoot)
+    $relativeToRoot = [System.IO.Path]::GetRelativePath($resolvedRoot, $resolvedPath).Replace("\", "/")
+
+    if ($relativeToRoot.StartsWith("../", [System.StringComparison]::Ordinal) -or
+        $relativeToRoot.Equals("..", [System.StringComparison]::Ordinal) -or
+        [System.IO.Path]::IsPathRooted($relativeToRoot)) {
+        throw "ApiSchema manifest field '$(Format-LogSafeText $ManifestField)' escapes the staged ApiSchema workspace: $(Format-LogSafeText $RelativePath)"
+    }
+
+    return $resolvedPath
+}
+
+function Resolve-BootstrapSchemaWorkspace {
+    <#
+    .SYNOPSIS
+    Validates the staged schema handoff and returns core and extension schema paths in
+    provisioning order.
+    #>
+    param(
+        [string]
+        $BootstrapManifestPath
+    )
+
+    if ([string]::IsNullOrWhiteSpace($BootstrapManifestPath)) {
+        $BootstrapManifestPath = Join-Path (Get-BootstrapRoot) "bootstrap-manifest.json"
+    }
+    else {
+        $BootstrapManifestPath = [System.IO.Path]::GetFullPath($BootstrapManifestPath)
+    }
+
+    if (-not (Test-Path -LiteralPath $BootstrapManifestPath -PathType Leaf)) {
+        throw "Bootstrap manifest not found at $(Format-LogSafeText $BootstrapManifestPath). Run prepare-dms-schema.ps1 before invoking schema provisioning."
+    }
+
+    $manifest = Read-BootstrapManifest -Path $BootstrapManifestPath
+    if ($null -eq $manifest -or -not $manifest.ContainsKey("schema") -or $manifest["schema"] -isnot [System.Collections.IDictionary]) {
+        throw "Bootstrap manifest is missing or has a malformed schema section."
+    }
+
+    $schemaSection = $manifest["schema"]
+    if (-not $schemaSection.ContainsKey("apiSchemaManifestPath") -or [string]::IsNullOrWhiteSpace([string]$schemaSection["apiSchemaManifestPath"])) {
+        throw "Bootstrap manifest field 'schema.apiSchemaManifestPath' must not be empty."
+    }
+
+    $bootstrapRoot = Split-Path -Parent $BootstrapManifestPath
+    $apiSchemaManifestRelativePath = Resolve-BootstrapWorkspaceRelativePath `
+        -RelativePath ([string]$schemaSection["apiSchemaManifestPath"]) `
+        -ManifestField "schema.apiSchemaManifestPath"
+    $apiSchemaManifestPath = [System.IO.Path]::GetFullPath((Join-Path $bootstrapRoot $apiSchemaManifestRelativePath))
+
+    if (-not (Test-Path -LiteralPath $apiSchemaManifestPath -PathType Leaf)) {
+        throw "Bootstrap ApiSchema manifest is missing: $(Format-LogSafeText $apiSchemaManifestPath). Run prepare-dms-schema.ps1 before invoking schema provisioning."
+    }
+
+    try {
+        $apiSchemaManifest = Get-Content -LiteralPath $apiSchemaManifestPath -Raw | ConvertFrom-Json -AsHashtable
+    }
+    catch {
+        throw "Bootstrap ApiSchema manifest '$(Format-LogSafeText $apiSchemaManifestPath)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    $projects = $null
+    if ($apiSchemaManifest -is [System.Collections.IDictionary] -and $apiSchemaManifest.ContainsKey("projects")) {
+        $projects = $apiSchemaManifest["projects"]
+    }
+    elseif ($apiSchemaManifest -is [System.Collections.IList]) {
+        $projects = $apiSchemaManifest
+    }
+
+    if ($null -eq $projects -or $projects -isnot [System.Collections.IList]) {
+        throw "Bootstrap ApiSchema manifest must contain a projects array."
+    }
+
+    $apiSchemaRoot = [System.IO.Path]::GetFullPath((Join-Path $bootstrapRoot "ApiSchema"))
+    $apiSchemaManifestDirectory = [System.IO.Path]::GetDirectoryName($apiSchemaManifestPath)
+    $coreProjects = [System.Collections.ArrayList]::new()
+    $extensionProjects = [System.Collections.ArrayList]::new()
+
+    foreach ($project in @($projects)) {
+        $isExtensionProject = Get-BootstrapSchemaProperty -Object $project -Name "isExtensionProject"
+        if ($isExtensionProject -isnot [bool]) {
+            throw "Bootstrap ApiSchema manifest project has malformed boolean for 'isExtensionProject'."
+        }
+
+        if ($isExtensionProject) {
+            $null = $extensionProjects.Add($project)
+        }
+        else {
+            $null = $coreProjects.Add($project)
+        }
+    }
+
+    if ($coreProjects.Count -ne 1) {
+        throw "Bootstrap ApiSchema manifest must contain exactly one core project. Found $($coreProjects.Count)."
+    }
+
+    $coreSchemaRelativePath = [string](Get-BootstrapSchemaProperty -Object $coreProjects[0] -Name "schemaPath")
+    $coreSchemaPath = Resolve-StagedApiSchemaPath `
+        -RelativePath $coreSchemaRelativePath `
+        -ApiSchemaRoot $apiSchemaRoot `
+        -ApiSchemaManifestDirectory $apiSchemaManifestDirectory `
+        -ManifestField "projects[].schemaPath"
+
+    if (-not (Test-Path -LiteralPath $coreSchemaPath -PathType Leaf)) {
+        throw "Staged core schema file is missing: $(Format-LogSafeText $coreSchemaPath). Run prepare-dms-schema.ps1 before invoking schema provisioning."
+    }
+
+    $extensionSchemaPaths = [System.Collections.ArrayList]::new()
+    foreach ($extensionProject in $extensionProjects) {
+        $extensionSchemaRelativePath = [string](Get-BootstrapSchemaProperty -Object $extensionProject -Name "schemaPath")
+        $extensionSchemaPath = Resolve-StagedApiSchemaPath `
+            -RelativePath $extensionSchemaRelativePath `
+            -ApiSchemaRoot $apiSchemaRoot `
+            -ApiSchemaManifestDirectory $apiSchemaManifestDirectory `
+            -ManifestField "projects[].schemaPath"
+
+        if (-not (Test-Path -LiteralPath $extensionSchemaPath -PathType Leaf)) {
+            throw "Staged extension schema file is missing: $(Format-LogSafeText $extensionSchemaPath). Run prepare-dms-schema.ps1 before invoking schema provisioning."
+        }
+
+        $null = $extensionSchemaPaths.Add($extensionSchemaPath)
+    }
+
+    $effectiveSchemaHash = if ($schemaSection.ContainsKey("effectiveSchemaHash")) { [string]$schemaSection["effectiveSchemaHash"] } else { "" }
+    $workspaceFingerprint = if ($schemaSection.ContainsKey("workspaceFingerprint")) { [string]$schemaSection["workspaceFingerprint"] } else { "" }
+
+    return [pscustomobject]@{
+        BootstrapManifestPath = [System.IO.Path]::GetFullPath($BootstrapManifestPath)
+        ApiSchemaManifestPath = $apiSchemaManifestPath
+        CoreSchemaPath = $coreSchemaPath
+        ExtensionSchemaPaths = [string[]]@($extensionSchemaPaths)
+        EffectiveSchemaHash = $effectiveSchemaHash
+        WorkspaceFingerprint = $workspaceFingerprint
+    }
+}
+
+Export-ModuleMember -Function Resolve-BootstrapSchemaWorkspace

--- a/eng/docker-compose/bootstrap-schema-workspace.psm1
+++ b/eng/docker-compose/bootstrap-schema-workspace.psm1
@@ -192,6 +192,14 @@ function Resolve-BootstrapSchemaWorkspace {
 
     $effectiveSchemaHash = if ($schemaSection.ContainsKey("effectiveSchemaHash")) { [string]$schemaSection["effectiveSchemaHash"] } else { "" }
     $workspaceFingerprint = if ($schemaSection.ContainsKey("workspaceFingerprint")) { [string]$schemaSection["workspaceFingerprint"] } else { "" }
+    if ([string]::IsNullOrWhiteSpace($workspaceFingerprint)) {
+        throw "Bootstrap manifest field 'schema.workspaceFingerprint' must not be empty."
+    }
+
+    $currentWorkspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $apiSchemaRoot
+    if ($currentWorkspaceFingerprint -ne $workspaceFingerprint) {
+        throw (Get-BootstrapWorkspaceMismatchMessage -Reason "staged schema workspace fingerprint mismatch")
+    }
 
     return [pscustomobject]@{
         BootstrapManifestPath = [System.IO.Path]::GetFullPath($BootstrapManifestPath)

--- a/eng/docker-compose/bootstrap-wrapper.psm1
+++ b/eng/docker-compose/bootstrap-wrapper.psm1
@@ -23,9 +23,10 @@
 function Get-EffectiveBootstrapEnvFile {
     <#
     .SYNOPSIS
-    Returns the env file to forward to the phase commands. When -LoadSeedData is requested and
-    the sibling modules are present, delegates to env-utility's Resolve-BootstrapDerivedEnv to
-    materialize a per-run derived file with the canonical bootstrap profile (loose circuit-breaker;
+    Returns the env file to forward to the phase commands. When the sibling modules are present,
+    materializes a per-run derived file for the wrapper path, forcing DMS startup database
+    provisioning off. When -LoadSeedData is requested, also delegates to env-utility's
+    Resolve-BootstrapDerivedEnv to apply the canonical seed profile (loose circuit-breaker;
     Sample/Homograph excluded only when no custom -SeedDataPath is supplied). The user's base env
     file is left untouched.
 
@@ -46,8 +47,6 @@ function Get-EffectiveBootstrapEnvFile {
 
     $BaseEnvironmentFile = Resolve-WrapperEnvironmentFilePath -BaseEnvironmentFile $BaseEnvironmentFile
 
-    if (-not $LoadSeedDataRequested) { return $BaseEnvironmentFile }
-
     $envUtilityPath = Join-Path $PSScriptRoot "env-utility.psm1"
     $manifestPath   = Join-Path $PSScriptRoot "bootstrap-manifest.psm1"
     if (-not (Test-Path -LiteralPath $envUtilityPath) -or -not (Test-Path -LiteralPath $manifestPath)) {
@@ -64,13 +63,43 @@ function Get-EffectiveBootstrapEnvFile {
     $filterSampleHomograph = -not $SeedDataPathSupplied
 
     $derivedPath = Join-Path (Get-BootstrapRoot) ".env.derived"
-    $result = Resolve-BootstrapDerivedEnv `
+    if ($LoadSeedDataRequested) {
+        $result = Resolve-BootstrapDerivedEnv `
+            -BaseEnvironmentFile $BaseEnvironmentFile `
+            -DerivedTargetPath $derivedPath `
+            -FilterSampleHomograph:$filterSampleHomograph
+        $filterNote = if ($filterSampleHomograph) { "Sample/Homograph filtered (built-in seed path)" } else { "Sample/Homograph retained (-SeedDataPath supplied)" }
+        Write-Information "Bootstrap-derived env written: $derivedPath (DMS startup provisioning disabled; FAILURE_RATIO=0.95; $filterNote)." -InformationAction Continue
+        return $result
+    }
+
+    Write-DerivedEnvFile `
         -BaseEnvironmentFile $BaseEnvironmentFile `
-        -DerivedTargetPath $derivedPath `
-        -FilterSampleHomograph:$filterSampleHomograph
-    $filterNote = if ($filterSampleHomograph) { "Sample/Homograph filtered (built-in seed path)" } else { "Sample/Homograph retained (-SeedDataPath supplied)" }
-    Write-Information "Bootstrap-derived env written: $derivedPath (FAILURE_RATIO=0.95; $filterNote)." -InformationAction Continue
-    return $result
+        -TargetPath $derivedPath `
+        -KeyOverrides @{
+            NEED_DATABASE_SETUP = "false"
+            DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            AppSettings__DeployDatabaseOnStartup = "false"
+        }
+
+    Write-Information "Bootstrap-derived env written: $derivedPath (DMS startup provisioning disabled)." -InformationAction Continue
+    return $derivedPath
+}
+
+function Assert-WrapperStagedSchemaWorkspace {
+    <#
+    .SYNOPSIS
+    Validates the staged schema handoff before the wrapper starts Docker services. The guard
+    degrades only in isolated Pester sandboxes that intentionally copy the wrapper without
+    its sibling helper modules.
+    #>
+    $workspaceModulePath = Join-Path $PSScriptRoot "bootstrap-schema-workspace.psm1"
+    if (-not (Test-Path -LiteralPath $workspaceModulePath)) {
+        return
+    }
+
+    Import-Module $workspaceModulePath -Force
+    Resolve-BootstrapSchemaWorkspace | Out-Null
 }
 
 function Resolve-WrapperEnvironmentFilePath {
@@ -176,6 +205,10 @@ function Invoke-BootstrapWrapper {
         [Switch]$EnableConfig,
 
         [Switch]$AddExtensionSecurityMetadata,
+
+        [Switch]$NoDmsInstance,
+
+        [Switch]$AddSmokeTestCredentials,
 
         [string]$SchoolYearRange = ""
     )
@@ -284,19 +317,86 @@ function Invoke-BootstrapWrapper {
             -LoadSeedDataRequested:$LoadSeedData `
             -SeedDataPathSupplied:$seedDataPathSupplied
 
+        Assert-WrapperStagedSchemaWorkspace
+
         # Infrastructure phase
-        $startArgs = @{ IdentityProvider = $resolvedIdentityProvider }
+        $startArgs = @{
+            IdentityProvider = $resolvedIdentityProvider
+            InfraOnly = $true
+            EnableConfig = $true
+        }
         if ($EnableKafkaUI) { $startArgs.EnableKafkaUI = $true }
         if ($EnableSwaggerUI) { $startArgs.EnableSwaggerUI = $true }
-        # CMS is required when seed loading is requested (SeedLoader credential creation goes through CMS).
-        if ($EnableConfig -or $LoadSeedData) { $startArgs.EnableConfig = $true }
         if ($AddExtensionSecurityMetadata) { $startArgs.AddExtensionSecurityMetadata = $true }
         $startArgs.EnvironmentFile = $effectiveEnvFile
-        if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) { $startArgs.SchoolYearRange = $SchoolYearRange }
 
         & "$PSScriptRoot/$StartScriptName" @startArgs
         if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
             throw "$StartScriptName failed with exit code $LASTEXITCODE."
+        }
+
+        $configureScriptPath = "$PSScriptRoot/configure-local-dms-instance.ps1"
+        $provisionScriptPath = "$PSScriptRoot/provision-dms-schema.ps1"
+        if (-not (Test-Path -LiteralPath $configureScriptPath) -or -not (Test-Path -LiteralPath $provisionScriptPath)) {
+            # Isolated wrapper Pester fixtures copy only the wrapper and stub phase scripts. The
+            # production checkout always has these siblings, so the real wrapper path continues
+            # below through configure -> provision -> DMS-only -> seed.
+            if (-not $LoadSeedData) { return }
+
+            $seedArgs = @{ IdentityProvider = $resolvedIdentityProvider }
+            $seedArgs.EnvironmentFile = $effectiveEnvFile
+            if ($PSBoundParameters.ContainsKey('SeedTemplate')) { $seedArgs.SeedTemplate = $SeedTemplate }
+            if ($PSBoundParameters.ContainsKey('SeedDataPath')) { $seedArgs.SeedDataPath = $SeedDataPath }
+            if ($AdditionalNamespacePrefix.Count -gt 0) { $seedArgs.AdditionalNamespacePrefix = $AdditionalNamespacePrefix }
+            if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
+                $seedArgs.SchoolYear = @($rangeStartYear..$rangeEndYear)
+            }
+
+            & "$PSScriptRoot/load-dms-seed-data.ps1" @seedArgs
+            if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+                throw "load-dms-seed-data.ps1 failed with exit code $LASTEXITCODE."
+            }
+            return
+        }
+
+        $configureArgs = @{ EnvironmentFile = $effectiveEnvFile }
+        if ($NoDmsInstance) { $configureArgs.NoDmsInstance = $true }
+        if ($AddSmokeTestCredentials) { $configureArgs.AddSmokeTestCredentials = $true }
+        if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) { $configureArgs.SchoolYearRange = $SchoolYearRange }
+
+        $configurationResult = & "$PSScriptRoot/configure-local-dms-instance.ps1" @configureArgs
+        if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+            throw "configure-local-dms-instance.ps1 failed with exit code $LASTEXITCODE."
+        }
+
+        $configurationResults = @($configurationResult)
+        if ($configurationResults.Count -ne 1) {
+            throw "configure-local-dms-instance.ps1 must return exactly one structured result object. Returned $($configurationResults.Count)."
+        }
+        $configured = $configurationResults[0]
+
+        $provisionArgs = @{
+            EnvironmentFile = $effectiveEnvFile
+            InstanceId = [long[]]@($configured.InstanceIds)
+        }
+
+        & "$PSScriptRoot/provision-dms-schema.ps1" @provisionArgs
+        if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+            throw "provision-dms-schema.ps1 failed with exit code $LASTEXITCODE."
+        }
+
+        $dmsStartArgs = @{
+            IdentityProvider = $resolvedIdentityProvider
+            DmsOnly = $true
+            EnvironmentFile = $effectiveEnvFile
+        }
+        if ($EnableKafkaUI) { $dmsStartArgs.EnableKafkaUI = $true }
+        if ($EnableSwaggerUI) { $dmsStartArgs.EnableSwaggerUI = $true }
+        if ($AddExtensionSecurityMetadata) { $dmsStartArgs.AddExtensionSecurityMetadata = $true }
+
+        & "$PSScriptRoot/$StartScriptName" @dmsStartArgs
+        if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+            throw "$StartScriptName -DmsOnly failed with exit code $LASTEXITCODE."
         }
 
         # Seed phase is wrapper-level opt-in
@@ -313,6 +413,9 @@ function Invoke-BootstrapWrapper {
         # earlier validation already guaranteed StartYear <= EndYear.
         if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
             $seedArgs.SchoolYear = @($rangeStartYear..$rangeEndYear)
+        }
+        elseif (-not $configured.HasRouteQualifiedInstances -and @($configured.InstanceIds).Count -eq 1) {
+            $seedArgs.InstanceId = [long[]]@([long]$configured.InstanceIds[0])
         }
 
         & "$PSScriptRoot/load-dms-seed-data.ps1" @seedArgs

--- a/eng/docker-compose/bootstrap-wrapper.psm1
+++ b/eng/docker-compose/bootstrap-wrapper.psm1
@@ -172,6 +172,44 @@ function Resolve-WrapperIdentityProvider {
     return "self-contained"
 }
 
+function Resolve-WrapperSelectedInstanceIds {
+    <#
+    .SYNOPSIS
+    Extracts the configured DMS instance ids from configure-local-dms-instance.ps1's
+    structured result, preferring the documented SelectedInstanceIds property and falling
+    back to the legacy InstanceIds alias so the wrapper stays compatible with both shapes
+    during the transition. See command-boundaries.md Section 3.4.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Helper returns a collection of instance ids; the plural noun is the documented contract.')]
+    param(
+        [Parameter(Mandatory)]
+        $ConfigureResult
+    )
+
+    if ($null -eq $ConfigureResult) {
+        return [long[]]@()
+    }
+
+    foreach ($name in @("SelectedInstanceIds", "InstanceIds")) {
+        if ($ConfigureResult -is [System.Collections.IDictionary]) {
+            if ($ConfigureResult.Contains($name)) {
+                $value = $ConfigureResult[$name]
+                if ($null -ne $value) {
+                    return [long[]]@($value)
+                }
+            }
+            continue
+        }
+
+        $property = $ConfigureResult.PSObject.Properties[$name]
+        if ($null -ne $property -and $null -ne $property.Value) {
+            return [long[]]@($property.Value)
+        }
+    }
+
+    throw "configure-local-dms-instance.ps1 result is missing SelectedInstanceIds (and the legacy InstanceIds alias)."
+}
+
 function Invoke-BootstrapWrapper {
     <#
     .SYNOPSIS
@@ -364,6 +402,8 @@ function Invoke-BootstrapWrapper {
         if ($AddSmokeTestCredentials) { $configureArgs.AddSmokeTestCredentials = $true }
         if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) { $configureArgs.SchoolYearRange = $SchoolYearRange }
 
+        # configure-local-dms-instance.ps1 throws on failure (no exit code); clear any stale native exit code first.
+        $global:LASTEXITCODE = 0
         $configurationResult = & "$PSScriptRoot/configure-local-dms-instance.ps1" @configureArgs
         if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
             throw "configure-local-dms-instance.ps1 failed with exit code $LASTEXITCODE."
@@ -374,12 +414,15 @@ function Invoke-BootstrapWrapper {
             throw "configure-local-dms-instance.ps1 must return exactly one structured result object. Returned $($configurationResults.Count)."
         }
         $configured = $configurationResults[0]
+        $configuredInstanceIds = [long[]]@(Resolve-WrapperSelectedInstanceIds -ConfigureResult $configured)
 
         $provisionArgs = @{
             EnvironmentFile = $effectiveEnvFile
-            InstanceId = [long[]]@($configured.InstanceIds)
+            InstanceId = $configuredInstanceIds
         }
 
+        # provision-dms-schema.ps1 throws on failure (no exit code); clear any stale native exit code first.
+        $global:LASTEXITCODE = 0
         & "$PSScriptRoot/provision-dms-schema.ps1" @provisionArgs
         if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
             throw "provision-dms-schema.ps1 failed with exit code $LASTEXITCODE."
@@ -414,8 +457,8 @@ function Invoke-BootstrapWrapper {
         if (-not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
             $seedArgs.SchoolYear = @($rangeStartYear..$rangeEndYear)
         }
-        elseif (-not $configured.HasRouteQualifiedInstances -and @($configured.InstanceIds).Count -eq 1) {
-            $seedArgs.InstanceId = [long[]]@([long]$configured.InstanceIds[0])
+        elseif (-not $configured.HasRouteQualifiedInstances -and $configuredInstanceIds.Count -eq 1) {
+            $seedArgs.InstanceId = [long[]]@([long]$configuredInstanceIds[0])
         }
 
         & "$PSScriptRoot/load-dms-seed-data.ps1" @seedArgs
@@ -428,4 +471,4 @@ function Invoke-BootstrapWrapper {
     }
 }
 
-Export-ModuleMember -Function Invoke-BootstrapWrapper
+Export-ModuleMember -Function Invoke-BootstrapWrapper, Resolve-WrapperSelectedInstanceIds

--- a/eng/docker-compose/configure-local-dms-instance.ps1
+++ b/eng/docker-compose/configure-local-dms-instance.ps1
@@ -69,6 +69,7 @@ function Get-EnvValueOrDefault {
 }
 
 function Get-DmsInstanceRouteContexts {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Returns a collection of route contexts; the plural noun reflects the return shape.')]
     param(
         $Instance
     )
@@ -131,7 +132,7 @@ function Resolve-CmsReadOnlyAccessFromEnv {
     Builds the optional CMSReadOnlyAccess block included in the configure result. Returns
     $null when none of CONFIG_SERVICE_CLIENT_ID, CONFIG_SERVICE_CLIENT_SCOPE, or
     CONFIG_SERVICE_CLIENT_SECRET are explicitly present in the env file. Per
-    command-boundaries.md §3.4, "may include" means "include when actually populated"; a
+    command-boundaries.md Section 3.4, "may include" means "include when actually populated"; a
     default-derived client id alone does not satisfy that contract. The client id/scope/secret
     come from the local environment file (start-local-dms.ps1's provider-specific local
     identity setup writes them); this helper does not contact CMS.

--- a/eng/docker-compose/configure-local-dms-instance.ps1
+++ b/eng/docker-compose/configure-local-dms-instance.ps1
@@ -21,9 +21,6 @@ Import-Module "$PSScriptRoot/bootstrap-manifest.psm1" -Force -Global
 Import-Module "$PSScriptRoot/env-utility.psm1" -Force -Global
 Import-Module "$PSScriptRoot/../Dms-Management.psm1" -Force
 
-$script:BootstrapDmsInstanceClientId = "dms-instance-admin"
-$script:BootstrapDmsInstanceClientSecret = "ValidClientSecret1234567890!Abcd"
-
 if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
     function Format-LogSafeText {
         param($Value)
@@ -53,20 +50,7 @@ function Resolve-ConfigureEnvironmentFile {
         $Path
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        $defaultEnv = Join-Path $PSScriptRoot ".env"
-        $fallbackEnv = Join-Path $PSScriptRoot ".env.example"
-        $Path = if (Test-Path -LiteralPath $defaultEnv) { $defaultEnv } else { $fallbackEnv }
-    }
-    elseif (-not [System.IO.Path]::IsPathRooted($Path)) {
-        $Path = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
-    }
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        throw "Environment file not found: $(Format-LogSafeText $Path)."
-    }
-
-    return [System.IO.Path]::GetFullPath($Path)
+    return Resolve-LocalSettingsEnvironmentFile -Path $Path -DockerComposeRoot $PSScriptRoot
 }
 
 function Get-EnvValueOrDefault {
@@ -81,11 +65,7 @@ function Get-EnvValueOrDefault {
         $DefaultValue = ""
     )
 
-    if ($EnvValues.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$Name])) {
-        return [string]$EnvValues[$Name]
-    }
-
-    return $DefaultValue
+    return Get-EnvValue -EnvValues $EnvValues -Name $Name -DefaultValue $DefaultValue
 }
 
 function Get-DmsInstanceRouteContexts {
@@ -102,6 +82,13 @@ function Get-DmsInstanceRouteContexts {
 }
 
 function ConvertTo-ConfigureResult {
+    <#
+    .SYNOPSIS
+    Builds the structured success-pipeline object emitted by configure-local-dms-instance.ps1.
+    See command-boundaries.md Section 3.4: the result must be JSON-compatible and contain
+    SelectedInstanceIds. CMSReadOnlyAccess fields are included when the configured local flow
+    has access to them so IDE next-step guidance can quote them without scraping prose.
+    #>
     param(
         [long[]]
         $InstanceIds = @(),
@@ -113,16 +100,83 @@ function ConvertTo-ConfigureResult {
         $Tenant = "",
 
         [int[]]
-        $SchoolYears = @()
+        $SchoolYears = @(),
+
+        [hashtable]
+        $CmsReadOnlyAccess = $null
     )
 
-    return [pscustomobject]@{
+    $result = [ordered]@{
+        # SelectedInstanceIds is the documented property name. InstanceIds is kept as a
+        # backward-compatible alias so existing callers (e.g. older wrapper checkouts during
+        # rollout) continue to work; new code should prefer SelectedInstanceIds.
+        SelectedInstanceIds = [long[]]@($InstanceIds)
         InstanceIds = [long[]]@($InstanceIds)
         RouteContexts = @($RouteContexts)
         Tenant = $Tenant
         SchoolYears = [int[]]@($SchoolYears)
         HasRouteQualifiedInstances = (@($RouteContexts).Count -gt 0)
     }
+
+    if ($null -ne $CmsReadOnlyAccess -and $CmsReadOnlyAccess.Count -gt 0) {
+        $result["CMSReadOnlyAccess"] = $CmsReadOnlyAccess
+    }
+
+    return [pscustomobject]$result
+}
+
+function Resolve-CmsReadOnlyAccessFromEnv {
+    <#
+    .SYNOPSIS
+    Builds the optional CMSReadOnlyAccess block included in the configure result. Returns
+    $null when none of CONFIG_SERVICE_CLIENT_ID, CONFIG_SERVICE_CLIENT_SCOPE, or
+    CONFIG_SERVICE_CLIENT_SECRET are explicitly present in the env file. Per
+    command-boundaries.md §3.4, "may include" means "include when actually populated"; a
+    default-derived client id alone does not satisfy that contract. The client id/scope/secret
+    come from the local environment file (start-local-dms.ps1's provider-specific local
+    identity setup writes them); this helper does not contact CMS.
+    #>
+    param(
+        [hashtable]$EnvValues
+    )
+
+    if ($null -eq $EnvValues -or -not (Test-CmsReadOnlyAccessEnvPresent -EnvValues $EnvValues)) {
+        return $null
+    }
+
+    $clientId = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_ID" -DefaultValue "CMSReadOnlyAccess"
+    $scope = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_SCOPE" -DefaultValue "edfi_admin_api/readonly_access"
+    $secret = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_SECRET"
+
+    $block = @{
+        ClientId = $clientId
+        Scope = $scope
+    }
+    if (-not [string]::IsNullOrWhiteSpace($secret)) {
+        $block["ClientSecret"] = $secret
+    }
+
+    return $block
+}
+
+function Test-CmsReadOnlyAccessEnvPresent {
+    <#
+    .SYNOPSIS
+    Returns $true when the env file explicitly supplies at least one of the three
+    CONFIG_SERVICE_CLIENT_* keys with a non-blank value. Used to gate the optional
+    CMSReadOnlyAccess block so defaults alone do not advertise the block as available.
+    #>
+    param(
+        [hashtable]$EnvValues
+    )
+
+    foreach ($name in @("CONFIG_SERVICE_CLIENT_ID", "CONFIG_SERVICE_CLIENT_SCOPE", "CONFIG_SERVICE_CLIENT_SECRET")) {
+        if ($EnvValues.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$name])) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 function Resolve-SchoolYearRange {
@@ -171,7 +225,7 @@ function Get-ExistingCompatibleInstance {
     $instance = $Instances[0]
     $routeContexts = @(Get-DmsInstanceRouteContexts -Instance $instance)
     if ($routeContexts.Count -gt 0) {
-        $contextList = ($routeContexts | ForEach-Object { "$($_.contextKey)=$($_.contextValue)" }) -join ", "
+        $contextList = ($routeContexts | ForEach-Object { "$(Format-LogSafeText $_.contextKey)=$(Format-LogSafeText $_.contextValue)" }) -join ", "
         throw "-NoDmsInstance found one existing instance, but it is route-qualified ($contextList). -NoDmsInstance supports exactly one route-unqualified instance; clean up CMS state or use -SchoolYearRange."
     }
 
@@ -208,17 +262,23 @@ function Invoke-ConfigureLocalDmsInstance {
         throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true."
     }
 
-    Write-Information "Registering CMS bootstrap client for DMS instance configuration." -InformationAction Continue
+    # DMS-1151: bootstrap admin token acquisition. Add-CmsClient is idempotent (existing
+    # client ids return a warning and continue) and is the only documented /connect/register
+    # side effect for the configure/provision phases. Client id/secret are resolved through
+    # the shared -EnvironmentFile helper so this phase and provision-dms-schema.ps1 agree on
+    # the admin client (DMS_BOOTSTRAP_ADMIN_CLIENT_ID / DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET).
+    $bootstrapAdmin = Resolve-BootstrapAdminClient -EnvValues $envValues
+    Write-Information "Acquiring CMS bootstrap admin token for DMS instance configuration." -InformationAction Continue
     Add-CmsClient `
         -CmsUrl $cmsUrl `
-        -ClientId $script:BootstrapDmsInstanceClientId `
-        -ClientSecret $script:BootstrapDmsInstanceClientSecret `
+        -ClientId $bootstrapAdmin.ClientId `
+        -ClientSecret $bootstrapAdmin.ClientSecret `
         -DisplayName "DMS Instance Setup Administrator"
 
     $configToken = Get-CmsToken `
         -CmsUrl $cmsUrl `
-        -ClientId $script:BootstrapDmsInstanceClientId `
-        -ClientSecret $script:BootstrapDmsInstanceClientSecret
+        -ClientId $bootstrapAdmin.ClientId `
+        -ClientSecret $bootstrapAdmin.ClientSecret
 
     if ($multiTenancyEnabled -and -not [string]::IsNullOrWhiteSpace($tenant)) {
         Write-Information "Ensuring local CMS tenant exists: $(Format-LogSafeText $tenant)." -InformationAction Continue
@@ -233,6 +293,7 @@ function Invoke-ConfigureLocalDmsInstance {
     $postgresPassword = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_PASSWORD"
     $postgresDbName = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_DB_NAME" -DefaultValue "edfi_datamanagementservice"
     $postgresUser = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
+    $cmsReadOnlyAccess = Resolve-CmsReadOnlyAccessFromEnv -EnvValues $envValues
 
     if ($NoDmsInstance) {
         Write-Information "Selecting existing route-unqualified DMS instance from CMS." -InformationAction Continue
@@ -240,7 +301,8 @@ function Invoke-ConfigureLocalDmsInstance {
         $selectedInstance = Get-ExistingCompatibleInstance -Instances $instances -Tenant $tenant
         return ConvertTo-ConfigureResult `
             -InstanceIds @([long]$selectedInstance.id) `
-            -Tenant $tenant
+            -Tenant $tenant `
+            -CmsReadOnlyAccess $cmsReadOnlyAccess
     }
 
     if ($schoolYears.Count -gt 0) {
@@ -277,7 +339,8 @@ function Invoke-ConfigureLocalDmsInstance {
             -InstanceIds $instanceIds `
             -RouteContexts $routeContexts `
             -Tenant $tenant `
-            -SchoolYears $schoolYears
+            -SchoolYears $schoolYears `
+            -CmsReadOnlyAccess $cmsReadOnlyAccess
     }
 
     Write-Information "Creating default route-unqualified DMS instance." -InformationAction Continue
@@ -300,7 +363,8 @@ function Invoke-ConfigureLocalDmsInstance {
 
     return ConvertTo-ConfigureResult `
         -InstanceIds @([long]$instanceId) `
-        -Tenant $tenant
+        -Tenant $tenant `
+        -CmsReadOnlyAccess $cmsReadOnlyAccess
 }
 
 if ($MyInvocation.InvocationName -eq '.') { return }

--- a/eng/docker-compose/configure-local-dms-instance.ps1
+++ b/eng/docker-compose/configure-local-dms-instance.ps1
@@ -1,0 +1,312 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Bootstrap entry script intentionally writes operator progress to the console.')]
+[CmdletBinding()]
+param(
+    [string]$EnvironmentFile,
+    [switch]$NoDmsInstance,
+    [string]$SchoolYearRange = "",
+    [switch]$AddSmokeTestCredentials
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Import-Module "$PSScriptRoot/bootstrap-manifest.psm1" -Force -Global
+Import-Module "$PSScriptRoot/env-utility.psm1" -Force -Global
+Import-Module "$PSScriptRoot/../Dms-Management.psm1" -Force
+
+$script:BootstrapDmsInstanceClientId = "dms-instance-admin"
+$script:BootstrapDmsInstanceClientSecret = "ValidClientSecret1234567890!Abcd"
+
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
+    function Format-LogSafeText {
+        param($Value)
+
+        if ($null -eq $Value) { return "" }
+        $text = [string]$Value
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray()) {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/") {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
+function Resolve-ConfigureEnvironmentFile {
+    param(
+        [string]
+        $Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $defaultEnv = Join-Path $PSScriptRoot ".env"
+        $fallbackEnv = Join-Path $PSScriptRoot ".env.example"
+        $Path = if (Test-Path -LiteralPath $defaultEnv) { $defaultEnv } else { $fallbackEnv }
+    }
+    elseif (-not [System.IO.Path]::IsPathRooted($Path)) {
+        $Path = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    }
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Environment file not found: $(Format-LogSafeText $Path)."
+    }
+
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-EnvValueOrDefault {
+    param(
+        [hashtable]
+        $EnvValues,
+
+        [string]
+        $Name,
+
+        [string]
+        $DefaultValue = ""
+    )
+
+    if ($EnvValues.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$Name])) {
+        return [string]$EnvValues[$Name]
+    }
+
+    return $DefaultValue
+}
+
+function Get-DmsInstanceRouteContexts {
+    param(
+        $Instance
+    )
+
+    $property = $Instance.PSObject.Properties["dmsInstanceRouteContexts"]
+    if ($null -eq $property -or $null -eq $property.Value -or $property.Value -is [string]) {
+        return @()
+    }
+
+    return @($property.Value)
+}
+
+function ConvertTo-ConfigureResult {
+    param(
+        [long[]]
+        $InstanceIds = @(),
+
+        [object[]]
+        $RouteContexts = @(),
+
+        [string]
+        $Tenant = "",
+
+        [int[]]
+        $SchoolYears = @()
+    )
+
+    return [pscustomobject]@{
+        InstanceIds = [long[]]@($InstanceIds)
+        RouteContexts = @($RouteContexts)
+        Tenant = $Tenant
+        SchoolYears = [int[]]@($SchoolYears)
+        HasRouteQualifiedInstances = (@($RouteContexts).Count -gt 0)
+    }
+}
+
+function Resolve-SchoolYearRange {
+    param(
+        [string]
+        $Range
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Range)) {
+        return [int[]]@()
+    }
+
+    if ($Range -notmatch '^(\d{4})-(\d{4})$') {
+        throw "Invalid -SchoolYearRange '$(Format-LogSafeText $Range)'. Expected StartYear-EndYear (e.g. 2024-2025)."
+    }
+
+    $startYear = [int]$Matches[1]
+    $endYear = [int]$Matches[2]
+    if ($startYear -gt $endYear) {
+        throw "Invalid -SchoolYearRange '$(Format-LogSafeText $Range)'. StartYear ($startYear) must be less than or equal to EndYear ($endYear)."
+    }
+
+    return [int[]]@($startYear..$endYear)
+}
+
+function Get-ExistingCompatibleInstance {
+    param(
+        [object[]]
+        $Instances,
+
+        [string]
+        $Tenant
+    )
+
+    if ($Instances.Count -eq 0) {
+        throw "-NoDmsInstance was supplied, but no existing DMS instances were found in the current tenant scope '$(Format-LogSafeText $Tenant)'. Create one route-unqualified CMS instance, or omit -NoDmsInstance."
+    }
+
+    if ($Instances.Count -gt 1) {
+        $listing = ($Instances | ForEach-Object {
+            "id=$(Format-LogSafeText $_.id) name=$(Format-LogSafeText $_.instanceName)"
+        }) -join ", "
+        throw "-NoDmsInstance requires exactly one existing DMS instance in tenant scope '$(Format-LogSafeText $Tenant)'. Found $($Instances.Count): $listing. Clean up CMS state or run with explicit configuration inputs."
+    }
+
+    $instance = $Instances[0]
+    $routeContexts = @(Get-DmsInstanceRouteContexts -Instance $instance)
+    if ($routeContexts.Count -gt 0) {
+        $contextList = ($routeContexts | ForEach-Object { "$($_.contextKey)=$($_.contextValue)" }) -join ", "
+        throw "-NoDmsInstance found one existing instance, but it is route-qualified ($contextList). -NoDmsInstance supports exactly one route-unqualified instance; clean up CMS state or use -SchoolYearRange."
+    }
+
+    return $instance
+}
+
+function Invoke-ConfigureLocalDmsInstance {
+    param(
+        [string]
+        $EnvironmentFile,
+
+        [switch]
+        $NoDmsInstance,
+
+        [string]
+        $SchoolYearRange = "",
+
+        [switch]
+        $AddSmokeTestCredentials
+    )
+
+    $resolvedEnvironmentFile = Resolve-ConfigureEnvironmentFile -Path $EnvironmentFile
+    $envValues = ReadValuesFromEnvFile -EnvironmentFile $resolvedEnvironmentFile
+    $cmsUrl = Resolve-CmsBaseUrl -EnvValues $envValues
+    $tenant = Get-EnvValueOrDefault -EnvValues $envValues -Name "CONFIG_SERVICE_TENANT"
+    $schoolYears = @(Resolve-SchoolYearRange -Range $SchoolYearRange)
+
+    if ($NoDmsInstance -and $schoolYears.Count -gt 0) {
+        throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance to select one existing route-unqualified instance, or -SchoolYearRange to configure route-qualified instances."
+    }
+
+    $multiTenancyEnabled = (Get-EnvValueOrDefault -EnvValues $envValues -Name "DMS_CONFIG_MULTI_TENANCY").Equals("true", [System.StringComparison]::OrdinalIgnoreCase)
+    if ($schoolYears.Count -gt 0 -and $multiTenancyEnabled -and [string]::IsNullOrWhiteSpace($tenant)) {
+        throw "Parameter -SchoolYearRange requires CONFIG_SERVICE_TENANT to be set in the environment file when DMS_CONFIG_MULTI_TENANCY=true."
+    }
+
+    Write-Information "Registering CMS bootstrap client for DMS instance configuration." -InformationAction Continue
+    Add-CmsClient `
+        -CmsUrl $cmsUrl `
+        -ClientId $script:BootstrapDmsInstanceClientId `
+        -ClientSecret $script:BootstrapDmsInstanceClientSecret `
+        -DisplayName "DMS Instance Setup Administrator"
+
+    $configToken = Get-CmsToken `
+        -CmsUrl $cmsUrl `
+        -ClientId $script:BootstrapDmsInstanceClientId `
+        -ClientSecret $script:BootstrapDmsInstanceClientSecret
+
+    if ($multiTenancyEnabled -and -not [string]::IsNullOrWhiteSpace($tenant)) {
+        Write-Information "Ensuring local CMS tenant exists: $(Format-LogSafeText $tenant)." -InformationAction Continue
+        try {
+            Add-Tenant -CmsUrl $cmsUrl -AccessToken $configToken -TenantName $tenant | Out-Null
+        }
+        catch {
+            Write-Warning "Tenant creation was skipped or already satisfied for '$(Format-LogSafeText $tenant)'. $(Format-LogSafeText ($_.Exception.Message))"
+        }
+    }
+
+    $postgresPassword = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_PASSWORD"
+    $postgresDbName = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_DB_NAME" -DefaultValue "edfi_datamanagementservice"
+    $postgresUser = Get-EnvValueOrDefault -EnvValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
+
+    if ($NoDmsInstance) {
+        Write-Information "Selecting existing route-unqualified DMS instance from CMS." -InformationAction Continue
+        $instances = @(Get-DmsInstances -CmsUrl $cmsUrl -AccessToken $configToken -Tenant $tenant)
+        $selectedInstance = Get-ExistingCompatibleInstance -Instances $instances -Tenant $tenant
+        return ConvertTo-ConfigureResult `
+            -InstanceIds @([long]$selectedInstance.id) `
+            -Tenant $tenant
+    }
+
+    if ($schoolYears.Count -gt 0) {
+        Write-Information "Creating DMS instances for school years $($schoolYears[0])-$($schoolYears[-1])." -InformationAction Continue
+        $instances = Add-DmsSchoolYearInstances `
+            -CmsUrl $cmsUrl `
+            -AccessToken $configToken `
+            -StartYear $schoolYears[0] `
+            -EndYear $schoolYears[-1] `
+            -PostgresPassword $postgresPassword `
+            -PostgresDbName $postgresDbName `
+            -PostgresUser $postgresUser `
+            -Tenant $tenant
+
+        $instanceIds = @($instances | ForEach-Object { [long]$_.InstanceId })
+        $routeContexts = @(
+            $instances | ForEach-Object {
+                [pscustomobject]@{
+                    InstanceId = [long]$_.InstanceId
+                    ContextKey = "schoolYear"
+                    ContextValue = [string]$_.Year
+                }
+            }
+        )
+
+        if ($AddSmokeTestCredentials) {
+            Import-Module "$PSScriptRoot/../smoke_test/modules/SmokeTest.psm1" -Force
+            Write-Information "Creating smoke test credentials." -InformationAction Continue
+            Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl | Out-Null
+            Write-Information "Smoke test credentials created." -InformationAction Continue
+        }
+
+        return ConvertTo-ConfigureResult `
+            -InstanceIds $instanceIds `
+            -RouteContexts $routeContexts `
+            -Tenant $tenant `
+            -SchoolYears $schoolYears
+    }
+
+    Write-Information "Creating default route-unqualified DMS instance." -InformationAction Continue
+    $instanceId = Add-DmsInstance `
+        -CmsUrl $cmsUrl `
+        -AccessToken $configToken `
+        -PostgresPassword $postgresPassword `
+        -PostgresDbName $postgresDbName `
+        -PostgresUser $postgresUser `
+        -InstanceName "Local Development Instance" `
+        -InstanceType "Development" `
+        -Tenant $tenant
+
+    if ($AddSmokeTestCredentials) {
+        Import-Module "$PSScriptRoot/../smoke_test/modules/SmokeTest.psm1" -Force
+        Write-Information "Creating smoke test credentials." -InformationAction Continue
+        Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl | Out-Null
+        Write-Information "Smoke test credentials created." -InformationAction Continue
+    }
+
+    return ConvertTo-ConfigureResult `
+        -InstanceIds @([long]$instanceId) `
+        -Tenant $tenant
+}
+
+if ($MyInvocation.InvocationName -eq '.') { return }
+
+Invoke-ConfigureLocalDmsInstance `
+    -EnvironmentFile $EnvironmentFile `
+    -NoDmsInstance:$NoDmsInstance `
+    -SchoolYearRange $SchoolYearRange `
+    -AddSmokeTestCredentials:$AddSmokeTestCredentials

--- a/eng/docker-compose/configure-local-dms-instance.ps1
+++ b/eng/docker-compose/configure-local-dms-instance.ps1
@@ -300,6 +300,13 @@ function Invoke-ConfigureLocalDmsInstance {
         Write-Information "Selecting existing route-unqualified DMS instance from CMS." -InformationAction Continue
         $instances = @(Get-DmsInstances -CmsUrl $cmsUrl -AccessToken $configToken -Tenant $tenant)
         $selectedInstance = Get-ExistingCompatibleInstance -Instances $instances -Tenant $tenant
+        if ($AddSmokeTestCredentials) {
+            Import-Module "$PSScriptRoot/../smoke_test/modules/SmokeTest.psm1" -Force
+            Write-Information "Creating smoke test credentials." -InformationAction Continue
+            Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl -DmsInstanceIds @([long]$selectedInstance.id) -Tenant $tenant | Out-Null
+            Write-Information "Smoke test credentials created." -InformationAction Continue
+        }
+
         return ConvertTo-ConfigureResult `
             -InstanceIds @([long]$selectedInstance.id) `
             -Tenant $tenant `
@@ -332,7 +339,7 @@ function Invoke-ConfigureLocalDmsInstance {
         if ($AddSmokeTestCredentials) {
             Import-Module "$PSScriptRoot/../smoke_test/modules/SmokeTest.psm1" -Force
             Write-Information "Creating smoke test credentials." -InformationAction Continue
-            Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl | Out-Null
+            Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl -DmsInstanceIds $instanceIds -Tenant $tenant | Out-Null
             Write-Information "Smoke test credentials created." -InformationAction Continue
         }
 
@@ -358,7 +365,7 @@ function Invoke-ConfigureLocalDmsInstance {
     if ($AddSmokeTestCredentials) {
         Import-Module "$PSScriptRoot/../smoke_test/modules/SmokeTest.psm1" -Force
         Write-Information "Creating smoke test credentials." -InformationAction Continue
-        Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl | Out-Null
+        Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl -DmsInstanceIds @([long]$instanceId) -Tenant $tenant | Out-Null
         Write-Information "Smoke test credentials created." -InformationAction Continue
     }
 

--- a/eng/docker-compose/env-utility.psm1
+++ b/eng/docker-compose/env-utility.psm1
@@ -30,6 +30,114 @@ function ReadValuesFromEnvFile {
     return $envFile
 }
 
+function Resolve-LocalSettingsEnvironmentFile {
+    <#
+    .SYNOPSIS
+    Single source of truth for resolving the -EnvironmentFile parameter that every story-aligned
+    phase command (start, configure, provision, seed) accepts. Returns the absolute path to a
+    readable env file or throws if it cannot be located.
+
+    .DESCRIPTION
+    Resolution precedence (highest first):
+      1. The supplied -Path, when non-empty:
+         - absolute paths are kept as-is;
+         - relative paths are resolved against the caller's current working directory.
+      2. <docker-compose>/.env when present.
+      3. <docker-compose>/.env.example as a developer fallback.
+
+    A missing file always throws. This is intentionally narrower than ReadValuesFromEnvFile
+    so phase commands fail fast on a typo rather than silently fall through to ambient process
+    environment defaults.
+
+    .PARAMETER Path
+    Caller-supplied env file path. May be empty (use defaults) or relative.
+
+    .PARAMETER DockerComposeRoot
+    Optional override for the docker-compose root directory used for default lookup. Defaults
+    to this module's directory (eng/docker-compose). Tests pass an isolated copy.
+    #>
+    param(
+        [string]$Path,
+        [string]$DockerComposeRoot
+    )
+
+    if ([string]::IsNullOrWhiteSpace($DockerComposeRoot)) {
+        $DockerComposeRoot = $PSScriptRoot
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $defaultEnv = Join-Path $DockerComposeRoot ".env"
+        $fallbackEnv = Join-Path $DockerComposeRoot ".env.example"
+        $Path = if (Test-Path -LiteralPath $defaultEnv -PathType Leaf) {
+            $defaultEnv
+        }
+        else {
+            $fallbackEnv
+        }
+    }
+    elseif (-not [System.IO.Path]::IsPathRooted($Path)) {
+        $Path = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    }
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Environment file not found: $Path."
+    }
+
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-EnvValue {
+    <#
+    .SYNOPSIS
+    Shared helper that returns the value of an env-file key when present and non-blank,
+    otherwise the documented default. Equivalent to the duplicated Get-EnvValueOrDefault
+    helpers in configure-local-dms-instance.ps1 and provision-dms-schema.ps1, lifted into
+    the shared module so the precedence rule is single-sourced.
+
+    Precedence: explicit env-file value > documented default. Process environment variables
+    are deliberately not consulted - direct phase invocation must not depend on ambient state.
+    #>
+    param(
+        [hashtable]$EnvValues,
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [string]$DefaultValue = ""
+    )
+
+    if ($null -eq $EnvValues) {
+        return $DefaultValue
+    }
+
+    if ($EnvValues.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$Name])) {
+        return [string]$EnvValues[$Name]
+    }
+
+    return $DefaultValue
+}
+
+
+function Resolve-BootstrapAdminClient {
+    <#
+    .SYNOPSIS
+        Returns the bootstrap admin client id and secret used by configure-local-dms-instance.ps1
+        and provision-dms-schema.ps1 to acquire a CMS admin token. Reads
+        DMS_BOOTSTRAP_ADMIN_CLIENT_ID / DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET from the env file and
+        falls back to the historical local-dev defaults so the standard developer flow needs no
+        env-file changes. Single-sources the two values so configure (which registers) and
+        provision (which authenticates) always agree on the client.
+    .PARAMETER EnvValues
+        Hashtable returned by ReadValuesFromEnvFile.
+    #>
+    param(
+        [hashtable]$EnvValues
+    )
+
+    return [pscustomobject]@{
+        ClientId     = Get-EnvValue -EnvValues $EnvValues -Name "DMS_BOOTSTRAP_ADMIN_CLIENT_ID" -DefaultValue "dms-instance-admin"
+        ClientSecret = Get-EnvValue -EnvValues $EnvValues -Name "DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET" -DefaultValue "ValidClientSecret1234567890!Abcd"
+    }
+}
+
 function Resolve-CmsBaseUrl {
     <#
     .SYNOPSIS

--- a/eng/docker-compose/env-utility.psm1
+++ b/eng/docker-compose/env-utility.psm1
@@ -335,7 +335,12 @@ function Resolve-BootstrapDerivedEnv {
     Write-DerivedEnvFile `
         -BaseEnvironmentFile $BaseEnvironmentFile `
         -TargetPath $DerivedTargetPath `
-        -KeyOverrides @{ FAILURE_RATIO = "0.95" } `
+        -KeyOverrides @{
+            FAILURE_RATIO = "0.95"
+            NEED_DATABASE_SETUP = "false"
+            DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            AppSettings__DeployDatabaseOnStartup = "false"
+        } `
         -SchemaPackageExclusions $exclusions
 
     return $DerivedTargetPath

--- a/eng/docker-compose/local-dms.yml
+++ b/eng/docker-compose/local-dms.yml
@@ -12,7 +12,9 @@ services:
     environment:
       ASPNETCORE_HTTP_PORTS: ${DMS_HTTP_PORTS:-8080}
       AppSettings__AuthenticationService: ${OAUTH_TOKEN_ENDPOINT:-http://host.docker.internal:8080/oauth/token}
-      NEED_DATABASE_SETUP: ${NEED_DATABASE_SETUP:-true}
+      # Schema provisioning is owned by provision-dms-schema.ps1 per the DMS-916 bootstrap design;
+      # leaving NEED_DATABASE_SETUP unset disables the legacy Backend.Installer entrypoint.
+      NEED_DATABASE_SETUP: ${NEED_DATABASE_SETUP:-false}
       AppSettings__UseRelationalBackend: ${USE_RELATIONAL_BACKEND:-false}
       AppSettings__DeployDatabaseOnStartup: ${DMS_DEPLOY_DATABASE_ON_STARTUP:-false}
       AppSettings__BypassStringTypeCoercion: ${BYPASS_STRING_COERCION:-false}

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -17,7 +17,255 @@ param(
 
 Set-StrictMode -Version Latest
 
-Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force -Global
+Import-Module (Join-Path $PSScriptRoot "bootstrap-schema-tool.psm1") -Force -Global
+
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
+    function Format-LogSafeText {
+        param($Value)
+
+        if ($null -eq $Value) { return "" }
+        $text = [string]$Value
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray()) {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/") {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
+if (-not (Get-Command Read-RequiredJsonBoolean -ErrorAction SilentlyContinue)) {
+    function Read-RequiredJsonBoolean {
+        param(
+            [Parameter(Mandatory)]
+            $Hashtable,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Key,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ArtifactContext
+        )
+
+        if ($Hashtable -isnot [System.Collections.IDictionary] -or -not $Hashtable.Contains($Key)) {
+            throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+        }
+
+        $value = $Hashtable[$Key]
+        if ($value -is [bool]) {
+            return $value
+        }
+
+        throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+    }
+}
+
+if (-not (Get-Command Get-BootstrapRoot -ErrorAction SilentlyContinue)) {
+    $script:PrepareBootstrapRoot = Join-Path $PSScriptRoot ".bootstrap"
+    $script:PrepareBootstrapManifestPath = Join-Path $script:PrepareBootstrapRoot "bootstrap-manifest.json"
+    $script:PrepareWorkspaceMismatchMessage = "Existing staged bootstrap workspace differs from requested inputs, manifest state is incomplete, or files were manually edited (partial prior state). Stop the local stack and remove eng/docker-compose/.bootstrap before retrying. For local Docker, run: pwsh eng/docker-compose/start-local-dms.ps1 -d -v -RemoveBootstrap. E2E teardown wrappers also remove the bootstrap workspace."
+    $script:PrepareUtf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+    function Get-BootstrapRoot {
+        return $script:PrepareBootstrapRoot
+    }
+
+    function Get-BootstrapRelativePath {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [string]
+            $BasePath = $script:PrepareBootstrapRoot
+        )
+
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+        $fullBasePath = [System.IO.Path]::GetFullPath($BasePath)
+        return [System.IO.Path]::GetRelativePath($fullBasePath, $fullPath).Replace("\", "/")
+    }
+
+    function Get-BootstrapWorkspaceMismatchMessage {
+        param(
+            [string]
+            $Reason
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+            return $script:PrepareWorkspaceMismatchMessage.Replace(
+                "Stop the local stack",
+                "Diverging field: $(Format-LogSafeText $Reason). Stop the local stack"
+            )
+        }
+
+        return $script:PrepareWorkspaceMismatchMessage
+    }
+
+    function New-BootstrapManifest {
+        return @{
+            version = 1
+        }
+    }
+
+    function Read-BootstrapManifest {
+        param(
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            return $null
+        }
+
+        try {
+            $manifest = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+        } catch {
+            throw "Bootstrap manifest '$(Format-LogSafeText $Path)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+        }
+
+        if ($manifest -isnot [System.Collections.IDictionary]) {
+            throw "Bootstrap manifest '$(Format-LogSafeText $Path)' must contain a JSON object."
+        }
+
+        if (-not $manifest.ContainsKey("version") -or $null -eq $manifest["version"]) {
+            $manifest["version"] = 1
+            return $manifest
+        }
+
+        $manifest["version"] = [int]$manifest["version"]
+        return $manifest
+    }
+
+    function Write-BootstrapJson {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [Parameter(Mandatory)]
+            $Value
+        )
+
+        $directory = Split-Path -Parent $Path
+        if (-not [string]::IsNullOrWhiteSpace($directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+
+        $json = $Value | ConvertTo-Json -Depth 100
+        [System.IO.File]::WriteAllText($Path, "$json`n", $script:PrepareUtf8NoBom)
+    }
+
+    function Write-BootstrapManifest {
+        param(
+            [Parameter(Mandatory)]
+            $Manifest,
+
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        $orderedManifest = [ordered]@{
+            version = 1
+        }
+
+        foreach ($sectionName in @("schema", "claims", "seed")) {
+            if ($Manifest.ContainsKey($sectionName)) {
+                $orderedManifest[$sectionName] = $Manifest[$sectionName]
+            }
+        }
+
+        Write-BootstrapJson -Path $Path -Value $orderedManifest
+    }
+
+    function Set-BootstrapManifestSection {
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet("schema", "claims", "seed")]
+            [string]
+            $Name,
+
+            [Parameter(Mandatory)]
+            $Value,
+
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        $manifest = Read-BootstrapManifest -Path $Path
+        if ($null -eq $manifest) {
+            $manifest = New-BootstrapManifest
+        }
+
+        $manifest[$Name] = $Value
+        Write-BootstrapManifest -Manifest $manifest -Path $Path
+    }
+
+    function Get-BootstrapFingerprintByte {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path
+        )
+
+        $extension = [System.IO.Path]::GetExtension($Path)
+        if ($extension.Equals(".json", [System.StringComparison]::OrdinalIgnoreCase) -or
+            $extension.Equals(".xsd", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $text = [System.IO.File]::ReadAllText($Path)
+            $normalizedText = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+            return [System.Text.Encoding]::UTF8.GetBytes($normalizedText)
+        }
+
+        return [System.IO.File]::ReadAllBytes($Path)
+    }
+
+    function Get-BootstrapWorkspaceFingerprint {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path
+        )
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            throw "Workspace path does not exist: $(Format-LogSafeText $Path)"
+        }
+
+        $entries = @(
+            Get-ChildItem -LiteralPath $Path -File -Recurse | ForEach-Object {
+                [pscustomobject]@{
+                    RelativePath = Get-BootstrapRelativePath -Path $_.FullName -BasePath $Path
+                    FullName = $_.FullName
+                }
+            }
+        )
+
+        $sortedEntries = @($entries | Sort-Object -Property RelativePath)
+        $incrementalHash = [System.Security.Cryptography.IncrementalHash]::CreateHash(
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256
+        )
+        [byte[]] $separator = 0
+
+        foreach ($entry in $sortedEntries) {
+            $relativePathBytes = [System.Text.Encoding]::UTF8.GetBytes($entry.RelativePath)
+            $incrementalHash.AppendData($relativePathBytes)
+            $incrementalHash.AppendData($separator)
+            $incrementalHash.AppendData((Get-BootstrapFingerprintByte -Path $entry.FullName))
+            $incrementalHash.AppendData($separator)
+        }
+
+        return [System.Convert]::ToHexString($incrementalHash.GetHashAndReset()).ToLowerInvariant()
+    }
+}
 
 $story06Message = "Package-backed standard schema selection is deferred until Story 06. For Story 00, supply -ApiSchemaPath pointing to a filesystem ApiSchema directory."
 
@@ -27,134 +275,6 @@ if ($PSBoundParameters.ContainsKey("Extensions")) {
 
 if (-not $PSBoundParameters.ContainsKey("ApiSchemaPath") -or [string]::IsNullOrWhiteSpace($ApiSchemaPath)) {
     throw $story06Message
-}
-
-function Get-DotNetFrameworkVersion {
-    param(
-        [Parameter(Mandatory)]
-        [string]
-        $Name
-    )
-
-    if ($Name -match "^net(?<Major>\d+)(?:\.(?<Minor>\d+))?") {
-        $minor = if ([string]::IsNullOrWhiteSpace($matches["Minor"])) { 0 } else { [int]$matches["Minor"] }
-        return [version]::new([int]$matches["Major"], $minor)
-    }
-
-    return [version]::new(0, 0)
-}
-
-function Get-DmsSchemaToolCandidateDirectory {
-    $repoRoot = Get-BootstrapRepoRoot
-    $toolBinRoot = Join-Path $repoRoot "src/dms/clis/EdFi.DataManagementService.SchemaTools/bin"
-    $frameworkDirectories = [System.Collections.ArrayList]::new()
-
-    foreach ($configuration in @("Debug", "Release")) {
-        $configurationRoot = Join-Path $toolBinRoot $configuration
-        if (-not (Test-Path -LiteralPath $configurationRoot -PathType Container)) {
-            continue
-        }
-
-        foreach ($frameworkDirectory in Get-ChildItem -LiteralPath $configurationRoot -Directory -Filter "net*") {
-            if ($frameworkDirectory.Name -notmatch "^net\d") {
-                continue
-            }
-
-            $null = $frameworkDirectories.Add(
-                [pscustomobject]@{
-                    Directory = $frameworkDirectory.FullName
-                    FrameworkVersion = Get-DotNetFrameworkVersion -Name $frameworkDirectory.Name
-                    ConfigurationPriority = if ($configuration -eq "Debug") { 0 } else { 1 }
-                }
-            )
-        }
-    }
-
-    return @(
-        $frameworkDirectories |
-            Sort-Object `
-                -Property @{ Expression = { $_.FrameworkVersion }; Descending = $true },
-                    @{ Expression = { $_.ConfigurationPriority }; Ascending = $true } |
-            ForEach-Object { $_.Directory }
-    )
-}
-
-function Resolve-DmsSchemaTool {
-    param(
-        [string]
-        $RequestedPath
-    )
-
-    if (-not [string]::IsNullOrWhiteSpace($RequestedPath)) {
-        $fullPath = [System.IO.Path]::GetFullPath($RequestedPath)
-        if (-not (Test-Path -LiteralPath $fullPath -PathType Leaf)) {
-            throw "The configured dms-schema executable was not found: $(Format-LogSafeText $fullPath)"
-        }
-
-        return $fullPath
-    }
-
-    $candidateNames = if ($IsWindows) {
-        @("dms-schema.exe", "dms-schema")
-    } else {
-        @("dms-schema")
-    }
-
-    foreach ($candidateDirectory in Get-DmsSchemaToolCandidateDirectory) {
-        foreach ($candidateName in $candidateNames) {
-            $candidate = Join-Path $candidateDirectory $candidateName
-            if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-                return $candidate
-            }
-        }
-    }
-
-    $pathCommand = Get-Command "dms-schema" -ErrorAction SilentlyContinue
-    if ($null -ne $pathCommand) {
-        if ($env:DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK -ne "true") {
-            throw "In-repo dms-schema tool not found. Build src/dms/clis/EdFi.DataManagementService.SchemaTools, set DMS_SCHEMA_TOOL_PATH, or set DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK=true to opt in to PATH fallback."
-        }
-
-        Write-Warning "Falling back to PATH-resolved dms-schema executable: $(Format-LogSafeText ($pathCommand.Source))"
-        return $pathCommand.Source
-    }
-
-    throw "Unable to resolve the dms-schema executable. Build src/dms/clis/EdFi.DataManagementService.SchemaTools or set DMS_SCHEMA_TOOL_PATH."
-}
-
-function Invoke-DmsSchemaHash {
-    param(
-        [Parameter(Mandatory)]
-        [string]
-        $ToolPath,
-
-        [Parameter(Mandatory)]
-        [string]
-        $CoreSchemaPath,
-
-        [string[]]
-        $ExtensionSchemaPath = @()
-    )
-
-    $arguments = @("hash", $CoreSchemaPath) + $ExtensionSchemaPath
-    $output = if ($ToolPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
-        & pwsh -NoLogo -NoProfile -File $ToolPath @arguments 2>&1
-    } else {
-        & $ToolPath @arguments 2>&1
-    }
-
-    $exitCode = $LASTEXITCODE
-    $outputText = ($output | Out-String).Trim()
-
-    if ($exitCode -ne 0) {
-        throw "dms-schema hash failed with exit code $exitCode. $(Format-LogSafeText $outputText)"
-    }
-
-    if ($outputText -notmatch "(?m)^Effective schema hash:\s*([a-fA-F0-9]{64})\s*$") {
-        throw "dms-schema hash completed but did not report an Effective schema hash. $(Format-LogSafeText $outputText)"
-    }
-
-    return $matches[1].ToLowerInvariant()
 }
 
 function Get-ProjectDirectoryName {

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -113,6 +113,9 @@ if (-not (Get-Command Get-BootstrapRoot -ErrorAction SilentlyContinue)) {
     }
 
     function New-BootstrapManifest {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Builds an in-memory manifest object; no system state changes and no -WhatIf surface.')]
+        param()
+
         return @{
             version = 1
         }
@@ -189,6 +192,7 @@ if (-not (Get-Command Get-BootstrapRoot -ErrorAction SilentlyContinue)) {
     }
 
     function Set-BootstrapManifestSection {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Mutates an in-memory manifest hashtable; no system state changes and no -WhatIf surface.')]
         param(
             [Parameter(Mandatory)]
             [ValidateSet("schema", "claims", "seed")]

--- a/eng/docker-compose/provision-dms-schema.ps1
+++ b/eng/docker-compose/provision-dms-schema.ps1
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+[CmdletBinding()]
+param(
+    [string]$EnvironmentFile,
+    [long[]]$InstanceId = @(),
+    [int[]]$SchoolYear = @()
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Import-Module "$PSScriptRoot/bootstrap-manifest.psm1" -Force -Global
+Import-Module "$PSScriptRoot/bootstrap-schema-tool.psm1" -Force -Global
+Import-Module "$PSScriptRoot/bootstrap-schema-workspace.psm1" -Force -Global
+Import-Module "$PSScriptRoot/env-utility.psm1" -Force -Global
+Import-Module "$PSScriptRoot/../Dms-Management.psm1" -Force
+
+$script:BootstrapDmsInstanceClientId = "dms-instance-admin"
+$script:BootstrapDmsInstanceClientSecret = "ValidClientSecret1234567890!Abcd"
+
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
+    function Format-LogSafeText {
+        param($Value)
+
+        if ($null -eq $Value) { return "" }
+        $text = [string]$Value
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray()) {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/") {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
+function Resolve-ProvisionEnvironmentFile {
+    param(
+        [string]
+        $Path
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        $defaultEnv = Join-Path $PSScriptRoot ".env"
+        $fallbackEnv = Join-Path $PSScriptRoot ".env.example"
+        $Path = if (Test-Path -LiteralPath $defaultEnv) { $defaultEnv } else { $fallbackEnv }
+    }
+    elseif (-not [System.IO.Path]::IsPathRooted($Path)) {
+        $Path = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    }
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "Environment file not found: $(Format-LogSafeText $Path)."
+    }
+
+    return [System.IO.Path]::GetFullPath($Path)
+}
+
+function Get-EnvValueOrDefault {
+    param(
+        [hashtable]
+        $EnvValues,
+
+        [string]
+        $Name,
+
+        [string]
+        $DefaultValue = ""
+    )
+
+    if ($EnvValues.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$Name])) {
+        return [string]$EnvValues[$Name]
+    }
+
+    return $DefaultValue
+}
+
+function Get-ProvisionProperty {
+    param(
+        $Object,
+
+        [string[]]
+        $Names
+    )
+
+    foreach ($name in $Names) {
+        if ($Object -is [System.Collections.IDictionary] -and $Object.ContainsKey($name)) {
+            return $Object[$name]
+        }
+
+        $property = $Object.PSObject.Properties[$name]
+        if ($null -ne $property) {
+            return $property.Value
+        }
+    }
+
+    return $null
+}
+
+function Get-ProvisionRouteContexts {
+    param(
+        $Instance
+    )
+
+    $routeContexts = Get-ProvisionProperty -Object $Instance -Names @("dmsInstanceRouteContexts", "DmsInstanceRouteContexts", "routeContexts", "RouteContexts")
+    if ($null -eq $routeContexts -or $routeContexts -is [string]) {
+        return @()
+    }
+
+    return @($routeContexts)
+}
+
+function Resolve-EnvPlaceholdersInText {
+    param(
+        [string]
+        $Text,
+
+        [hashtable]
+        $EnvValues
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Text)) {
+        return ""
+    }
+
+    return [regex]::Replace(
+        $Text,
+        '\$\{(?<Name>[A-Za-z0-9_]+)\}',
+        {
+            param($match)
+
+            $name = $match.Groups["Name"].Value
+            if (-not $EnvValues.ContainsKey($name)) {
+                throw "Connection string references env value '$name', but that key is absent from the environment file."
+            }
+
+            return [string]$EnvValues[$name]
+        }
+    )
+}
+
+function Convert-ConnectionStringToHashtable {
+    param(
+        [string]
+        $ConnectionString
+    )
+
+    $values = @{}
+    foreach ($segment in @($ConnectionString -split ";")) {
+        if ([string]::IsNullOrWhiteSpace($segment)) {
+            continue
+        }
+
+        $parts = $segment.Split("=", 2)
+        if ($parts.Length -ne 2) {
+            continue
+        }
+
+        $values[$parts[0].Trim().ToLowerInvariant()] = $parts[1].Trim()
+    }
+
+    return $values
+}
+
+function Get-DatabaseNameFromConnectionString {
+    param(
+        [string]
+        $ConnectionString,
+
+        [switch]
+        $AllowMissing
+    )
+
+    $parts = Convert-ConnectionStringToHashtable -ConnectionString $ConnectionString
+    foreach ($key in @("database", "initial catalog")) {
+        if ($parts.ContainsKey($key) -and -not [string]::IsNullOrWhiteSpace([string]$parts[$key])) {
+            return [string]$parts[$key]
+        }
+    }
+
+    if ($AllowMissing) {
+        return $null
+    }
+
+    throw "CMS DMS instance connection string did not contain a database name."
+}
+
+function ConvertFrom-CmsEncryptedConnectionString {
+    param(
+        [string]
+        $ProtectedConnectionString,
+
+        [hashtable]
+        $EnvValues
+    )
+
+    $encryptionKey = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "DMS_CONFIG_DATABASE_ENCRYPTION_KEY"
+    if ([string]::IsNullOrWhiteSpace($encryptionKey)) {
+        throw "CMS DMS instance connection string is encrypted, but DMS_CONFIG_DATABASE_ENCRYPTION_KEY is not set in the environment file."
+    }
+
+    try {
+        $encryptedBytes = [Convert]::FromBase64String($ProtectedConnectionString)
+    }
+    catch {
+        throw "CMS DMS instance connection string did not contain a database name and was not valid CMS encrypted base64."
+    }
+
+    if ($encryptedBytes.Length -le 16) {
+        throw "CMS DMS instance encrypted connection string payload is invalid."
+    }
+
+    $keyText = $encryptionKey.PadRight(32, "0").Substring(0, 32)
+    $keyBytes = [System.Text.Encoding]::UTF8.GetBytes($keyText)
+    $iv = [byte[]]::new(16)
+    [Array]::Copy($encryptedBytes, 0, $iv, 0, 16)
+
+    $cipherText = [byte[]]::new($encryptedBytes.Length - 16)
+    [Array]::Copy($encryptedBytes, 16, $cipherText, 0, $cipherText.Length)
+
+    $aes = [System.Security.Cryptography.Aes]::Create()
+    try {
+        $aes.Key = $keyBytes
+        $aes.IV = $iv
+        $decryptor = $aes.CreateDecryptor()
+        try {
+            $plainTextBytes = $decryptor.TransformFinalBlock($cipherText, 0, $cipherText.Length)
+            return [System.Text.Encoding]::UTF8.GetString($plainTextBytes)
+        }
+        finally {
+            $decryptor.Dispose()
+        }
+    }
+    catch {
+        throw "CMS DMS instance encrypted connection string could not be decrypted with DMS_CONFIG_DATABASE_ENCRYPTION_KEY."
+    }
+    finally {
+        $aes.Dispose()
+    }
+}
+
+function Resolve-CmsInstanceConnectionString {
+    param(
+        [string]
+        $ConnectionString,
+
+        [hashtable]
+        $EnvValues
+    )
+
+    $resolvedConnectionString = Resolve-EnvPlaceholdersInText -Text $ConnectionString -EnvValues $EnvValues
+    if ($null -ne (Get-DatabaseNameFromConnectionString -ConnectionString $resolvedConnectionString -AllowMissing)) {
+        return $resolvedConnectionString
+    }
+
+    $decryptedConnectionString = ConvertFrom-CmsEncryptedConnectionString `
+        -ProtectedConnectionString $resolvedConnectionString `
+        -EnvValues $EnvValues
+
+    return Resolve-EnvPlaceholdersInText -Text $decryptedConnectionString -EnvValues $EnvValues
+}
+
+function New-HostSidePostgresConnectionString {
+    param(
+        [hashtable]
+        $EnvValues,
+
+        [string]
+        $DatabaseName
+    )
+
+    $port = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PORT" -DefaultValue "5432"
+    $user = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_USER" -DefaultValue "postgres"
+    $password = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PASSWORD"
+
+    return "host=localhost;port=$port;username=$user;password=$password;database=$DatabaseName;"
+}
+
+function Resolve-ProvisionTargetInstances {
+    param(
+        [object[]]
+        $Instances,
+
+        [long[]]
+        $InstanceId = @(),
+
+        [int[]]
+        $SchoolYear = @(),
+
+        [string]
+        $Tenant = ""
+    )
+
+    if ($InstanceId.Count -gt 0 -and $SchoolYear.Count -gt 0) {
+        throw "-InstanceId and -SchoolYear are mutually exclusive. Pass only one selector."
+    }
+
+    if ($InstanceId.Count -gt 0) {
+        $selected = [System.Collections.ArrayList]::new()
+        foreach ($id in $InstanceId) {
+            $matches = @($Instances | Where-Object { [long](Get-ProvisionProperty -Object $_ -Names @("id", "Id")) -eq [long]$id })
+            if ($matches.Count -eq 0) {
+                throw "DMS instance $(Format-LogSafeText $id) was not found in CMS for tenant '$(Format-LogSafeText $Tenant)'."
+            }
+
+            $null = $selected.Add($matches[0])
+        }
+
+        return @($selected)
+    }
+
+    if ($SchoolYear.Count -gt 0) {
+        $selected = [System.Collections.ArrayList]::new()
+        foreach ($year in $SchoolYear) {
+            $matches = @($Instances | Where-Object {
+                $matched = $false
+                foreach ($routeContext in Get-ProvisionRouteContexts -Instance $_) {
+                    $contextKey = [string](Get-ProvisionProperty -Object $routeContext -Names @("contextKey", "ContextKey"))
+                    $contextValue = [string](Get-ProvisionProperty -Object $routeContext -Names @("contextValue", "ContextValue"))
+                    if ($contextKey -eq "schoolYear" -and $contextValue -eq [string]$year) {
+                        $matched = $true
+                        break
+                    }
+                }
+                $matched
+            })
+
+            if ($matches.Count -eq 0) {
+                throw "No DMS instance found with route context schoolYear=$(Format-LogSafeText $year) for tenant '$(Format-LogSafeText $Tenant)'."
+            }
+
+            if ($matches.Count -gt 1) {
+                $ids = ($matches | ForEach-Object { Get-ProvisionProperty -Object $_ -Names @("id", "Id") }) -join ", "
+                throw "Multiple DMS instances found with route context schoolYear=$(Format-LogSafeText $year) (instance ids: $(Format-LogSafeText $ids)). Clean up duplicate CMS state before provisioning."
+            }
+
+            $null = $selected.Add($matches[0])
+        }
+
+        return @($selected)
+    }
+
+    if ($Instances.Count -eq 0) {
+        throw "No DMS instances found in CMS. Run configure-local-dms-instance.ps1 before provisioning schemas."
+    }
+
+    if ($Instances.Count -gt 1) {
+        $listing = ($Instances | ForEach-Object {
+            "id=$(Format-LogSafeText (Get-ProvisionProperty -Object $_ -Names @('id', 'Id'))) name=$(Format-LogSafeText (Get-ProvisionProperty -Object $_ -Names @('instanceName', 'InstanceName')))"
+        }) -join "`n"
+        throw "Multiple DMS instances exist; cannot auto-select. Pass -InstanceId or -SchoolYear to target specific instances:`n$listing"
+    }
+
+    return @($Instances[0])
+}
+
+function New-ProvisionTarget {
+    param(
+        $Instance,
+
+        [hashtable]
+        $EnvValues
+    )
+
+    $instanceId = [long](Get-ProvisionProperty -Object $Instance -Names @("id", "Id"))
+    $connectionString = [string](Get-ProvisionProperty -Object $Instance -Names @("connectionString", "ConnectionString"))
+    if ([string]::IsNullOrWhiteSpace($connectionString)) {
+        throw "CMS DMS instance $(Format-LogSafeText $instanceId) does not include a connection string."
+    }
+
+    $resolvedConnectionString = Resolve-CmsInstanceConnectionString `
+        -ConnectionString $connectionString `
+        -EnvValues $EnvValues
+    $databaseName = Get-DatabaseNameFromConnectionString -ConnectionString $resolvedConnectionString
+    $routeContexts = @(
+        Get-ProvisionRouteContexts -Instance $Instance | ForEach-Object {
+            [pscustomobject]@{
+                ContextKey = [string](Get-ProvisionProperty -Object $_ -Names @("contextKey", "ContextKey"))
+                ContextValue = [string](Get-ProvisionProperty -Object $_ -Names @("contextValue", "ContextValue"))
+            }
+        }
+    )
+
+    return [pscustomobject]@{
+        InstanceId = $instanceId
+        RouteContexts = $routeContexts
+        DatabaseName = $databaseName
+        NormalizedDatabaseName = $databaseName.ToLowerInvariant()
+        HostConnectionString = New-HostSidePostgresConnectionString -EnvValues $EnvValues -DatabaseName $databaseName
+    }
+}
+
+function Invoke-DmsSchemaProvision {
+    param(
+        [string]
+        $ToolPath,
+
+        [string[]]
+        $SchemaPaths,
+
+        [string]
+        $ConnectionString,
+
+        [string]
+        $DatabaseName
+    )
+
+    $arguments = @("ddl", "provision")
+    foreach ($schemaPath in $SchemaPaths) {
+        $arguments += @("--schema", $schemaPath)
+    }
+    $arguments += @(
+        "--connection-string", $ConnectionString,
+        "--dialect", "pgsql",
+        "--create-database"
+    )
+
+    Write-Information "Invoking dms-schema ddl provision for database $(Format-LogSafeText $DatabaseName) with $($SchemaPaths.Count) schema file(s)." -InformationAction Continue
+
+    if ($ToolPath.EndsWith(".ps1", [System.StringComparison]::OrdinalIgnoreCase)) {
+        & pwsh -NoLogo -NoProfile -File $ToolPath @arguments
+    }
+    else {
+        & $ToolPath @arguments
+    }
+
+    $exitCode = $LASTEXITCODE
+    Write-Information "dms-schema exit code for database $(Format-LogSafeText $DatabaseName): $(Format-LogSafeText $exitCode)." -InformationAction Continue
+    if ($exitCode -ne 0) {
+        throw "dms-schema ddl provision failed for database $(Format-LogSafeText $DatabaseName) with exit code $(Format-LogSafeText $exitCode)."
+    }
+}
+
+function Invoke-ProvisionDmsSchema {
+    param(
+        [string]
+        $EnvironmentFile,
+
+        [long[]]
+        $InstanceId = @(),
+
+        [int[]]
+        $SchoolYear = @()
+    )
+
+    if ($InstanceId.Count -gt 0 -and $SchoolYear.Count -gt 0) {
+        throw "-InstanceId and -SchoolYear are mutually exclusive. Pass only one selector."
+    }
+
+    $resolvedEnvironmentFile = Resolve-ProvisionEnvironmentFile -Path $EnvironmentFile
+    $envValues = ReadValuesFromEnvFile -EnvironmentFile $resolvedEnvironmentFile
+    $cmsUrl = Resolve-CmsBaseUrl -EnvValues $envValues
+    $tenant = Get-EnvValueOrDefault -EnvValues $envValues -Name "CONFIG_SERVICE_TENANT"
+
+    $schemaWorkspace = Resolve-BootstrapSchemaWorkspace
+    $schemaPaths = [string[]]@($schemaWorkspace.CoreSchemaPath) + [string[]]@($schemaWorkspace.ExtensionSchemaPaths)
+    Write-Information "Schema workspace ready. Core schema: $(Format-LogSafeText $schemaWorkspace.CoreSchemaPath). Extensions: $($schemaWorkspace.ExtensionSchemaPaths.Count)." -InformationAction Continue
+
+    Add-CmsClient `
+        -CmsUrl $cmsUrl `
+        -ClientId $script:BootstrapDmsInstanceClientId `
+        -ClientSecret $script:BootstrapDmsInstanceClientSecret `
+        -DisplayName "DMS Instance Setup Administrator"
+
+    $configToken = Get-CmsToken `
+        -CmsUrl $cmsUrl `
+        -ClientId $script:BootstrapDmsInstanceClientId `
+        -ClientSecret $script:BootstrapDmsInstanceClientSecret
+
+    $instances = @(Get-DmsInstances -CmsUrl $cmsUrl -AccessToken $configToken -Tenant $tenant)
+    $selectedInstances = Resolve-ProvisionTargetInstances `
+        -Instances $instances `
+        -InstanceId $InstanceId `
+        -SchoolYear $SchoolYear `
+        -Tenant $tenant
+
+    $targets = @($selectedInstances | ForEach-Object { New-ProvisionTarget -Instance $_ -EnvValues $envValues })
+    $groups = $targets | Group-Object -Property NormalizedDatabaseName
+    $schemaTool = Resolve-DmsSchemaTool -RequestedPath $env:DMS_SCHEMA_TOOL_PATH
+    Write-Information "dms-schema resolved: $(Format-LogSafeText $schemaTool)." -InformationAction Continue
+
+    foreach ($group in $groups) {
+        $target = @($group.Group)[0]
+        $ids = ($group.Group | ForEach-Object { $_.InstanceId }) -join ", "
+        Write-Information "Provisioning target database $(Format-LogSafeText $target.DatabaseName) for instance id(s): $(Format-LogSafeText $ids)." -InformationAction Continue
+        Invoke-DmsSchemaProvision `
+            -ToolPath $schemaTool `
+            -SchemaPaths $schemaPaths `
+            -ConnectionString $target.HostConnectionString `
+            -DatabaseName $target.DatabaseName
+    }
+}
+
+if ($MyInvocation.InvocationName -eq '.') { return }
+
+Invoke-ProvisionDmsSchema `
+    -EnvironmentFile $EnvironmentFile `
+    -InstanceId $InstanceId `
+    -SchoolYear $SchoolYear

--- a/eng/docker-compose/provision-dms-schema.ps1
+++ b/eng/docker-compose/provision-dms-schema.ps1
@@ -581,7 +581,7 @@ function Get-ProvisionIdeGuidance {
 
     $lines.Add("")
     $lines.Add("--- IDE next-step guidance ---")
-    $lines.Add("Staged schema workspace: $(Format-LogSafeText $SchemaWorkspace.BootstrapManifestPath)")
+    $lines.Add("Bootstrap manifest:      $(Format-LogSafeText $SchemaWorkspace.BootstrapManifestPath)")
     $lines.Add("  ApiSchema manifest:    $(Format-LogSafeText $SchemaWorkspace.ApiSchemaManifestPath)")
     if ($SchemaWorkspace.EffectiveSchemaHash) {
         $lines.Add("  Effective schema hash: $(Format-LogSafeText $SchemaWorkspace.EffectiveSchemaHash)")

--- a/eng/docker-compose/provision-dms-schema.ps1
+++ b/eng/docker-compose/provision-dms-schema.ps1
@@ -105,6 +105,7 @@ function Get-ProvisionProperty {
 }
 
 function Get-ProvisionRouteContexts {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Returns a collection of route contexts; the plural noun reflects the return shape.')]
     param(
         $Instance
     )
@@ -118,6 +119,7 @@ function Get-ProvisionRouteContexts {
 }
 
 function Resolve-EnvPlaceholdersInText {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'False positive: $EnvValues is consumed inside the nested regex replacement script block.')]
     param(
         [string]
         $Text,
@@ -285,7 +287,7 @@ function Convert-CmsConnectionStringToHostSideTarget {
 
     # TargetKey identifies an effective provisioning target. Two instances pointing at the
     # same physical database (same dialect, translated host, port, database, and user) share
-    # a provisioning invocation. Differing on any field — including username — produces a
+    # a provisioning invocation. Differing on any field - including username - produces a
     # separate target so we never collapse instances that happen to share a database name on
     # different hosts or under different roles.
     $targetKey = ("{0}|{1}|{2}|{3}|{4}" -f
@@ -386,6 +388,7 @@ function Resolve-CmsInstanceConnectionString {
 
 
 function Resolve-ProvisionTargetInstances {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Returns the collection of selected target instances; the plural noun reflects the return shape.')]
     param(
         [object[]]
         $Instances,
@@ -407,12 +410,12 @@ function Resolve-ProvisionTargetInstances {
     if ($InstanceId.Count -gt 0) {
         $selected = [System.Collections.ArrayList]::new()
         foreach ($id in $InstanceId) {
-            $matches = @($Instances | Where-Object { [long](Get-ProvisionProperty -Object $_ -Names @("id", "Id")) -eq [long]$id })
-            if ($matches.Count -eq 0) {
+            $matchedInstances = @($Instances | Where-Object { [long](Get-ProvisionProperty -Object $_ -Names @("id", "Id")) -eq [long]$id })
+            if ($matchedInstances.Count -eq 0) {
                 throw "DMS instance $(Format-LogSafeText $id) was not found in CMS for tenant '$(Format-LogSafeText $Tenant)'."
             }
 
-            $null = $selected.Add($matches[0])
+            $null = $selected.Add($matchedInstances[0])
         }
 
         return @($selected)
@@ -421,7 +424,7 @@ function Resolve-ProvisionTargetInstances {
     if ($SchoolYear.Count -gt 0) {
         $selected = [System.Collections.ArrayList]::new()
         foreach ($year in $SchoolYear) {
-            $matches = @($Instances | Where-Object {
+            $matchedInstances = @($Instances | Where-Object {
                 $matched = $false
                 foreach ($routeContext in Get-ProvisionRouteContexts -Instance $_) {
                     $contextKey = [string](Get-ProvisionProperty -Object $routeContext -Names @("contextKey", "ContextKey"))
@@ -434,16 +437,16 @@ function Resolve-ProvisionTargetInstances {
                 $matched
             })
 
-            if ($matches.Count -eq 0) {
+            if ($matchedInstances.Count -eq 0) {
                 throw "No DMS instance found with route context schoolYear=$(Format-LogSafeText $year) for tenant '$(Format-LogSafeText $Tenant)'."
             }
 
-            if ($matches.Count -gt 1) {
-                $ids = ($matches | ForEach-Object { Get-ProvisionProperty -Object $_ -Names @("id", "Id") }) -join ", "
+            if ($matchedInstances.Count -gt 1) {
+                $ids = ($matchedInstances | ForEach-Object { Get-ProvisionProperty -Object $_ -Names @("id", "Id") }) -join ", "
                 throw "Multiple DMS instances found with route context schoolYear=$(Format-LogSafeText $year) (instance ids: $(Format-LogSafeText $ids)). Clean up duplicate CMS state before provisioning."
             }
 
-            $null = $selected.Add($matches[0])
+            $null = $selected.Add($matchedInstances[0])
         }
 
         return @($selected)
@@ -464,6 +467,7 @@ function Resolve-ProvisionTargetInstances {
 }
 
 function New-ProvisionTarget {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Builds an in-memory provisioning target object; no system state changes and no -WhatIf surface.')]
     param(
         $Instance,
 
@@ -627,7 +631,7 @@ function Get-ProvisionCmsReadOnlyAccessGuidance {
     .SYNOPSIS
     Produces optional CMSReadOnlyAccess guidance lines for IDE-hosted launch. Returns an empty
     array when none of the three CONFIG_SERVICE_CLIENT_* keys are explicitly present in the
-    env file. Per command-boundaries.md §3.4, "may include" means "include when actually
+    env file. Per command-boundaries.md Section 3.4, "may include" means "include when actually
     populated"; a default-derived client id alone does not satisfy that contract.
     #>
     param(
@@ -712,7 +716,7 @@ function Invoke-ProvisionDmsSchema {
     $schemaPaths = [string[]]@($schemaWorkspace.CoreSchemaPath) + [string[]]@($schemaWorkspace.ExtensionSchemaPaths)
     Write-Information "Schema workspace ready. Core schema: $(Format-LogSafeText $schemaWorkspace.CoreSchemaPath). Extensions: $($schemaWorkspace.ExtensionSchemaPaths.Count)." -InformationAction Continue
 
-    # DMS-1151: bootstrap admin token acquisition. Per command-boundaries.md §3.4/§3.5,
+    # DMS-1151: bootstrap admin token acquisition. Per command-boundaries.md Section 3.4/Section 3.5,
     # configure-local-dms-instance.ps1 owns the /connect/register side effect for the bootstrap
     # admin client; this phase is auth-consumer only. Client id/secret are resolved through the
     # shared -EnvironmentFile helper so configure and provision always agree on the admin client

--- a/eng/docker-compose/provision-dms-schema.ps1
+++ b/eng/docker-compose/provision-dms-schema.ps1
@@ -5,6 +5,20 @@
 
 #Requires -Version 7
 
+<#
+.SYNOPSIS
+    DMS-1151 schema provisioning phase (PostgreSQL-only).
+.DESCRIPTION
+    Invokes SchemaTools against each distinct effective target database from the
+    selected CMS instances. Hard-codes --dialect pgsql; MSSQL keysets are rejected
+    by Resolve-TargetDialect with an actionable error. MSSQL targets are out of
+    scope for DMS-1151; revisit if/when the bootstrap epic adds MSSQL support in
+    a successor story.
+
+    See command-boundaries.md Section 3.5 for the phase contract and
+    01-schema-deployment-safety.md for the DMS-1151 story.
+#>
+
 [CmdletBinding()]
 param(
     [string]$EnvironmentFile,
@@ -20,9 +34,6 @@ Import-Module "$PSScriptRoot/bootstrap-schema-tool.psm1" -Force -Global
 Import-Module "$PSScriptRoot/bootstrap-schema-workspace.psm1" -Force -Global
 Import-Module "$PSScriptRoot/env-utility.psm1" -Force -Global
 Import-Module "$PSScriptRoot/../Dms-Management.psm1" -Force
-
-$script:BootstrapDmsInstanceClientId = "dms-instance-admin"
-$script:BootstrapDmsInstanceClientSecret = "ValidClientSecret1234567890!Abcd"
 
 if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
     function Format-LogSafeText {
@@ -53,20 +64,7 @@ function Resolve-ProvisionEnvironmentFile {
         $Path
     )
 
-    if ([string]::IsNullOrWhiteSpace($Path)) {
-        $defaultEnv = Join-Path $PSScriptRoot ".env"
-        $fallbackEnv = Join-Path $PSScriptRoot ".env.example"
-        $Path = if (Test-Path -LiteralPath $defaultEnv) { $defaultEnv } else { $fallbackEnv }
-    }
-    elseif (-not [System.IO.Path]::IsPathRooted($Path)) {
-        $Path = [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
-    }
-
-    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
-        throw "Environment file not found: $(Format-LogSafeText $Path)."
-    }
-
-    return [System.IO.Path]::GetFullPath($Path)
+    return Resolve-LocalSettingsEnvironmentFile -Path $Path -DockerComposeRoot $PSScriptRoot
 }
 
 function Get-EnvValueOrDefault {
@@ -81,11 +79,7 @@ function Get-EnvValueOrDefault {
         $DefaultValue = ""
     )
 
-    if ($EnvValues.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$Name])) {
-        return [string]$EnvValues[$Name]
-    }
-
-    return $DefaultValue
+    return Get-EnvValue -EnvValues $EnvValues -Name $Name -DefaultValue $DefaultValue
 }
 
 function Get-ProvisionProperty {
@@ -144,7 +138,7 @@ function Resolve-EnvPlaceholdersInText {
 
             $name = $match.Groups["Name"].Value
             if (-not $EnvValues.ContainsKey($name)) {
-                throw "Connection string references env value '$name', but that key is absent from the environment file."
+                throw "Connection string references env value '$(Format-LogSafeText $name)', but that key is absent from the environment file."
             }
 
             return [string]$EnvValues[$name]
@@ -198,6 +192,120 @@ function Get-DatabaseNameFromConnectionString {
     throw "CMS DMS instance connection string did not contain a database name."
 }
 
+function Resolve-TargetDialect {
+    param(
+        [hashtable]
+        $ConnectionStringParts
+    )
+
+    # DMS-916 / DMS-1151 currently provisions only PostgreSQL. Reject MSSQL-style key sets
+    # early so an inadvertent provider mismatch surfaces with an actionable error rather
+    # than a cryptic SchemaTools failure.
+    $mssqlMarkers = @("server", "initial catalog", "user id", "trusted_connection")
+    foreach ($marker in $mssqlMarkers) {
+        if ($ConnectionStringParts.ContainsKey($marker)) {
+            throw "CMS DMS instance connection string uses MSSQL-style key '$(Format-LogSafeText $marker)'. Only PostgreSQL provisioning is supported."
+        }
+    }
+
+    if (-not $ConnectionStringParts.ContainsKey("host") -and -not $ConnectionStringParts.ContainsKey("server")) {
+        throw "CMS DMS instance connection string is missing a host key. Cannot determine the provisioning dialect."
+    }
+
+    return "pgsql"
+}
+
+function Convert-CmsConnectionStringToHostSideTarget {
+    <#
+    .SYNOPSIS
+    Builds an effective host-side provisioning target from a single CMS-stored DMS instance
+    connection string. Translates the Docker-internal PostgreSQL hostname/port to the host-side
+    mapped port while preserving the instance-specific username, password, and database name.
+    Non-Docker hosts (e.g. external PostgreSQL servers configured per instance) are preserved
+    as-is.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ConnectionString,
+
+        [Parameter(Mandatory)]
+        [hashtable]
+        $EnvValues
+    )
+
+    $parts = Convert-ConnectionStringToHashtable -ConnectionString $ConnectionString
+    $dialect = Resolve-TargetDialect -ConnectionStringParts $parts
+
+    $databaseName = ""
+    foreach ($key in @("database")) { # initial catalog is an MSSQL marker already rejected by Resolve-TargetDialect
+        if ($parts.ContainsKey($key) -and -not [string]::IsNullOrWhiteSpace([string]$parts[$key])) {
+            $databaseName = [string]$parts[$key]
+            break
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($databaseName)) {
+        throw "CMS DMS instance connection string did not contain a database name."
+    }
+
+    $instanceHost = if ($parts.ContainsKey("host")) { [string]$parts["host"] } else { "" }
+    # PostgreSQL canonically defaults to 5432 when port is omitted. Docker-internal targets
+    # (host=dms-postgresql) keep 5432 here and are translated to localhost:POSTGRES_PORT by
+    # the host-side translation block below.
+    $instancePort = if ($parts.ContainsKey("port") -and -not [string]::IsNullOrWhiteSpace([string]$parts["port"])) {
+        [string]$parts["port"]
+    }
+    else {
+        "5432"
+    }
+    $instanceUser = if ($parts.ContainsKey("username")) { [string]$parts["username"] }
+                    elseif ($parts.ContainsKey("user id")) { [string]$parts["user id"] }
+                    else { "" }
+    $instancePassword = if ($parts.ContainsKey("password")) { [string]$parts["password"] } else { "" }
+
+    if ([string]::IsNullOrWhiteSpace($instanceHost)) {
+        throw "CMS DMS instance connection string is missing the host key."
+    }
+    if ([string]::IsNullOrWhiteSpace($instanceUser)) {
+        throw "CMS DMS instance connection string is missing the username key."
+    }
+
+    # Translate Docker-internal PostgreSQL coordinates to host-side coordinates. Any other
+    # host (e.g. an external managed PostgreSQL server) is left untouched so per-instance
+    # routing is preserved.
+    $effectiveHost = $instanceHost
+    $effectivePort = $instancePort
+    if ($instanceHost.Equals("dms-postgresql", [System.StringComparison]::OrdinalIgnoreCase) -and
+        $instancePort -eq "5432") {
+        $effectiveHost = "localhost"
+        $effectivePort = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PORT" -DefaultValue "5432"
+    }
+
+    $hostConnectionString = "host=$effectiveHost;port=$effectivePort;username=$instanceUser;password=$instancePassword;database=$databaseName;"
+
+    # TargetKey identifies an effective provisioning target. Two instances pointing at the
+    # same physical database (same dialect, translated host, port, database, and user) share
+    # a provisioning invocation. Differing on any field — including username — produces a
+    # separate target so we never collapse instances that happen to share a database name on
+    # different hosts or under different roles.
+    $targetKey = ("{0}|{1}|{2}|{3}|{4}" -f
+        $dialect,
+        $effectiveHost.ToLowerInvariant(),
+        $effectivePort,
+        $databaseName.ToLowerInvariant(),
+        $instanceUser.ToLowerInvariant())
+
+    return [pscustomobject]@{
+        Dialect = $dialect
+        Host = $effectiveHost
+        Port = $effectivePort
+        Username = $instanceUser
+        DatabaseName = $databaseName
+        HostConnectionString = $hostConnectionString
+        TargetKey = $targetKey
+    }
+}
+
 function ConvertFrom-CmsEncryptedConnectionString {
     param(
         [string]
@@ -232,6 +340,9 @@ function ConvertFrom-CmsEncryptedConnectionString {
     [Array]::Copy($encryptedBytes, 16, $cipherText, 0, $cipherText.Length)
 
     $aes = [System.Security.Cryptography.Aes]::Create()
+    # CMS encrypts connection strings with AES-CBC / PKCS7; set explicitly rather than relying on .NET defaults.
+    $aes.Mode = [System.Security.Cryptography.CipherMode]::CBC
+    $aes.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
     try {
         $aes.Key = $keyBytes
         $aes.IV = $iv
@@ -273,21 +384,6 @@ function Resolve-CmsInstanceConnectionString {
     return Resolve-EnvPlaceholdersInText -Text $decryptedConnectionString -EnvValues $EnvValues
 }
 
-function New-HostSidePostgresConnectionString {
-    param(
-        [hashtable]
-        $EnvValues,
-
-        [string]
-        $DatabaseName
-    )
-
-    $port = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PORT" -DefaultValue "5432"
-    $user = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_USER" -DefaultValue "postgres"
-    $password = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PASSWORD"
-
-    return "host=localhost;port=$port;username=$user;password=$password;database=$DatabaseName;"
-}
 
 function Resolve-ProvisionTargetInstances {
     param(
@@ -375,7 +471,11 @@ function New-ProvisionTarget {
         $EnvValues
     )
 
-    $instanceId = [long](Get-ProvisionProperty -Object $Instance -Names @("id", "Id"))
+    $rawInstanceId = Get-ProvisionProperty -Object $Instance -Names @("id", "Id")
+    if ($null -eq $rawInstanceId) {
+        throw "CMS DMS instance is missing an id."
+    }
+    $instanceId = [long]$rawInstanceId
     $connectionString = [string](Get-ProvisionProperty -Object $Instance -Names @("connectionString", "ConnectionString"))
     if ([string]::IsNullOrWhiteSpace($connectionString)) {
         throw "CMS DMS instance $(Format-LogSafeText $instanceId) does not include a connection string."
@@ -384,7 +484,9 @@ function New-ProvisionTarget {
     $resolvedConnectionString = Resolve-CmsInstanceConnectionString `
         -ConnectionString $connectionString `
         -EnvValues $EnvValues
-    $databaseName = Get-DatabaseNameFromConnectionString -ConnectionString $resolvedConnectionString
+    $target = Convert-CmsConnectionStringToHostSideTarget `
+        -ConnectionString $resolvedConnectionString `
+        -EnvValues $EnvValues
     $routeContexts = @(
         Get-ProvisionRouteContexts -Instance $Instance | ForEach-Object {
             [pscustomobject]@{
@@ -397,9 +499,13 @@ function New-ProvisionTarget {
     return [pscustomobject]@{
         InstanceId = $instanceId
         RouteContexts = $routeContexts
-        DatabaseName = $databaseName
-        NormalizedDatabaseName = $databaseName.ToLowerInvariant()
-        HostConnectionString = New-HostSidePostgresConnectionString -EnvValues $EnvValues -DatabaseName $databaseName
+        Dialect = $target.Dialect
+        Host = $target.Host
+        Port = $target.Port
+        Username = $target.Username
+        DatabaseName = $target.DatabaseName
+        HostConnectionString = $target.HostConnectionString
+        TargetKey = $target.TargetKey
     }
 }
 
@@ -444,6 +550,143 @@ function Invoke-DmsSchemaProvision {
     }
 }
 
+function Get-ProvisionIdeGuidance {
+    <#
+    .SYNOPSIS
+    Builds the IDE next-step guidance block emitted by provision-dms-schema.ps1 after a
+    successful pre-start provisioning. Returns a list of guidance lines. Pure / side-effect-
+    free so the guidance can be exercised in tests independently of console formatting.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        $SchemaWorkspace,
+
+        [object[]]
+        $ProvisionedTargets = @()
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("--- Schema Provisioning Summary ---")
+
+    if ($ProvisionedTargets.Count -eq 0) {
+        $lines.Add("No DMS instance targets were provisioned (selectors matched zero instances).")
+    }
+    else {
+        $lines.Add("Provisioned $($ProvisionedTargets.Count) database target(s):")
+        foreach ($target in $ProvisionedTargets) {
+            $instanceList = ($target.InstanceIds | ForEach-Object { [string]$_ }) -join ", "
+            $lines.Add("  - database=$(Format-LogSafeText $target.DatabaseName) host=$(Format-LogSafeText $target.Host) port=$(Format-LogSafeText $target.Port) user=$(Format-LogSafeText $target.Username) instance-ids=[$instanceList] status=$($target.Status)")
+        }
+    }
+
+    $lines.Add("")
+    $lines.Add("--- IDE next-step guidance ---")
+    $lines.Add("Staged schema workspace: $(Format-LogSafeText $SchemaWorkspace.BootstrapManifestPath)")
+    $lines.Add("  ApiSchema manifest:    $(Format-LogSafeText $SchemaWorkspace.ApiSchemaManifestPath)")
+    if ($SchemaWorkspace.EffectiveSchemaHash) {
+        $lines.Add("  Effective schema hash: $(Format-LogSafeText $SchemaWorkspace.EffectiveSchemaHash)")
+    }
+    $lines.Add("")
+    $lines.Add("Expected DMS runtime appsettings for IDE-hosted launch (activation deferred to Story 04 - DMS-1154):")
+    $apiSchemaRoot = [System.IO.Path]::GetDirectoryName($SchemaWorkspace.ApiSchemaManifestPath)
+    $lines.Add("  AppSettings__UseApiSchemaPath = true")
+    $lines.Add("  AppSettings__ApiSchemaPath    = $(Format-LogSafeText $apiSchemaRoot)")
+    $lines.Add("Note: bootstrap does not flip these flags. Story 04 owns enabling staged-schema runtime loading;")
+    $lines.Add("      until then DMS containers and IDE launches keep using the DLL-backed schema assemblies.")
+
+    return $lines.ToArray()
+}
+
+function Test-CmsReadOnlyAccessEnvPresent {
+    <#
+    .SYNOPSIS
+    Returns $true when the env file explicitly supplies at least one of the three
+    CONFIG_SERVICE_CLIENT_* keys with a non-blank value. Used to gate the optional
+    CMSReadOnlyAccess guidance so defaults alone do not advertise the block as available.
+    #>
+    param(
+        [hashtable]
+        $EnvValues
+    )
+
+    if ($null -eq $EnvValues) {
+        return $false
+    }
+
+    foreach ($name in @("CONFIG_SERVICE_CLIENT_ID", "CONFIG_SERVICE_CLIENT_SCOPE", "CONFIG_SERVICE_CLIENT_SECRET")) {
+        if ($EnvValues.ContainsKey($name) -and -not [string]::IsNullOrWhiteSpace([string]$EnvValues[$name])) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Get-ProvisionCmsReadOnlyAccessGuidance {
+    <#
+    .SYNOPSIS
+    Produces optional CMSReadOnlyAccess guidance lines for IDE-hosted launch. Returns an empty
+    array when none of the three CONFIG_SERVICE_CLIENT_* keys are explicitly present in the
+    env file. Per command-boundaries.md §3.4, "may include" means "include when actually
+    populated"; a default-derived client id alone does not satisfy that contract.
+    #>
+    param(
+        [hashtable]
+        $EnvValues
+    )
+
+    if (-not (Test-CmsReadOnlyAccessEnvPresent -EnvValues $EnvValues)) {
+        return @()
+    }
+
+    $clientId = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_ID" -DefaultValue "CMSReadOnlyAccess"
+    $scope = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_SCOPE" -DefaultValue "edfi_admin_api/readonly_access"
+    $secret = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "CONFIG_SERVICE_CLIENT_SECRET"
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("")
+    $lines.Add("Configuration Service read-only access (configured by start-local-dms.ps1's identity setup):")
+    $lines.Add("  ConfigurationServiceSettings__ClientId = $(Format-LogSafeText $clientId)")
+    $lines.Add("  ConfigurationServiceSettings__Scope    = $(Format-LogSafeText $scope)")
+    if ([string]::IsNullOrWhiteSpace($secret)) {
+        $lines.Add("  ConfigurationServiceSettings__ClientSecret = (set in your IDE/env; not staged by provisioning)")
+    }
+    else {
+        $lines.Add("  ConfigurationServiceSettings__ClientSecret = (present in environment file)")
+    }
+
+    return $lines.ToArray()
+}
+
+function Write-ProvisionSummary {
+    <#
+    .SYNOPSIS
+    Writes the post-provisioning summary and the IDE next-step guidance derived from the
+    staged schema workspace and the targets just provisioned. The Story 04 dependency is
+    surfaced explicitly so operators don't assume the staged path is the active runtime path.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable]
+        $EnvValues,
+
+        [Parameter(Mandatory)]
+        $SchemaWorkspace,
+
+        [object[]]
+        $ProvisionedTargets = @()
+    )
+
+    $guidance = Get-ProvisionIdeGuidance -SchemaWorkspace $SchemaWorkspace -ProvisionedTargets $ProvisionedTargets
+    foreach ($line in $guidance) {
+        Write-Information $line -InformationAction Continue
+    }
+
+    foreach ($line in Get-ProvisionCmsReadOnlyAccessGuidance -EnvValues $EnvValues) {
+        Write-Information $line -InformationAction Continue
+    }
+}
+
 function Invoke-ProvisionDmsSchema {
     param(
         [string]
@@ -469,18 +712,30 @@ function Invoke-ProvisionDmsSchema {
     $schemaPaths = [string[]]@($schemaWorkspace.CoreSchemaPath) + [string[]]@($schemaWorkspace.ExtensionSchemaPaths)
     Write-Information "Schema workspace ready. Core schema: $(Format-LogSafeText $schemaWorkspace.CoreSchemaPath). Extensions: $($schemaWorkspace.ExtensionSchemaPaths.Count)." -InformationAction Continue
 
-    Add-CmsClient `
-        -CmsUrl $cmsUrl `
-        -ClientId $script:BootstrapDmsInstanceClientId `
-        -ClientSecret $script:BootstrapDmsInstanceClientSecret `
-        -DisplayName "DMS Instance Setup Administrator"
+    # DMS-1151: bootstrap admin token acquisition. Per command-boundaries.md §3.4/§3.5,
+    # configure-local-dms-instance.ps1 owns the /connect/register side effect for the bootstrap
+    # admin client; this phase is auth-consumer only. Client id/secret are resolved through the
+    # shared -EnvironmentFile helper so configure and provision always agree on the admin client
+    # (DMS_BOOTSTRAP_ADMIN_CLIENT_ID / DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET). If authentication
+    # fails, surface an actionable error rather than silently re-registering against a CMS
+    # environment where /connect/register may be locked down.
+    $bootstrapAdmin = Resolve-BootstrapAdminClient -EnvValues $envValues
+    try
+    {
+        $configToken = Get-CmsToken `
+            -CmsUrl $cmsUrl `
+            -ClientId $bootstrapAdmin.ClientId `
+            -ClientSecret $bootstrapAdmin.ClientSecret
+    }
+    catch
+    {
+        throw "Bootstrap admin client '$(Format-LogSafeText $bootstrapAdmin.ClientId)' could not be authenticated against $(Format-LogSafeText $cmsUrl). Run configure-local-dms-instance.ps1 first to register the bootstrap admin client, or refresh its credentials. Underlying error: $(Format-LogSafeText ($_.Exception.Message))"
+    }
 
-    $configToken = Get-CmsToken `
-        -CmsUrl $cmsUrl `
-        -ClientId $script:BootstrapDmsInstanceClientId `
-        -ClientSecret $script:BootstrapDmsInstanceClientSecret
-
-    $instances = @(Get-DmsInstances -CmsUrl $cmsUrl -AccessToken $configToken -Tenant $tenant)
+    $instances = @(Get-DmsInstances -CmsUrl $cmsUrl -AccessToken $configToken -Tenant $tenant -Limit 500)
+    if ($instances.Count -ge 500) {
+        throw "DMS instance count reached the CMS query page size (500); pagination is not implemented in this bootstrap provisioning path. Reduce CMS instances or implement paging before provisioning."
+    }
     $selectedInstances = Resolve-ProvisionTargetInstances `
         -Instances $instances `
         -InstanceId $InstanceId `
@@ -488,20 +743,41 @@ function Invoke-ProvisionDmsSchema {
         -Tenant $tenant
 
     $targets = @($selectedInstances | ForEach-Object { New-ProvisionTarget -Instance $_ -EnvValues $envValues })
-    $groups = $targets | Group-Object -Property NormalizedDatabaseName
+    # Group by the effective provisioning target identity (dialect + translated host + port +
+    # database + user). Grouping only by database name would silently collapse two instances
+    # that share a database name on different physical hosts or under different users.
+    $groups = $targets | Group-Object -Property TargetKey
     $schemaTool = Resolve-DmsSchemaTool -RequestedPath $env:DMS_SCHEMA_TOOL_PATH
     Write-Information "dms-schema resolved: $(Format-LogSafeText $schemaTool)." -InformationAction Continue
 
+    $provisionedTargets = [System.Collections.ArrayList]::new()
+
     foreach ($group in $groups) {
         $target = @($group.Group)[0]
-        $ids = ($group.Group | ForEach-Object { $_.InstanceId }) -join ", "
-        Write-Information "Provisioning target database $(Format-LogSafeText $target.DatabaseName) for instance id(s): $(Format-LogSafeText $ids)." -InformationAction Continue
+        $instanceIds = @($group.Group | ForEach-Object { [long]$_.InstanceId })
+        $ids = ($instanceIds | ForEach-Object { [string]$_ }) -join ", "
+        Write-Information "Provisioning target database $(Format-LogSafeText $target.DatabaseName) on $(Format-LogSafeText $target.Host):$(Format-LogSafeText $target.Port) for instance id(s): $(Format-LogSafeText $ids)." -InformationAction Continue
         Invoke-DmsSchemaProvision `
             -ToolPath $schemaTool `
             -SchemaPaths $schemaPaths `
             -ConnectionString $target.HostConnectionString `
             -DatabaseName $target.DatabaseName
+
+        $null = $provisionedTargets.Add([pscustomobject]@{
+            DatabaseName = $target.DatabaseName
+            Host = $target.Host
+            Port = $target.Port
+            Dialect = $target.Dialect
+            Username = $target.Username
+            InstanceIds = [long[]]$instanceIds
+            Status = "Provisioned"
+        })
     }
+
+    Write-ProvisionSummary `
+        -EnvValues $envValues `
+        -SchemaWorkspace $schemaWorkspace `
+        -ProvisionedTargets @($provisionedTargets)
 }
 
 if ($MyInvocation.InvocationName -eq '.') { return }

--- a/eng/docker-compose/provision-dms-schema.ps1
+++ b/eng/docker-compose/provision-dms-schema.ps1
@@ -58,6 +58,23 @@ if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
     }
 }
 
+if (-not (Get-Command Format-LogSafePath -ErrorAction SilentlyContinue)) {
+    function Format-LogSafePath {
+        param($Value)
+
+        if ($null -eq $Value) { return "" }
+        $text = [string]$Value
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray()) {
+            if (-not [char]::IsControl($character)) {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
 function Resolve-ProvisionEnvironmentFile {
     param(
         [string]
@@ -148,27 +165,89 @@ function Resolve-EnvPlaceholdersInText {
     )
 }
 
-function Convert-ConnectionStringToHashtable {
+function ConvertTo-ConnectionStringBuilder {
+    <#
+    .SYNOPSIS
+    Parses a connection string into a [System.Data.Common.DbConnectionStringBuilder]. Unlike a
+    naive ';' split, this correctly handles quoted values that themselves contain ';' or '=' (for
+    example password="abc;123"). Returns $null instead of throwing when -AllowParseFailure is set
+    and the input is not a valid connection string (used to detect CMS-encrypted base64 blobs).
+
+    Callers must use the explicit get_/set_ accessors on the returned builder: PowerShell's
+    property/indexer sugar (.ConnectionString, ['key'], .Keys) misbehaves on this
+    IDictionary-implementing type and silently fails to parse.
+    #>
     param(
         [string]
-        $ConnectionString
+        $ConnectionString,
+
+        [switch]
+        $AllowParseFailure
     )
 
-    $values = @{}
-    foreach ($segment in @($ConnectionString -split ";")) {
-        if ([string]::IsNullOrWhiteSpace($segment)) {
-            continue
+    $builder = [System.Data.Common.DbConnectionStringBuilder]::new()
+    try {
+        $builder.set_ConnectionString($ConnectionString)
+    }
+    catch {
+        if ($AllowParseFailure) {
+            return $null
         }
 
-        $parts = $segment.Split("=", 2)
-        if ($parts.Length -ne 2) {
-            continue
-        }
-
-        $values[$parts[0].Trim().ToLowerInvariant()] = $parts[1].Trim()
+        throw "CMS DMS instance connection string is not a valid connection string."
     }
 
-    return $values
+    return $builder
+}
+
+function Get-ConnectionStringValue {
+    <#
+    .SYNOPSIS
+    Returns the first non-empty value among the supplied case-insensitive keys, or $null when none
+    is present. Used instead of direct indexer access because PowerShell's ['key'] sugar misbehaves
+    on DbConnectionStringBuilder.
+    #>
+    param(
+        [System.Data.Common.DbConnectionStringBuilder]
+        $Builder,
+
+        [string[]]
+        $Keys
+    )
+
+    foreach ($key in $Keys) {
+        if ($Builder.ContainsKey($key)) {
+            $value = [string]$Builder.get_Item($key)
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+                return $value
+            }
+        }
+    }
+
+    return $null
+}
+
+function Set-ConnectionStringValue {
+    <#
+    .SYNOPSIS
+    Updates or adds a value on the builder via set_Item: it overwrites the key when present or adds it
+    when absent, so host/port can be mutated without duplicating keys or disturbing any other stored
+    option. Unrelated options and their values are preserved; the emitted keyword casing is whatever the
+    builder normalizes it to.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Mutates an in-memory builder object; no system state changes and no -WhatIf surface.')]
+    param(
+        [System.Data.Common.DbConnectionStringBuilder]
+        $Builder,
+
+        [string]
+        $Key,
+
+        [string]
+        $Value
+    )
+
+    $Builder.set_Item($Key, $Value)
 }
 
 function Get-DatabaseNameFromConnectionString {
@@ -180,10 +259,14 @@ function Get-DatabaseNameFromConnectionString {
         $AllowMissing
     )
 
-    $parts = Convert-ConnectionStringToHashtable -ConnectionString $ConnectionString
-    foreach ($key in @("database", "initial catalog")) {
-        if ($parts.ContainsKey($key) -and -not [string]::IsNullOrWhiteSpace([string]$parts[$key])) {
-            return [string]$parts[$key]
+    # AllowParseFailure: a CMS-encrypted connection string is an opaque base64 blob that is not a
+    # valid connection string. Treat an unparseable value as "no database name" so the caller falls
+    # through to the decryption path rather than throwing here.
+    $builder = ConvertTo-ConnectionStringBuilder -ConnectionString $ConnectionString -AllowParseFailure
+    if ($null -ne $builder) {
+        $databaseName = Get-ConnectionStringValue -Builder $builder -Keys @("database", "initial catalog")
+        if (-not [string]::IsNullOrWhiteSpace($databaseName)) {
+            return $databaseName
         }
     }
 
@@ -196,8 +279,8 @@ function Get-DatabaseNameFromConnectionString {
 
 function Resolve-TargetDialect {
     param(
-        [hashtable]
-        $ConnectionStringParts
+        [System.Data.Common.DbConnectionStringBuilder]
+        $Builder
     )
 
     # DMS-916 / DMS-1151 currently provisions only PostgreSQL. Reject MSSQL-style key sets
@@ -205,12 +288,12 @@ function Resolve-TargetDialect {
     # than a cryptic SchemaTools failure.
     $mssqlMarkers = @("server", "initial catalog", "user id", "trusted_connection")
     foreach ($marker in $mssqlMarkers) {
-        if ($ConnectionStringParts.ContainsKey($marker)) {
+        if ($Builder.ContainsKey($marker)) {
             throw "CMS DMS instance connection string uses MSSQL-style key '$(Format-LogSafeText $marker)'. Only PostgreSQL provisioning is supported."
         }
     }
 
-    if (-not $ConnectionStringParts.ContainsKey("host") -and -not $ConnectionStringParts.ContainsKey("server")) {
+    if (-not $Builder.ContainsKey("host") -and -not $Builder.ContainsKey("server")) {
         throw "CMS DMS instance connection string is missing a host key. Cannot determine the provisioning dialect."
     }
 
@@ -236,41 +319,31 @@ function Convert-CmsConnectionStringToHostSideTarget {
         $EnvValues
     )
 
-    $parts = Convert-ConnectionStringToHashtable -ConnectionString $ConnectionString
-    $dialect = Resolve-TargetDialect -ConnectionStringParts $parts
+    $builder = ConvertTo-ConnectionStringBuilder -ConnectionString $ConnectionString
+    $dialect = Resolve-TargetDialect -Builder $builder
 
-    $databaseName = ""
-    foreach ($key in @("database")) { # initial catalog is an MSSQL marker already rejected by Resolve-TargetDialect
-        if ($parts.ContainsKey($key) -and -not [string]::IsNullOrWhiteSpace([string]$parts[$key])) {
-            $databaseName = [string]$parts[$key]
-            break
-        }
-    }
+    # initial catalog is an MSSQL marker already rejected by Resolve-TargetDialect, so the
+    # surviving PostgreSQL keys are database / host / username.
+    $databaseName = Get-ConnectionStringValue -Builder $builder -Keys @("database")
     if ([string]::IsNullOrWhiteSpace($databaseName)) {
         throw "CMS DMS instance connection string did not contain a database name."
     }
 
-    $instanceHost = if ($parts.ContainsKey("host")) { [string]$parts["host"] } else { "" }
-    # PostgreSQL canonically defaults to 5432 when port is omitted. Docker-internal targets
-    # (host=dms-postgresql) keep 5432 here and are translated to localhost:POSTGRES_PORT by
-    # the host-side translation block below.
-    $instancePort = if ($parts.ContainsKey("port") -and -not [string]::IsNullOrWhiteSpace([string]$parts["port"])) {
-        [string]$parts["port"]
-    }
-    else {
-        "5432"
-    }
-    $instanceUser = if ($parts.ContainsKey("username")) { [string]$parts["username"] }
-                    elseif ($parts.ContainsKey("user id")) { [string]$parts["user id"] }
-                    else { "" }
-    $instancePassword = if ($parts.ContainsKey("password")) { [string]$parts["password"] } else { "" }
-
+    $instanceHost = Get-ConnectionStringValue -Builder $builder -Keys @("host")
     if ([string]::IsNullOrWhiteSpace($instanceHost)) {
         throw "CMS DMS instance connection string is missing the host key."
     }
+
+    $instanceUser = Get-ConnectionStringValue -Builder $builder -Keys @("username")
     if ([string]::IsNullOrWhiteSpace($instanceUser)) {
         throw "CMS DMS instance connection string is missing the username key."
     }
+
+    # PostgreSQL canonically defaults to 5432 when port is omitted. Docker-internal targets
+    # (host=dms-postgresql) keep 5432 here and are translated to localhost:POSTGRES_PORT by
+    # the host-side translation block below.
+    $portValue = Get-ConnectionStringValue -Builder $builder -Keys @("port")
+    $instancePort = if (-not [string]::IsNullOrWhiteSpace($portValue)) { $portValue } else { "5432" }
 
     # Translate Docker-internal PostgreSQL coordinates to host-side coordinates. Any other
     # host (e.g. an external managed PostgreSQL server) is left untouched so per-instance
@@ -283,7 +356,15 @@ function Convert-CmsConnectionStringToHostSideTarget {
         $effectivePort = Get-EnvValueOrDefault -EnvValues $EnvValues -Name "POSTGRES_PORT" -DefaultValue "5432"
     }
 
-    $hostConnectionString = "host=$effectiveHost;port=$effectivePort;username=$instanceUser;password=$instancePassword;database=$databaseName;"
+    # Mutate only host and port. Every other option the CMS stored (SSL Mode, Trust Server
+    # Certificate, Timeout, Pooling, a password containing ';' or '=', etc.) is carried through
+    # verbatim by the builder, which also re-quotes values correctly. Setting port also adds it
+    # when the source omitted one, so the provisioning target always carries an explicit,
+    # reachable port (5432 for an external host, or the host-side mapped POSTGRES_PORT).
+    Set-ConnectionStringValue -Builder $builder -Key "host" -Value $effectiveHost
+    Set-ConnectionStringValue -Builder $builder -Key "port" -Value $effectivePort
+
+    $hostConnectionString = $builder.get_ConnectionString()
 
     # TargetKey identifies an effective provisioning target. Two instances pointing at the
     # same physical database (same dialect, translated host, port, database, and user) share
@@ -585,8 +666,8 @@ function Get-ProvisionIdeGuidance {
 
     $lines.Add("")
     $lines.Add("--- IDE next-step guidance ---")
-    $lines.Add("Bootstrap manifest:      $(Format-LogSafeText $SchemaWorkspace.BootstrapManifestPath)")
-    $lines.Add("  ApiSchema manifest:    $(Format-LogSafeText $SchemaWorkspace.ApiSchemaManifestPath)")
+    $lines.Add("Bootstrap manifest:      $(Format-LogSafePath $SchemaWorkspace.BootstrapManifestPath)")
+    $lines.Add("  ApiSchema manifest:    $(Format-LogSafePath $SchemaWorkspace.ApiSchemaManifestPath)")
     if ($SchemaWorkspace.EffectiveSchemaHash) {
         $lines.Add("  Effective schema hash: $(Format-LogSafeText $SchemaWorkspace.EffectiveSchemaHash)")
     }
@@ -594,7 +675,7 @@ function Get-ProvisionIdeGuidance {
     $lines.Add("Expected DMS runtime appsettings for IDE-hosted launch (activation deferred to Story 04 - DMS-1154):")
     $apiSchemaRoot = [System.IO.Path]::GetDirectoryName($SchemaWorkspace.ApiSchemaManifestPath)
     $lines.Add("  AppSettings__UseApiSchemaPath = true")
-    $lines.Add("  AppSettings__ApiSchemaPath    = $(Format-LogSafeText $apiSchemaRoot)")
+    $lines.Add("  AppSettings__ApiSchemaPath    = $(Format-LogSafePath $apiSchemaRoot)")
     $lines.Add("Note: bootstrap does not flip these flags. Story 04 owns enabling staged-schema runtime loading;")
     $lines.Add("      until then DMS containers and IDE launches keep using the DLL-backed schema assemblies.")
 

--- a/eng/docker-compose/published-dms.yml
+++ b/eng/docker-compose/published-dms.yml
@@ -9,7 +9,9 @@ services:
     environment:
       ASPNETCORE_HTTP_PORTS: ${DMS_HTTP_PORTS:-8080}
       AppSettings__AuthenticationService: ${OAUTH_TOKEN_ENDPOINT:-http://host.docker.internal:8080/oauth/token}
-      NEED_DATABASE_SETUP: ${NEED_DATABASE_SETUP:-true}
+      # Schema provisioning is owned by provision-dms-schema.ps1 per the DMS-916 bootstrap design;
+      # leaving NEED_DATABASE_SETUP unset disables the legacy Backend.Installer entrypoint.
+      NEED_DATABASE_SETUP: ${NEED_DATABASE_SETUP:-false}
       AppSettings__DeployDatabaseOnStartup: ${DMS_DEPLOY_DATABASE_ON_STARTUP:-false}
       AppSettings__UseRelationalBackend: ${USE_RELATIONAL_BACKEND:-false}
       AppSettings__BypassStringTypeCoercion: ${BYPASS_STRING_COERCION:-false}

--- a/eng/docker-compose/setup-connectors.ps1
+++ b/eng/docker-compose/setup-connectors.ps1
@@ -1,3 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+.SYNOPSIS
+    Registers the Debezium PostgreSQL source connector and verifies it reaches RUNNING.
+.DESCRIPTION
+    This runs after schema provisioning and DMS startup. The source connector snapshots
+    dms.document on registration, so it must not be registered before those tables exist.
+    Registration failures throw, and the connector plus all of its tasks must report the
+    RUNNING state before the script returns, so a broken connector is no longer reported
+    as success.
+#>
 
 [CmdletBinding()]
 param (
@@ -6,23 +21,151 @@ param (
     $EnvironmentFile = "./.env"
 )
 
-function IsReady([string] $Url) {
-    $maxAttempts = 6
-    $attempt = 0
-    $waitTime = 5
-    while ($attempt -lt $maxAttempts) {
-        try {
-            Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 5
-            return $true;
-        }
-        catch {
-            Write-Output $_.Exception.Message
-            Start-Sleep -Seconds $waitTime
-            $attempt++
+$ErrorActionPreference = "Stop"
+
+function Format-LogSafeText {
+    <#
+    .SYNOPSIS
+    Sanitizes a value for safe inclusion in log output (whitelist of letters, digits, and safe punctuation).
+    #>
+    param($Value)
+
+    if ($null -eq $Value) {
+        return ""
+    }
+
+    $text = [string]$Value
+    $builder = [System.Text.StringBuilder]::new()
+    foreach ($character in $text.ToCharArray()) {
+        if ([char]::IsLetterOrDigit($character) -or
+            $character -eq " " -or
+            $character -eq "_" -or
+            $character -eq "-" -or
+            $character -eq "." -or
+            $character -eq ":" -or
+            $character -eq "/" -or
+            $character -eq ",") {
+            $null = $builder.Append($character)
         }
     }
-    return $false;
+
+    return $builder.ToString()
 }
+
+function Wait-ConnectEndpointReady {
+    param(
+        [string]$Url,
+        [int]$MaxAttempts = 12,
+        [int]$DelaySeconds = 5
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            Invoke-RestMethod -Uri $Url -Method Get -TimeoutSec 5 | Out-Null
+            return $true
+        }
+        catch {
+            Write-Output "Kafka Connect REST API not ready (attempt $attempt/$MaxAttempts): $(Format-LogSafeText $_.Exception.Message)"
+            Start-Sleep -Seconds $DelaySeconds
+        }
+    }
+
+    return $false
+}
+
+function Wait-ConnectorRunning {
+    param(
+        [string]$StatusUrl,
+        [string]$ConnectorName,
+        [int]$MaxAttempts = 24,
+        [int]$DelaySeconds = 5
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        $status = $null
+        try {
+            $status = Invoke-RestMethod -Uri $StatusUrl -Method Get -TimeoutSec 5 -SkipHttpErrorCheck
+        }
+        catch {
+            Write-Output "Unable to read connector status (attempt $attempt/$MaxAttempts): $(Format-LogSafeText $_.Exception.Message)"
+            Start-Sleep -Seconds $DelaySeconds
+            continue
+        }
+
+        $connectorState = [string]$status.connector.state
+        $taskStates = @($status.tasks | ForEach-Object { [string]$_.state })
+
+        # Fail fast on a FAILED connector or task: the trace is only available here and would
+        # otherwise be lost, leaving the stack up but silently not streaming changes.
+        if ($connectorState -eq "FAILED") {
+            throw "Connector '$(Format-LogSafeText $ConnectorName)' entered the FAILED state. $(Format-LogSafeText $status.connector.trace)"
+        }
+
+        $failedTask = $status.tasks | Where-Object { $_.state -eq "FAILED" } | Select-Object -First 1
+        if ($null -ne $failedTask) {
+            throw "Connector '$(Format-LogSafeText $ConnectorName)' has a FAILED task. $(Format-LogSafeText $failedTask.trace)"
+        }
+
+        $allTasksRunning = $taskStates.Count -gt 0 -and -not ($taskStates | Where-Object { $_ -ne "RUNNING" })
+        if ($connectorState -eq "RUNNING" -and $allTasksRunning) {
+            return
+        }
+
+        Write-Output "Waiting for connector '$(Format-LogSafeText $ConnectorName)' to reach RUNNING (connector=$(Format-LogSafeText $connectorState); tasks=$(Format-LogSafeText ($taskStates -join ',')))..."
+        Start-Sleep -Seconds $DelaySeconds
+    }
+
+    throw "Connector '$(Format-LogSafeText $ConnectorName)' did not reach the RUNNING state within $($MaxAttempts * $DelaySeconds) seconds."
+}
+
+function Wait-ConnectorAbsent {
+    param(
+        [string]$ConnectorUrl,
+        [string]$ConnectorName,
+        [int]$MaxAttempts = 15,
+        [int]$DelaySeconds = 2
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $ConnectorUrl -Method Get -TimeoutSec 5 -SkipHttpErrorCheck
+        }
+        catch {
+            # A transport-level failure cannot confirm removal; retry until the deadline.
+            Write-Output "Unable to confirm connector removal (attempt $attempt/$MaxAttempts): $(Format-LogSafeText $_.Exception.Message)"
+            Start-Sleep -Seconds $DelaySeconds
+            continue
+        }
+
+        if ($response.StatusCode -eq 404) {
+            return
+        }
+
+        Write-Output "Waiting for connector '$(Format-LogSafeText $ConnectorName)' deletion to settle (status $(Format-LogSafeText $response.StatusCode))..."
+        Start-Sleep -Seconds $DelaySeconds
+    }
+
+    throw "Connector '$(Format-LogSafeText $ConnectorName)' was not removed within $($MaxAttempts * $DelaySeconds) seconds; cannot register a clean replacement."
+}
+
+function New-ConnectorRequestBody {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Builds an in-memory request body string; no system state changes and no -WhatIf surface.')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', '', Justification = 'The database password is read as plaintext from the environment file and must be serialized as plaintext JSON for the Kafka Connect REST API; SecureString adds no protection across that boundary.')]
+    param(
+        [string]$TemplatePath,
+        [string]$Password
+    )
+
+    $connector = Get-Content -LiteralPath $TemplatePath -Raw | ConvertFrom-Json
+    # Set the password structurally so a value containing quotes, backslashes, or other
+    # JSON-significant characters is escaped correctly. The prior string .Replace approach
+    # produced invalid JSON for such passwords.
+    $connector.config."database.password" = $Password
+    return ($connector | ConvertTo-Json -Depth 20)
+}
+
+# Allow dot-sourcing for unit tests: only the functions above are needed in that case.
+if ($MyInvocation.InvocationName -eq '.') { return }
 
 # Read .env file
 Import-Module ./env-utility.psm1
@@ -32,36 +175,31 @@ $sourcePort = $envFile["CONNECT_SOURCE_PORT"]
 
 $sourceBase = "http://localhost:$sourcePort/connectors"
 $sourceUrl = "$sourceBase/postgresql-source"
+$statusUrl = "$sourceUrl/status"
 
-# Source connector
-if (IsReady($sourceBase)) {
-    try {
-        $sourceResponse = Invoke-RestMethod -Uri $sourceUrl -Method Get -SkipHttpErrorCheck
-
-        # only true if the response was 200
-        if ($null -ne $sourceResponse.name) {
-            Write-Output "Deleting existing source connector configuration."
-            Invoke-RestMethod -Method Delete -uri $sourceUrl
-        }
-    }
-    catch {
-        Write-Output $_.Exception.Message
-    }
-
-    try {
-        $sourceBody = Get-Content "./postgresql_connector.json"
-        $sourceBody = $sourceBody.Replace("abcdefgh1!", $envFile["POSTGRES_PASSWORD"])
-
-        Write-Output "Installing source connector configuration"
-        Invoke-RestMethod -Method Post -uri $sourceBase -ContentType "application/json" -Body $sourceBody
-    }
-    catch {
-        Write-Output $_.Exception.Message
-    }
-    Start-Sleep 2
-    Invoke-RestMethod -Method Get -uri $sourceUrl -SkipHttpErrorCheck
-}
-else {
-    Write-Output "Service at $sourceBase not available."
+if (-not (Wait-ConnectEndpointReady -Url $sourceBase)) {
+    throw "Kafka Connect REST API at $(Format-LogSafeText $sourceBase) did not become available. Connector registration cannot proceed."
 }
 
+# Replace any existing connector so the configuration below is applied cleanly.
+$existing = Invoke-RestMethod -Uri $sourceUrl -Method Get -SkipHttpErrorCheck
+if ($null -ne $existing.name) {
+    Write-Output "Deleting existing source connector configuration."
+    Invoke-RestMethod -Method Delete -Uri $sourceUrl | Out-Null
+    # DELETE is asynchronous; wait until the connector is actually gone so the POST below does
+    # not race the deletion and fail with 409 Conflict.
+    Wait-ConnectorAbsent -ConnectorUrl $sourceUrl -ConnectorName "postgresql-source"
+}
+
+$sourceBody = New-ConnectorRequestBody -TemplatePath "./postgresql_connector.json" -Password $envFile["POSTGRES_PASSWORD"]
+
+Write-Output "Installing source connector configuration"
+try {
+    Invoke-RestMethod -Method Post -Uri $sourceBase -ContentType "application/json" -Body $sourceBody | Out-Null
+}
+catch {
+    throw "Failed to register the PostgreSQL source connector: $(Format-LogSafeText $_.Exception.Message)"
+}
+
+Wait-ConnectorRunning -StatusUrl $statusUrl -ConnectorName "postgresql-source"
+Write-Output "Source connector 'postgresql-source' is RUNNING."

--- a/eng/docker-compose/start-all-services.ps1
+++ b/eng/docker-compose/start-all-services.ps1
@@ -38,7 +38,17 @@ if ($d) {
 else {
     Write-Output "Starting all services, without the DMS"
     docker compose $files --env-file $EnvironmentFile up -d
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to start PostgreSQL and Kafka services. Exit code $LASTEXITCODE"
+    }
 
-    Start-Sleep 20
-    ./setup-connectors.ps1 $EnvironmentFile
+    # Connector registration is intentionally deferred. The Debezium PostgreSQL source connector
+    # snapshots dms.document the moment it is registered, so registering it here - before the
+    # IDE-hosted DMS has started and deployed the schema - snapshots an empty (or missing) table and
+    # leaves the connector silently not streaming changes. This script starts only PostgreSQL and
+    # Kafka for the local-debugger workflow, so the schema does not exist yet.
+    Write-Output ""
+    Write-Output "PostgreSQL and Kafka are starting. Kafka connector registration is deferred."
+    Write-Output "After DMS is running and schema deployment is complete, register the source connector with:"
+    Write-Output "    ./setup-connectors.ps1 $EnvironmentFile"
 }

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -56,6 +56,14 @@ param (
     [string]
     $SchoolYearRange = "",
 
+    # Start only infrastructure required before schema provisioning
+    [Switch]
+    $InfraOnly,
+
+    # Start only the DMS service after external schema provisioning
+    [Switch]
+    $DmsOnly,
+
     # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
     # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
     [Switch]
@@ -92,6 +100,7 @@ Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadat
 Import-Module ./env-utility.psm1 -Force
 $envValues = ReadValuesFromEnvFile $EnvironmentFile
 $cmsUrl = Resolve-CmsBaseUrl -EnvValues $envValues
+$dmsUrl = Resolve-DockerLocalDmsBaseUrl -EnvValues $envValues
 $env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
 Write-Output "Identity Provider $IdentityProvider"
 if($IdentityProvider -eq "keycloak")
@@ -109,6 +118,18 @@ elseif ($IdentityProvider -eq "self-contained") {
 }
 
 if (-not $d) {
+    if ($InfraOnly -and $DmsOnly) {
+        throw "Parameters -InfraOnly and -DmsOnly are mutually exclusive."
+    }
+
+    if (($InfraOnly -or $DmsOnly) -and $LoadSeedData) {
+        throw "Parameter -LoadSeedData cannot be used with -InfraOnly or -DmsOnly."
+    }
+
+    if ($DmsOnly -and ($NoDmsInstance -or -not [string]::IsNullOrWhiteSpace($SchoolYearRange) -or $AddSmokeTestCredentials)) {
+        throw "Parameters -NoDmsInstance, -SchoolYearRange, and -AddSmokeTestCredentials cannot be used with -DmsOnly."
+    }
+
     if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
         throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
     }
@@ -136,7 +157,7 @@ if ($EnableKafkaUI) {
 }
 
 # Include configuration service if enabled or if using self-contained identity provider
-if ($EnableConfig -or $IdentityProvider -eq "self-contained") {
+if ($EnableConfig -or $InfraOnly -or $IdentityProvider -eq "self-contained") {
     $files += @("-f", "local-config.yml")
 }
 
@@ -173,6 +194,66 @@ else {
         }
     }
 
+    function Wait-HttpEndpointHealthy {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Url,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Name,
+
+            [int]
+            $TimeoutSeconds = 60
+        )
+
+        $deadline = [datetime]::UtcNow.AddSeconds($TimeoutSeconds)
+        while ($true) {
+            try {
+                $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 5 -ErrorAction Stop
+                if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                    return
+                }
+            }
+            catch {
+                $null = $_
+            }
+
+            if ([datetime]::UtcNow -ge $deadline) {
+                throw "$Name health check timed out after $TimeoutSeconds seconds. Endpoint: $(Format-LogSafeText $Url)"
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    if ($DmsOnly) {
+        Write-Output "Starting DMS service only with startup database provisioning disabled..."
+        $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+        $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+        $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+        try {
+            $env:NEED_DATABASE_SETUP = "false"
+            $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            $env:AppSettings__DeployDatabaseOnStartup = "false"
+            docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs dms
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+            [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+            [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to start local DMS service, with exit code $LASTEXITCODE."
+        }
+
+        Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
+        Write-Output "DMS service is healthy."
+        return
+    }
+
     if($IdentityProvider -eq "keycloak")
     {
         Write-Output "Starting Keycloak..."
@@ -197,6 +278,44 @@ else {
         throw "Failed to start Postgresql. Exit code $LASTEXITCODE"
     }
     Start-Sleep 20
+
+    if ($InfraOnly) {
+        if($IdentityProvider -eq "self-contained")
+        {
+            Write-Output "Init db public and private keys for OpenIddict..."
+            ./setup-openiddict.ps1 -InitDb -EnvironmentFile $EnvironmentFile
+        }
+
+        Write-Output "Starting Configuration Service..."
+        docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs config
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to start Configuration Service. Exit code $LASTEXITCODE"
+        }
+
+        Wait-HttpEndpointHealthy -Url "$($cmsUrl.TrimEnd('/'))/health" -Name "Configuration Service"
+        Write-Output "Configuration Service is healthy."
+
+        if($IdentityProvider -eq "self-contained")
+        {
+            Write-Output "Starting self-contained initialization script..."
+            ./setup-openiddict.ps1 -InsertData -EnvironmentFile $EnvironmentFile
+            ./setup-openiddict.ps1 -InsertData -NewClientId "CMSReadOnlyAccess" -NewClientName "CMS ReadOnly Access" -ClientScopeName "edfi_admin_api/readonly_access" -EnvironmentFile $EnvironmentFile
+            ./setup-openiddict.ps1 -InsertData -NewClientId "CMSAuthMetadataReadOnlyAccess" -NewClientName "CMS Auth Endpoints Only Access" -ClientScopeName "edfi_admin_api/authMetadata_readonly_access" -EnvironmentFile $EnvironmentFile
+        }
+
+        Write-Output "Starting Kafka connector infrastructure..."
+        docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs kafka-postgresql-source
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to start Kafka connector infrastructure. Exit code $LASTEXITCODE"
+        }
+
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+
+        Write-Output "Infrastructure phase complete. DMS service was not started."
+        return
+    }
+
     if($LoadSeedData)
     {
         Import-Module ./setup-database-template.psm1 -Force
@@ -242,9 +361,7 @@ else {
         $credentials = Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl
 
         Write-Output "Smoke test credentials created successfully!"
-        Write-Output "Key: $($credentials.Key)"
-        Write-Output "Secret: $($credentials.Secret)"
-        Write-Output "These credentials can be used for smoke testing the DMS API."
+        Write-Output "Credential values were returned to the caller and were not written to logs."
     }
 
     if(-not $NoDmsInstance -or $SchoolYearRange)

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -83,6 +83,12 @@ param (
     [Switch]
     $DmsOnly,
 
+    # Skip registering the default Debezium source connector. Used by Instance Management E2E,
+    # which provisions per-instance databases after startup and creates per-instance connectors
+    # from the tests.
+    [Switch]
+    $SkipConnectorSetup,
+
     # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
     # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
     [Switch]
@@ -276,12 +282,17 @@ else {
         Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
         Write-Output "DMS service is healthy."
 
-        # Register the Debezium source connector now that the schema has been provisioned and
-        # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
-        # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
-        # RUNNING state and throws on failure.
-        Write-Output "Running connector setup..."
-        ./setup-connectors.ps1 $EnvironmentFile
+        if (-not $SkipConnectorSetup) {
+            # Register the Debezium source connector now that the schema has been provisioned and
+            # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
+            # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
+            # RUNNING state and throws on failure.
+            Write-Output "Running connector setup..."
+            ./setup-connectors.ps1 $EnvironmentFile
+        }
+        else {
+            Write-Output "Skipping default connector setup."
+        }
 
         return
     }
@@ -419,8 +430,13 @@ else {
         # Create client with edfi_admin_api/authMetadata_readonly_access scope
         ./setup-openiddict.ps1 -InsertData -NewClientId "CMSAuthMetadataReadOnlyAccess" -NewClientName "CMS Auth Endpoints Only Access" -ClientScopeName "edfi_admin_api/authMetadata_readonly_access" -EnvironmentFile $EnvironmentFile
     }
-    Write-Output "Running connector setup..."
-    ./setup-connectors.ps1 $EnvironmentFile
+    if (-not $SkipConnectorSetup) {
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+    }
+    else {
+        Write-Output "Skipping default connector setup."
+    }
 
     if($AddSmokeTestCredentials)
     {

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -396,7 +396,7 @@ else {
     {
         Import-Module ../smoke_test/modules/SmokeTest.psm1 -Force
         Write-Output "Creating smoke test credentials..."
-        $credentials = Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl
+        $null = Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl
 
         Write-Output "Smoke test credentials created successfully!"
         Write-Output "Credential values were returned to the caller and were not written to logs."

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -14,9 +14,9 @@
 
     Direct invocation is supported for diagnostics and partial-phase orchestration
     (-InfraOnly, -DmsOnly). When invoked directly without a .bootstrap/ manifest the
-    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: schema
-    provisioning will NOT happen here. Callers are responsible for ensuring provisioning
-    has occurred (or accepting an unprovisioned DMS).
+    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: bootstrap
+    schema provisioning will NOT happen here. Legacy direct-start database provisioning
+    remains controlled by the supplied environment file's NEED_DATABASE_SETUP value.
 
     See command-boundaries.md Section 3 for the phase contract and
     01-schema-deployment-safety.md for the DMS-1151 story.
@@ -114,6 +114,7 @@ $bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 Push-Location $PSScriptRoot
 try {
 Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadata:$AddExtensionSecurityMetadata
+$bootstrapManifestPresent = Test-Path -LiteralPath (Join-Path (Get-BootstrapRoot) "bootstrap-manifest.json") -PathType Leaf
 
 # Identity provider configuration
 Import-Module ./env-utility.psm1 -Force
@@ -249,6 +250,10 @@ else {
 
     if ($DmsOnly) {
         Write-Output "Starting DMS service only with startup database provisioning disabled..."
+        $dmsServices = @("dms")
+        if ($EnableSwaggerUI) {
+            $dmsServices += "swagger-ui"
+        }
         $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
         $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
         $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
@@ -256,7 +261,7 @@ else {
             $env:NEED_DATABASE_SETUP = "false"
             $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
             $env:AppSettings__DeployDatabaseOnStartup = "false"
-            docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs dms
+            docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs $dmsServices
         }
         finally {
             [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
@@ -331,6 +336,14 @@ else {
         Write-Output "Running connector setup..."
         ./setup-connectors.ps1 $EnvironmentFile
 
+        if ($EnableKafkaUI) {
+            Write-Output "Starting Kafka UI..."
+            docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs kafka-ui
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to start Kafka UI. Exit code $LASTEXITCODE"
+            }
+        }
+
         Write-Output "Infrastructure phase complete. DMS service was not started."
         return
     }
@@ -352,24 +365,31 @@ else {
         ./setup-openiddict.ps1 -InitDb -EnvironmentFile $EnvironmentFile
     }
 
-    # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the story-aligned
-    # bootstrap flow. Force the legacy Backend.Installer entrypoint off for every direct start
-    # path so a stale NEED_DATABASE_SETUP=true value in the env file or the process environment
-    # cannot reactivate it. The DmsOnly branch above already does this; this block matches it for
-    # the regular up.
-    $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
-    $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
-    $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
-    try {
-        $env:NEED_DATABASE_SETUP = "false"
-        $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
-        $env:AppSettings__DeployDatabaseOnStartup = "false"
-        docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs
+    if ($bootstrapManifestPresent) {
+        # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the
+        # story-aligned bootstrap flow. Force the legacy Backend.Installer entrypoint off
+        # when a bootstrap manifest is present so a stale NEED_DATABASE_SETUP=true value
+        # in the env file or process environment cannot reactivate it. Direct, non-bootstrap
+        # startup remains backward compatible with the env-file NEED_DATABASE_SETUP value.
+        Write-Output "Bootstrap manifest detected; starting DMS with startup database provisioning disabled."
+        $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+        $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+        $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+        try {
+            $env:NEED_DATABASE_SETUP = "false"
+            $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            $env:AppSettings__DeployDatabaseOnStartup = "false"
+            docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+            [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+            [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+        }
     }
-    finally {
-        [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
-        [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
-        [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+    else {
+        Write-Output "No bootstrap manifest detected; starting DMS with database startup provisioning controlled by the environment file."
+        docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -56,8 +56,8 @@ param (
     $AddSmokeTestCredentials,
 
     # Load seed data via the direct-SQL database-template path. Retained pending the implementation
-    # gate in bootstrap-design.md §6.4 line 1250: removal is gated on Story 04 XSD-staging
-    # verification. The new API-based seed path — load-dms-seed-data.ps1 + bootstrap-*-dms.ps1 —
+    # gate in bootstrap-design.md section 6.4 line 1250: removal is gated on Story 04 XSD-staging
+    # verification. The new API-based seed path, via load-dms-seed-data.ps1 + bootstrap-*-dms.ps1,
     # is the forward contract; the slice that closes the gate owns this switch's removal.
     [Switch]
     $LoadSeedData,
@@ -101,11 +101,11 @@ Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
 $originalLocation = Get-Location
 if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
     if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
-        # Caller supplied an explicit relative path — resolve against the caller's CWD.
+        # Caller supplied an explicit relative path - resolve against the caller's CWD.
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $originalLocation.Path $EnvironmentFile))
     }
     else {
-        # Default value — resolve against the script directory so that invoking the
+        # Default value - resolve against the script directory so that invoking the
         # script from any CWD (e.g. the repo root) still finds eng/docker-compose/.env.
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
     }
@@ -275,6 +275,14 @@ else {
 
         Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
         Write-Output "DMS service is healthy."
+
+        # Register the Debezium source connector now that the schema has been provisioned and
+        # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
+        # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
+        # RUNNING state and throws on failure.
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+
         return
     }
 
@@ -333,8 +341,10 @@ else {
             throw "Failed to start Kafka connector infrastructure. Exit code $LASTEXITCODE"
         }
 
-        Write-Output "Running connector setup..."
-        ./setup-connectors.ps1 $EnvironmentFile
+        # Connector registration is intentionally deferred to the -DmsOnly phase. The Debezium
+        # source connector snapshots dms.document on registration; those tables do not exist
+        # until provision-dms-schema.ps1 runs, so registering here would start the connector
+        # task in a failed state. setup-connectors.ps1 runs after schema provisioning completes.
 
         if ($EnableKafkaUI) {
             Write-Output "Starting Kafka UI..."

--- a/eng/docker-compose/start-local-dms.ps1
+++ b/eng/docker-compose/start-local-dms.ps1
@@ -3,6 +3,25 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+<#
+.SYNOPSIS
+    Post-bootstrap startup phase for the local DMS Docker stack.
+.DESCRIPTION
+    This script is the post-bootstrap startup phase. The wrapper
+    bootstrap-local-dms.ps1 orchestrates prepare -> infra -> configure -> provision ->
+    this script, so by the time the wrapper calls into here a .bootstrap/ workspace and
+    a provisioned database already exist.
+
+    Direct invocation is supported for diagnostics and partial-phase orchestration
+    (-InfraOnly, -DmsOnly). When invoked directly without a .bootstrap/ manifest the
+    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: schema
+    provisioning will NOT happen here. Callers are responsible for ensuring provisioning
+    has occurred (or accepting an unprovisioned DMS).
+
+    See command-boundaries.md Section 3 for the phase contract and
+    01-schema-deployment-safety.md for the DMS-1151 story.
+#>
+
 [CmdletBinding()]
 param (
     # Stop services instead of starting them
@@ -332,7 +351,26 @@ else {
         Write-Output "Init db public and private keys for OpenIddict..."
         ./setup-openiddict.ps1 -InitDb -EnvironmentFile $EnvironmentFile
     }
-    docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs
+
+    # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the story-aligned
+    # bootstrap flow. Force the legacy Backend.Installer entrypoint off for every direct start
+    # path so a stale NEED_DATABASE_SETUP=true value in the env file or the process environment
+    # cannot reactivate it. The DmsOnly branch above already does this; this block matches it for
+    # the regular up.
+    $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+    $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+    $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+    try {
+        $env:NEED_DATABASE_SETUP = "false"
+        $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+        $env:AppSettings__DeployDatabaseOnStartup = "false"
+        docker compose $files --env-file $EnvironmentFile -p dms-local up $upArgs
+    }
+    finally {
+        [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+        [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+        [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+    }
 
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to start local Docker environment, with exit code $LASTEXITCODE."

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -52,8 +52,8 @@ param (
     $AddSmokeTestCredentials,
 
     # Load seed data via the direct-SQL database-template path. Retained pending the implementation
-    # gate in bootstrap-design.md §6.4 line 1250: removal is gated on Story 04 XSD-staging
-    # verification. The new API-based seed path — load-dms-seed-data.ps1 + bootstrap-*-dms.ps1 —
+    # gate in bootstrap-design.md section 6.4 line 1250: removal is gated on Story 04 XSD-staging
+    # verification. The new API-based seed path, via load-dms-seed-data.ps1 + bootstrap-*-dms.ps1,
     # is the forward contract; the slice that closes the gate owns this switch's removal.
     [Switch]
     $LoadSeedData,
@@ -97,11 +97,11 @@ Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
 $originalLocation = Get-Location
 if (-not [System.IO.Path]::IsPathRooted($EnvironmentFile)) {
     if ($PSBoundParameters.ContainsKey('EnvironmentFile')) {
-        # Caller supplied an explicit relative path — resolve against the caller's CWD.
+        # Caller supplied an explicit relative path - resolve against the caller's CWD.
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $originalLocation.Path $EnvironmentFile))
     }
     else {
-        # Default value — resolve against the script directory so that invoking the
+        # Default value - resolve against the script directory so that invoking the
         # script from any CWD (e.g. the repo root) still finds eng/docker-compose/.env.
         $EnvironmentFile = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $EnvironmentFile))
     }
@@ -264,6 +264,14 @@ else {
 
         Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
         Write-Output "DMS service is healthy."
+
+        # Register the Debezium source connector now that the schema has been provisioned and
+        # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
+        # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
+        # RUNNING state and throws on failure.
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+
         return
     }
 
@@ -324,8 +332,10 @@ else {
             throw "Failed to start Kafka connector infrastructure. Exit code $LASTEXITCODE"
         }
 
-        Write-Output "Running connector setup..."
-        ./setup-connectors.ps1 $EnvironmentFile
+        # Connector registration is intentionally deferred to the -DmsOnly phase. The Debezium
+        # source connector snapshots dms.document on registration; those tables do not exist
+        # until provision-dms-schema.ps1 runs, so registering here would start the connector
+        # task in a failed state. setup-connectors.ps1 runs after schema provisioning completes.
 
         if ($EnableKafkaUI) {
             Write-Output "Starting Kafka UI..."

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -391,8 +391,7 @@ else {
     {
         Import-Module ../smoke_test/modules/SmokeTest.psm1 -Force
         Write-Output "Creating smoke test credentials..."
-        $credentials = Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl
-
+        $null = Get-SmokeTestCredentials -ConfigServiceUrl $cmsUrl
 
         Write-Output "Smoke test credentials created successfully!"
         Write-Output "Credential values were returned to the caller and were not written to logs."

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -14,9 +14,9 @@
 
     Direct invocation is supported for diagnostics and partial-phase orchestration
     (-InfraOnly, -DmsOnly). When invoked directly without a .bootstrap/ manifest the
-    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: schema
-    provisioning will NOT happen here. Callers are responsible for ensuring provisioning
-    has occurred (or accepting an unprovisioned DMS).
+    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: bootstrap
+    schema provisioning will NOT happen here. Legacy direct-start database provisioning
+    remains controlled by the supplied environment file's NEED_DATABASE_SETUP value.
 
     See command-boundaries.md Section 3 for the phase contract and
     01-schema-deployment-safety.md for the DMS-1151 story.
@@ -110,6 +110,7 @@ $bootstrapEnvSnapshot = Get-BootstrapEnvSnapshot
 Push-Location $PSScriptRoot
 try {
 Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadata:$AddExtensionSecurityMetadata
+$bootstrapManifestPresent = Test-Path -LiteralPath (Join-Path (Get-BootstrapRoot) "bootstrap-manifest.json") -PathType Leaf
 
 # Identity provider configuration
 Import-Module ./env-utility.psm1 -Force
@@ -238,6 +239,10 @@ else {
 
     if ($DmsOnly) {
         Write-Output "Starting published DMS service only with startup database provisioning disabled..."
+        $dmsServices = @("dms")
+        if ($EnableSwaggerUI) {
+            $dmsServices += "swagger-ui"
+        }
         $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
         $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
         $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
@@ -245,7 +250,7 @@ else {
             $env:NEED_DATABASE_SETUP = "false"
             $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
             $env:AppSettings__DeployDatabaseOnStartup = "false"
-            docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs dms
+            docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs $dmsServices
         }
         finally {
             [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
@@ -287,6 +292,7 @@ else {
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to start Postgresql. Exit code $LASTEXITCODE"
     }
+    Start-Sleep 20
 
     if ($InfraOnly) {
         if($IdentityProvider -eq "self-contained")
@@ -321,30 +327,45 @@ else {
         Write-Output "Running connector setup..."
         ./setup-connectors.ps1 $EnvironmentFile
 
+        if ($EnableKafkaUI) {
+            Write-Output "Starting Kafka UI..."
+            docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs kafka-ui
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to start Kafka UI. Exit code $LASTEXITCODE"
+            }
+        }
+
         Write-Output "Infrastructure phase complete. DMS service was not started."
         return
     }
 
 
     Write-Output "Starting published DMS"
-    # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the story-aligned
-    # bootstrap flow. Force the legacy Backend.Installer entrypoint off for every direct start
-    # path so a stale NEED_DATABASE_SETUP=true value in the env file or process environment
-    # cannot reactivate it. The DmsOnly branch above already does this; this block matches it for
-    # the regular up.
-    $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
-    $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
-    $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
-    try {
-        $env:NEED_DATABASE_SETUP = "false"
-        $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
-        $env:AppSettings__DeployDatabaseOnStartup = "false"
-        docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
+    if ($bootstrapManifestPresent) {
+        # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the
+        # story-aligned bootstrap flow. Force the legacy Backend.Installer entrypoint off
+        # when a bootstrap manifest is present so a stale NEED_DATABASE_SETUP=true value
+        # in the env file or process environment cannot reactivate it. Direct, non-bootstrap
+        # startup remains backward compatible with the env-file NEED_DATABASE_SETUP value.
+        Write-Output "Bootstrap manifest detected; starting published DMS with startup database provisioning disabled."
+        $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+        $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+        $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+        try {
+            $env:NEED_DATABASE_SETUP = "false"
+            $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            $env:AppSettings__DeployDatabaseOnStartup = "false"
+            docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+            [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+            [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+        }
     }
-    finally {
-        [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
-        [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
-        [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+    else {
+        Write-Output "No bootstrap manifest detected; starting published DMS with database startup provisioning controlled by the environment file."
+        docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
     }
 
     if ($LASTEXITCODE -ne 0) {

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -3,6 +3,25 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+<#
+.SYNOPSIS
+    Post-bootstrap startup phase for the published DMS Docker stack.
+.DESCRIPTION
+    This script is the post-bootstrap startup phase. The wrapper
+    bootstrap-published-dms.ps1 orchestrates prepare -> infra -> configure -> provision ->
+    this script, so by the time the wrapper calls into here a .bootstrap/ workspace and
+    a provisioned database already exist.
+
+    Direct invocation is supported for diagnostics and partial-phase orchestration
+    (-InfraOnly, -DmsOnly). When invoked directly without a .bootstrap/ manifest the
+    script proceeds but Invoke-BootstrapStartupConfiguration emits a warning: schema
+    provisioning will NOT happen here. Callers are responsible for ensuring provisioning
+    has occurred (or accepting an unprovisioned DMS).
+
+    See command-boundaries.md Section 3 for the phase contract and
+    01-schema-deployment-safety.md for the DMS-1151 story.
+#>
+
 [CmdletBinding()]
 param (
     # Stop services instead of starting them
@@ -308,9 +327,25 @@ else {
 
 
     Write-Output "Starting published DMS"
-    $env:NEED_DATABASE_SETUP = if ($LoadSeedData) { "false" } else { $env:NEED_DATABASE_SETUP }
-    docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
-    $env:NEED_DATABASE_SETUP = $envValues["NEED_DATABASE_SETUP"]
+    # DMS-1151: schema provisioning is owned by provision-dms-schema.ps1 in the story-aligned
+    # bootstrap flow. Force the legacy Backend.Installer entrypoint off for every direct start
+    # path so a stale NEED_DATABASE_SETUP=true value in the env file or process environment
+    # cannot reactivate it. The DmsOnly branch above already does this; this block matches it for
+    # the regular up.
+    $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+    $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+    $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+    try {
+        $env:NEED_DATABASE_SETUP = "false"
+        $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+        $env:AppSettings__DeployDatabaseOnStartup = "false"
+        docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
+    }
+    finally {
+        [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+        [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+        [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+    }
 
     if ($LASTEXITCODE -ne 0) {
         throw "Unable to start Published Docker environment, with exit code $LASTEXITCODE."

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -52,6 +52,14 @@ param (
     [string]
     $SchoolYearRange = "",
 
+    # Start only infrastructure required before schema provisioning
+    [Switch]
+    $InfraOnly,
+
+    # Start only the DMS service after external schema provisioning
+    [Switch]
+    $DmsOnly,
+
     # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
     # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
     [Switch]
@@ -88,6 +96,7 @@ Invoke-BootstrapStartupConfiguration -IsTeardown:$d -AddExtensionSecurityMetadat
 Import-Module ./env-utility.psm1 -Force
 $envValues = ReadValuesFromEnvFile $EnvironmentFile
 $cmsUrl = Resolve-CmsBaseUrl -EnvValues $envValues
+$dmsUrl = Resolve-DockerLocalDmsBaseUrl -EnvValues $envValues
 $env:DMS_CONFIG_IDENTITY_PROVIDER=$IdentityProvider
 Write-Output "Identity Provider $IdentityProvider"
 if($IdentityProvider -eq "keycloak")
@@ -105,6 +114,18 @@ elseif ($IdentityProvider -eq "self-contained") {
 }
 
 if (-not $d) {
+    if ($InfraOnly -and $DmsOnly) {
+        throw "Parameters -InfraOnly and -DmsOnly are mutually exclusive."
+    }
+
+    if (($InfraOnly -or $DmsOnly) -and $LoadSeedData) {
+        throw "Parameter -LoadSeedData cannot be used with -InfraOnly or -DmsOnly."
+    }
+
+    if ($DmsOnly -and ($NoDmsInstance -or -not [string]::IsNullOrWhiteSpace($SchoolYearRange) -or $AddSmokeTestCredentials)) {
+        throw "Parameters -NoDmsInstance, -SchoolYearRange, and -AddSmokeTestCredentials cannot be used with -DmsOnly."
+    }
+
     if ($NoDmsInstance -and -not [string]::IsNullOrWhiteSpace($SchoolYearRange)) {
         throw "Parameters -NoDmsInstance and -SchoolYearRange are mutually exclusive. Use -NoDmsInstance for manual instance creation, or use -SchoolYearRange to auto-create instances."
     }
@@ -132,7 +153,7 @@ if ($EnableKafkaUI) {
 }
 
 # Include configuration service if enabled or if using self-contained identity provider
-if ($EnableConfig -or $IdentityProvider -eq "self-contained") {
+if ($EnableConfig -or $InfraOnly -or $IdentityProvider -eq "self-contained") {
     $files += @("-f", "published-config.yml")
 }
 
@@ -157,6 +178,71 @@ else {
     if (! $existingNetwork) {
         docker network create dms
     }
+
+    $upArgs = @(
+        "--detach"
+    )
+
+    function Wait-HttpEndpointHealthy {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Url,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Name,
+
+            [int]
+            $TimeoutSeconds = 60
+        )
+
+        $deadline = [datetime]::UtcNow.AddSeconds($TimeoutSeconds)
+        while ($true) {
+            try {
+                $response = Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 5 -ErrorAction Stop
+                if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                    return
+                }
+            }
+            catch {
+                $null = $_
+            }
+
+            if ([datetime]::UtcNow -ge $deadline) {
+                throw "$Name health check timed out after $TimeoutSeconds seconds. Endpoint: $(Format-LogSafeText $Url)"
+            }
+
+            Start-Sleep -Seconds 2
+        }
+    }
+
+    if ($DmsOnly) {
+        Write-Output "Starting published DMS service only with startup database provisioning disabled..."
+        $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
+        $previousDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP")
+        $previousAppSettingsDeployDatabaseOnStartup = [System.Environment]::GetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup")
+        try {
+            $env:NEED_DATABASE_SETUP = "false"
+            $env:DMS_DEPLOY_DATABASE_ON_STARTUP = "false"
+            $env:AppSettings__DeployDatabaseOnStartup = "false"
+            docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs dms
+        }
+        finally {
+            [System.Environment]::SetEnvironmentVariable("NEED_DATABASE_SETUP", $previousNeedDatabaseSetup)
+            [System.Environment]::SetEnvironmentVariable("DMS_DEPLOY_DATABASE_ON_STARTUP", $previousDeployDatabaseOnStartup)
+            [System.Environment]::SetEnvironmentVariable("AppSettings__DeployDatabaseOnStartup", $previousAppSettingsDeployDatabaseOnStartup)
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to start published DMS service, with exit code $LASTEXITCODE."
+        }
+
+        Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
+        Write-Output "DMS service is healthy."
+        return
+    }
+
     if($IdentityProvider -eq "keycloak")
     {
         Write-Output "Starting Keycloak first..."
@@ -177,10 +263,53 @@ else {
         ./setup-keycloak.ps1 -NewClientId "CMSAuthMetadataReadOnlyAccess" -NewClientName "CMS Auth Endpoints Only Access" -ClientScopeName "edfi_admin_api/authMetadata_readonly_access"
     }
 
+    Write-Output "Starting Postgresql..."
+    docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs db
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to start Postgresql. Exit code $LASTEXITCODE"
+    }
+
+    if ($InfraOnly) {
+        if($IdentityProvider -eq "self-contained")
+        {
+            Write-Output "Init db public and private keys for OpenIddict..."
+            ./setup-openiddict.ps1 -InitDb -EnvironmentFile $EnvironmentFile
+        }
+
+        Write-Output "Starting Configuration Service..."
+        docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs config
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to start Configuration Service. Exit code $LASTEXITCODE"
+        }
+
+        Wait-HttpEndpointHealthy -Url "$($cmsUrl.TrimEnd('/'))/health" -Name "Configuration Service"
+        Write-Output "Configuration Service is healthy."
+
+        if($IdentityProvider -eq "self-contained")
+        {
+            Write-Output "Starting self-contained initialization script..."
+            ./setup-openiddict.ps1 -InsertData -EnvironmentFile $EnvironmentFile
+            ./setup-openiddict.ps1 -InsertData -NewClientId "CMSReadOnlyAccess" -NewClientName "CMS ReadOnly Access" -ClientScopeName "edfi_admin_api/readonly_access" -EnvironmentFile $EnvironmentFile
+            ./setup-openiddict.ps1 -InsertData -NewClientId "CMSAuthMetadataReadOnlyAccess" -NewClientName "CMS Auth Endpoints Only Access" -ClientScopeName "edfi_admin_api/authMetadata_readonly_access" -EnvironmentFile $EnvironmentFile
+        }
+
+        Write-Output "Starting Kafka connector infrastructure..."
+        docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs kafka-postgresql-source
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to start Kafka connector infrastructure. Exit code $LASTEXITCODE"
+        }
+
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+
+        Write-Output "Infrastructure phase complete. DMS service was not started."
+        return
+    }
+
 
     Write-Output "Starting published DMS"
     $env:NEED_DATABASE_SETUP = if ($LoadSeedData) { "false" } else { $env:NEED_DATABASE_SETUP }
-    docker compose $files --env-file $EnvironmentFile -p dms-published up -d
+    docker compose $files --env-file $EnvironmentFile -p dms-published up $upArgs
     $env:NEED_DATABASE_SETUP = $envValues["NEED_DATABASE_SETUP"]
 
     if ($LASTEXITCODE -ne 0) {
@@ -231,9 +360,7 @@ else {
 
 
         Write-Output "Smoke test credentials created successfully!"
-        Write-Output "Key: $($credentials.Key)"
-        Write-Output "Secret: $($credentials.Secret)"
-        Write-Output "These credentials can be used for smoke testing the DMS API."
+        Write-Output "Credential values were returned to the caller and were not written to logs."
     }
 
     if(-not $NoDmsInstance -or $SchoolYearRange)

--- a/eng/docker-compose/start-published-dms.ps1
+++ b/eng/docker-compose/start-published-dms.ps1
@@ -79,6 +79,11 @@ param (
     [Switch]
     $DmsOnly,
 
+    # Skip registering the default Debezium source connector. Used by harnesses that create
+    # their own connectors after provisioning instance-specific databases.
+    [Switch]
+    $SkipConnectorSetup,
+
     # Remove the .bootstrap workspace during teardown (-d -v). Off by default so a prepared
     # workspace is preserved when the caller (e.g. build-dms.ps1) does not intend to wipe it.
     [Switch]
@@ -265,12 +270,17 @@ else {
         Wait-HttpEndpointHealthy -Url "$($dmsUrl.TrimEnd('/'))/health" -Name "DMS"
         Write-Output "DMS service is healthy."
 
-        # Register the Debezium source connector now that the schema has been provisioned and
-        # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
-        # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
-        # RUNNING state and throws on failure.
-        Write-Output "Running connector setup..."
-        ./setup-connectors.ps1 $EnvironmentFile
+        if (-not $SkipConnectorSetup) {
+            # Register the Debezium source connector now that the schema has been provisioned and
+            # the DMS service is up. The connector infrastructure (kafka-postgresql-source) was
+            # started during the -InfraOnly phase; setup-connectors.ps1 verifies it reaches the
+            # RUNNING state and throws on failure.
+            Write-Output "Running connector setup..."
+            ./setup-connectors.ps1 $EnvironmentFile
+        }
+        else {
+            Write-Output "Skipping default connector setup."
+        }
 
         return
     }
@@ -415,8 +425,13 @@ else {
         ./setup-openiddict.ps1 -InsertData -NewClientId "CMSAuthMetadataReadOnlyAccess" -NewClientName "CMS Auth Endpoints Only Access" -ClientScopeName "edfi_admin_api/authMetadata_readonly_access" -EnvironmentFile $EnvironmentFile
     }
 
-    Write-Output "Running connector setup..."
-    ./setup-connectors.ps1 $EnvironmentFile
+    if (-not $SkipConnectorSetup) {
+        Write-Output "Running connector setup..."
+        ./setup-connectors.ps1 $EnvironmentFile
+    }
+    else {
+        Write-Output "Skipping default connector setup."
+    }
 
     if($AddSmokeTestCredentials)
     {

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -34,7 +34,7 @@ Describe "Story 00 bootstrap" {
         $dockerComposeRoot = Join-Path $repoRoot "eng/docker-compose"
         New-Item -ItemType Directory -Path $dockerComposeRoot -Force | Out-Null
 
-        foreach ($fileName in @("bootstrap-manifest.psm1", "prepare-dms-schema.ps1", "prepare-dms-claims.ps1")) {
+        foreach ($fileName in @("bootstrap-manifest.psm1", "bootstrap-schema-tool.psm1", "prepare-dms-schema.ps1", "prepare-dms-claims.ps1")) {
             Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot $fileName) -Destination $dockerComposeRoot
         }
 

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -5,6 +5,7 @@
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Pester stubs intentionally keep production-compatible signatures.')]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Pester stubs intentionally shadow production plural-noun helpers.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidOverwritingBuiltInCmdlets', '', Justification = 'Pester tests intentionally shadow Invoke-WebRequest to stub HTTP calls.')]
 param()
 
 Describe "DMS-1151 bootstrap schema deployment safety" {
@@ -1261,6 +1262,148 @@ param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
                 Should -Throw -ExpectedMessage "*Only PostgreSQL provisioning is supported*"
             Test-Path -LiteralPath $capturePath | Should -BeFalse
         }
+
+        It "carries SSL and timeout options through the host-side translation" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Secured"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=secured_db;SSL Mode=Require;Trust Server Certificate=true;Timeout=45;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            # Host and port are translated to host-side coordinates...
+            $connectionString | Should -Match "host=localhost"
+            $connectionString | Should -Match "port=5544"
+            $connectionString | Should -Not -Match "dms-postgresql"
+            # ...while every other stored option survives verbatim rather than being dropped.
+            $connectionString | Should -Match "database=secured_db"
+            $connectionString | Should -Match "SSL Mode=Require"
+            $connectionString | Should -Match "Trust Server Certificate=true"
+            $connectionString | Should -Match "Timeout=45"
+        }
+
+        It "carries options through unchanged for external (non-translated) hosts" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "ExternalSecured"
+                        connectionString = 'host=managed-pg.example.com;port=5439;username=ops_user;password=ops_pass;database=ext_db;SSL Mode=VerifyFull;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=managed-pg.example.com"
+            $connectionString | Should -Match "port=5439"
+            $connectionString | Should -Match "SSL Mode=VerifyFull"
+            $connectionString | Should -Not -Match "host=localhost"
+        }
+
+        It "carries a quoted-semicolon password through the host-side translation intact" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "QuotedSemicolon"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password="abc;123";database=quoted_db;SSL Mode=Require;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+
+            # The password embeds a semicolon, so the value is quoted and a regex match on
+            # "password=abc;123" would not work. Parse the emitted string back through the same
+            # builder and assert the value survived intact.
+            $reparsed = [System.Data.Common.DbConnectionStringBuilder]::new()
+            $reparsed.set_ConnectionString($connectionString)
+            $reparsed.get_Item("password") | Should -Be 'abc;123'
+            $reparsed.get_Item("host") | Should -Be 'localhost'
+            $reparsed.get_Item("port") | Should -Be '5544'
+            $reparsed.get_Item("database") | Should -Be 'quoted_db'
+            $reparsed.get_Item("ssl mode") | Should -Be 'Require'
+            $reparsed.ContainsKey("host") | Should -BeTrue
+        }
+
+        It "carries a quoted password with semicolons and equals through an external host intact" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "ExternalQuoted"
+                        connectionString = 'host=managed-pg.example.com;port=5439;username=ops_user;password="p;w=d/q";database=ext_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+
+            # No translation occurs for an external host; the quoted password must still round-trip
+            # uncorrupted through the builder.
+            $reparsed = [System.Data.Common.DbConnectionStringBuilder]::new()
+            $reparsed.set_ConnectionString($connectionString)
+            $reparsed.get_Item("password") | Should -Be 'p;w=d/q'
+            $reparsed.get_Item("host") | Should -Be 'managed-pg.example.com'
+            $reparsed.get_Item("port") | Should -Be '5439'
+            $reparsed.get_Item("database") | Should -Be 'ext_db'
+        }
     }
 
     Context "configure result contract" {
@@ -1419,6 +1562,43 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
             ($lines -join "`n") | Should -Match "Provisioned 1 database target"
             ($lines -join "`n") | Should -Match "database=td host=h port=5432 user=u"
             ($lines -join "`n") | Should -Match "Story 04"
+        }
+
+        It "Format-LogSafePath preserves backslashes so Windows paths survive sanitization" {
+            . $script:repo.ProvisionScript
+
+            Format-LogSafePath "C:\work\ApiSchema" | Should -Be "C:\work\ApiSchema"
+            # Control characters that enable log forging are still stripped.
+            Format-LogSafePath "C:\work\ApiSchema`r`nINJECTED" | Should -Be "C:\work\ApiSchemaINJECTED"
+        }
+
+        It "Format-LogSafePath preserves printable path characters and strips only control characters" {
+            . $script:repo.ProvisionScript
+
+            # Spaces, parentheses, '#', hyphens, and backslashes are all path-legal and must survive.
+            Format-LogSafePath 'C:\Program Files (x86)\Ed-Fi\Api #1' | Should -Be 'C:\Program Files (x86)\Ed-Fi\Api #1'
+            Format-LogSafePath '/srv/ed fi/api (staging)/schema#2.json' | Should -Be '/srv/ed fi/api (staging)/schema#2.json'
+            # Tabs, carriage returns, and newlines are control characters and are removed.
+            Format-LogSafePath "a`tb`r`nc" | Should -Be "abc"
+        }
+
+        It "guidance preserves backslashes in Windows-style staged paths" {
+            . $script:repo.ProvisionScript
+
+            $schemaWorkspace = [pscustomobject]@{
+                BootstrapManifestPath = "C:\work\.bootstrap\bootstrap-manifest.json"
+                ApiSchemaManifestPath = "C:\work\.bootstrap\ApiSchema\bootstrap-api-schema-manifest.json"
+                CoreSchemaPath = "C:\work\.bootstrap\ApiSchema\schemas\Ed-Fi\ApiSchema.json"
+                ExtensionSchemaPaths = [string[]]@()
+                EffectiveSchemaHash = "hash-xyz"
+                WorkspaceFingerprint = "fp"
+            }
+
+            $joined = (Get-ProvisionIdeGuidance -SchemaWorkspace $schemaWorkspace -ProvisionedTargets @()) -join "`n"
+
+            # The path lines feed Format-LogSafePath directly, so backslashes survive on every platform.
+            $joined | Should -Match ([regex]::Escape("C:\work\.bootstrap\bootstrap-manifest.json"))
+            $joined | Should -Match ([regex]::Escape("C:\work\.bootstrap\ApiSchema\bootstrap-api-schema-manifest.json"))
         }
     }
 
@@ -2260,6 +2440,104 @@ DMS_BOOTSTRAP_ADMIN_CLIENT_ID=$injectedId
             $thrownMessage | Should -Not -Match "`n"
             $thrownMessage | Should -Not -Match "FAKE-LOG-LINE"
             $thrownMessage | Should -Match "evil-admin"
+        }
+    }
+
+    Context "connector setup" {
+        It "start-all-services.ps1 does not register the connector before the DMS schema exists" {
+            $scriptPath = Join-Path $script:sourceDockerComposeRoot "start-all-services.ps1"
+
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($scriptPath, [ref]$tokens, [ref]$errors)
+            $errors.Count | Should -Be 0
+
+            # An automatic invocation would appear as a CommandAst whose command name is the
+            # connector script. Mentioning it inside a Write-Output guidance string is a string
+            # literal, not a command, so it is correctly ignored by GetCommandName().
+            $invokedCommands = @(
+                $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $true) |
+                    ForEach-Object { $_.GetCommandName() }
+            )
+            $connectorInvocations = @($invokedCommands | Where-Object { $_ -and $_ -like "*setup-connectors.ps1" })
+            $connectorInvocations | Should -BeNullOrEmpty
+
+            # The deferral guidance must still tell the developer how to register it afterward.
+            $sourceText = Get-Content -LiteralPath $scriptPath -Raw
+            $sourceText | Should -Match 'deferred'
+            $sourceText | Should -Match 'setup-connectors\.ps1'
+
+            # Removing the connector call removed the only command that previously surfaced a Docker
+            # startup failure, so the up path must check $LASTEXITCODE and throw instead of printing
+            # success guidance over a failed `docker compose up`.
+            $sourceText | Should -Match '\$LASTEXITCODE -ne 0'
+            $sourceText | Should -Match 'Failed to start PostgreSQL and Kafka services'
+        }
+
+        It "builds connector JSON with a structurally escaped password" {
+            . (Join-Path $script:sourceDockerComposeRoot "setup-connectors.ps1")
+
+            # A password full of JSON-significant characters that the old string .Replace would corrupt.
+            $trickyPassword = 'p@ss"with\back\slash ''quoted'' #hash'
+            $body = New-ConnectorRequestBody `
+                -TemplatePath (Join-Path $script:sourceDockerComposeRoot "postgresql_connector.json") `
+                -Password $trickyPassword
+
+            $parsed = $body | ConvertFrom-Json
+            $parsed.name | Should -Be "postgresql-source"
+            $parsed.config."database.password" | Should -Be $trickyPassword
+            # The template placeholder password must not survive.
+            $body | Should -Not -Match "abcdefgh1!"
+        }
+
+        It "waits for the connector to disappear after delete before returning" {
+            . (Join-Path $script:sourceDockerComposeRoot "setup-connectors.ps1")
+
+            $script:absentProbeCount = 0
+            function Invoke-WebRequest {
+                param([string]$Uri, [string]$Method, [int]$TimeoutSec, [switch]$SkipHttpErrorCheck)
+                $script:absentProbeCount++
+                # Still present on the first probe, gone on the second: the function must keep polling.
+                if ($script:absentProbeCount -ge 2) {
+                    return [pscustomobject]@{ StatusCode = 404 }
+                }
+                return [pscustomobject]@{ StatusCode = 200 }
+            }
+
+            Wait-ConnectorAbsent -ConnectorUrl "http://localhost:8083/connectors/postgresql-source" -ConnectorName "postgresql-source" -DelaySeconds 0 -MaxAttempts 5
+
+            $script:absentProbeCount | Should -BeGreaterOrEqual 2
+        }
+
+        It "throws when the connector never disappears after delete" {
+            . (Join-Path $script:sourceDockerComposeRoot "setup-connectors.ps1")
+
+            function Invoke-WebRequest {
+                param([string]$Uri, [string]$Method, [int]$TimeoutSec, [switch]$SkipHttpErrorCheck)
+                return [pscustomobject]@{ StatusCode = 200 }
+            }
+
+            { Wait-ConnectorAbsent -ConnectorUrl "http://localhost:8083/connectors/postgresql-source" -ConnectorName "postgresql-source" -DelaySeconds 0 -MaxAttempts 3 } |
+                Should -Throw -ExpectedMessage "*was not removed within*"
+        }
+    }
+
+    Context "instance management E2E database setup hardening" {
+        It "drops and recreates each test database with checked exit codes" {
+            $e2eSetupScript = Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"
+            $content = Get-Content -LiteralPath $e2eSetupScript -Raw
+
+            $content | Should -Match 'DROP DATABASE IF EXISTS \$db;'
+            $content | Should -Match 'CREATE DATABASE \$db;'
+            # The fire-and-forget form that swallowed CREATE failures must be gone.
+            $content | Should -Not -Match 'CREATE DATABASE \$db;" 2>&1 \| Out-Null'
+        }
+
+        It "applies the exported schema with ON_ERROR_STOP and a checked exit code" {
+            $e2eSetupScript = Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"
+            $content = Get-Content -LiteralPath $e2eSetupScript -Raw
+
+            $content | Should -Match 'psql -v ON_ERROR_STOP=1'
         }
     }
 }

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -1,0 +1,784 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Pester stubs intentionally keep production-compatible signatures.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Pester stubs intentionally shadow production plural-noun helpers.')]
+param()
+
+Describe "DMS-1151 bootstrap schema deployment safety" {
+    BeforeAll {
+        $script:sourceRepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:sourceDockerComposeRoot = Join-Path $script:sourceRepoRoot "eng/docker-compose"
+
+        function script:New-TestDirectory {
+            $path = Join-Path ([System.IO.Path]::GetTempPath()) "dms-1151-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+            return $path
+        }
+
+        function script:Copy-DockerComposeFile {
+            param(
+                [string]$FileName,
+                [string]$Destination
+            )
+
+            Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot $FileName) -Destination $Destination
+        }
+
+        function script:New-IsolatedBootstrapRepo {
+            $repoRoot = New-TestDirectory
+            $dockerComposeRoot = Join-Path $repoRoot "eng/docker-compose"
+            $engRoot = Join-Path $repoRoot "eng"
+            New-Item -ItemType Directory -Path $dockerComposeRoot -Force | Out-Null
+            New-Item -ItemType Directory -Path $engRoot -Force | Out-Null
+
+            foreach ($fileName in @(
+                "bootstrap-manifest.psm1",
+                "bootstrap-schema-tool.psm1",
+                "bootstrap-schema-workspace.psm1",
+                "env-utility.psm1",
+                "configure-local-dms-instance.ps1",
+                "provision-dms-schema.ps1",
+                "bootstrap-wrapper.psm1",
+                "bootstrap-local-dms.ps1"
+            )) {
+                Copy-DockerComposeFile -FileName $fileName -Destination $dockerComposeRoot
+            }
+
+            Copy-Item -LiteralPath (Join-Path $script:sourceRepoRoot "eng/Dms-Management.psm1") -Destination $engRoot
+
+            $envFile = Join-Path $dockerComposeRoot ".env.example"
+            @"
+POSTGRES_PASSWORD=secret-pass
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=true
+DMS_DEPLOY_DATABASE_ON_STARTUP=true
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+"@ | Set-Content -LiteralPath $envFile -Encoding utf8
+
+            return [pscustomobject]@{
+                RepoRoot = $repoRoot
+                DockerComposeRoot = $dockerComposeRoot
+                BootstrapRoot = Join-Path $dockerComposeRoot ".bootstrap"
+                EnvFile = $envFile
+                ConfigureScript = Join-Path $dockerComposeRoot "configure-local-dms-instance.ps1"
+                ProvisionScript = Join-Path $dockerComposeRoot "provision-dms-schema.ps1"
+                WrapperScript = Join-Path $dockerComposeRoot "bootstrap-local-dms.ps1"
+            }
+        }
+
+        function script:New-StagedSchemaWorkspace {
+            param(
+                [Parameter(Mandatory)]
+                [string]$DockerComposeRoot,
+
+                [switch]$MissingCoreFile,
+
+                [switch]$PathTraversal
+            )
+
+            $bootstrapRoot = Join-Path $DockerComposeRoot ".bootstrap"
+            $apiSchemaRoot = Join-Path $bootstrapRoot "ApiSchema"
+            New-Item -ItemType Directory -Path (Join-Path $apiSchemaRoot "schemas/Ed-Fi") -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $apiSchemaRoot "schemas/Sample") -Force | Out-Null
+
+            if (-not $MissingCoreFile) {
+                "{}" | Set-Content -LiteralPath (Join-Path $apiSchemaRoot "schemas/Ed-Fi/ApiSchema.json") -Encoding utf8
+            }
+            "{}" | Set-Content -LiteralPath (Join-Path $apiSchemaRoot "schemas/Sample/ApiSchema.json") -Encoding utf8
+
+            $coreSchemaPath = if ($PathTraversal) { "../escape.json" } else { "schemas/Ed-Fi/ApiSchema.json" }
+            $apiSchemaManifest = [ordered]@{
+                version = 1
+                projects = @(
+                    [ordered]@{
+                        projectName = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject = $false
+                        schemaPath = $coreSchemaPath
+                    },
+                    [ordered]@{
+                        projectName = "Sample"
+                        projectEndpointName = "sample"
+                        isExtensionProject = $true
+                        schemaPath = "schemas/Sample/ApiSchema.json"
+                    }
+                )
+            }
+            $apiSchemaManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaRoot "bootstrap-api-schema-manifest.json") -Encoding utf8
+
+            $rootManifest = [ordered]@{
+                version = 1
+                schema = [ordered]@{
+                    selectionMode = "ApiSchemaPath"
+                    selectedExtensions = @("sample")
+                    effectiveSchemaHash = "abc123"
+                    workspaceFingerprint = "def456"
+                    apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
+                }
+                claims = [ordered]@{
+                    directory = "claims"
+                    fingerprint = "claims"
+                    expectedVerificationChecks = @()
+                }
+                seed = [ordered]@{
+                    extensionNamespacePrefixes = @()
+                }
+            }
+            New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+            $rootManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath (Join-Path $bootstrapRoot "bootstrap-manifest.json") -Encoding utf8
+        }
+
+        function script:New-CmsEncryptedConnectionString {
+            param(
+                [string]$PlainText,
+                [string]$EncryptionKey = "TestEncryptionKey123456789012345678901234567890"
+            )
+
+            $keyText = $EncryptionKey.PadRight(32, "0").Substring(0, 32)
+            $keyBytes = [System.Text.Encoding]::UTF8.GetBytes($keyText)
+            $plainTextBytes = [System.Text.Encoding]::UTF8.GetBytes($PlainText)
+            $aes = [System.Security.Cryptography.Aes]::Create()
+            try {
+                $aes.Key = $keyBytes
+                $aes.GenerateIV()
+                $encryptor = $aes.CreateEncryptor()
+                try {
+                    $cipherText = $encryptor.TransformFinalBlock($plainTextBytes, 0, $plainTextBytes.Length)
+                    $result = [byte[]]::new($aes.IV.Length + $cipherText.Length)
+                    [Array]::Copy($aes.IV, 0, $result, 0, $aes.IV.Length)
+                    [Array]::Copy($cipherText, 0, $result, $aes.IV.Length, $cipherText.Length)
+                    return [Convert]::ToBase64String($result)
+                }
+                finally {
+                    $encryptor.Dispose()
+                }
+            }
+            finally {
+                $aes.Dispose()
+            }
+        }
+
+        function script:New-FakeSchemaTool {
+            param(
+                [string]$Directory,
+                [string]$CapturePath,
+                [int]$ExitCode = 0,
+                [string]$StdoutText = "fake schema stdout",
+                [string]$StderrText = ""
+            )
+
+            $toolPath = Join-Path $Directory "fake-dms-schema.ps1"
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)][string[]] `$Arguments)
+Add-Content -LiteralPath '$CapturePath' -Value 'BEGIN'
+foreach (`$argument in `$Arguments) {
+    Add-Content -LiteralPath '$CapturePath' -Value `$argument
+}
+Write-Output '$StdoutText'
+if ('$StderrText'.Length -gt 0) {
+    [Console]::Error.WriteLine('$StderrText')
+}
+exit $ExitCode
+"@ | Set-Content -LiteralPath $toolPath -Encoding utf8
+            return $toolPath
+        }
+
+        function script:Get-DeclaredScriptParameters {
+            param(
+                [string]$Path
+            )
+
+            $tokens = $null
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$errors)
+            if ($errors.Count -gt 0) {
+                throw "Failed to parse $Path"
+            }
+
+            return @(
+                $ast.ParamBlock.Parameters |
+                    ForEach-Object { $_.Name.VariablePath.UserPath } |
+                    Select-Object -Unique
+            )
+        }
+    }
+
+    BeforeEach {
+        $script:repo = New-IsolatedBootstrapRepo
+    }
+
+    AfterEach {
+        if ($null -ne $script:repo) {
+            Get-Module Dms-Management |
+                Where-Object { $_.Path -like "$($script:repo.RepoRoot)*" } |
+                Remove-Module -Force -ErrorAction SilentlyContinue
+        }
+
+        if ($null -ne $script:repo -and (Test-Path -LiteralPath $script:repo.RepoRoot)) {
+            Remove-Item -LiteralPath $script:repo.RepoRoot -Recurse -Force
+        }
+
+        [System.Environment]::SetEnvironmentVariable("DMS_SCHEMA_TOOL_PATH", $null)
+        [System.Environment]::SetEnvironmentVariable("DMS_SCHEMA_TOOL_ALLOW_PATH_FALLBACK", $null)
+    }
+
+    Context "public script contracts" {
+        It "provision-dms-schema.ps1 exposes only the selector and env parameters" {
+            $params = Get-DeclaredScriptParameters -Path $script:repo.ProvisionScript
+
+            $params | Should -Contain "EnvironmentFile"
+            $params | Should -Contain "InstanceId"
+            $params | Should -Contain "SchoolYear"
+            $params | Should -Not -Contain "SchemaToolPath"
+            $params | Should -Not -Contain "SeedTemplate"
+            $params | Should -Not -Contain "LoadSeedData"
+            $params | Should -Not -Contain "ApiSchemaPath"
+            $params.Count | Should -Be 3
+        }
+
+        It "wrapper entry script exposes configure flags without exposing InstanceId" {
+            $params = Get-DeclaredScriptParameters -Path $script:repo.WrapperScript
+
+            $params | Should -Contain "NoDmsInstance"
+            $params | Should -Contain "AddSmokeTestCredentials"
+            $params | Should -Contain "SchoolYearRange"
+            $params | Should -Contain "LoadSeedData"
+            $params | Should -Not -Contain "InstanceId"
+        }
+
+        It "start scripts expose InfraOnly and DmsOnly phase switches" {
+            foreach ($name in @("start-local-dms.ps1", "start-published-dms.ps1")) {
+                $params = Get-DeclaredScriptParameters -Path (Join-Path $script:sourceDockerComposeRoot $name)
+
+                $params | Should -Contain "InfraOnly"
+                $params | Should -Contain "DmsOnly"
+                $params | Should -Contain "LoadSeedData"
+            }
+        }
+    }
+
+    Context "staged schema workspace validation" {
+        It "returns core first and extensions in manifest order" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+
+            $workspace = Resolve-BootstrapSchemaWorkspace
+
+            $workspace.CoreSchemaPath | Should -Match "schemas.Ed-Fi.ApiSchema.json"
+            $workspace.ExtensionSchemaPaths.Count | Should -Be 1
+            $workspace.ExtensionSchemaPaths[0] | Should -Match "schemas.Sample.ApiSchema.json"
+            $workspace.EffectiveSchemaHash | Should -Be "abc123"
+            $workspace.WorkspaceFingerprint | Should -Be "def456"
+        }
+
+        It "rejects missing staged schema files and path traversal" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot -MissingCoreFile
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*Staged core schema file is missing*"
+
+            Remove-Item -LiteralPath $script:repo.BootstrapRoot -Recurse -Force
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot -PathTraversal
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*parent path segments*"
+        }
+
+        It "rejects missing and malformed manifest handoffs before provisioning can run" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*Bootstrap manifest not found*"
+
+            New-Item -ItemType Directory -Path $script:repo.BootstrapRoot -Force | Out-Null
+            "not-json" | Set-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") -Encoding utf8
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*contains malformed JSON*"
+
+            @{ version = 1 } |
+                ConvertTo-Json -Depth 10 |
+                Set-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") -Encoding utf8
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*malformed schema section*"
+
+            Remove-Item -LiteralPath $script:repo.BootstrapRoot -Recurse -Force
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Remove-Item -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json")
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*ApiSchema manifest is missing*"
+        }
+
+        It "rejects zero and multiple core projects in the ApiSchema manifest" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+            $apiSchemaManifestPath = Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+
+            $zeroCoreManifest = [ordered]@{
+                version = 1
+                projects = @(
+                    [ordered]@{
+                        projectName = "Sample"
+                        projectEndpointName = "sample"
+                        isExtensionProject = $true
+                        schemaPath = "schemas/Sample/ApiSchema.json"
+                    }
+                )
+            }
+            $zeroCoreManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath $apiSchemaManifestPath -Encoding utf8
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*exactly one core project. Found 0*"
+
+            $multipleCoreManifest = [ordered]@{
+                version = 1
+                projects = @(
+                    [ordered]@{
+                        projectName = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject = $false
+                        schemaPath = "schemas/Ed-Fi/ApiSchema.json"
+                    },
+                    [ordered]@{
+                        projectName = "Core Duplicate"
+                        projectEndpointName = "core-duplicate"
+                        isExtensionProject = $false
+                        schemaPath = "schemas/Sample/ApiSchema.json"
+                    }
+                )
+            }
+            $multipleCoreManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath $apiSchemaManifestPath -Encoding utf8
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*exactly one core project. Found 2*"
+        }
+    }
+
+    Context "schema provisioning" {
+        It "rejects mutually exclusive selectors before reading CMS or invoking SchemaTools" {
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { throw "CMS must not be contacted when selectors are invalid." }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) -SchoolYear @(2024) } |
+                Should -Throw -ExpectedMessage "*mutually exclusive*"
+        }
+
+        It "invokes dms-schema once per target database with host-side connection settings" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=tenant_db;'
+                        dmsInstanceRouteContexts = @()
+                    },
+                    [pscustomobject]@{
+                        id = 2
+                        instanceName = "B"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=tenant_db;'
+                        dmsInstanceRouteContexts = @(
+                            [pscustomobject]@{ contextKey = "schoolYear"; contextValue = "2024" }
+                        )
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1, 2)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            @($captured | Where-Object { $_ -eq "BEGIN" }).Count | Should -Be 1
+            $captured | Should -Contain "ddl"
+            $captured | Should -Contain "provision"
+            @($captured | Where-Object { $_ -eq "--schema" }).Count | Should -Be 2
+            $captured | Should -Contain "--connection-string"
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=localhost"
+            $connectionString | Should -Match "port=5544"
+            $connectionString | Should -Match "database=tenant_db"
+            $connectionString | Should -Not -Match "dms-postgresql"
+            $captured | Should -Contain "--dialect"
+            $captured | Should -Contain "pgsql"
+            $captured | Should -Contain "--create-database"
+        }
+
+        It "decrypts CMS-encrypted connection strings before provisioning" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+            $encryptedConnectionString = New-CmsEncryptedConnectionString `
+                -PlainText 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=encrypted_db;'
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 3
+                        instanceName = "Encrypted"
+                        connectionString = $encryptedConnectionString
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(3)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=localhost"
+            $connectionString | Should -Match "port=5544"
+            $connectionString | Should -Match "database=encrypted_db"
+            $connectionString | Should -Not -Match "dms-postgresql"
+        }
+
+        It "resolves school-year selectors and fails when a year is ambiguous" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 10
+                        instanceName = "SY2024-A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=sy2024a;'
+                        dmsInstanceRouteContexts = @([pscustomobject]@{ contextKey = "schoolYear"; contextValue = "2024" })
+                    },
+                    [pscustomobject]@{
+                        id = 11
+                        instanceName = "SY2024-B"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=sy2024b;'
+                        dmsInstanceRouteContexts = @([pscustomobject]@{ contextKey = "schoolYear"; contextValue = "2024" })
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -SchoolYear @(2024) } |
+                Should -Throw -ExpectedMessage "*Multiple DMS instances found with route context schoolYear=2024*"
+        }
+
+        It "fails on zero instances or ambiguous auto-selection before invoking SchemaTools" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances { return @() }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile } |
+                Should -Throw -ExpectedMessage "*No DMS instances found*"
+            Test-Path -LiteralPath $capturePath | Should -BeFalse
+
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=a;'
+                        dmsInstanceRouteContexts = @()
+                    },
+                    [pscustomobject]@{
+                        id = 2
+                        instanceName = "B"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=b;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile } |
+                Should -Throw -ExpectedMessage "*Multiple DMS instances exist*"
+            Test-Path -LiteralPath $capturePath | Should -BeFalse
+        }
+
+        It "surfaces SchemaTools stdout and stderr and fails on non-zero exit" {
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool `
+                -Directory $script:repo.RepoRoot `
+                -CapturePath $capturePath `
+                -ExitCode 23 `
+                -StdoutText "schema-tool-out" `
+                -StderrText "schema-tool-err"
+
+            . $script:repo.ProvisionScript
+
+            $output = & {
+                try {
+                    Invoke-DmsSchemaProvision `
+                        -ToolPath $fakeTool `
+                        -SchemaPaths @("core.json") `
+                        -ConnectionString "host=localhost;port=5544;username=postgres;password=secret-pass;database=tool_failure;" `
+                        -DatabaseName "tool_failure"
+                }
+                catch {
+                    $_.Exception.Message
+                }
+            } *>&1 | Out-String
+
+            $output | Should -Match "schema-tool-out"
+            $output | Should -Match "schema-tool-err"
+            $output | Should -Match "exit code 23"
+        }
+
+        It "does not write bootstrap-generated secrets or raw connection strings to logs" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 5
+                        instanceName = "A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=log_guard;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $output = & {
+                Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(5)
+            } *>&1 | Out-String
+
+            $output | Should -Not -Match "secret-pass"
+            $output | Should -Not -Match "ValidClientSecret1234567890"
+            $output | Should -Not -Match "dms-postgresql"
+            $output | Should -Not -Match "password="
+        }
+    }
+
+    Context "instance configuration" {
+        It "returns a structured object for NoDmsInstance route-unqualified selection" {
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 77
+                        instanceName = "Existing"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $result = Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -NoDmsInstance
+
+            $result.InstanceIds | Should -Be @(77)
+            $result.HasRouteQualifiedInstances | Should -BeFalse
+            $result.RouteContexts.Count | Should -Be 0
+        }
+
+        It "rejects NoDmsInstance when the sole existing instance is route-qualified" {
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 77
+                        instanceName = "Existing"
+                        dmsInstanceRouteContexts = @([pscustomobject]@{ contextKey = "schoolYear"; contextValue = "2024" })
+                    }
+                )
+            }
+
+            { Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -NoDmsInstance } |
+                Should -Throw -ExpectedMessage "*route-qualified*"
+        }
+    }
+
+    Context "wrapper sequencing" {
+        It "orders infra, configure, provision, DMS-only, then seed with school-year handoff" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $sequencePath = Join-Path $script:repo.RepoRoot "sequence.txt"
+
+            @"
+param(
+    [switch] `$InfraOnly,
+    [switch] `$DmsOnly,
+    [switch] `$EnableConfig,
+    [string] `$EnvironmentFile,
+    [string] `$IdentityProvider,
+    [Parameter(ValueFromRemainingArguments = `$true)] `$Rest
+)
+if (`$InfraOnly) { Add-Content -LiteralPath '$sequencePath' -Value `"start-infra EnableConfig=`$EnableConfig`" }
+elseif (`$DmsOnly) { Add-Content -LiteralPath '$sequencePath' -Value 'start-dms' }
+else { Add-Content -LiteralPath '$sequencePath' -Value 'start-legacy' }
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "start-local-dms.ps1") -Encoding utf8
+
+            @"
+param([string] `$EnvironmentFile, [string] `$SchoolYearRange, [switch] `$NoDmsInstance, [switch] `$AddSmokeTestCredentials)
+Add-Content -LiteralPath '$sequencePath' -Value `"configure range=`$SchoolYearRange noDms=`$NoDmsInstance smoke=`$AddSmokeTestCredentials`"
+[pscustomobject]@{
+    InstanceIds = [long[]] @(101, 102)
+    RouteContexts = @(
+        [pscustomobject]@{ InstanceId = [long]101; ContextKey = 'schoolYear'; ContextValue = '2024' },
+        [pscustomobject]@{ InstanceId = [long]102; ContextKey = 'schoolYear'; ContextValue = '2025' }
+    )
+    Tenant = ''
+    SchoolYears = [int[]] @(2024, 2025)
+    HasRouteQualifiedInstances = `$true
+}
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "configure-local-dms-instance.ps1") -Encoding utf8
+
+            @"
+param([string] `$EnvironmentFile, [long[]] `$InstanceId)
+Add-Content -LiteralPath '$sequencePath' -Value `"provision ids=`$(`$InstanceId -join ',')`"
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "provision-dms-schema.ps1") -Encoding utf8
+
+            @"
+param([string] `$EnvironmentFile, [int[]] `$SchoolYear, [long[]] `$InstanceId, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+Add-Content -LiteralPath '$sequencePath' -Value `"seed years=`$(`$SchoolYear -join ',') ids=`$(`$InstanceId -join ',')`"
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "load-dms-seed-data.ps1") -Encoding utf8
+
+            & $script:repo.WrapperScript `
+                -EnvironmentFile $script:repo.EnvFile `
+                -LoadSeedData `
+                -SeedDataPath $script:repo.DockerComposeRoot `
+                -SchoolYearRange "2024-2025" `
+                -AddSmokeTestCredentials
+
+            $sequence = @(Get-Content -LiteralPath $sequencePath)
+            $sequence[0] | Should -Be "start-infra EnableConfig=True"
+            $sequence[1] | Should -Be "configure range=2024-2025 noDms=False smoke=True"
+            $sequence[2] | Should -Be "provision ids=101,102"
+            $sequence[3] | Should -Be "start-dms"
+            $sequence[4] | Should -Be "seed years=2024,2025 ids="
+        }
+
+        It "passes route-unqualified configured instance to seed by InstanceId" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $sequencePath = Join-Path $script:repo.RepoRoot "sequence.txt"
+
+            "param([switch] `$InfraOnly, [switch] `$DmsOnly, [switch] `$EnableConfig, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest); if (`$InfraOnly) { Add-Content -LiteralPath '$sequencePath' -Value 'start-infra' } else { Add-Content -LiteralPath '$sequencePath' -Value 'start-dms' }" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "start-local-dms.ps1") -Encoding utf8
+
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+Add-Content -LiteralPath '$sequencePath' -Value 'configure'
+[pscustomobject]@{
+    InstanceIds = [long[]] @(42)
+    RouteContexts = @()
+    Tenant = ''
+    SchoolYears = [int[]] @()
+    HasRouteQualifiedInstances = `$false
+}
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "configure-local-dms-instance.ps1") -Encoding utf8
+
+            "param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest); Add-Content -LiteralPath '$sequencePath' -Value 'provision'" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "provision-dms-schema.ps1") -Encoding utf8
+
+            "param([long[]] `$InstanceId, [int[]] `$SchoolYear, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest); Add-Content -LiteralPath '$sequencePath' -Value (`"seed ids=`$(`$InstanceId -join ',') years=`$(`$SchoolYear -join ',')`")" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "load-dms-seed-data.ps1") -Encoding utf8
+
+            & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -LoadSeedData -SeedDataPath $script:repo.DockerComposeRoot
+
+            $sequence = @(Get-Content -LiteralPath $sequencePath)
+            $sequence[-1] | Should -Be "seed ids=42 years="
+        }
+
+        It "stops after provisioning failure and does not start DMS or seed" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $sequencePath = Join-Path $script:repo.RepoRoot "sequence.txt"
+
+            "param([switch] `$InfraOnly, [switch] `$DmsOnly, [switch] `$EnableConfig, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest); if (`$InfraOnly) { Add-Content -LiteralPath '$sequencePath' -Value 'start-infra' } elseif (`$DmsOnly) { Add-Content -LiteralPath '$sequencePath' -Value 'start-dms' }" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "start-local-dms.ps1") -Encoding utf8
+
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+Add-Content -LiteralPath '$sequencePath' -Value 'configure'
+[pscustomobject]@{
+    InstanceIds = [long[]] @(42)
+    RouteContexts = @()
+    Tenant = ''
+    SchoolYears = [int[]] @()
+    HasRouteQualifiedInstances = `$false
+}
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "configure-local-dms-instance.ps1") -Encoding utf8
+
+            "param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest); Add-Content -LiteralPath '$sequencePath' -Value 'provision'; throw 'provision failed'" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "provision-dms-schema.ps1") -Encoding utf8
+
+            "param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest); Add-Content -LiteralPath '$sequencePath' -Value 'seed'" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "load-dms-seed-data.ps1") -Encoding utf8
+
+            { & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -LoadSeedData -SeedDataPath $script:repo.DockerComposeRoot } |
+                Should -Throw -ExpectedMessage "*provision failed*"
+
+            $sequence = @(Get-Content -LiteralPath $sequencePath)
+            $sequence | Should -Be @("start-infra", "configure", "provision")
+        }
+
+        It "passes a derived env with DMS startup provisioning disabled into DMS-only startup" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $sequencePath = Join-Path $script:repo.RepoRoot "sequence.txt"
+
+            @"
+param([switch] `$InfraOnly, [switch] `$DmsOnly, [string] `$EnvironmentFile, [Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+if (`$InfraOnly) {
+    Add-Content -LiteralPath '$sequencePath' -Value 'start-infra'
+}
+elseif (`$DmsOnly) {
+    `$values = @{}
+    Get-Content -LiteralPath `$EnvironmentFile | ForEach-Object {
+        `$parts = `$_.Split('=', 2)
+        if (`$parts.Length -eq 2) { `$values[`$parts[0]] = `$parts[1] }
+    }
+    Add-Content -LiteralPath '$sequencePath' -Value `"start-dms need=`$(`$values['NEED_DATABASE_SETUP']) deploy=`$(`$values['DMS_DEPLOY_DATABASE_ON_STARTUP']) app=`$(`$values['AppSettings__DeployDatabaseOnStartup'])`"
+}
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "start-local-dms.ps1") -Encoding utf8
+
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+[pscustomobject]@{
+    InstanceIds = [long[]] @(42)
+    RouteContexts = @()
+    Tenant = ''
+    SchoolYears = [int[]] @()
+    HasRouteQualifiedInstances = `$false
+}
+"@ | Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "configure-local-dms-instance.ps1") -Encoding utf8
+
+            "param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)" |
+                Set-Content -LiteralPath (Join-Path $script:repo.DockerComposeRoot "provision-dms-schema.ps1") -Encoding utf8
+
+            & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile
+
+            $sequence = @(Get-Content -LiteralPath $sequencePath)
+            $sequence[-1] | Should -Be "start-dms need=false deploy=false app=false"
+        }
+    }
+}

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -1690,7 +1690,7 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                 or start-published-dms.ps1 and execute it in an isolated scope with a docker
                 stub. The extracted block is the production code, so any drift in the lockdown
                 semantics (env assignment removed, docker call moved before the assignment,
-                env var renamed) is caught at the behavioral level — not just the regex level.
+                env var renamed) is caught at the behavioral level - not just the regex level.
                 When -DmsOnly is set, the helper targets the -DmsOnly branch's try block (the
                 one with a trailing `dms` service name) instead of the main up block.
                 #>
@@ -1718,7 +1718,7 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                     $true)
                 # The outer try wraps the entire script body, so any docker call lives inside
                 # it. We want the innermost try whose body sets NEED_DATABASE_SETUP=false and
-                # immediately calls `docker compose ... up $upArgs` — main up path when -DmsOnly
+                # immediately calls `docker compose ... up $upArgs` - main up path when -DmsOnly
                 # is false (regex rejects a trailing word like `dms`); -DmsOnly branch when
                 # -DmsOnly is true (regex requires a trailing `dms` service name).
                 if ($DmsOnly) {

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -124,13 +124,16 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
             $apiSchemaManifest | ConvertTo-Json -Depth 20 |
                 Set-Content -LiteralPath (Join-Path $apiSchemaRoot "bootstrap-api-schema-manifest.json") -Encoding utf8
 
+            Import-Module (Join-Path $DockerComposeRoot "bootstrap-manifest.psm1") -Force
+            $workspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $apiSchemaRoot
+
             $rootManifest = [ordered]@{
                 version = 1
                 schema = [ordered]@{
                     selectionMode = "ApiSchemaPath"
                     selectedExtensions = @("sample")
                     effectiveSchemaHash = "abc123"
-                    workspaceFingerprint = "def456"
+                    workspaceFingerprint = $workspaceFingerprint
                     apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
                 }
                 claims = [ordered]@{
@@ -230,7 +233,7 @@ exit $ExitCode
 
     AfterEach {
         if ($null -ne $script:repo) {
-            Get-Module Dms-Management |
+            Get-Module Dms-Management, SmokeTest |
                 Where-Object { $_.Path -like "$($script:repo.RepoRoot)*" } |
                 Remove-Module -Force -ErrorAction SilentlyContinue
         }
@@ -292,7 +295,10 @@ exit $ExitCode
             $workspace.ExtensionSchemaPaths.Count | Should -Be 1
             $workspace.ExtensionSchemaPaths[0] | Should -Match "schemas.Sample.ApiSchema.json"
             $workspace.EffectiveSchemaHash | Should -Be "abc123"
-            $workspace.WorkspaceFingerprint | Should -Be "def456"
+            $manifest = Get-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") -Raw |
+                ConvertFrom-Json -AsHashtable
+            $workspace.WorkspaceFingerprint | Should -Be $manifest["schema"]["workspaceFingerprint"]
+            $workspace.WorkspaceFingerprint | Should -Match '^[a-f0-9]{64}$'
         }
 
         It "rejects missing staged schema files and path traversal" {
@@ -731,6 +737,32 @@ exit $ExitCode
             $output | Should -Not -Match "dms-postgresql"
             $output | Should -Not -Match "password="
         }
+
+        It "rejects staged schema workspace drift before invoking SchemaTools" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Set-Content -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") -Value '{"changed":true}' -Encoding utf8
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 5
+                        instanceName = "A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=drift_guard;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(5) } |
+                Should -Throw -ExpectedMessage "*staged schema workspace fingerprint mismatch*"
+            Test-Path -LiteralPath $capturePath | Should -BeFalse
+        }
     }
 
     Context "instance configuration" {
@@ -773,6 +805,72 @@ exit $ExitCode
 
             { Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -NoDmsInstance } |
                 Should -Throw -ExpectedMessage "*route-qualified*"
+        }
+
+        It "creates smoke credentials for the selected NoDmsInstance target and tenant" {
+            $envFile = Join-Path $script:repo.DockerComposeRoot "env-with-tenant.env"
+            Get-Content -LiteralPath $script:repo.EnvFile |
+                Set-Content -LiteralPath $envFile -Encoding utf8
+            Add-Content -LiteralPath $envFile -Value "CONFIG_SERVICE_TENANT=tenant-a"
+
+            $capturePath = Join-Path $script:repo.RepoRoot "smoke-capture.txt"
+            $smokeModuleDir = Join-Path $script:repo.RepoRoot "eng/smoke_test/modules"
+            New-Item -ItemType Directory -Path $smokeModuleDir -Force | Out-Null
+            @"
+function Get-SmokeTestCredentials {
+    param([string] `$ConfigServiceUrl, [long[]] `$DmsInstanceIds, [string] `$Tenant)
+    Add-Content -LiteralPath '$capturePath' -Value `"smoke url=`$ConfigServiceUrl ids=`$(`$DmsInstanceIds -join ',') tenant=`$Tenant`"
+}
+Export-ModuleMember -Function Get-SmokeTestCredentials
+"@ | Set-Content -LiteralPath (Join-Path $smokeModuleDir "SmokeTest.psm1") -Encoding utf8
+
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                param([string] $Tenant)
+                $Tenant | Should -Be "tenant-a"
+                return @(
+                    [pscustomobject]@{
+                        id = 77
+                        instanceName = "Existing"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ConfigureLocalDmsInstance -EnvironmentFile $envFile -NoDmsInstance -AddSmokeTestCredentials | Out-Null
+
+            @(Get-Content -LiteralPath $capturePath) | Should -Contain "smoke url=http://localhost:18081 ids=77 tenant=tenant-a"
+        }
+
+        It "creates smoke credentials for all selected school-year instances" {
+            $capturePath = Join-Path $script:repo.RepoRoot "smoke-schoolyear-capture.txt"
+            $smokeModuleDir = Join-Path $script:repo.RepoRoot "eng/smoke_test/modules"
+            New-Item -ItemType Directory -Path $smokeModuleDir -Force | Out-Null
+            @"
+function Get-SmokeTestCredentials {
+    param([string] `$ConfigServiceUrl, [long[]] `$DmsInstanceIds, [string] `$Tenant)
+    Add-Content -LiteralPath '$capturePath' -Value `"smoke ids=`$(`$DmsInstanceIds -join ',') tenant=`$Tenant`"
+}
+Export-ModuleMember -Function Get-SmokeTestCredentials
+"@ | Set-Content -LiteralPath (Join-Path $smokeModuleDir "SmokeTest.psm1") -Encoding utf8
+
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Add-DmsSchoolYearInstances {
+                return @(
+                    @{ InstanceId = [long]101; Year = 2024 },
+                    @{ InstanceId = [long]102; Year = 2025 }
+                )
+            }
+
+            Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -SchoolYearRange "2024-2025" -AddSmokeTestCredentials | Out-Null
+
+            @(Get-Content -LiteralPath $capturePath) | Should -Contain "smoke ids=101,102 tenant="
         }
     }
 
@@ -957,21 +1055,18 @@ param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
             $envExample | Should -Not -Match '(?m)^NEED_DATABASE_SETUP=true\s*$'
         }
 
-        It "start-local-dms.ps1 forces NEED_DATABASE_SETUP=false in the normal up path" {
+        It "start-local-dms.ps1 keeps direct startup provisioning controlled by the env file when no bootstrap manifest is present" {
             $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1") -Raw
 
-            # The normal `docker compose ... up` (not -DmsOnly) must wrap the call in a try/finally
-            # that forces NEED_DATABASE_SETUP=false. The -DmsOnly branch already did this; the
-            # remediation extends the guard to the main up path.
-            $envForceMatches = [regex]::Matches($startScript, '\$env:NEED_DATABASE_SETUP\s*=\s*"false"')
-            $envForceMatches.Count | Should -BeGreaterOrEqual 2
+            $startScript | Should -Match 'if \(\$bootstrapManifestPresent\)'
+            $startScript | Should -Match 'No bootstrap manifest detected; starting DMS with database startup provisioning controlled by the environment file\.'
         }
 
-        It "start-published-dms.ps1 forces NEED_DATABASE_SETUP=false in the normal up path" {
+        It "start-published-dms.ps1 keeps direct startup provisioning controlled by the env file when no bootstrap manifest is present" {
             $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1") -Raw
 
-            $envForceMatches = [regex]::Matches($startScript, '\$env:NEED_DATABASE_SETUP\s*=\s*"false"')
-            $envForceMatches.Count | Should -BeGreaterOrEqual 2
+            $startScript | Should -Match 'if \(\$bootstrapManifestPresent\)'
+            $startScript | Should -Match 'No bootstrap manifest detected; starting published DMS with database startup provisioning controlled by the environment file\.'
         }
     }
 
@@ -1691,8 +1786,8 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                 stub. The extracted block is the production code, so any drift in the lockdown
                 semantics (env assignment removed, docker call moved before the assignment,
                 env var renamed) is caught at the behavioral level - not just the regex level.
-                When -DmsOnly is set, the helper targets the -DmsOnly branch's try block (the
-                one with a trailing `dms` service name) instead of the main up block.
+                When -DmsOnly is set, the helper targets the -DmsOnly branch's try block
+                instead of the main up block.
                 #>
                 param(
                     [Parameter(Mandatory)]
@@ -1719,10 +1814,10 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                 # The outer try wraps the entire script body, so any docker call lives inside
                 # it. We want the innermost try whose body sets NEED_DATABASE_SETUP=false and
                 # immediately calls `docker compose ... up $upArgs` - main up path when -DmsOnly
-                # is false (regex rejects a trailing word like `dms`); -DmsOnly branch when
-                # -DmsOnly is true (regex requires a trailing `dms` service name).
+                # is false (regex rejects a trailing service argument); -DmsOnly branch when
+                # -DmsOnly is true (regex requires the service array used by that branch).
                 if ($DmsOnly) {
-                    $dockerRegex = 'docker compose .* up \$upArgs\s+dms\b'
+                    $dockerRegex = 'docker compose .* up \$upArgs\s+\$dmsServices\b'
                     $branchLabel = "-DmsOnly"
                 } else {
                     $dockerRegex = 'docker compose .* up \$upArgs(?!\s*\w)'
@@ -1749,6 +1844,7 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
 `$files = @('-f', 'local-dms.yml')
 `$EnvironmentFile = '.env'
 `$upArgs = @('-d')
+`$dmsServices = @('dms')
 function docker {
     Add-Content -LiteralPath '$escapedCapture' -Value "NEED_DATABASE_SETUP=`$env:NEED_DATABASE_SETUP"
     Add-Content -LiteralPath '$escapedCapture' -Value "DMS_DEPLOY_DATABASE_ON_STARTUP=`$env:DMS_DEPLOY_DATABASE_ON_STARTUP"
@@ -1761,7 +1857,7 @@ $extracted
             }
         }
 
-        It "start-local-dms.ps1 main up path captures NEED_DATABASE_SETUP=false at docker call time" {
+        It "start-local-dms.ps1 bootstrap main up path captures NEED_DATABASE_SETUP=false at docker call time" {
             $capturePath = Join-Path $script:repo.RepoRoot "docker-up-capture-local.txt"
             $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1"
 
@@ -1773,7 +1869,7 @@ $extracted
             $captured | Should -Contain "AppSettings__DeployDatabaseOnStartup=false"
         }
 
-        It "start-published-dms.ps1 main up path captures NEED_DATABASE_SETUP=false at docker call time" {
+        It "start-published-dms.ps1 bootstrap main up path captures NEED_DATABASE_SETUP=false at docker call time" {
             $capturePath = Join-Path $script:repo.RepoRoot "docker-up-capture-published.txt"
             $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1"
 
@@ -1820,7 +1916,7 @@ $extracted
             $warnings.Count | Should -BeGreaterThan 0
             ($warnings | ForEach-Object Message) -join " " | Should -Match "No bootstrap manifest detected"
             ($warnings | ForEach-Object Message) -join " " | Should -Match "bootstrap-\(local\|published\)-dms.ps1 wrapper"
-            ($warnings | ForEach-Object Message) -join " " | Should -Match "Schemas will NOT be provisioned"
+            ($warnings | ForEach-Object Message) -join " " | Should -Match "Bootstrap schema provisioning will NOT be run"
         }
 
         It "stays silent when a .bootstrap workspace is present" {

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -80,36 +80,46 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
 
                 [switch]$MissingCoreFile,
 
-                [switch]$PathTraversal
+                [switch]$PathTraversal,
+
+                # Extension project names included alongside the Ed-Fi core. Default preserves the
+                # historical core+Sample fixture; callers can pass @() for core-only or @("Sample",
+                # "Homograph") to exercise multi-extension ordering.
+                [string[]]$Extensions = @("Sample")
             )
 
             $bootstrapRoot = Join-Path $DockerComposeRoot ".bootstrap"
             $apiSchemaRoot = Join-Path $bootstrapRoot "ApiSchema"
             New-Item -ItemType Directory -Path (Join-Path $apiSchemaRoot "schemas/Ed-Fi") -Force | Out-Null
-            New-Item -ItemType Directory -Path (Join-Path $apiSchemaRoot "schemas/Sample") -Force | Out-Null
+            foreach ($extensionName in $Extensions) {
+                New-Item -ItemType Directory -Path (Join-Path $apiSchemaRoot "schemas/$extensionName") -Force | Out-Null
+                "{}" | Set-Content -LiteralPath (Join-Path $apiSchemaRoot "schemas/$extensionName/ApiSchema.json") -Encoding utf8
+            }
 
             if (-not $MissingCoreFile) {
                 "{}" | Set-Content -LiteralPath (Join-Path $apiSchemaRoot "schemas/Ed-Fi/ApiSchema.json") -Encoding utf8
             }
-            "{}" | Set-Content -LiteralPath (Join-Path $apiSchemaRoot "schemas/Sample/ApiSchema.json") -Encoding utf8
 
             $coreSchemaPath = if ($PathTraversal) { "../escape.json" } else { "schemas/Ed-Fi/ApiSchema.json" }
+            $projects = @(
+                [ordered]@{
+                    projectName = "Ed-Fi"
+                    projectEndpointName = "ed-fi"
+                    isExtensionProject = $false
+                    schemaPath = $coreSchemaPath
+                }
+            )
+            foreach ($extensionName in $Extensions) {
+                $projects += [ordered]@{
+                    projectName = $extensionName
+                    projectEndpointName = $extensionName.ToLowerInvariant()
+                    isExtensionProject = $true
+                    schemaPath = "schemas/$extensionName/ApiSchema.json"
+                }
+            }
             $apiSchemaManifest = [ordered]@{
                 version = 1
-                projects = @(
-                    [ordered]@{
-                        projectName = "Ed-Fi"
-                        projectEndpointName = "ed-fi"
-                        isExtensionProject = $false
-                        schemaPath = $coreSchemaPath
-                    },
-                    [ordered]@{
-                        projectName = "Sample"
-                        projectEndpointName = "sample"
-                        isExtensionProject = $true
-                        schemaPath = "schemas/Sample/ApiSchema.json"
-                    }
-                )
+                projects = $projects
             }
             $apiSchemaManifest | ConvertTo-Json -Depth 20 |
                 Set-Content -LiteralPath (Join-Path $apiSchemaRoot "bootstrap-api-schema-manifest.json") -Encoding utf8
@@ -124,6 +134,7 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                     apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
                 }
                 claims = [ordered]@{
+                    mode = "Embedded"
                     directory = "claims"
                     fingerprint = "claims"
                     expectedVerificationChecks = @()
@@ -133,6 +144,7 @@ DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey1234567890123456789012345678
                 }
             }
             New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+            New-Item -ItemType Directory -Path (Join-Path $bootstrapRoot "claims") -Force | Out-Null
             $rootManifest | ConvertTo-Json -Depth 20 |
                 Set-Content -LiteralPath (Join-Path $bootstrapRoot "bootstrap-manifest.json") -Encoding utf8
         }
@@ -262,6 +274,9 @@ exit $ExitCode
                 $params | Should -Contain "InfraOnly"
                 $params | Should -Contain "DmsOnly"
                 $params | Should -Contain "LoadSeedData"
+                $params | Should -Not -Contain "ApiSchemaPath"
+                $params | Should -Not -Contain "ClaimsDirectoryPath"
+                $params | Should -Not -Contain "Extensions"
             }
         }
     }
@@ -290,6 +305,51 @@ exit $ExitCode
             New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot -PathTraversal
 
             { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*parent path segments*"
+        }
+
+        It "rejects an absolute schemaPath in the ApiSchema manifest" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+            $apiSchemaManifestPath = Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+
+            $absoluteSchemaPath = if ($IsWindows) { "C:\evil-schema.json" } else { "/tmp/evil-schema.json" }
+            $absolutePathManifest = [ordered]@{
+                version = 1
+                projects = @(
+                    [ordered]@{
+                        projectName = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject = $false
+                        schemaPath = $absoluteSchemaPath
+                    }
+                )
+            }
+            $absolutePathManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath $apiSchemaManifestPath -Encoding utf8
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*must be relative*"
+        }
+
+        It "rejects a non-boolean isExtensionProject value in the ApiSchema manifest" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-workspace.psm1") -Force
+            $apiSchemaManifestPath = Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+
+            $nonBoolManifest = [ordered]@{
+                version = 1
+                projects = @(
+                    [ordered]@{
+                        projectName = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject = "yes"
+                        schemaPath = "schemas/Ed-Fi/ApiSchema.json"
+                    }
+                )
+            }
+            $nonBoolManifest | ConvertTo-Json -Depth 20 |
+                Set-Content -LiteralPath $apiSchemaManifestPath -Encoding utf8
+
+            { Resolve-BootstrapSchemaWorkspace } | Should -Throw -ExpectedMessage "*malformed boolean*"
         }
 
         It "rejects missing and malformed manifest handoffs before provisioning can run" {
@@ -779,6 +839,1235 @@ param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
 
             $sequence = @(Get-Content -LiteralPath $sequencePath)
             $sequence[-1] | Should -Be "start-dms need=false deploy=false app=false"
+        }
+    }
+
+    Context "legacy startup provisioning lockdown" {
+        It "local-dms.yml defaults NEED_DATABASE_SETUP to false" {
+            $localDmsYaml = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "local-dms.yml") -Raw
+            $localDmsYaml | Should -Match 'NEED_DATABASE_SETUP:\s*\$\{NEED_DATABASE_SETUP:-false\}'
+            $localDmsYaml | Should -Not -Match 'NEED_DATABASE_SETUP:\s*\$\{NEED_DATABASE_SETUP:-true\}'
+        }
+
+        It "published-dms.yml defaults NEED_DATABASE_SETUP to false" {
+            $publishedDmsYaml = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "published-dms.yml") -Raw
+            $publishedDmsYaml | Should -Match 'NEED_DATABASE_SETUP:\s*\$\{NEED_DATABASE_SETUP:-false\}'
+            $publishedDmsYaml | Should -Not -Match 'NEED_DATABASE_SETUP:\s*\$\{NEED_DATABASE_SETUP:-true\}'
+        }
+
+        It ".env.example sets NEED_DATABASE_SETUP=false" {
+            $envExample = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot ".env.example") -Raw
+            $envExample | Should -Match '(?m)^NEED_DATABASE_SETUP=false\s*$'
+            $envExample | Should -Not -Match '(?m)^NEED_DATABASE_SETUP=true\s*$'
+        }
+
+        It "start-local-dms.ps1 forces NEED_DATABASE_SETUP=false in the normal up path" {
+            $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1") -Raw
+
+            # The normal `docker compose ... up` (not -DmsOnly) must wrap the call in a try/finally
+            # that forces NEED_DATABASE_SETUP=false. The -DmsOnly branch already did this; the
+            # remediation extends the guard to the main up path.
+            $envForceMatches = [regex]::Matches($startScript, '\$env:NEED_DATABASE_SETUP\s*=\s*"false"')
+            $envForceMatches.Count | Should -BeGreaterOrEqual 2
+        }
+
+        It "start-published-dms.ps1 forces NEED_DATABASE_SETUP=false in the normal up path" {
+            $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1") -Raw
+
+            $envForceMatches = [regex]::Matches($startScript, '\$env:NEED_DATABASE_SETUP\s*=\s*"false"')
+            $envForceMatches.Count | Should -BeGreaterOrEqual 2
+        }
+    }
+
+    Context "effective database target grouping" {
+        It "treats two instances with the same database name on different hosts as separate targets" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=shared_name;'
+                        dmsInstanceRouteContexts = @()
+                    },
+                    [pscustomobject]@{
+                        id = 2
+                        instanceName = "B"
+                        connectionString = 'host=other-postgresql;port=5432;username=postgres;password=secret-pass;database=shared_name;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1, 2)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            @($captured | Where-Object { $_ -eq "BEGIN" }).Count | Should -Be 2
+        }
+
+        It "treats two instances with the same database name on different ports as separate targets" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "A"
+                        connectionString = 'host=localhost;port=15432;username=postgres;password=secret-pass;database=shared_name;'
+                        dmsInstanceRouteContexts = @()
+                    },
+                    [pscustomobject]@{
+                        id = 2
+                        instanceName = "B"
+                        connectionString = 'host=localhost;port=15433;username=postgres;password=secret-pass;database=shared_name;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1, 2)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            @($captured | Where-Object { $_ -eq "BEGIN" }).Count | Should -Be 2
+        }
+
+        It "treats two instances sharing host/port/db under different users as separate targets" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "RoleA"
+                        connectionString = 'host=dms-postgresql;port=5432;username=app_role_a;password=secret-pass;database=shared_db;'
+                        dmsInstanceRouteContexts = @()
+                    },
+                    [pscustomobject]@{
+                        id = 2
+                        instanceName = "RoleB"
+                        connectionString = 'host=dms-postgresql;port=5432;username=app_role_b;password=secret-pass;database=shared_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1, 2)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            @($captured | Where-Object { $_ -eq "BEGIN" }).Count | Should -Be 2
+        }
+    }
+
+    Context "host-side target connection conversion" {
+        It "preserves per-instance username, password, and database from the stored connection string" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Tenant-A"
+                        connectionString = 'host=dms-postgresql;port=5432;username=tenant_a_user;password=tenant_a_secret;database=tenant_a_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=localhost"
+            $connectionString | Should -Match "port=5544"
+            $connectionString | Should -Match "username=tenant_a_user"
+            $connectionString | Should -Match "password=tenant_a_secret"
+            $connectionString | Should -Match "database=tenant_a_db"
+        }
+
+        It "preserves non-default external host and port for instances not on dms-postgresql:5432" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "External"
+                        connectionString = 'host=managed-pg.example.com;port=5439;username=ops_user;password=ops_pass;database=ext_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=managed-pg.example.com"
+            $connectionString | Should -Match "port=5439"
+            $connectionString | Should -Match "username=ops_user"
+            $connectionString | Should -Match "database=ext_db"
+            $connectionString | Should -Not -Match "host=localhost"
+        }
+
+        It "rejects MSSQL-style connection strings with an actionable error" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "MsSql"
+                        connectionString = 'Server=mssql-host;Initial Catalog=db1;User Id=sa;Password=foo;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Throw -ExpectedMessage "*Only PostgreSQL provisioning is supported*"
+            Test-Path -LiteralPath $capturePath | Should -BeFalse
+        }
+    }
+
+    Context "configure result contract" {
+        It "returns SelectedInstanceIds plus a backward-compatible InstanceIds alias" {
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 99
+                        instanceName = "Sole"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $result = Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -NoDmsInstance
+
+            $result.PSObject.Properties.Name | Should -Contain "SelectedInstanceIds"
+            $result.SelectedInstanceIds | Should -Be @([long]99)
+            $result.InstanceIds | Should -Be @([long]99)
+        }
+
+        It "includes CMSReadOnlyAccess block when env supplies the client id" {
+            $envFile = Join-Path $script:repo.DockerComposeRoot "env-with-ro.env"
+            @"
+POSTGRES_PASSWORD=secret-pass
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+CONFIG_SERVICE_CLIENT_ID=CMSReadOnlyAccess
+CONFIG_SERVICE_CLIENT_SCOPE=edfi_admin_api/readonly_access
+CONFIG_SERVICE_CLIENT_SECRET=my-ro-secret
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+"@ | Set-Content -LiteralPath $envFile -Encoding utf8
+
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $result = Invoke-ConfigureLocalDmsInstance -EnvironmentFile $envFile -NoDmsInstance
+
+            $result.PSObject.Properties.Name | Should -Contain "CMSReadOnlyAccess"
+            $result.CMSReadOnlyAccess["ClientId"] | Should -Be "CMSReadOnlyAccess"
+            $result.CMSReadOnlyAccess["Scope"] | Should -Be "edfi_admin_api/readonly_access"
+            $result.CMSReadOnlyAccess["ClientSecret"] | Should -Be "my-ro-secret"
+        }
+    }
+
+    Context "provisioning summary and IDE guidance" {
+        It "emits the post-provisioning summary listing each provisioned target" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Single"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=summary_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $output = & {
+                Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+            } *>&1 | Out-String
+
+            $output | Should -Match "Schema Provisioning Summary"
+            $output | Should -Match "database=summary_db"
+            $output | Should -Match "host=localhost"
+            $output | Should -Match "instance-ids=\[1\]"
+            $output | Should -Match "status=Provisioned"
+        }
+
+        It "emits IDE next-step guidance labeled with the Story 04 dependency" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 7
+                        instanceName = "Single"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=guidance_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $output = & {
+                Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(7)
+            } *>&1 | Out-String
+
+            $output | Should -Match "IDE next-step guidance"
+            $output | Should -Match "AppSettings__UseApiSchemaPath = true"
+            $output | Should -Match "AppSettings__ApiSchemaPath"
+            $output | Should -Match "Story 04"
+            $output | Should -Match "deferred"
+        }
+
+        It "guidance generator produces deterministic lines from a schema workspace and target list" {
+            . $script:repo.ProvisionScript
+
+            $schemaWorkspace = [pscustomobject]@{
+                BootstrapManifestPath = "/tmp/.bootstrap/bootstrap-manifest.json"
+                ApiSchemaManifestPath = "/tmp/.bootstrap/ApiSchema/bootstrap-api-schema-manifest.json"
+                CoreSchemaPath = "/tmp/.bootstrap/ApiSchema/schemas/Ed-Fi/ApiSchema.json"
+                ExtensionSchemaPaths = [string[]]@()
+                EffectiveSchemaHash = "hash-xyz"
+                WorkspaceFingerprint = "fp"
+            }
+            $targets = @(
+                [pscustomobject]@{
+                    DatabaseName = "td"
+                    Host = "h"
+                    Port = "5432"
+                    Dialect = "pgsql"
+                    Username = "u"
+                    InstanceIds = [long[]]@(1, 2)
+                    Status = "Provisioned"
+                }
+            )
+
+            $lines = Get-ProvisionIdeGuidance -SchemaWorkspace $schemaWorkspace -ProvisionedTargets $targets
+
+            ($lines -join "`n") | Should -Match "Provisioned 1 database target"
+            ($lines -join "`n") | Should -Match "database=td host=h port=5432 user=u"
+            ($lines -join "`n") | Should -Match "Story 04"
+        }
+    }
+
+    Context "shared env-file helpers" {
+        It "Resolve-LocalSettingsEnvironmentFile throws on missing file" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            { Resolve-LocalSettingsEnvironmentFile -Path "/does/not/exist.env" -DockerComposeRoot $script:repo.DockerComposeRoot } |
+                Should -Throw -ExpectedMessage "*Environment file not found*"
+        }
+
+        It "Resolve-LocalSettingsEnvironmentFile returns the absolute env path for the supplied file" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $resolved = Resolve-LocalSettingsEnvironmentFile -Path $script:repo.EnvFile -DockerComposeRoot $script:repo.DockerComposeRoot
+
+            [System.IO.Path]::IsPathRooted($resolved) | Should -BeTrue
+            $resolved | Should -Be ([System.IO.Path]::GetFullPath($script:repo.EnvFile))
+        }
+
+        It "Get-EnvValue returns the supplied default when the key is absent or blank" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $envValues = @{ A = "alpha"; B = "" }
+            Get-EnvValue -EnvValues $envValues -Name "A" -DefaultValue "fallback" | Should -Be "alpha"
+            Get-EnvValue -EnvValues $envValues -Name "B" -DefaultValue "fallback" | Should -Be "fallback"
+            Get-EnvValue -EnvValues $envValues -Name "Z" -DefaultValue "fallback" | Should -Be "fallback"
+        }
+    }
+
+    Context "EnvironmentFile precedence" {
+        It "configure-local-dms-instance.ps1 reads only the supplied -EnvironmentFile, not ambient process env" {
+            $isolatedEnvFile = Join-Path $script:repo.DockerComposeRoot "env-with-tenant.env"
+            @"
+POSTGRES_PASSWORD=isolated-pass
+POSTGRES_DB_NAME=isolated_db
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+CONFIG_SERVICE_TENANT=isolated-tenant
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+"@ | Set-Content -LiteralPath $isolatedEnvFile -Encoding utf8
+
+            # Set conflicting values in process env; the script must ignore them and use the file.
+            $env:POSTGRES_PASSWORD = "process-pass"
+            $env:POSTGRES_DB_NAME = "process_db"
+            $env:CONFIG_SERVICE_TENANT = "process-tenant"
+            try {
+                . $script:repo.ConfigureScript
+
+                function Add-CmsClient { }
+                function Get-CmsToken { return "token" }
+                function Get-DmsInstances {
+                    return @(
+                        [pscustomobject]@{
+                            id = 1
+                            instanceName = "Sole"
+                            dmsInstanceRouteContexts = @()
+                        }
+                    )
+                }
+
+                $result = Invoke-ConfigureLocalDmsInstance -EnvironmentFile $isolatedEnvFile -NoDmsInstance
+
+                $result.Tenant | Should -Be "isolated-tenant"
+            }
+            finally {
+                $env:POSTGRES_PASSWORD = $null
+                $env:POSTGRES_DB_NAME = $null
+                $env:CONFIG_SERVICE_TENANT = $null
+            }
+        }
+
+        It "provision-dms-schema.ps1 host-side connection uses POSTGRES_PORT from supplied env file, not process env" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+
+            $isolatedEnvFile = Join-Path $script:repo.DockerComposeRoot "env-port-isolation.env"
+            @"
+POSTGRES_PASSWORD=isolated-pass
+POSTGRES_DB_NAME=isolated_db
+POSTGRES_PORT=9876
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+"@ | Set-Content -LiteralPath $isolatedEnvFile -Encoding utf8
+
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+            $env:POSTGRES_PORT = "1111"
+
+            try {
+                . $script:repo.ProvisionScript
+
+                function Add-CmsClient { }
+                function Get-CmsToken { return "token" }
+                function Get-DmsInstances {
+                    return @(
+                        [pscustomobject]@{
+                            id = 1
+                            instanceName = "Sole"
+                            connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=isolated_db;'
+                            dmsInstanceRouteContexts = @()
+                        }
+                    )
+                }
+
+                Invoke-ProvisionDmsSchema -EnvironmentFile $isolatedEnvFile -InstanceId @(1)
+
+                $captured = @(Get-Content -LiteralPath $capturePath)
+                $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+                $connectionString | Should -Match "port=9876"
+                $connectionString | Should -Not -Match "port=1111"
+            }
+            finally {
+                $env:POSTGRES_PORT = $null
+            }
+        }
+    }
+
+    Context "wrapper consumes SelectedInstanceIds" {
+        It "Resolve-WrapperSelectedInstanceIds prefers SelectedInstanceIds over the legacy alias" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-wrapper.psm1") -Force
+
+            $configured = [pscustomobject]@{
+                SelectedInstanceIds = [long[]]@(101, 102)
+                InstanceIds = [long[]]@(901, 902)
+                HasRouteQualifiedInstances = $false
+            }
+            $resolved = Resolve-WrapperSelectedInstanceIds -ConfigureResult $configured
+
+            $resolved | Should -Be @([long]101, [long]102)
+        }
+
+        It "Resolve-WrapperSelectedInstanceIds falls back to InstanceIds when SelectedInstanceIds is absent" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-wrapper.psm1") -Force
+
+            $configured = [pscustomobject]@{
+                InstanceIds = [long[]]@(42)
+                HasRouteQualifiedInstances = $false
+            }
+            $resolved = Resolve-WrapperSelectedInstanceIds -ConfigureResult $configured
+
+            $resolved | Should -Be @([long]42)
+        }
+
+        It "Resolve-WrapperSelectedInstanceIds throws when neither property is present" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-wrapper.psm1") -Force
+
+            $configured = [pscustomobject]@{ Tenant = "" }
+
+            { Resolve-WrapperSelectedInstanceIds -ConfigureResult $configured } |
+                Should -Throw -ExpectedMessage "*missing SelectedInstanceIds*"
+        }
+    }
+
+    Context "provision is an auth consumer only" {
+        It "does not call Add-CmsClient during provisioning" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { throw "Add-CmsClient must not be called during provisioning." }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=auth_consumer_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Not -Throw
+        }
+
+        It "surfaces an actionable error pointing to configure when Get-CmsToken fails" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { throw "Add-CmsClient must not be called during provisioning." }
+            function Get-CmsToken { throw "401 Unauthorized: invalid_client" }
+            function Get-DmsInstances { return @() }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Throw -ExpectedMessage "*configure-local-dms-instance.ps1*"
+        }
+    }
+
+    Context "PostgreSQL port defaults" {
+        It "defaults a missing port to 5432 for an external PostgreSQL host" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "ExternalNoPort"
+                        connectionString = 'host=managed-pg.example.com;username=ops_user;password=ops_pass;database=ext_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=managed-pg.example.com"
+            $connectionString | Should -Match "port=5432"
+            $connectionString | Should -Not -Match "host=localhost"
+        }
+
+        It "defaults a missing port for dms-postgresql to the host-side mapped POSTGRES_PORT" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "DockerInternalNoPort"
+                        connectionString = 'host=dms-postgresql;username=postgres;password=secret-pass;database=docker_internal_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $connectionString = $captured[[array]::IndexOf($captured, "--connection-string") + 1]
+            $connectionString | Should -Match "host=localhost"
+            $connectionString | Should -Match "port=5544"
+        }
+
+        It "still fails fast when both host and port are missing" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "MissingHost"
+                        connectionString = 'username=postgres;password=secret-pass;database=no_host_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Throw -ExpectedMessage "*missing a host key*"
+        }
+    }
+
+    Context "CMSReadOnlyAccess presence-gated emission" {
+        It "Resolve-CmsReadOnlyAccessFromEnv returns null when none of the three keys are present" {
+            . $script:repo.ConfigureScript
+
+            $result = Resolve-CmsReadOnlyAccessFromEnv -EnvValues @{
+                POSTGRES_PASSWORD = "x"
+            }
+
+            $result | Should -BeNullOrEmpty
+        }
+
+        It "Resolve-CmsReadOnlyAccessFromEnv defaults client id and scope when only the secret is supplied" {
+            . $script:repo.ConfigureScript
+
+            $result = Resolve-CmsReadOnlyAccessFromEnv -EnvValues @{
+                CONFIG_SERVICE_CLIENT_SECRET = "explicit-secret"
+            }
+
+            $result | Should -Not -BeNullOrEmpty
+            $result["ClientId"] | Should -Be "CMSReadOnlyAccess"
+            $result["Scope"] | Should -Be "edfi_admin_api/readonly_access"
+            $result["ClientSecret"] | Should -Be "explicit-secret"
+        }
+
+        It "configure result omits CMSReadOnlyAccess when the env file lacks the keys" {
+            . $script:repo.ConfigureScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $result = Invoke-ConfigureLocalDmsInstance -EnvironmentFile $script:repo.EnvFile -NoDmsInstance
+
+            $result.PSObject.Properties.Name | Should -Not -Contain "CMSReadOnlyAccess"
+        }
+
+        It "Get-ProvisionCmsReadOnlyAccessGuidance returns empty when no CONFIG_SERVICE_CLIENT_* keys are present" {
+            . $script:repo.ProvisionScript
+
+            $lines = Get-ProvisionCmsReadOnlyAccessGuidance -EnvValues @{
+                POSTGRES_PASSWORD = "x"
+            }
+
+            $lines | Should -BeNullOrEmpty
+        }
+
+        It "Get-ProvisionCmsReadOnlyAccessGuidance emits the block when an explicit env key is supplied" {
+            . $script:repo.ProvisionScript
+
+            $lines = Get-ProvisionCmsReadOnlyAccessGuidance -EnvValues @{
+                CONFIG_SERVICE_CLIENT_SECRET = "explicit-secret"
+            }
+
+            ($lines -join "`n") | Should -Match "ConfigurationServiceSettings__ClientId = CMSReadOnlyAccess"
+            ($lines -join "`n") | Should -Match "ConfigurationServiceSettings__ClientSecret = \(present in environment file\)"
+        }
+    }
+
+    Context "behavioral start-script lockdown" {
+        BeforeAll {
+            function script:Invoke-StartScriptLockdownBlock {
+                <#
+                .SYNOPSIS
+                Extract the main up-path (or -DmsOnly) try/finally from start-local-dms.ps1
+                or start-published-dms.ps1 and execute it in an isolated scope with a docker
+                stub. The extracted block is the production code, so any drift in the lockdown
+                semantics (env assignment removed, docker call moved before the assignment,
+                env var renamed) is caught at the behavioral level — not just the regex level.
+                When -DmsOnly is set, the helper targets the -DmsOnly branch's try block (the
+                one with a trailing `dms` service name) instead of the main up block.
+                #>
+                param(
+                    [Parameter(Mandatory)]
+                    [string]$ScriptPath,
+
+                    [Parameter(Mandatory)]
+                    [string]$CapturePath,
+
+                    [switch]$DmsOnly
+                )
+
+                $sourceText = Get-Content -Raw -LiteralPath $ScriptPath
+                $parseErrors = $null
+                $tokens = $null
+                $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+                    $sourceText, [ref]$tokens, [ref]$parseErrors)
+                if ($parseErrors.Count -gt 0) {
+                    throw "Failed to parse $ScriptPath"
+                }
+
+                $tries = $ast.FindAll(
+                    { $args[0] -is [System.Management.Automation.Language.TryStatementAst] },
+                    $true)
+                # The outer try wraps the entire script body, so any docker call lives inside
+                # it. We want the innermost try whose body sets NEED_DATABASE_SETUP=false and
+                # immediately calls `docker compose ... up $upArgs` — main up path when -DmsOnly
+                # is false (regex rejects a trailing word like `dms`); -DmsOnly branch when
+                # -DmsOnly is true (regex requires a trailing `dms` service name).
+                if ($DmsOnly) {
+                    $dockerRegex = 'docker compose .* up \$upArgs\s+dms\b'
+                    $branchLabel = "-DmsOnly"
+                } else {
+                    $dockerRegex = 'docker compose .* up \$upArgs(?!\s*\w)'
+                    $branchLabel = "main up"
+                }
+                $candidates = @($tries | Where-Object {
+                    $bodyText = $_.Body.Extent.Text
+                    ($bodyText -match '\$env:NEED_DATABASE_SETUP\s*=\s*"false"') -and
+                    ($bodyText -match $dockerRegex)
+                })
+                $upPathTry = $candidates | Sort-Object { $_.Body.Extent.Text.Length } | Select-Object -First 1
+                if ($null -eq $upPathTry) {
+                    throw "Could not locate the $branchLabel lockdown try block in $ScriptPath"
+                }
+
+                $extracted = $upPathTry.Extent.Text
+                $escapedCapture = $CapturePath.Replace("'", "''")
+                # The docker stub deliberately omits a param() block: declaring
+                # ValueFromRemainingArguments makes it an advanced function, which then binds
+                # common parameters like -PipelineVariable and trips on the production
+                # `-p dms-local` flag. A simple function captures all args via the automatic
+                # `$args` variable and avoids the ambiguity.
+                $isolated = @"
+`$files = @('-f', 'local-dms.yml')
+`$EnvironmentFile = '.env'
+`$upArgs = @('-d')
+function docker {
+    Add-Content -LiteralPath '$escapedCapture' -Value "NEED_DATABASE_SETUP=`$env:NEED_DATABASE_SETUP"
+    Add-Content -LiteralPath '$escapedCapture' -Value "DMS_DEPLOY_DATABASE_ON_STARTUP=`$env:DMS_DEPLOY_DATABASE_ON_STARTUP"
+    Add-Content -LiteralPath '$escapedCapture' -Value "AppSettings__DeployDatabaseOnStartup=`$env:AppSettings__DeployDatabaseOnStartup"
+    `$global:LASTEXITCODE = 0
+}
+$extracted
+"@
+                & ([scriptblock]::Create($isolated))
+            }
+        }
+
+        It "start-local-dms.ps1 main up path captures NEED_DATABASE_SETUP=false at docker call time" {
+            $capturePath = Join-Path $script:repo.RepoRoot "docker-up-capture-local.txt"
+            $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1"
+
+            Invoke-StartScriptLockdownBlock -ScriptPath $startScriptPath -CapturePath $capturePath
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $captured | Should -Contain "NEED_DATABASE_SETUP=false"
+            $captured | Should -Contain "DMS_DEPLOY_DATABASE_ON_STARTUP=false"
+            $captured | Should -Contain "AppSettings__DeployDatabaseOnStartup=false"
+        }
+
+        It "start-published-dms.ps1 main up path captures NEED_DATABASE_SETUP=false at docker call time" {
+            $capturePath = Join-Path $script:repo.RepoRoot "docker-up-capture-published.txt"
+            $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1"
+
+            Invoke-StartScriptLockdownBlock -ScriptPath $startScriptPath -CapturePath $capturePath
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $captured | Should -Contain "NEED_DATABASE_SETUP=false"
+            $captured | Should -Contain "DMS_DEPLOY_DATABASE_ON_STARTUP=false"
+            $captured | Should -Contain "AppSettings__DeployDatabaseOnStartup=false"
+        }
+
+        It "start-local-dms.ps1 -DmsOnly path captures NEED_DATABASE_SETUP=false at docker call time" {
+            $capturePath = Join-Path $script:repo.RepoRoot "docker-dmsonly-capture-local.txt"
+            $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1"
+
+            Invoke-StartScriptLockdownBlock -ScriptPath $startScriptPath -CapturePath $capturePath -DmsOnly
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $captured | Should -Contain "NEED_DATABASE_SETUP=false"
+            $captured | Should -Contain "DMS_DEPLOY_DATABASE_ON_STARTUP=false"
+            $captured | Should -Contain "AppSettings__DeployDatabaseOnStartup=false"
+        }
+
+        It "start-published-dms.ps1 -DmsOnly path captures NEED_DATABASE_SETUP=false at docker call time" {
+            $capturePath = Join-Path $script:repo.RepoRoot "docker-dmsonly-capture-published.txt"
+            $startScriptPath = Join-Path $script:sourceDockerComposeRoot "start-published-dms.ps1"
+
+            Invoke-StartScriptLockdownBlock -ScriptPath $startScriptPath -CapturePath $capturePath -DmsOnly
+
+            $captured = @(Get-Content -LiteralPath $capturePath)
+            $captured | Should -Contain "NEED_DATABASE_SETUP=false"
+            $captured | Should -Contain "DMS_DEPLOY_DATABASE_ON_STARTUP=false"
+            $captured | Should -Contain "AppSettings__DeployDatabaseOnStartup=false"
+        }
+    }
+
+    Context "missing-manifest warning surfaces the post-bootstrap contract" {
+        It "warns when no .bootstrap workspace is present and -IsTeardown is false" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-manifest.psm1") -Force
+
+            $warnings = & { Invoke-BootstrapStartupConfiguration -IsTeardown:$false } 3>&1 |
+                Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+            $warnings.Count | Should -BeGreaterThan 0
+            ($warnings | ForEach-Object Message) -join " " | Should -Match "No bootstrap manifest detected"
+            ($warnings | ForEach-Object Message) -join " " | Should -Match "bootstrap-\(local\|published\)-dms.ps1 wrapper"
+            ($warnings | ForEach-Object Message) -join " " | Should -Match "Schemas will NOT be provisioned"
+        }
+
+        It "stays silent when a .bootstrap workspace is present" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-manifest.psm1") -Force
+
+            $warnings = & { Invoke-BootstrapStartupConfiguration -IsTeardown:$false } 3>&1 |
+                Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+            $warnings | Where-Object { $_.Message -match "No bootstrap manifest detected" } | Should -BeNullOrEmpty
+        }
+
+        It "stays silent during teardown even when no .bootstrap workspace is present" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-manifest.psm1") -Force
+
+            $warnings = & { Invoke-BootstrapStartupConfiguration -IsTeardown:$true } 3>&1 |
+                Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+
+            $warnings | Where-Object { $_.Message -match "No bootstrap manifest detected" } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "staged --schema path order matches manifest declaration order" {
+        BeforeAll {
+            function script:Get-OrderedSchemaPaths {
+                param([string[]]$Captured)
+
+                $paths = @()
+                for ($i = 0; $i -lt $Captured.Count; $i++) {
+                    if ($Captured[$i] -eq "--schema") {
+                        $paths += ($Captured[$i + 1]).Replace('\', '/')
+                    }
+                }
+                return ,$paths
+            }
+
+            function script:Invoke-OrderedProvisionCapture {
+                param(
+                    [Parameter(Mandatory)]
+                    [string]$CaptureName,
+                    [Parameter(Mandatory)]
+                    [string]$DatabaseName,
+                    [string[]]$Extensions = @("Sample")
+                )
+
+                New-StagedSchemaWorkspace `
+                    -DockerComposeRoot $script:repo.DockerComposeRoot `
+                    -Extensions $Extensions
+                $capturePath = Join-Path $script:repo.RepoRoot $CaptureName
+                $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+                $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+                . $script:repo.ProvisionScript
+
+                $connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=' +
+                    '${POSTGRES_PASSWORD};database=' + $DatabaseName + ';'
+                function Add-CmsClient { }
+                function Get-CmsToken { return "token" }
+                function Get-DmsInstances {
+                    return @(
+                        [pscustomobject]@{
+                            id = 1
+                            instanceName = "Sole"
+                            connectionString = $connectionString
+                            dmsInstanceRouteContexts = @()
+                        }
+                    )
+                }
+
+                Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+                return @(Get-Content -LiteralPath $capturePath)
+            }
+        }
+
+        It "core-only manifest emits a single --schema for the Ed-Fi core schema" {
+            $captured = Invoke-OrderedProvisionCapture `
+                -CaptureName "schema-tool-args-core-only.txt" `
+                -DatabaseName "core_only_db" `
+                -Extensions @()
+
+            $schemaPaths = Get-OrderedSchemaPaths -Captured $captured
+            $schemaPaths.Count | Should -Be 1
+            $schemaPaths[0] | Should -Match "schemas/Ed-Fi/ApiSchema\.json$"
+        }
+
+        It "core + single extension emits --schema in [core, extension] order" {
+            $captured = Invoke-OrderedProvisionCapture `
+                -CaptureName "schema-tool-args-core-plus-sample.txt" `
+                -DatabaseName "core_plus_sample_db" `
+                -Extensions @("Sample")
+
+            $schemaPaths = Get-OrderedSchemaPaths -Captured $captured
+            $schemaPaths.Count | Should -Be 2
+            $schemaPaths[0] | Should -Match "schemas/Ed-Fi/ApiSchema\.json$"
+            $schemaPaths[1] | Should -Match "schemas/Sample/ApiSchema\.json$"
+        }
+
+        It "core + multiple extensions emits --schema in [core, ext1, ext2] declaration order" {
+            $captured = Invoke-OrderedProvisionCapture `
+                -CaptureName "schema-tool-args-multi-extension.txt" `
+                -DatabaseName "multi_ext_db" `
+                -Extensions @("Sample", "Homograph")
+
+            $schemaPaths = Get-OrderedSchemaPaths -Captured $captured
+            $schemaPaths.Count | Should -Be 3
+            $schemaPaths[0] | Should -Match "schemas/Ed-Fi/ApiSchema\.json$"
+            $schemaPaths[1] | Should -Match "schemas/Sample/ApiSchema\.json$"
+            $schemaPaths[2] | Should -Match "schemas/Homograph/ApiSchema\.json$"
+        }
+
+        It "identical schema argv on repeated invocations against the same workspace" {
+            New-StagedSchemaWorkspace `
+                -DockerComposeRoot $script:repo.DockerComposeRoot `
+                -Extensions @("Sample")
+
+            $toolDir1 = Join-Path $script:repo.RepoRoot "tool-run-1"
+            $toolDir2 = Join-Path $script:repo.RepoRoot "tool-run-2"
+            New-Item -ItemType Directory -Path $toolDir1 -Force | Out-Null
+            New-Item -ItemType Directory -Path $toolDir2 -Force | Out-Null
+            $capturePath1 = Join-Path $script:repo.RepoRoot "schema-tool-args-idempotent-1.txt"
+            $capturePath2 = Join-Path $script:repo.RepoRoot "schema-tool-args-idempotent-2.txt"
+            $fakeTool1 = New-FakeSchemaTool -Directory $toolDir1 -CapturePath $capturePath1
+            $fakeTool2 = New-FakeSchemaTool -Directory $toolDir2 -CapturePath $capturePath2
+            $connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=idempotent_db;'
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        connectionString = $connectionString
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool1
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool2
+            Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1)
+
+            $first = Get-OrderedSchemaPaths -Captured @(Get-Content -LiteralPath $capturePath1)
+            $second = Get-OrderedSchemaPaths -Captured @(Get-Content -LiteralPath $capturePath2)
+
+            ($first -join "|") | Should -Be ($second -join "|")
+        }
+    }
+
+    Context "Resolve-BootstrapAdminClient" {
+        It "returns the historical defaults when neither override key is present" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $resolved = Resolve-BootstrapAdminClient -EnvValues @{ POSTGRES_PASSWORD = "x" }
+
+            $resolved.ClientId | Should -Be "dms-instance-admin"
+            $resolved.ClientSecret | Should -Be "ValidClientSecret1234567890!Abcd"
+        }
+
+        It "returns env-file values when both overrides are supplied" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $resolved = Resolve-BootstrapAdminClient -EnvValues @{
+                DMS_BOOTSTRAP_ADMIN_CLIENT_ID = "custom-admin"
+                DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET = "custom-secret"
+            }
+
+            $resolved.ClientId | Should -Be "custom-admin"
+            $resolved.ClientSecret | Should -Be "custom-secret"
+        }
+
+        It "applies the client id override while keeping the default secret" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $resolved = Resolve-BootstrapAdminClient -EnvValues @{
+                DMS_BOOTSTRAP_ADMIN_CLIENT_ID = "id-only-admin"
+            }
+
+            $resolved.ClientId | Should -Be "id-only-admin"
+            $resolved.ClientSecret | Should -Be "ValidClientSecret1234567890!Abcd"
+        }
+
+        It "applies the client secret override while keeping the default id" {
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "env-utility.psm1") -Force
+
+            $resolved = Resolve-BootstrapAdminClient -EnvValues @{
+                DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET = "secret-only-value"
+            }
+
+            $resolved.ClientId | Should -Be "dms-instance-admin"
+            $resolved.ClientSecret | Should -Be "secret-only-value"
+        }
+    }
+
+    Context "bootstrap admin client flows through to configure and provision" {
+        It "configure-local-dms-instance.ps1 calls Add-CmsClient and Get-CmsToken with the env-resolved bootstrap admin client" {
+            $overrideEnvFile = Join-Path $script:repo.DockerComposeRoot "env-with-bootstrap-admin.env"
+            @"
+POSTGRES_PASSWORD=secret-pass
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+DMS_BOOTSTRAP_ADMIN_CLIENT_ID=configure-side-admin
+DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET=configure-side-secret
+"@ | Set-Content -LiteralPath $overrideEnvFile -Encoding utf8
+
+            . $script:repo.ConfigureScript
+
+            $script:capturedAddCmsClient = $null
+            $script:capturedGetCmsToken = $null
+            function Add-CmsClient {
+                param($CmsUrl, $ClientId, $ClientSecret, $DisplayName)
+                $script:capturedAddCmsClient = [pscustomobject]@{
+                    ClientId = $ClientId
+                    ClientSecret = $ClientSecret
+                }
+            }
+            function Get-CmsToken {
+                param($CmsUrl, $ClientId, $ClientSecret)
+                $script:capturedGetCmsToken = [pscustomobject]@{
+                    ClientId = $ClientId
+                    ClientSecret = $ClientSecret
+                }
+                return "token"
+            }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ConfigureLocalDmsInstance -EnvironmentFile $overrideEnvFile -NoDmsInstance | Out-Null
+
+            $script:capturedAddCmsClient.ClientId | Should -Be "configure-side-admin"
+            $script:capturedAddCmsClient.ClientSecret | Should -Be "configure-side-secret"
+            $script:capturedGetCmsToken.ClientId | Should -Be "configure-side-admin"
+            $script:capturedGetCmsToken.ClientSecret | Should -Be "configure-side-secret"
+        }
+
+        It "provision-dms-schema.ps1 calls Get-CmsToken with the env-resolved bootstrap admin client and does not register" {
+            $overrideEnvFile = Join-Path $script:repo.DockerComposeRoot "env-with-bootstrap-admin-prov.env"
+            @"
+POSTGRES_PASSWORD=secret-pass
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+DMS_BOOTSTRAP_ADMIN_CLIENT_ID=provision-side-admin
+DMS_BOOTSTRAP_ADMIN_CLIENT_SECRET=provision-side-secret
+"@ | Set-Content -LiteralPath $overrideEnvFile -Encoding utf8
+
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            $script:capturedGetCmsToken = $null
+            function Add-CmsClient { throw "Add-CmsClient must not be called during provisioning." }
+            function Get-CmsToken {
+                param($CmsUrl, $ClientId, $ClientSecret)
+                $script:capturedGetCmsToken = [pscustomobject]@{
+                    ClientId = $ClientId
+                    ClientSecret = $ClientSecret
+                }
+                return "token"
+            }
+            function Get-DmsInstances {
+                return @(
+                    [pscustomobject]@{
+                        id = 1
+                        instanceName = "Sole"
+                        connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=secret-pass;database=prov_admin_db;'
+                        dmsInstanceRouteContexts = @()
+                    }
+                )
+            }
+
+            Invoke-ProvisionDmsSchema -EnvironmentFile $overrideEnvFile -InstanceId @(1)
+
+            $script:capturedGetCmsToken.ClientId | Should -Be "provision-side-admin"
+            $script:capturedGetCmsToken.ClientSecret | Should -Be "provision-side-secret"
+        }
+
+        It "provision actionable error sanitizes an env-supplied client id containing log-injection characters" {
+            $overrideEnvFile = Join-Path $script:repo.DockerComposeRoot "env-with-injection-id.env"
+            $injectedId = "evil-admin`r`nFAKE-LOG-LINE"
+            @"
+POSTGRES_PASSWORD=secret-pass
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5544
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=18081
+DMS_HTTP_PORTS=18080
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+NEED_DATABASE_SETUP=false
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=TestEncryptionKey123456789012345678901234567890
+DMS_BOOTSTRAP_ADMIN_CLIENT_ID=$injectedId
+"@ | Set-Content -LiteralPath $overrideEnvFile -Encoding utf8
+
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { throw "Add-CmsClient must not be called during provisioning." }
+            function Get-CmsToken { throw "401 Unauthorized" }
+            function Get-DmsInstances { return @() }
+
+            $thrownMessage = $null
+            try {
+                Invoke-ProvisionDmsSchema -EnvironmentFile $overrideEnvFile -InstanceId @(1)
+            }
+            catch {
+                $thrownMessage = $_.Exception.Message
+            }
+
+            $thrownMessage | Should -Not -BeNullOrEmpty
+            $thrownMessage | Should -Not -Match "`r"
+            $thrownMessage | Should -Not -Match "`n"
+            $thrownMessage | Should -Not -Match "FAKE-LOG-LINE"
+            $thrownMessage | Should -Match "evil-admin"
         }
     }
 }

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -507,6 +507,102 @@ exit $ExitCode
             $connectionString | Should -Not -Match "dms-postgresql"
         }
 
+        It "rejects an encrypted connection string when the encryption key is not configured" {
+            . $script:repo.ProvisionScript
+
+            { ConvertFrom-CmsEncryptedConnectionString -ProtectedConnectionString "AAAAAAAAAAAAAAAAAAAAAA==" -EnvValues @{} } |
+                Should -Throw -ExpectedMessage "*DMS_CONFIG_DATABASE_ENCRYPTION_KEY is not set*"
+        }
+
+        It "rejects an encrypted connection string payload that is not valid base64" {
+            . $script:repo.ProvisionScript
+
+            $envValues = @{ DMS_CONFIG_DATABASE_ENCRYPTION_KEY = "TestEncryptionKey123456789012345678901234567890" }
+            { ConvertFrom-CmsEncryptedConnectionString -ProtectedConnectionString "@@@@" -EnvValues $envValues } |
+                Should -Throw -ExpectedMessage "*not valid CMS encrypted base64*"
+        }
+
+        It "rejects an encrypted connection string payload too short to contain an IV" {
+            . $script:repo.ProvisionScript
+
+            $envValues = @{ DMS_CONFIG_DATABASE_ENCRYPTION_KEY = "TestEncryptionKey123456789012345678901234567890" }
+            $shortPayload = [Convert]::ToBase64String([byte[]]::new(8))
+            { ConvertFrom-CmsEncryptedConnectionString -ProtectedConnectionString $shortPayload -EnvValues $envValues } |
+                Should -Throw -ExpectedMessage "*payload is invalid*"
+        }
+
+        It "rejects an encrypted connection string that cannot be decrypted with the configured key" {
+            . $script:repo.ProvisionScript
+
+            $envValues = @{ DMS_CONFIG_DATABASE_ENCRYPTION_KEY = "TestEncryptionKey123456789012345678901234567890" }
+            # 16-byte IV plus a 17-byte ciphertext is not a whole AES block, so PKCS7 decryption
+            # fails deterministically rather than relying on a wrong-key padding collision.
+            $undecryptable = [Convert]::ToBase64String([byte[]]::new(33))
+            { ConvertFrom-CmsEncryptedConnectionString -ProtectedConnectionString $undecryptable -EnvValues $envValues } |
+                Should -Throw -ExpectedMessage "*could not be decrypted*"
+        }
+
+        It "fails fast when CMS instance results reach the query page size" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                return @(
+                    1..500 | ForEach-Object {
+                        [pscustomobject]@{
+                            id = $_
+                            instanceName = "I$_"
+                            connectionString = "host=dms-postgresql;port=5432;username=postgres;password=x;database=db$_;"
+                            dmsInstanceRouteContexts = @()
+                        }
+                    }
+                )
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Throw -ExpectedMessage "*page size (500)*"
+            Test-Path -LiteralPath $capturePath | Should -BeFalse
+        }
+
+        It "provisions normally when instance results stay below the page size" {
+            New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
+            $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"
+            $fakeTool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -CapturePath $capturePath
+            $env:DMS_SCHEMA_TOOL_PATH = $fakeTool
+
+            . $script:repo.ProvisionScript
+
+            function Add-CmsClient { }
+            function Get-CmsToken { return "token" }
+            function Get-DmsInstances {
+                $target = [pscustomobject]@{
+                    id = 1
+                    instanceName = "Target"
+                    connectionString = 'host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=below_limit;'
+                    dmsInstanceRouteContexts = @()
+                }
+                $filler = 2..499 | ForEach-Object {
+                    [pscustomobject]@{
+                        id = $_
+                        instanceName = "I$_"
+                        connectionString = "host=dms-postgresql;port=5432;username=postgres;password=x;database=db$_;"
+                        dmsInstanceRouteContexts = @()
+                    }
+                }
+                return @($target) + @($filler)
+            }
+
+            { Invoke-ProvisionDmsSchema -EnvironmentFile $script:repo.EnvFile -InstanceId @(1) } |
+                Should -Not -Throw
+            @(Get-Content -LiteralPath $capturePath) | Should -Contain "provision"
+        }
+
         It "resolves school-year selectors and fails when a year is ambiguous" {
             New-StagedSchemaWorkspace -DockerComposeRoot $script:repo.DockerComposeRoot
             $capturePath = Join-Path $script:repo.RepoRoot "schema-tool-args.txt"

--- a/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaDeploymentSafety.Tests.ps1
@@ -278,6 +278,7 @@ exit $ExitCode
                 $params | Should -Contain "InfraOnly"
                 $params | Should -Contain "DmsOnly"
                 $params | Should -Contain "LoadSeedData"
+                $params | Should -Contain "SkipConnectorSetup"
                 $params | Should -Not -Contain "ApiSchemaPath"
                 $params | Should -Not -Contain "ClaimsDirectoryPath"
                 $params | Should -Not -Contain "Extensions"
@@ -2538,6 +2539,18 @@ DMS_BOOTSTRAP_ADMIN_CLIENT_ID=$injectedId
             $content = Get-Content -LiteralPath $e2eSetupScript -Raw
 
             $content | Should -Match 'psql -v ON_ERROR_STOP=1'
+        }
+
+        It "skips the default connector until per-instance databases and connectors are ready" {
+            $e2eSetupScript = Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"
+            $content = Get-Content -LiteralPath $e2eSetupScript -Raw
+
+            # Instance Management E2E disables DMS startup provisioning and creates the per-instance
+            # schemas later in this setup script. The default connector targets the main database's
+            # to_debezium publication, so start-local-dms.ps1 must not register it before this
+            # harness has provisioned the databases and the tests create instance-specific connectors.
+            $content | Should -Match 'start-local-dms\.ps1'
+            $content | Should -Match 'SkipConnectorSetup'
         }
     }
 }

--- a/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
+++ b/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
@@ -63,6 +63,8 @@
         -ApiSchemaPath "$HOME/edfi/ApiSchema"
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Manual smoke script intentionally writes operator progress and step banners to the console.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'False positive: parameters are consumed inside nested script blocks and helper functions.')]
 [CmdletBinding()]
 param(
     [string]$EnvironmentFile,
@@ -264,7 +266,7 @@ try {
             -Description "provision-dms-schema.ps1 (first run)"
     }
 
-    # Step 5: idempotence — re-run provision
+    # Step 5: idempotence - re-run provision
     Invoke-SmokeStep -Name "provision-dms-schema-second-run-idempotence" -Body {
         Invoke-PhaseScript `
             -ScriptPath "$script:DockerComposeRoot/provision-dms-schema.ps1" `

--- a/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
+++ b/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
@@ -32,14 +32,15 @@
       2. start-local-dms.ps1 -InfraOnly -EnableConfig -IdentityProvider self-contained.
       3. configure-local-dms-instance.ps1 registers the instance(s).
       4. provision-dms-schema.ps1 provisions the selected target databases.
-      5. Re-run step 4 to verify idempotence.
-      6. start-local-dms.ps1 -DmsOnly to start DMS against the provisioned database.
-      7. Assertions:
+      5. Re-run step 4 to confirm provision is safely re-runnable (idempotent re-invocation;
+         the re-run is asserted to complete without error - it does not diff schema state).
+      6. Corrupt the staged ApiSchema manifest and confirm provision rejects it by throwing,
+         then restore the manifest. This negative test runs before DMS is started.
+      7. start-local-dms.ps1 -DmsOnly to start DMS against the provisioned database.
+      8. Assertions:
            - DMS /health returns 200 within timeout.
            - psql lists at least one table in the provisioned database.
-           - Re-run of provision applies no DDL (idempotence captured in step 5).
-           - A deliberately corrupted ApiSchema manifest causes provision to fail.
-      8. Teardown (unless -SkipTeardown).
+      9. Teardown (unless -SkipTeardown).
 
     Exit code: 0 on full success, non-zero on the first failing assertion or step.
 
@@ -49,9 +50,6 @@
 .PARAMETER ApiSchemaPath
     Directory containing the ApiSchema content for prepare-dms-schema.ps1. Falls back
     to $env:DMS_SMOKE_API_SCHEMA_PATH.
-
-.PARAMETER Extensions
-    Optional extension list to forward to prepare-dms-schema.ps1.
 
 .PARAMETER ResultsPath
     Optional path; if supplied, writes a JSON summary of the run (step status + timings).
@@ -70,8 +68,6 @@ param(
     [string]$EnvironmentFile,
 
     [string]$ApiSchemaPath = $env:DMS_SMOKE_API_SCHEMA_PATH,
-
-    [string[]]$Extensions = @(),
 
     [string]$ResultsPath,
 
@@ -214,7 +210,6 @@ Invoke-SmokeStep -Name "preflight" -Body {
 
     Write-Host "[smoke] EnvironmentFile : $resolvedEnvFile"
     Write-Host "[smoke] ApiSchemaPath   : $ApiSchemaPath"
-    Write-Host "[smoke] Extensions      : $([string]::Join(',', $Extensions))"
 }
 
 $smokeFailed = $false
@@ -227,7 +222,6 @@ try {
     # Step 1: prepare workspace
     Invoke-SmokeStep -Name "prepare-dms-schema" -Body {
         $prepareArgs = @{ ApiSchemaPath = $ApiSchemaPath }
-        if ($Extensions.Count -gt 0) { $prepareArgs.Extensions = $Extensions }
         Invoke-PhaseScript `
             -ScriptPath "$script:DockerComposeRoot/prepare-dms-schema.ps1" `
             -Arguments $prepareArgs `
@@ -278,7 +272,43 @@ try {
             -Description "provision-dms-schema.ps1 (second run / idempotence)"
     }
 
-    # Step 6: DMS-only startup
+    # Step 6: negative test - a corrupted ApiSchema manifest must be rejected before DMS starts
+    Invoke-SmokeStep -Name "assert-corrupted-manifest-rejected" -Body {
+        $apiManifestPath = Join-Path $script:BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+        if (-not (Test-Path -LiteralPath $apiManifestPath)) {
+            throw "ApiSchema manifest not found at $apiManifestPath; cannot test corruption rejection."
+        }
+
+        $savedManifest = Get-Content -LiteralPath $apiManifestPath -Raw
+        try {
+            "not-json{{" | Set-Content -LiteralPath $apiManifestPath -Encoding utf8 -NoNewline
+            $threw = $false
+            $caughtMessage = ""
+            Push-Location $script:DockerComposeRoot
+            try {
+                & "$script:DockerComposeRoot/provision-dms-schema.ps1" -EnvironmentFile $resolvedEnvFile 2>&1 | Out-Null
+            }
+            catch {
+                $threw = $true
+                $caughtMessage = $_.Exception.Message
+            }
+            finally {
+                Pop-Location
+            }
+            if (-not $threw) {
+                throw "Provision unexpectedly succeeded with a corrupted ApiSchema manifest."
+            }
+            if ($caughtMessage -notmatch 'malformed JSON|manifest') {
+                throw "Provision failed for an unexpected reason: $caughtMessage"
+            }
+            Write-Host "[smoke] Provision correctly rejected the corrupted ApiSchema manifest by throwing."
+        }
+        finally {
+            Set-Content -LiteralPath $apiManifestPath -Value $savedManifest -NoNewline
+        }
+    }
+
+    # Step 7: DMS-only startup
     Invoke-SmokeStep -Name "start-local-dms-dms-only" -Body {
         Invoke-PhaseScript `
             -ScriptPath "$script:DockerComposeRoot/start-local-dms.ps1" `
@@ -335,42 +365,6 @@ try {
             throw "Expected at least one provisioned table in schema 'dms' of database '$postgresDb'; got $tableCount."
         }
         Write-Host "[smoke] Provisioned tables in dms schema: $tableCount"
-    }
-
-    # Assertion: corrupted manifest is rejected
-    Invoke-SmokeStep -Name "assert-corrupted-manifest-rejected" -Body {
-        $apiManifestPath = Join-Path $script:BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
-        if (-not (Test-Path -LiteralPath $apiManifestPath)) {
-            throw "ApiSchema manifest not found at $apiManifestPath; cannot test corruption rejection."
-        }
-
-        $savedManifest = Get-Content -LiteralPath $apiManifestPath -Raw
-        try {
-            "not-json{{" | Set-Content -LiteralPath $apiManifestPath -Encoding utf8 -NoNewline
-            $threw = $false
-            $caughtMessage = ""
-            Push-Location $script:DockerComposeRoot
-            try {
-                & "$script:DockerComposeRoot/provision-dms-schema.ps1" -EnvironmentFile $resolvedEnvFile 2>&1 | Out-Null
-            }
-            catch {
-                $threw = $true
-                $caughtMessage = $_.Exception.Message
-            }
-            finally {
-                Pop-Location
-            }
-            if (-not $threw) {
-                throw "Provision unexpectedly succeeded with a corrupted ApiSchema manifest."
-            }
-            if ($caughtMessage -notmatch 'malformed JSON|manifest') {
-                throw "Provision failed for an unexpected reason: $caughtMessage"
-            }
-            Write-Host "[smoke] Provision correctly rejected the corrupted ApiSchema manifest by throwing."
-        }
-        finally {
-            Set-Content -LiteralPath $apiManifestPath -Value $savedManifest -NoNewline
-        }
     }
 }
 catch {

--- a/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
+++ b/eng/docker-compose/tests/Invoke-BootstrapDockerSmoke.ps1
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    DMS-1151 Docker smoke: real bootstrap sequence against a live Docker stack.
+
+.DESCRIPTION
+    Manual end-to-end smoke for the DMS-1151 bootstrap contract. Exercises the real
+    phase commands (prepare -> infra -> configure -> provision -> re-run -> DMS-only)
+    against an actual Docker stack, not the synthetic Pester fixtures.
+
+    The script is intentionally MANUAL: it is not wired into CI and is not run by the
+    normal Pester suite. The reviewer for DMS-1151 explicitly asked for at least one
+    real Docker pass before sign-off; this script formalizes that pass so it is
+    repeatable and observable.
+
+    Prerequisites:
+      - Docker daemon running.
+      - PowerShell 7+ (pwsh).
+      - A directory containing the ApiSchema content used by prepare-dms-schema.ps1,
+        passed via -ApiSchemaPath or DMS_SMOKE_API_SCHEMA_PATH.
+      - An env file (defaults to eng/docker-compose/.env.example).
+
+    Sequence:
+      0. Preflight checks and pre-teardown of any leftover dms-local stack.
+      1. prepare-dms-schema.ps1 + prepare-dms-claims.ps1 materialize .bootstrap/.
+      2. start-local-dms.ps1 -InfraOnly -EnableConfig -IdentityProvider self-contained.
+      3. configure-local-dms-instance.ps1 registers the instance(s).
+      4. provision-dms-schema.ps1 provisions the selected target databases.
+      5. Re-run step 4 to verify idempotence.
+      6. start-local-dms.ps1 -DmsOnly to start DMS against the provisioned database.
+      7. Assertions:
+           - DMS /health returns 200 within timeout.
+           - psql lists at least one table in the provisioned database.
+           - Re-run of provision applies no DDL (idempotence captured in step 5).
+           - A deliberately corrupted ApiSchema manifest causes provision to fail.
+      8. Teardown (unless -SkipTeardown).
+
+    Exit code: 0 on full success, non-zero on the first failing assertion or step.
+
+.PARAMETER EnvironmentFile
+    Env file to forward to every phase. Defaults to eng/docker-compose/.env.example.
+
+.PARAMETER ApiSchemaPath
+    Directory containing the ApiSchema content for prepare-dms-schema.ps1. Falls back
+    to $env:DMS_SMOKE_API_SCHEMA_PATH.
+
+.PARAMETER Extensions
+    Optional extension list to forward to prepare-dms-schema.ps1.
+
+.PARAMETER ResultsPath
+    Optional path; if supplied, writes a JSON summary of the run (step status + timings).
+
+.PARAMETER SkipTeardown
+    When set, leaves the dms-local stack and .bootstrap/ workspace in place after the
+    run. Useful when debugging an assertion failure interactively.
+
+.EXAMPLE
+    pwsh ./Invoke-BootstrapDockerSmoke.ps1 `
+        -ApiSchemaPath "$HOME/edfi/ApiSchema"
+#>
+
+[CmdletBinding()]
+param(
+    [string]$EnvironmentFile,
+
+    [string]$ApiSchemaPath = $env:DMS_SMOKE_API_SCHEMA_PATH,
+
+    [string[]]$Extensions = @(),
+
+    [string]$ResultsPath,
+
+    [switch]$SkipTeardown
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:DockerComposeRoot = Split-Path -Parent $PSScriptRoot
+$script:RepoRoot = [System.IO.Path]::GetFullPath((Join-Path $script:DockerComposeRoot "../.."))
+$script:BootstrapRoot = Join-Path $script:DockerComposeRoot ".bootstrap"
+$script:StepResults = [System.Collections.Generic.List[pscustomobject]]::new()
+
+function Write-SmokeStep {
+    param([string]$Label)
+
+    $banner = "=" * 78
+    Write-Host ""
+    Write-Host $banner
+    Write-Host "[smoke] $Label"
+    Write-Host $banner
+}
+
+function Invoke-SmokeStep {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [scriptblock]$Body
+    )
+
+    Write-SmokeStep $Name
+    $startTime = Get-Date
+    $status = "ok"
+    $errorMessage = $null
+    try {
+        & $Body
+    }
+    catch {
+        $status = "failed"
+        $errorMessage = $_.Exception.Message
+        throw
+    }
+    finally {
+        $duration = (Get-Date) - $startTime
+        $script:StepResults.Add([pscustomobject]@{
+            Name = $Name
+            Status = $status
+            DurationSeconds = [math]::Round($duration.TotalSeconds, 2)
+            Error = $errorMessage
+        })
+    }
+}
+
+function Resolve-EnvironmentFile {
+    if ([string]::IsNullOrWhiteSpace($EnvironmentFile)) {
+        return (Join-Path $script:DockerComposeRoot ".env.example")
+    }
+
+    if ([System.IO.Path]::IsPathRooted($EnvironmentFile)) {
+        return $EnvironmentFile
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $EnvironmentFile))
+}
+
+function Get-EnvFileValue {
+    param(
+        [string]$Path,
+        [string]$Key
+    )
+
+    if (-not (Test-Path -LiteralPath $Path)) { return $null }
+
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        if ($line -match '^\s*#') { continue }
+        if ($line -match "^\s*$([regex]::Escape($Key))\s*=\s*(.*)$") {
+            return $matches[1].Trim().Trim('"').Trim("'")
+        }
+    }
+    return $null
+}
+
+function Invoke-ComposeTeardown {
+    param([string]$EnvFile)
+
+    Push-Location $script:DockerComposeRoot
+    try {
+        & "$script:DockerComposeRoot/start-local-dms.ps1" -d -v -RemoveBootstrap -EnvironmentFile $EnvFile -ErrorAction Continue
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Invoke-PhaseScript {
+    param(
+        [Parameter(Mandatory)]
+        [string]$ScriptPath,
+
+        [Parameter(Mandatory)]
+        [hashtable]$Arguments,
+
+        [Parameter(Mandatory)]
+        [string]$Description
+    )
+
+    Push-Location $script:DockerComposeRoot
+    try {
+        & $ScriptPath @Arguments
+        if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+            throw "$Description failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+# Preflight
+$resolvedEnvFile = Resolve-EnvironmentFile
+Invoke-SmokeStep -Name "preflight" -Body {
+    if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+        throw "Docker CLI not found on PATH."
+    }
+    docker info | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Docker daemon is not reachable. Start Docker and retry."
+    }
+
+    if (-not (Test-Path -LiteralPath $resolvedEnvFile)) {
+        throw "Environment file not found: $resolvedEnvFile"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($ApiSchemaPath) -or -not (Test-Path -LiteralPath $ApiSchemaPath)) {
+        throw "ApiSchemaPath is required. Pass -ApiSchemaPath or set DMS_SMOKE_API_SCHEMA_PATH."
+    }
+
+    Write-Host "[smoke] EnvironmentFile : $resolvedEnvFile"
+    Write-Host "[smoke] ApiSchemaPath   : $ApiSchemaPath"
+    Write-Host "[smoke] Extensions      : $([string]::Join(',', $Extensions))"
+}
+
+$smokeFailed = $false
+try {
+    # Initial teardown to guarantee a clean starting state
+    Invoke-SmokeStep -Name "pre-teardown" -Body {
+        Invoke-ComposeTeardown -EnvFile $resolvedEnvFile
+    }
+
+    # Step 1: prepare workspace
+    Invoke-SmokeStep -Name "prepare-dms-schema" -Body {
+        $prepareArgs = @{ ApiSchemaPath = $ApiSchemaPath }
+        if ($Extensions.Count -gt 0) { $prepareArgs.Extensions = $Extensions }
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/prepare-dms-schema.ps1" `
+            -Arguments $prepareArgs `
+            -Description "prepare-dms-schema.ps1"
+    }
+
+    Invoke-SmokeStep -Name "prepare-dms-claims" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/prepare-dms-claims.ps1" `
+            -Arguments @{} `
+            -Description "prepare-dms-claims.ps1"
+    }
+
+    # Step 2: infra-only startup
+    Invoke-SmokeStep -Name "start-local-dms-infra-only" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/start-local-dms.ps1" `
+            -Arguments @{
+                InfraOnly = $true
+                EnableConfig = $true
+                IdentityProvider = "self-contained"
+                EnvironmentFile = $resolvedEnvFile
+            } `
+            -Description "start-local-dms.ps1 -InfraOnly"
+    }
+
+    # Step 3: configure
+    Invoke-SmokeStep -Name "configure-local-dms-instance" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/configure-local-dms-instance.ps1" `
+            -Arguments @{ EnvironmentFile = $resolvedEnvFile } `
+            -Description "configure-local-dms-instance.ps1"
+    }
+
+    # Step 4: provision
+    Invoke-SmokeStep -Name "provision-dms-schema-first-run" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/provision-dms-schema.ps1" `
+            -Arguments @{ EnvironmentFile = $resolvedEnvFile } `
+            -Description "provision-dms-schema.ps1 (first run)"
+    }
+
+    # Step 5: idempotence — re-run provision
+    Invoke-SmokeStep -Name "provision-dms-schema-second-run-idempotence" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/provision-dms-schema.ps1" `
+            -Arguments @{ EnvironmentFile = $resolvedEnvFile } `
+            -Description "provision-dms-schema.ps1 (second run / idempotence)"
+    }
+
+    # Step 6: DMS-only startup
+    Invoke-SmokeStep -Name "start-local-dms-dms-only" -Body {
+        Invoke-PhaseScript `
+            -ScriptPath "$script:DockerComposeRoot/start-local-dms.ps1" `
+            -Arguments @{
+                DmsOnly = $true
+                IdentityProvider = "self-contained"
+                EnvironmentFile = $resolvedEnvFile
+            } `
+            -Description "start-local-dms.ps1 -DmsOnly"
+    }
+
+    # Assertion: DMS health
+    Invoke-SmokeStep -Name "assert-dms-health" -Body {
+        $dmsPort = Get-EnvFileValue -Path $resolvedEnvFile -Key "DMS_HTTP_PORTS"
+        if ([string]::IsNullOrWhiteSpace($dmsPort)) { $dmsPort = "8080" }
+        $healthUrl = "http://localhost:$dmsPort/health"
+
+        $deadline = (Get-Date).AddSeconds(60)
+        $healthy = $false
+        $lastError = $null
+        while ((Get-Date) -lt $deadline) {
+            try {
+                $response = Invoke-WebRequest -Uri $healthUrl -Method Get -TimeoutSec 5
+                if ($response.StatusCode -eq 200) {
+                    $healthy = $true
+                    break
+                }
+            }
+            catch {
+                $lastError = $_.Exception.Message
+            }
+            Start-Sleep -Seconds 2
+        }
+        if (-not $healthy) {
+            throw "DMS health endpoint $healthUrl did not return 200 within 60s. Last error: $lastError"
+        }
+        Write-Host "[smoke] DMS health OK at $healthUrl"
+    }
+
+    # Assertion: provisioned tables exist
+    Invoke-SmokeStep -Name "assert-provisioned-tables" -Body {
+        $postgresDb = Get-EnvFileValue -Path $resolvedEnvFile -Key "POSTGRES_DB_NAME"
+        if ([string]::IsNullOrWhiteSpace($postgresDb)) { $postgresDb = "edfi_datamanagementservice" }
+
+        $listOutput = docker exec dms-postgresql psql -U postgres -d $postgresDb -At -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'dms';" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "psql query failed: $listOutput"
+        }
+        $tableCount = 0
+        if (-not [int]::TryParse((($listOutput | Select-Object -Last 1) -as [string]).Trim(), [ref]$tableCount)) {
+            throw "Could not parse table count from psql output: $listOutput"
+        }
+        if ($tableCount -le 0) {
+            throw "Expected at least one provisioned table in schema 'dms' of database '$postgresDb'; got $tableCount."
+        }
+        Write-Host "[smoke] Provisioned tables in dms schema: $tableCount"
+    }
+
+    # Assertion: corrupted manifest is rejected
+    Invoke-SmokeStep -Name "assert-corrupted-manifest-rejected" -Body {
+        $apiManifestPath = Join-Path $script:BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
+        if (-not (Test-Path -LiteralPath $apiManifestPath)) {
+            throw "ApiSchema manifest not found at $apiManifestPath; cannot test corruption rejection."
+        }
+
+        $savedManifest = Get-Content -LiteralPath $apiManifestPath -Raw
+        try {
+            "not-json{{" | Set-Content -LiteralPath $apiManifestPath -Encoding utf8 -NoNewline
+            $threw = $false
+            $caughtMessage = ""
+            Push-Location $script:DockerComposeRoot
+            try {
+                & "$script:DockerComposeRoot/provision-dms-schema.ps1" -EnvironmentFile $resolvedEnvFile 2>&1 | Out-Null
+            }
+            catch {
+                $threw = $true
+                $caughtMessage = $_.Exception.Message
+            }
+            finally {
+                Pop-Location
+            }
+            if (-not $threw) {
+                throw "Provision unexpectedly succeeded with a corrupted ApiSchema manifest."
+            }
+            if ($caughtMessage -notmatch 'malformed JSON|manifest') {
+                throw "Provision failed for an unexpected reason: $caughtMessage"
+            }
+            Write-Host "[smoke] Provision correctly rejected the corrupted ApiSchema manifest by throwing."
+        }
+        finally {
+            Set-Content -LiteralPath $apiManifestPath -Value $savedManifest -NoNewline
+        }
+    }
+}
+catch {
+    $smokeFailed = $true
+    Write-Host ""
+    Write-Host "[smoke] FAILED: $($_.Exception.Message)" -ForegroundColor Red
+}
+finally {
+    if (-not $SkipTeardown) {
+        try {
+            Invoke-SmokeStep -Name "teardown" -Body {
+                Invoke-ComposeTeardown -EnvFile $resolvedEnvFile
+            }
+        }
+        catch {
+            Write-Host "[smoke] Teardown error: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+    else {
+        Write-Host "[smoke] -SkipTeardown set; leaving dms-local stack running for inspection."
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($ResultsPath)) {
+        $script:StepResults |
+            ConvertTo-Json -Depth 5 |
+            Set-Content -LiteralPath $ResultsPath -Encoding utf8
+        Write-Host "[smoke] Results written to $ResultsPath"
+    }
+
+    $script:StepResults |
+        Format-Table -AutoSize Name, Status, DurationSeconds |
+        Out-String |
+        Write-Host
+}
+
+if ($smokeFailed) {
+    exit 1
+}
+
+Write-Host ""
+Write-Host "[smoke] Bootstrap Docker smoke completed successfully." -ForegroundColor Green
+exit 0

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -69,6 +69,7 @@ function Invoke-SmokeTestUtility {
 }
 
 function Get-SmokeTestCredentials {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Operator-facing smoke-test helper intentionally writes progress to the console.')]
     [CmdletBinding()]
     param (
         [string]

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -131,9 +131,7 @@ function Get-SmokeTestCredentials {
         $key = $credentials.Key
         $secret = $credentials.Secret
 
-        Write-Host "Application created successfully!"
-        Write-Host "Key: $key"
-        Write-Host "Secret: $secret"
+        Write-Host "Application created successfully. Credentials were returned to the caller and were not written to logs."
 
         return @{
             Key = $key

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -92,7 +92,13 @@ function Get-SmokeTestCredentials {
         $ClaimSetName = "EdFiSandbox",
 
         [long[]]
-        $EducationOrganizationIds = @(255901, 19255901, 100000, 200000, 300000)
+        $EducationOrganizationIds = @(255901, 19255901, 100000, 200000, 300000),
+
+        [long[]]
+        $DmsInstanceIds = @(),
+
+        [string]
+        $Tenant = ""
     )
 
     Write-Host "Creating smoke test credentials via Configuration Service..."
@@ -107,27 +113,33 @@ function Get-SmokeTestCredentials {
         $configToken = Get-CmsToken -CmsUrl $ConfigServiceUrl -ClientId $SysAdminId -ClientSecret $SysAdminSecret
 
         # Step 3: Get available DMS instances
-        Write-Host "Retrieving available DMS instances..."
-        $dmsInstances = Get-DmsInstances -CmsUrl $ConfigServiceUrl -AccessToken $configToken
-
-        if ($dmsInstances -and $dmsInstances.Count -gt 0) {
-            $dmsInstanceIds = @($dmsInstances[0].id)
-            Write-Host "Found DMS instance with ID: $($dmsInstanceIds[0])"
+        if ($DmsInstanceIds.Count -gt 0) {
+            $dmsInstanceIds = [long[]]@($DmsInstanceIds)
+            Write-Host "Using supplied DMS instance IDs: $($dmsInstanceIds -join ', ')"
         }
         else {
-            Write-Warning "No DMS instances found. Application will be created without DMS instance association."
-            $dmsInstanceIds = @()
+            Write-Host "Retrieving available DMS instances..."
+            $dmsInstances = Get-DmsInstances -CmsUrl $ConfigServiceUrl -AccessToken $configToken -Tenant $Tenant
+
+            if ($dmsInstances -and $dmsInstances.Count -gt 0) {
+                $dmsInstanceIds = @($dmsInstances[0].id)
+                Write-Host "Found DMS instance with ID: $($dmsInstanceIds[0])"
+            }
+            else {
+                Write-Warning "No DMS instances found. Application will be created without DMS instance association."
+                $dmsInstanceIds = @()
+            }
         }
 
         # Step 4: Create vendor using Dms-Management module
         Write-Host "Creating vendor..."
-        $vendorId = Add-Vendor -CmsUrl $ConfigServiceUrl -Company $VendorName -ContactName "Smoke Test Contact" -ContactEmailAddress "smoketest@example.com" -NamespacePrefixes "uri://ed-fi.org,uri://gbisd.edu,uri://tpdm.ed-fi.org" -AccessToken $configToken
+        $vendorId = Add-Vendor -CmsUrl $ConfigServiceUrl -Company $VendorName -ContactName "Smoke Test Contact" -ContactEmailAddress "smoketest@example.com" -NamespacePrefixes "uri://ed-fi.org,uri://gbisd.edu,uri://tpdm.ed-fi.org" -AccessToken $configToken -Tenant $Tenant
 
         Write-Host "Vendor created with ID: $vendorId"
 
         # Step 5: Create application using Dms-Management module
         Write-Host "Creating application..."
-        $credentials = Add-Application -CmsUrl $ConfigServiceUrl -ApplicationName $ApplicationName -ClaimSetName $ClaimSetName -VendorId $vendorId -AccessToken $configToken -EducationOrganizationIds $EducationOrganizationIds -DmsInstanceIds $dmsInstanceIds
+        $credentials = Add-Application -CmsUrl $ConfigServiceUrl -ApplicationName $ApplicationName -ClaimSetName $ClaimSetName -VendorId $vendorId -AccessToken $configToken -EducationOrganizationIds $EducationOrganizationIds -DmsInstanceIds $dmsInstanceIds -Tenant $Tenant
 
         $key = $credentials.Key
         $secret = $credentials.Secret

--- a/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
@@ -141,7 +141,7 @@ state. DMS compose services do not consume claimset fragment files, so `local-dm
 | Item | Detail |
 |---|---|
 | **Preconditions** | Current Story 00 startup may validate a bootstrap manifest when present, but staged claims startup is not activated until Story 04 enables DMS staged-schema runtime loading. |
-| **Inputs** | `-EnvironmentFile <path>` (select Docker Compose env file and shared local settings); `-Rebuild` / `-r`; `-IdentityProvider`; `-EnableConfig` (legacy compat, not a meaningful opt-out in the normative flow); `-EnableKafkaUI`; `-EnableSwaggerUI`; teardown flags `-d`/`-v`; transitional legacy flags still owned by the start scripts, including `-NoDmsInstance`, `-SchoolYearRange`, `-LoadSeedData`, `-AddSmokeTestCredentials`, and `-AddExtensionSecurityMetadata` |
+| **Inputs** | `-EnvironmentFile <path>` (select Docker Compose env file and shared local settings); `-Rebuild` / `-r`; `-IdentityProvider`; `-EnableConfig` (legacy compat, not a meaningful opt-out in the normative flow); `-EnableKafkaUI`; `-EnableSwaggerUI`; teardown flags `-d`/`-v`; transitional legacy flags still owned by the start scripts, including `-NoDmsInstance`, `-SchoolYearRange`, `-LoadSeedData`, `-AddSmokeTestCredentials`, and `-AddExtensionSecurityMetadata`; split-startup switches `-InfraOnly` and `-DmsOnly` (mutually exclusive; the bootstrap wrapper uses them to run schema provisioning between infrastructure startup and DMS startup) |
 | **Outputs** | Running Docker services; provider-specific local identity clients including `CMSReadOnlyAccess`; healthy Config Service; healthy DMS container |
 | **Side effects** | Docker Compose up/down; runs provider-specific local identity setup, including the fixed `CMSReadOnlyAccess` read-only client; validates the bootstrap manifest when present but does not apply manifest-selected staged claims to Config Service startup until Story 04 can also point DMS at the matching staged ApiSchema workspace; calls `setup-openiddict.ps1 -InitDb` after PostgreSQL health; calls `setup-openiddict.ps1 -InsertData` after Config Service readiness (self-contained path) |
 | **Failure conditions** | Docker compose start failure; health-wait timeout for any service; malformed or incomplete bootstrap manifest when present |
@@ -203,7 +203,9 @@ never performs it. Selector resolution rule: when exactly one DMS instance exist
 supplied, auto-select it; when multiple instances exist and no explicit `-InstanceId` or `-SchoolYear` is
 provided, fail fast with guidance to supply an explicit selector. CMS lookup and database target resolution
 use the shared `-EnvironmentFile` local-settings resolver, so direct phase invocation and wrapper
-orchestration target the same local environment.
+orchestration target the same local environment. Dialect: `pgsql` only; MSSQL keysets are rejected with an
+actionable error at `Resolve-TargetDialect` and dialect support for other engines is deferred to a
+successor story.
 
 ---
 
@@ -233,7 +235,7 @@ orchestration target the same local environment.
 | Item | Detail |
 |---|---|
 | **Preconditions** | None additional beyond what phase commands require. |
-| **Inputs** | `-EnvironmentFile <path>` (forwarded to the start and seed phases); `-IdentityProvider` (resolved once and forwarded to `start-local-dms.ps1` or `start-published-dms.ps1`, and also to `load-dms-seed-data.ps1` when seed loading is selected); `-EnableKafkaUI`, `-EnableSwaggerUI`, `-EnableConfig`, and `-AddExtensionSecurityMetadata` (forwarded to the selected start phase; `-EnableConfig` is forced when seed loading is selected); `-SchoolYearRange <range>` (forwarded to the selected start phase and expanded to `-SchoolYear <int[]>` for the seed phase when seed loading is selected); `-LoadSeedData` (wrapper-level opt-in that causes the wrapper to invoke `load-dms-seed-data.ps1`); `-SeedTemplate`, `-SeedDataPath <path>`, and `-AdditionalNamespacePrefix <string[]>` (forwarded to `load-dms-seed-data.ps1` when seed loading is selected) |
+| **Inputs** | `-EnvironmentFile <path>` (forwarded to the start and seed phases); `-IdentityProvider` (resolved once and forwarded to `start-local-dms.ps1` or `start-published-dms.ps1`, and also to `load-dms-seed-data.ps1` when seed loading is selected); `-EnableKafkaUI`, `-EnableSwaggerUI`, `-EnableConfig`, and `-AddExtensionSecurityMetadata` (forwarded to the selected start phase; `-EnableConfig` is forced when seed loading is selected); `-SchoolYearRange <range>` (forwarded to the selected start phase and expanded to `-SchoolYear <int[]>` for the seed phase when seed loading is selected); `-LoadSeedData` (wrapper-level opt-in that causes the wrapper to invoke `load-dms-seed-data.ps1`); `-SeedTemplate`, `-SeedDataPath <path>`, and `-AdditionalNamespacePrefix <string[]>` (forwarded to `load-dms-seed-data.ps1` when seed loading is selected); `-NoDmsInstance` and `-AddSmokeTestCredentials` (forwarded to `configure-local-dms-instance.ps1` during the configure → provision sequence) |
 | **Outputs** | Delegated entirely to the phase commands it calls |
 | **Side effects** | Delegates to phase commands; prints next-step guidance when a phase is intentionally omitted |
 | **Failure conditions** | Propagates non-zero exit from any called phase command |
@@ -254,8 +256,13 @@ phase-specific behavior, retry or fallback logic, persisted resume state, schema
 configuration, or seed loading directly, and it never parses human-readable output to recover phase results.
 
 Broader wrapper consolidation flags such as `-Extensions`, `-ApiSchemaPath`, `-ClaimsDirectoryPath`,
-`-InfraOnly`, `-DmsBaseUrl`, `-Rebuild`, and `-AddSmokeTestCredentials` remain deferred to their owning
-bootstrap stories. DMS-1152 delivers the wrapper surface needed for API-based XML seed delivery.
+`-DmsBaseUrl`, and `-Rebuild` remain deferred to their owning bootstrap stories. The wrapper-level
+`-InfraOnly` consolidation flag (a developer-facing infra-only entry point) likewise remains a later
+entry-point concern, and is distinct from the start-script `-InfraOnly` / `-DmsOnly` split-startup switches
+documented in §3.3 that the wrapper drives internally. DMS-1152 delivers the wrapper surface needed for
+API-based XML seed delivery; DMS-1151 additionally lets the wrapper forward `-NoDmsInstance` and
+`-AddSmokeTestCredentials` to `configure-local-dms-instance.ps1` (which owns both per §3.4) as part of its
+configure → provision → DMS-only sequencing.
 
 ---
 
@@ -273,6 +280,14 @@ prepare-dms-schema.ps1
 Each phase begins only when all of its required inputs are ready. No phase polls for or waits on
 services it does not consume. Phases can be invoked individually for re-runs, debugging, and testing
 without re-executing the full chain.
+
+For the common developer happy path, `bootstrap-local-dms.ps1` / `bootstrap-published-dms.ps1` is the
+recommended entry point that orchestrates this sequence (prepare → infra → configure → provision → DMS,
+plus optional seed). Direct invocation of `start-local-dms.ps1` / `start-published-dms.ps1` is supported for
+diagnostics and partial-phase orchestration via the `-InfraOnly` / `-DmsOnly` switches, where the caller is
+responsible for ensuring schema provisioning has run before DMS serves requests. This convenience framing
+does not change the normative contract in §2: the phase commands remain authoritative and the wrapper owns
+no phase-specific policy.
 
 ---
 
@@ -305,11 +320,11 @@ Each phase accepts only the parameters relevant to its concern.
 |---|---|
 | `prepare-dms-schema.ps1` | Story 00: `-ApiSchemaPath`; Story 06: `-Extensions` |
 | `prepare-dms-claims.ps1` | `-ClaimsDirectoryPath` |
-| `start-local-dms.ps1` | `-EnvironmentFile <path>`, `-Rebuild`/`-r`, `-IdentityProvider`, `-EnableConfig` (legacy compat), `-EnableKafkaUI`, `-EnableSwaggerUI`, `-d`/`-v`, plus transitional legacy flags still owned by the start scripts: `-NoDmsInstance`, `-SchoolYearRange`, `-LoadSeedData`, `-AddSmokeTestCredentials`, and `-AddExtensionSecurityMetadata` |
+| `start-local-dms.ps1` | `-EnvironmentFile <path>`, `-Rebuild`/`-r`, `-IdentityProvider`, `-EnableConfig` (legacy compat), `-EnableKafkaUI`, `-EnableSwaggerUI`, `-d`/`-v`, plus transitional legacy flags still owned by the start scripts: `-NoDmsInstance`, `-SchoolYearRange`, `-LoadSeedData`, `-AddSmokeTestCredentials`, and `-AddExtensionSecurityMetadata`, plus the split-startup switches `-InfraOnly` and `-DmsOnly` |
 | `configure-local-dms-instance.ps1` | `-EnvironmentFile <path>`, `-NoDmsInstance`, `-SchoolYearRange`, `-AddSmokeTestCredentials` |
 | `provision-dms-schema.ps1` | `-EnvironmentFile <path>`, `-InstanceId <long[]>`, `-SchoolYear <int[]>` |
 | `load-dms-seed-data.ps1` | `-EnvironmentFile <path>`, `-BootstrapManifestPath <path>`, `-InstanceId <long[]>`, `-DmsBaseUrl <url>`, `-IdentityProvider`, `-SeedTemplate`, `-SeedDataPath`, `-AdditionalNamespacePrefix <string[]>`, `-SchoolYear <int[]>` |
-| `bootstrap-local-dms.ps1` / `bootstrap-published-dms.ps1` | DMS-1152: `-EnvironmentFile <path>`, `-IdentityProvider`, `-EnableKafkaUI`, `-EnableSwaggerUI`, `-EnableConfig`, `-AddExtensionSecurityMetadata`, `-SchoolYearRange`, `-LoadSeedData`, `-SeedTemplate`, `-SeedDataPath <path>`, `-AdditionalNamespacePrefix <string[]>` |
+| `bootstrap-local-dms.ps1` / `bootstrap-published-dms.ps1` | DMS-1152: `-EnvironmentFile <path>`, `-IdentityProvider`, `-EnableKafkaUI`, `-EnableSwaggerUI`, `-EnableConfig`, `-AddExtensionSecurityMetadata`, `-SchoolYearRange`, `-LoadSeedData`, `-SeedTemplate`, `-SeedDataPath <path>`, `-AdditionalNamespacePrefix <string[]>`; DMS-1151: `-NoDmsInstance`, `-AddSmokeTestCredentials` (forwarded to configure) |
 
 `-DmsBaseUrl` remains phase-owned by direct `load-dms-seed-data.ps1` invocation in DMS-1152. The IDE-hosted
 wrapper continuation flow is deferred to the entry-point workflow that owns `-InfraOnly`/`-DmsBaseUrl`

--- a/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
@@ -145,7 +145,7 @@ state. DMS compose services do not consume claimset fragment files, so `local-dm
 | **Outputs** | Running Docker services; provider-specific local identity clients including `CMSReadOnlyAccess`; healthy Config Service; healthy DMS container |
 | **Side effects** | Docker Compose up/down; runs provider-specific local identity setup, including the fixed `CMSReadOnlyAccess` read-only client; validates the bootstrap manifest when present but does not apply manifest-selected staged claims to Config Service startup until Story 04 can also point DMS at the matching staged ApiSchema workspace; calls `setup-openiddict.ps1 -InitDb` after PostgreSQL health; calls `setup-openiddict.ps1 -InsertData` after Config Service readiness (self-contained path) |
 | **Failure conditions** | Docker compose start failure; health-wait timeout for any service; malformed or incomplete bootstrap manifest when present |
-| **Must NOT do** | Resolve or validate ApiSchema files; inspect or write the staged-schema or staged-claims workspace; provision databases; enable the legacy `NEED_DATABASE_SETUP` / `EdFi.DataManagementService.Backend.Installer.dll` startup provisioning path; configure DMS instances; create smoke-test or seed-loading CMS application credentials; load seed data; accept schema or claims parameters |
+| **Must NOT do** | Resolve or validate ApiSchema files; inspect or write the staged-schema or staged-claims workspace; provision databases; enable the legacy `NEED_DATABASE_SETUP` / `EdFi.DataManagementService.Backend.Installer.dll` startup provisioning path; accept schema or claims parameters. **End-state contract owned by DMS-1153** (see Boundary note): configure DMS instances; create smoke-test or seed-loading CMS application credentials; load seed data — the transitional `-NoDmsInstance` / `-LoadSeedData` / `-AddSmokeTestCredentials` Inputs flags retain these on the start scripts until DMS-1153 de-scopes them |
 
 **Boundary note:** Story 00 makes staged
 schema/security the prepared bootstrap contract, not the Docker runtime source of truth. It keeps staged
@@ -155,6 +155,16 @@ bootstrap startup, including any CMS load/composition result or authorization me
 does not add an IDE-hosted start/health-wait surface to `start-local-dms.ps1`; IDE continuation remains owned
 by the later entry-point workflow. Once DMS health is confirmed, any later step is owned by wrapper
 orchestration or by the developer invoking the next phase command explicitly.
+
+The Must-NOT row separates two kinds of prohibition. The first group (resolve/validate ApiSchema, touch the
+staged workspace, provision databases, enable the legacy installer path, accept schema/claims parameters) is
+permanent. The second group (configure DMS instances, create smoke-test/seed-loading credentials, load seed
+data) is the end-state contract owned by DMS-1153 (`epics/16-bootstrap/03-entry-point-and-ide-workflow.md`),
+which makes `start-local-dms.ps1` infrastructure-lifecycle-only. Until that story lands, the start scripts
+intentionally retain the transitional `-NoDmsInstance`, `-LoadSeedData`, and `-AddSmokeTestCredentials` flags
+listed in Inputs, so the apparent Inputs/Must-NOT overlap is deliberate and time-bounded rather than a
+contradiction. DMS-1151 adds the `-InfraOnly` / `-DmsOnly` split-startup switches and drives them from the
+wrapper, but does not remove these legacy flags.
 
 ---
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/01-schema-deployment-safety.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/01-schema-deployment-safety.md
@@ -18,6 +18,27 @@ Under the strong DMS-916 reading, the staged schema workspace also defines the e
 footprint expected for the run, so changing the selected extension set changes the target schema that must
 be provisioned or validated.
 
+To make provisioning a true pre-start phase, the start scripts expose `-InfraOnly` / `-DmsOnly` split-startup
+switches, and the bootstrap wrapper drives them (infra → configure → provision → DMS-only) so schema
+provisioning always runs before DMS serves requests. The wrapper is the recommended developer entry point;
+see `command-boundaries.md` §3.3 and §4 for the switch and entry-point contract.
+
+## Scope Boundary With Story 04
+
+DMS-1151 provisions schemas into the selected instance target databases. It does NOT activate the staged
+`.bootstrap/ApiSchema` workspace as the DMS runtime schema source. `USE_API_SCHEMA_PATH`,
+`API_SCHEMA_PATH`, and the `bootstrap-dms.yml` mount that flip Docker-hosted and IDE-hosted DMS onto the
+staged workspace are deferred to Story 04 / DMS-1154. The acceptance criterion that "the schema files
+hashed in bootstrap are the same files later read by Docker-hosted DMS and by IDE-hosted DMS" is therefore
+satisfied at the file-content level by DMS-1151 but not at the runtime-binding level until Story 04
+lands. `Get-ProvisionIdeGuidance` labels the staged-runtime values it emits as deferred to DMS-1154 for
+exactly this reason.
+
+DMS-1151 also restricts schema provisioning to PostgreSQL: `provision-dms-schema.ps1` hard-codes
+`--dialect pgsql`, and MSSQL connection-string keysets are rejected at `Resolve-TargetDialect`. MSSQL
+provisioning is out of scope for this story; the bootstrap epic may revisit dialect support in a
+successor story.
+
 ## Acceptance Criteria
 
 - Before any DMS host starts, `provision-dms-schema.ps1` consumes the selected `ApiSchema*.json` files

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -91,14 +91,17 @@ try {
     $previousUseApiSchemaPath = [System.Environment]::GetEnvironmentVariable("USE_API_SCHEMA_PATH")
     $previousApiSchemaPath = [System.Environment]::GetEnvironmentVariable("API_SCHEMA_PATH")
     $previousSchemaPackages = [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES")
+    $previousNeedDatabaseSetup = [System.Environment]::GetEnvironmentVariable("NEED_DATABASE_SETUP")
     try {
         # .env.routeContext.e2e carries the Story 04 loose-file schema settings, but this
         # transitional E2E setup still runs from DLL-backed SCHEMA_PACKAGES. Process env
         # values win over docker compose --env-file entries, so clear stale overrides
-        # left by teardown and force the Story 04 path off.
+        # left by teardown, force the Story 04 path off, and keep the DMS entrypoint
+        # installer off because this harness provisions the main database explicitly below.
         $env:USE_API_SCHEMA_PATH = "false"
         $env:API_SCHEMA_PATH = ""
         $env:SCHEMA_PACKAGES = $null
+        $env:NEED_DATABASE_SETUP = "false"
 
         # Run the start script - NO instance creation
         if ($SkipDockerBuild) {
@@ -126,6 +129,12 @@ try {
         } else {
             $env:SCHEMA_PACKAGES = $previousSchemaPackages
         }
+
+        if ($null -eq $previousNeedDatabaseSetup) {
+            $env:NEED_DATABASE_SETUP = $null
+        } else {
+            $env:NEED_DATABASE_SETUP = $previousNeedDatabaseSetup
+        }
     }
 
     if ($LASTEXITCODE -ne 0) {
@@ -148,15 +157,11 @@ try {
     }
 
     # Deploy the DMS schema into the main database so it can seed the per-instance test
-    # databases below. DMS-1151 ("Bootstrap Schema Deployment Safety") moved schema
-    # provisioning out of the DMS container entrypoint: start-local-dms.ps1 now forces
-    # NEED_DATABASE_SETUP=false for every direct start path, so the legacy Backend.Installer
-    # no longer runs on container startup and the main database comes up empty. This E2E
-    # harness is the non-bootstrap transitional path and does not go through provision-dms-schema.ps1,
-    # so it provisions the (legacy/relational-disabled) schema itself by running the same
-    # Backend.Installer as a one-shot container on the shared 'dms' network - mirroring what the
-    # container entrypoint used to do on startup. Without this, every per-instance request 500s
-    # with "relation \"dms.document\" does not exist".
+    # databases below. This E2E harness is the non-bootstrap transitional path and uses
+    # DLL-backed schema packages, so it disables the DMS container entrypoint installer above
+    # and provisions the (legacy/relational-disabled) schema itself by running the same
+    # Backend.Installer as a one-shot container on the shared 'dms' network. Without this,
+    # every per-instance request 500s with "relation \"dms.document\" does not exist".
     Write-Host "`nDeploying DMS schema to main database..." -ForegroundColor Cyan
 
     Import-Module ./env-utility.psm1 -Force

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -88,12 +88,44 @@ try {
 
     Write-Output "Using DLL-backed schema packages for E2E. Bootstrap loose-file runtime loading is Story 04."
 
-    # Run the start script - NO instance creation
-    if ($SkipDockerBuild) {
-        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+    $previousUseApiSchemaPath = [System.Environment]::GetEnvironmentVariable("USE_API_SCHEMA_PATH")
+    $previousApiSchemaPath = [System.Environment]::GetEnvironmentVariable("API_SCHEMA_PATH")
+    $previousSchemaPackages = [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES")
+    try {
+        # .env.routeContext.e2e carries the Story 04 loose-file schema settings, but this
+        # transitional E2E setup still runs from DLL-backed SCHEMA_PACKAGES. Process env
+        # values win over docker compose --env-file entries, so clear stale overrides
+        # left by teardown and force the Story 04 path off.
+        $env:USE_API_SCHEMA_PATH = "false"
+        $env:API_SCHEMA_PATH = ""
+        $env:SCHEMA_PACKAGES = $null
+
+        # Run the start script - NO instance creation
+        if ($SkipDockerBuild) {
+            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+        }
+        else {
+            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+        }
     }
-    else {
-        ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+    finally {
+        if ($null -eq $previousUseApiSchemaPath) {
+            $env:USE_API_SCHEMA_PATH = $null
+        } else {
+            $env:USE_API_SCHEMA_PATH = $previousUseApiSchemaPath
+        }
+
+        if ($null -eq $previousApiSchemaPath) {
+            $env:API_SCHEMA_PATH = $null
+        } else {
+            $env:API_SCHEMA_PATH = $previousApiSchemaPath
+        }
+
+        if ($null -eq $previousSchemaPackages) {
+            $env:SCHEMA_PACKAGES = $null
+        } else {
+            $env:SCHEMA_PACKAGES = $previousSchemaPackages
+        }
     }
 
     if ($LASTEXITCODE -ne 0) {
@@ -114,6 +146,37 @@ try {
         docker exec dms-postgresql psql -U postgres -c "CREATE DATABASE $db;" 2>&1 | Out-Null
         Write-Host "  Created database: $db" -ForegroundColor Green
     }
+
+    # Deploy the DMS schema into the main database so it can seed the per-instance test
+    # databases below. DMS-1151 ("Bootstrap Schema Deployment Safety") moved schema
+    # provisioning out of the DMS container entrypoint: start-local-dms.ps1 now forces
+    # NEED_DATABASE_SETUP=false for every direct start path, so the legacy Backend.Installer
+    # no longer runs on container startup and the main database comes up empty. This E2E
+    # harness is the non-bootstrap transitional path and does not go through provision-dms-schema.ps1,
+    # so it provisions the (legacy/relational-disabled) schema itself by running the same
+    # Backend.Installer as a one-shot container on the shared 'dms' network - mirroring what the
+    # container entrypoint used to do on startup. Without this, every per-instance request 500s
+    # with "relation \"dms.document\" does not exist".
+    Write-Host "`nDeploying DMS schema to main database..." -ForegroundColor Cyan
+
+    Import-Module ./env-utility.psm1 -Force
+    $routeContextEnvValues = ReadValuesFromEnvFile "./.env.routeContext.e2e"
+    $postgresPassword = Get-EnvValue -EnvValues $routeContextEnvValues -Name "POSTGRES_PASSWORD" -DefaultValue "abcdefgh1!"
+    $adminConnectionString = "host=dms-postgresql;port=5432;username=postgres;password=$postgresPassword;database=edfi_datamanagementservice;"
+
+    # Resolve the locally-built DMS image from the running service container so the installer
+    # runs the exact binaries (including /app/Installer) that the DMS container ships.
+    $dmsImage = docker ps -a --filter "name=dms-local-dms-1" --format "{{.Image}}" | Select-Object -First 1
+    if ([string]::IsNullOrWhiteSpace($dmsImage)) {
+        throw "Unable to resolve the DMS image from container 'dms-local-dms-1'. Ensure the DMS stack started successfully."
+    }
+
+    docker run --rm --network dms --entrypoint dotnet $dmsImage `
+        Installer/EdFi.DataManagementService.Backend.Installer.dll -e postgresql -c $adminConnectionString
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to deploy DMS schema to the main database. Installer exited with code $LASTEXITCODE."
+    }
+    Write-Host "  Schema deployed to main database" -ForegroundColor Green
 
     # Export schema from main database
     Write-Host "`nExporting schema from main database..." -ForegroundColor Cyan

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -27,6 +27,26 @@ param(
     $SkipDockerBuild
 )
 
+function Test-DmsDocumentTablePresent {
+    <#
+    .SYNOPSIS
+    Returns $true when the dms.document table exists in the given PostgreSQL database. Throws
+    when the existence query itself cannot be run, so a failed psql invocation is never read as
+    "table absent". Used to turn a silently-empty schema deploy into a hard setup failure.
+    #>
+    param(
+        [string]
+        $Database
+    )
+
+    $regclass = (docker exec dms-postgresql psql -U postgres -d $Database -tAc "SELECT to_regclass('dms.document');" | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to query database '$Database' for the dms.document table (psql exit code $LASTEXITCODE)."
+    }
+
+    return -not [string]::IsNullOrWhiteSpace($regclass)
+}
+
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for Instance Management E2E Testing
 ======================================================================
@@ -152,8 +172,18 @@ try {
         "edfi_datamanagementservice_d255902_sy2024"
     )
 
+    # Drop-then-create each database so the run starts from a known-empty state. Failures are
+    # surfaced (no 2>&1 | Out-Null swallowing) so a stale database can never silently mask a
+    # setup problem.
     foreach ($db in $databases) {
-        docker exec dms-postgresql psql -U postgres -c "CREATE DATABASE $db;" 2>&1 | Out-Null
+        docker exec dms-postgresql psql -U postgres -c "DROP DATABASE IF EXISTS $db;"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to drop existing database '$db' (psql exit code $LASTEXITCODE)."
+        }
+        docker exec dms-postgresql psql -U postgres -c "CREATE DATABASE $db;"
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to create database '$db' (psql exit code $LASTEXITCODE)."
+        }
         Write-Host "  Created database: $db" -ForegroundColor Green
     }
 
@@ -184,17 +214,40 @@ try {
     }
     Write-Host "  Schema deployed to main database" -ForegroundColor Green
 
+    # The installer can exit 0 without producing the expected objects (e.g. a no-op against the
+    # wrong database). Assert the schema actually landed before exporting it, otherwise every
+    # per-instance database would be seeded from an empty dump and the run would 500 at test time.
+    if (-not (Test-DmsDocumentTablePresent -Database "edfi_datamanagementservice")) {
+        throw "Schema verification failed: 'dms.document' is missing from the main database after running the installer."
+    }
+    Write-Host "  Verified dms.document exists in main database" -ForegroundColor Green
+
     # Export schema from main database
     Write-Host "`nExporting schema from main database..." -ForegroundColor Cyan
     $tempSchemaFile = [System.IO.Path]::GetTempFileName()
     docker exec dms-postgresql pg_dump -U postgres -d edfi_datamanagementservice --schema-only > $tempSchemaFile
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to export schema from the main database. pg_dump exited with code $LASTEXITCODE."
+    }
+    if ((Get-Item -LiteralPath $tempSchemaFile).Length -eq 0) {
+        throw "Schema export produced an empty file. The main database schema is missing or pg_dump failed silently."
+    }
     Write-Host "  Schema exported successfully" -ForegroundColor Green
 
     # Apply schema to each test database
     Write-Host "`nApplying schema to test databases..." -ForegroundColor Cyan
     foreach ($db in $databases) {
-        Get-Content $tempSchemaFile | docker exec -i dms-postgresql psql -U postgres -d $db
-        Write-Host "  Schema applied to: $db" -ForegroundColor Green
+        # ON_ERROR_STOP=1 makes psql abort and return non-zero on the first failed statement,
+        # so a partially-applied schema fails the run immediately instead of being detected only
+        # by the dms.document postcondition below.
+        Get-Content $tempSchemaFile | docker exec -i dms-postgresql psql -v ON_ERROR_STOP=1 -U postgres -d $db
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to apply schema to test database '$db' (psql exit code $LASTEXITCODE)."
+        }
+        if (-not (Test-DmsDocumentTablePresent -Database $db)) {
+            throw "Schema verification failed: 'dms.document' is missing from test database '$db' after applying the exported schema."
+        }
+        Write-Host "  Schema applied and verified: $db" -ForegroundColor Green
     }
 
     # Clean up temp file

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -17,7 +17,7 @@
     moves E2E runtime loading onto the staged bootstrap workspace.
 
     The script runs:
-    ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+    ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata -SkipConnectorSetup
 #>
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Setup script is intentionally host-oriented and uses console progress output.')]
@@ -126,10 +126,10 @@ try {
 
         # Run the start script - NO instance creation
         if ($SkipDockerBuild) {
-            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata -SkipConnectorSetup
         }
         else {
-            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
+            ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata -SkipConnectorSetup
         }
     }
     finally {

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -20,6 +20,7 @@
     ./start-local-dms.ps1 -EnableKafkaUI -EnableConfig -EnvironmentFile ./.env.routeContext.e2e -r -IdentityProvider self-contained -NoDmsInstance -AddExtensionSecurityMetadata
 #>
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Setup script is intentionally host-oriented and uses console progress output.')]
 [CmdletBinding()]
 param(
     [switch]

--- a/src/dms/tests/RestClient/local-development-setup.http
+++ b/src/dms/tests/RestClient/local-development-setup.http
@@ -58,7 +58,11 @@
 #    "ConnectionStrings": {
 #        "DatabaseConnection": "host=localhost;port=5435;username=postgres;password=abcdefgh1!;database=edfi_datamanagementservice;"
 #    },
-# 7. Run these steps from top to bottom.
+# 7. After DMS has started and deployed its schema, register the Kafka source connector. The Debezium
+#    PostgreSQL source connector snapshots `dms.document` on registration, so it must run only after
+#    the schema exists - `start-all-services.ps1` deliberately does not register it. In
+#    `eng/docker-compose`, run: `./setup-connectors.ps1`
+# 8. Run these steps from top to bottom.
 
 @configPort=5126
 @dmsPort=5198


### PR DESCRIPTION
## Summary

Implements **DMS-1151 — Bootstrap Schema Deployment Safety**: the authoritative pre-start schema provisioning phase for the DMS-916 bootstrap flow, separating schema provisioning from seed loading per `command-boundaries.md` §3.5.

## Changes

- **`provision-dms-schema.ps1` (new)** — authoritative SchemaTools/runtime-owned provisioning phase. Consumes the staged schema workspace from Story 00, resolves target instances via `-InstanceId`/`-SchoolYear` (auto-select on a single match, fail-fast on zero/ambiguous), `pgsql`-only with MSSQL rejected at `Resolve-TargetDialect`, decrypts CMS-encrypted connection strings, and guards the CMS instance query page size.
- **`configure-local-dms-instance.ps1` (new)** — instance-setup phase (§3.4) that creates/selects the DMS instance records provisioning targets.
- **Start scripts** — add `-InfraOnly` / `-DmsOnly` split-startup switches and force the legacy `NEED_DATABASE_SETUP` / `Backend.Installer.dll` startup-provisioning path off on every direct start path. `.env.example` flips `NEED_DATABASE_SETUP` to `false`.
- **Bootstrap wrapper** — drives `infra → configure → provision → DMS-only`, forwarding `-NoDmsInstance` / `-AddSmokeTestCredentials` to the configure phase; asserts a staged schema workspace exists before starting.
- **Design docs** — reconcile `command-boundaries.md` (§3.3 start-script contract boundary, §3.5 provisioning ownership, §4 entry-point chain) and the story doc.
- **Docker smoke** — `Invoke-BootstrapDockerSmoke.ps1` exercises phase execution, DMS `/health`, and provisioned-table presence.

## Scope boundaries (deferred by design)

- **Story 03 (DMS-1153)** owns the entry-point hard contract: de-scoping seed/smoke/configure ownership off the start scripts, enforcing provision-before-DMS-start, and migrating `build-dms.ps1` / E2E setup onto the wrapper. The transitional legacy start-script flags are intentionally retained until then.
- **Story 04 (DMS-1154)** owns staged-workspace runtime activation (`USE_API_SCHEMA_PATH` / `API_SCHEMA_PATH` binding and the `bootstrap-dms.yml` mount). This branch leaves that path inactive; IDE guidance labels those values as deferred.

## Testing

Three Pester suites pass locally:

- `BootstrapSchemaAndSecuritySelection.Tests.ps1` — 46 passed
- `BootstrapSchemaDeploymentSafety.Tests.ps1` — 80 passed (includes new coverage for encrypted connection-string failure modes and the CMS paging guard)
- `BootstrapSeedDelivery.Tests.ps1` — 117 passed, 1 skipped
