### PR TITLE
[DMS-1181] Validate Change-Version Query Parameters

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core.External/Model/ChangeVersionRange.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Model/ChangeVersionRange.cs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Model;
+
+/// <summary>
+/// The parsed and validated change-version window from the minChangeVersion /
+/// maxChangeVersion query parameters. Either bound may be null when that
+/// parameter was not supplied. Bounds are long-width to match the relational
+/// bigint change-version storage.
+/// </summary>
+public sealed record ChangeVersionRange(long? MinChangeVersion, long? MaxChangeVersion)
+{
+    /// <summary>
+    /// The no-bounds range used when neither change-version parameter is supplied.
+    /// </summary>
+    public static ChangeVersionRange None { get; } = new(null, null);
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
@@ -153,6 +153,25 @@ public class ChangeVersionParameterValidatorTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_Both_Values_Are_Whitespace : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", " " }, { "maxChangeVersion", "  " } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_treats_both_bounds_as_absent() => _result.Range.Should().Be(ChangeVersionRange.None);
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_Min_Is_Not_Numeric : ChangeVersionParameterValidatorTests
     {
         private ChangeVersionValidationResult _result = null!;
@@ -320,6 +339,26 @@ public class ChangeVersionParameterValidatorTests
 
         [Test]
         public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Value_Above_Long_Max : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "9223372036854775808" } }
+            );
+
+        [Test]
+        public void It_reports_the_min_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MinError);
+
+        [Test]
+        public void It_leaves_min_unset() => _result.Range.MinChangeVersion.Should().BeNull();
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
@@ -168,6 +168,9 @@ public class ChangeVersionParameterValidatorTests
         [Test]
         public void It_reports_the_max_error() =>
             _result.Errors.Should().ContainSingle().Which.Should().Be(MaxError);
+
+        [Test]
+        public void It_leaves_max_unset() => _result.Range.MaxChangeVersion.Should().BeNull();
     }
 
     [TestFixture]
@@ -185,6 +188,9 @@ public class ChangeVersionParameterValidatorTests
         [Test]
         public void It_reports_the_max_error() =>
             _result.Errors.Should().ContainSingle().Which.Should().Be(MaxError);
+
+        [Test]
+        public void It_leaves_max_unset() => _result.Range.MaxChangeVersion.Should().BeNull();
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.ChangeQueries;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.ChangeQueries;
+
+[TestFixture]
+[Parallelizable]
+public class ChangeVersionParameterValidatorTests
+{
+    private const string MinError = "MinChangeVersion must be a numeric value greater than or equal to 0.";
+    private const string MaxError = "MaxChangeVersion must be a numeric value greater than or equal to 0.";
+    private const string InvertedError = "MinChangeVersion must be less than or equal to MaxChangeVersion.";
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_No_Change_Version_Parameters : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(new Dictionary<string, string>());
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_returns_the_none_range() => _result.Range.Should().Be(ChangeVersionRange.None);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Only_Min_Is_Valid : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "5" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_sets_only_the_min_bound() =>
+            _result.Range.Should().Be(new ChangeVersionRange(5, null));
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Only_Max_Is_Valid : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "maxChangeVersion", "9" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_sets_only_the_max_bound() =>
+            _result.Range.Should().Be(new ChangeVersionRange(null, 9));
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Both_Valid_With_Min_Less_Than_Max : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "1" }, { "maxChangeVersion", "2" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_sets_both_bounds() => _result.Range.Should().Be(new ChangeVersionRange(1, 2));
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Both_Valid_And_Equal : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "7" }, { "maxChangeVersion", "7" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_sets_both_bounds() => _result.Range.Should().Be(new ChangeVersionRange(7, 7));
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Min_Is_Not_Numeric : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "abc" } }
+            );
+
+        [Test]
+        public void It_reports_the_min_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MinError);
+
+        [Test]
+        public void It_leaves_min_unset() => _result.Range.MinChangeVersion.Should().BeNull();
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Min_Is_Negative : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "-1" } }
+            );
+
+        [Test]
+        public void It_reports_the_min_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MinError);
+
+        [Test]
+        public void It_leaves_min_unset() => _result.Range.MinChangeVersion.Should().BeNull();
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Max_Is_Not_Numeric : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "maxChangeVersion", "xyz" } }
+            );
+
+        [Test]
+        public void It_reports_the_max_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MaxError);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Max_Is_Negative : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "maxChangeVersion", "-3" } }
+            );
+
+        [Test]
+        public void It_reports_the_max_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MaxError);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Inverted_Range : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "10" }, { "maxChangeVersion", "5" } }
+            );
+
+        [Test]
+        public void It_reports_only_the_inverted_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(InvertedError);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Both_Are_Not_Numeric : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "a" }, { "maxChangeVersion", "b" } }
+            );
+
+        [Test]
+        public void It_reports_min_before_max_and_no_inverted_error() =>
+            _result.Errors.Should().Equal(MinError, MaxError);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Min_Invalid_And_Max_Valid : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "a" }, { "maxChangeVersion", "5" } }
+            );
+
+        [Test]
+        public void It_reports_only_the_min_parse_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MinError);
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Value_Above_Int_Max : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "3000000000" } }
+            );
+
+        [Test]
+        public void It_accepts_the_long_value() =>
+            _result.Range.Should().Be(new ChangeVersionRange(3000000000L, null));
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Mixed_Case_Parameter_Keys : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "MinChangeVersion", "1" }, { "MAXCHANGEVERSION", "2" } }
+            );
+
+        [Test]
+        public void It_recognizes_the_keys_case_insensitively() =>
+            _result.Range.Should().Be(new ChangeVersionRange(1, 2));
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
@@ -115,6 +115,44 @@ public class ChangeVersionParameterValidatorTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_Both_Bounds_Are_Zero : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "0" }, { "maxChangeVersion", "0" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_sets_both_bounds_to_zero() => _result.Range.Should().Be(new ChangeVersionRange(0, 0));
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Both_Values_Are_Empty : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "" }, { "maxChangeVersion", "" } }
+            );
+
+        [Test]
+        public void It_returns_no_errors() => _result.Errors.Should().BeEmpty();
+
+        [Test]
+        public void It_treats_both_bounds_as_absent() => _result.Range.Should().Be(ChangeVersionRange.None);
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_Min_Is_Not_Numeric : ChangeVersionParameterValidatorTests
     {
         private ChangeVersionValidationResult _result = null!;
@@ -123,6 +161,26 @@ public class ChangeVersionParameterValidatorTests
         public void Setup() =>
             _result = ChangeVersionParameterValidator.Validate(
                 new Dictionary<string, string> { { "minChangeVersion", "abc" } }
+            );
+
+        [Test]
+        public void It_reports_the_min_error() =>
+            _result.Errors.Should().ContainSingle().Which.Should().Be(MinError);
+
+        [Test]
+        public void It_leaves_min_unset() => _result.Range.MinChangeVersion.Should().BeNull();
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Min_Is_A_Decimal : ChangeVersionParameterValidatorTests
+    {
+        private ChangeVersionValidationResult _result = null!;
+
+        [SetUp]
+        public void Setup() =>
+            _result = ChangeVersionParameterValidator.Validate(
+                new Dictionary<string, string> { { "minChangeVersion", "1.5" } }
             );
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ChangeQueries/ChangeVersionParameterValidatorTests.cs
@@ -132,6 +132,10 @@ public class ChangeVersionParameterValidatorTests
         public void It_sets_both_bounds_to_zero() => _result.Range.Should().Be(new ChangeVersionRange(0, 0));
     }
 
+    // Empty and whitespace-only values are deliberately accepted as absent, not rejected
+    // as unparseable: ODS binds these parameters as nullable longs, and ASP.NET model
+    // binding converts empty/whitespace query values to null before any parse is
+    // attempted, so ODS returns 200 (unfiltered on that bound) for the same input.
     [TestFixture]
     [Parallelizable]
     public class Given_Both_Values_Are_Empty : ChangeVersionParameterValidatorTests

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -1117,4 +1117,80 @@ public class ValidateQueryMiddlewareTests
             _requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
         }
     }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Mixed_Case_Pagination_Parameter : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        private static ApiSchemaDocuments NewApiSchemaDocuments()
+        {
+            return new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("AcademicWeek")
+                .WithStartQueryFieldMapping()
+                .WithQueryField("schoolId", [new("$.schoolId", "number")])
+                .WithEndQueryFieldMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+        }
+
+        private static RequestInfo NewRequestInfo(FrontendRequest frontendRequest, RequestMethod method)
+        {
+            RequestInfo docRefContext = new(frontendRequest, method, No.ServiceProvider)
+            {
+                ApiSchemaDocuments = NewApiSchemaDocuments(),
+                PathComponents = new(
+                    ProjectEndpointName: new("ed-fi"),
+                    EndpointName: new("academicWeeks"),
+                    DocumentUuid: No.DocumentUuid
+                ),
+            };
+            docRefContext.ProjectSchema =
+                docRefContext.ApiSchemaDocuments.FindProjectSchemaForProjectNamespace(new("ed-fi"))!;
+            docRefContext.ResourceSchema = new ResourceSchema(
+                docRefContext.ProjectSchema.FindResourceSchemaNodeByEndpointName(new("academicWeeks"))
+                    ?? new JsonObject()
+            );
+            return docRefContext;
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            // A pagination parameter in non-canonical casing is not parsed as pagination and
+            // must not be silently dropped; it falls through to ordinary query-field matching.
+            var queryParameters = new Dictionary<string, string> { { "Limit", "-1" } };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/academicWeeks",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+
+            _requestInfo = NewRequestInfo(frontendRequest, RequestMethod.GET);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_should_send_bad_request()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_report_the_invalid_query_field()
+        {
+            _requestInfo
+                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+                .Should()
+                .Be("The query field 'Limit' is not valid for this resource.");
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -819,4 +819,302 @@ public class ValidateQueryMiddlewareTests
                 .Be("The query field 'invalidSchoolId' is not valid for this resource.");
         }
     }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Invalid_Min_Change_Version : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var queryParameters = new Dictionary<string, string> { { "minChangeVersion", "abc" } };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/schools",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+            _requestInfo = new(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_should_send_bad_request()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_use_the_parameter_validation_failed_problem_details()
+        {
+            JsonNode? body = _requestInfo.FrontendResponse.Body;
+            body?["type"]?.GetValue<string>()
+                .Should()
+                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
+            body?["detail"]?.GetValue<string>()
+                .Should()
+                .Be("Parameters supplied to the request were invalid.");
+            body?["status"]?.GetValue<int>().Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_report_the_min_change_version_error()
+        {
+            _requestInfo
+                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+                .Should()
+                .Be("MinChangeVersion must be a numeric value greater than or equal to 0.");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Invalid_Max_Change_Version : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var queryParameters = new Dictionary<string, string> { { "maxChangeVersion", "-2" } };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/schools",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+            _requestInfo = new(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_should_send_bad_request()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_use_the_parameter_validation_failed_problem_details()
+        {
+            JsonNode? body = _requestInfo.FrontendResponse.Body;
+            body?["type"]?.GetValue<string>()
+                .Should()
+                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
+            body?["detail"]?.GetValue<string>()
+                .Should()
+                .Be("Parameters supplied to the request were invalid.");
+            body?["status"]?.GetValue<int>().Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_report_the_max_change_version_error()
+        {
+            _requestInfo
+                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+                .Should()
+                .Be("MaxChangeVersion must be a numeric value greater than or equal to 0.");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Inverted_Change_Version_Range : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var queryParameters = new Dictionary<string, string>
+            {
+                { "minChangeVersion", "10" },
+                { "maxChangeVersion", "5" },
+            };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/schools",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+            _requestInfo = new(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_should_send_bad_request()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_report_the_inverted_range_error()
+        {
+            _requestInfo
+                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+                .Should()
+                .Be("MinChangeVersion must be less than or equal to MaxChangeVersion.");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Valid_Change_Version_Range : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        private static ApiSchemaDocuments NewApiSchemaDocuments()
+        {
+            return new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("AcademicWeek")
+                .WithStartQueryFieldMapping()
+                .WithQueryField("schoolId", [new("$.schoolId", "number")])
+                .WithEndQueryFieldMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+        }
+
+        private static RequestInfo NewRequestInfo(FrontendRequest frontendRequest, RequestMethod method)
+        {
+            RequestInfo docRefContext = new(frontendRequest, method, No.ServiceProvider)
+            {
+                ApiSchemaDocuments = NewApiSchemaDocuments(),
+                PathComponents = new(
+                    ProjectEndpointName: new("ed-fi"),
+                    EndpointName: new("academicWeeks"),
+                    DocumentUuid: No.DocumentUuid
+                ),
+            };
+            docRefContext.ProjectSchema =
+                docRefContext.ApiSchemaDocuments.FindProjectSchemaForProjectNamespace(new("ed-fi"))!;
+            docRefContext.ResourceSchema = new ResourceSchema(
+                docRefContext.ProjectSchema.FindResourceSchemaNodeByEndpointName(new("academicWeeks"))
+                    ?? new JsonObject()
+            );
+            return docRefContext;
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var queryParameters = new Dictionary<string, string>
+            {
+                { "minChangeVersion", "1" },
+                { "maxChangeVersion", "2" },
+            };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/academicWeeks",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+
+            _requestInfo = NewRequestInfo(frontendRequest, RequestMethod.GET);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_provides_no_response()
+        {
+            _requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
+        }
+
+        [Test]
+        public void It_sets_the_parsed_change_version_range()
+        {
+            _requestInfo.ChangeVersionRange.Should().Be(new ChangeVersionRange(1, 2));
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Change_Version_Parameters_Are_Not_Treated_As_Query_Fields
+        : ValidateQueryMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+
+        private static ApiSchemaDocuments NewApiSchemaDocuments()
+        {
+            return new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource("AcademicWeek")
+                .WithStartQueryFieldMapping()
+                .WithQueryField("schoolId", [new("$.schoolId", "number")])
+                .WithEndQueryFieldMapping()
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+        }
+
+        private static RequestInfo NewRequestInfo(FrontendRequest frontendRequest, RequestMethod method)
+        {
+            RequestInfo docRefContext = new(frontendRequest, method, No.ServiceProvider)
+            {
+                ApiSchemaDocuments = NewApiSchemaDocuments(),
+                PathComponents = new(
+                    ProjectEndpointName: new("ed-fi"),
+                    EndpointName: new("academicWeeks"),
+                    DocumentUuid: No.DocumentUuid
+                ),
+            };
+            docRefContext.ProjectSchema =
+                docRefContext.ApiSchemaDocuments.FindProjectSchemaForProjectNamespace(new("ed-fi"))!;
+            docRefContext.ResourceSchema = new ResourceSchema(
+                docRefContext.ProjectSchema.FindResourceSchemaNodeByEndpointName(new("academicWeeks"))
+                    ?? new JsonObject()
+            );
+            return docRefContext;
+        }
+
+        [SetUp]
+        public async Task Setup()
+        {
+            // Mixed casing confirms the reserved-parameter exclusion is case-insensitive.
+            var queryParameters = new Dictionary<string, string>
+            {
+                { "MinChangeVersion", "1" },
+                { "maxChangeVersion", "2" },
+            };
+
+            FrontendRequest frontendRequest = new(
+                Path: "/ed-fi/academicWeeks",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: queryParameters,
+                TraceId: new TraceId(""),
+                RouteQualifiers: []
+            );
+
+            _requestInfo = NewRequestInfo(frontendRequest, RequestMethod.GET);
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_should_not_report_an_invalid_query_field()
+        {
+            _requestInfo.FrontendResponse.Should().Be(No.FrontendResponse);
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
@@ -13,7 +13,7 @@ namespace EdFi.DataManagementService.Core.ChangeQueries;
 /// used by live resource and descriptor GET-many requests and, in later stories,
 /// the /deletes and /keyChanges endpoints. Parses each bound as a long greater than
 /// or equal to 0 and enforces min &lt;= max when both are supplied. Present-but-empty
-/// values are treated as absent. Parameter lookup
+/// or whitespace-only values are treated as absent. Parameter lookup
 /// is case-insensitive so all callers behave the same regardless of client casing.
 /// </summary>
 internal static class ChangeVersionParameterValidator
@@ -65,9 +65,9 @@ internal static class ChangeVersionParameterValidator
             return null;
         }
 
-        // A present-but-empty value is treated as absent, matching ODS model binding,
-        // which converts an empty query value to null without a validation error.
-        if (string.IsNullOrEmpty(rawValue))
+        // A present-but-empty or whitespace-only value is treated as absent, matching ODS
+        // model binding, which converts such query values to null without a validation error.
+        if (string.IsNullOrWhiteSpace(rawValue))
         {
             return null;
         }
@@ -86,8 +86,7 @@ internal static class ChangeVersionParameterValidator
 
     /// <summary>
     /// Case-insensitive dictionary lookup. When multiple case-variant keys are present,
-    /// the first match in enumeration order wins, consistent with how the frontend
-    /// already resolves duplicate query keys to a single value.
+    /// duplicates collapse to a single value: the first match in enumeration order wins.
     /// </summary>
     private static bool TryGetValueIgnoreCase(
         IReadOnlyDictionary<string, string> source,

--- a/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.ChangeQueries;
+
+/// <summary>
+/// Shared validation for the minChangeVersion / maxChangeVersion query parameters
+/// used by live resource and descriptor GET-many requests and, in later stories,
+/// the /deletes and /keyChanges endpoints. Parses each bound as a long greater than
+/// or equal to 0 and enforces min &lt;= max when both are supplied. Parameter lookup
+/// is case-insensitive so all callers behave the same regardless of client casing.
+/// </summary>
+internal static class ChangeVersionParameterValidator
+{
+    public const string MinChangeVersion = "minChangeVersion";
+    public const string MaxChangeVersion = "maxChangeVersion";
+
+    private const string MinError = "MinChangeVersion must be a numeric value greater than or equal to 0.";
+    private const string MaxError = "MaxChangeVersion must be a numeric value greater than or equal to 0.";
+    private const string InvertedError = "MinChangeVersion must be less than or equal to MaxChangeVersion.";
+
+    /// <summary>
+    /// The query parameters this validator owns. Callers exclude these from ordinary
+    /// query-field matching (case-insensitively).
+    /// </summary>
+    public static readonly string[] ReservedParameterNames = [MinChangeVersion, MaxChangeVersion];
+
+    /// <summary>
+    /// Parses and validates the change-version parameters from the supplied query parameters.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="ChangeVersionValidationResult"/> carrying the parsed range and the ordered
+    /// list of validation errors (empty when the parameters are valid or absent).
+    /// </returns>
+    public static ChangeVersionValidationResult Validate(IReadOnlyDictionary<string, string> queryParameters)
+    {
+        List<string> errors = [];
+
+        long? min = ParseBound(queryParameters, MinChangeVersion, MinError, errors);
+        long? max = ParseBound(queryParameters, MaxChangeVersion, MaxError, errors);
+
+        if (min is not null && max is not null && min > max)
+        {
+            errors.Add(InvertedError);
+        }
+
+        return new ChangeVersionValidationResult(new ChangeVersionRange(min, max), errors);
+    }
+
+    private static long? ParseBound(
+        IReadOnlyDictionary<string, string> queryParameters,
+        string parameterName,
+        string error,
+        List<string> errors
+    )
+    {
+        if (!TryGetValueIgnoreCase(queryParameters, parameterName, out string rawValue))
+        {
+            return null;
+        }
+
+        if (
+            long.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value)
+            && value >= 0
+        )
+        {
+            return value;
+        }
+
+        errors.Add(error);
+        return null;
+    }
+
+    private static bool TryGetValueIgnoreCase(
+        IReadOnlyDictionary<string, string> source,
+        string key,
+        out string value
+    )
+    {
+        string? found = source
+            .Where(pair => string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            .Select(pair => pair.Value)
+            .FirstOrDefault();
+
+        if (found is not null)
+        {
+            value = found;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+}
+
+/// <summary>
+/// The outcome of change-version parameter validation: the parsed range plus an
+/// ordered list of error messages (empty when valid). Ordering is deterministic and
+/// request-independent: min parse error, then max parse error, then inverted-range
+/// error (only when both bounds parsed successfully).
+/// </summary>
+internal sealed record ChangeVersionValidationResult(ChangeVersionRange Range, IReadOnlyList<string> Errors);

--- a/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
@@ -12,7 +12,8 @@ namespace EdFi.DataManagementService.Core.ChangeQueries;
 /// Shared validation for the minChangeVersion / maxChangeVersion query parameters
 /// used by live resource and descriptor GET-many requests and, in later stories,
 /// the /deletes and /keyChanges endpoints. Parses each bound as a long greater than
-/// or equal to 0 and enforces min &lt;= max when both are supplied. Parameter lookup
+/// or equal to 0 and enforces min &lt;= max when both are supplied. Present-but-empty
+/// values are treated as absent. Parameter lookup
 /// is case-insensitive so all callers behave the same regardless of client casing.
 /// </summary>
 internal static class ChangeVersionParameterValidator
@@ -64,6 +65,13 @@ internal static class ChangeVersionParameterValidator
             return null;
         }
 
+        // A present-but-empty value is treated as absent, matching ODS model binding,
+        // which converts an empty query value to null without a validation error.
+        if (string.IsNullOrEmpty(rawValue))
+        {
+            return null;
+        }
+
         if (
             long.TryParse(rawValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out long value)
             && value >= 0
@@ -76,6 +84,11 @@ internal static class ChangeVersionParameterValidator
         return null;
     }
 
+    /// <summary>
+    /// Case-insensitive dictionary lookup. When multiple case-variant keys are present,
+    /// the first match in enumeration order wins, consistent with how the frontend
+    /// already resolves duplicate query keys to a single value.
+    /// </summary>
     private static bool TryGetValueIgnoreCase(
         IReadOnlyDictionary<string, string> source,
         string key,

--- a/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ChangeQueries/ChangeVersionParameterValidator.cs
@@ -13,7 +13,10 @@ namespace EdFi.DataManagementService.Core.ChangeQueries;
 /// used by live resource and descriptor GET-many requests and, in later stories,
 /// the /deletes and /keyChanges endpoints. Parses each bound as a long greater than
 /// or equal to 0 and enforces min &lt;= max when both are supplied. Present-but-empty
-/// or whitespace-only values are treated as absent. Parameter lookup
+/// or whitespace-only values are deliberately treated as absent rather than invalid:
+/// ODS binds these parameters as nullable longs, and ASP.NET model binding converts
+/// empty and whitespace query values to null before any parse is attempted, so ODS
+/// never returns a validation error for them. Parameter lookup
 /// is case-insensitive so all callers behave the same regardless of client casing.
 /// </summary>
 internal static class ChangeVersionParameterValidator

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -18,13 +18,7 @@ namespace EdFi.DataManagementService.Core.Middleware;
 
 internal class ValidateQueryMiddleware(ILogger _logger, int _maximumPageSize) : IPipelineStep
 {
-    private static readonly string[] _reservedQueryParameters =
-    [
-        "limit",
-        "offset",
-        "totalCount",
-        .. ChangeVersionParameterValidator.ReservedParameterNames,
-    ];
+    private static readonly string[] _paginationQueryParameters = ["limit", "offset", "totalCount"];
 
     /// <summary>
     /// Finds and sets PaginationParameters on the requestInfo by parsing the client request.
@@ -203,9 +197,13 @@ internal class ValidateQueryMiddleware(ILogger _logger, int _maximumPageSize) : 
 
         requestInfo.ChangeVersionRange = changeVersionResult.Range;
 
-        IEnumerable<KeyValuePair<string, string>> nonPaginationQueryTerms =
-            requestInfo.FrontendRequest.QueryParameters.ExceptBy(
-                _reservedQueryParameters,
+        // Pagination parameters are matched case-sensitively, consistent with how they are
+        // parsed above; change-version parameters are matched case-insensitively, consistent
+        // with how the validator looks them up.
+        IEnumerable<KeyValuePair<string, string>> nonPaginationQueryTerms = requestInfo
+            .FrontendRequest.QueryParameters.ExceptBy(_paginationQueryParameters, (term) => term.Key)
+            .ExceptBy(
+                ChangeVersionParameterValidator.ReservedParameterNames,
                 (term) => term.Key,
                 StringComparer.OrdinalIgnoreCase
             );

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.ApiSchema.Model;
+using EdFi.DataManagementService.Core.ChangeQueries;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
@@ -17,7 +18,13 @@ namespace EdFi.DataManagementService.Core.Middleware;
 
 internal class ValidateQueryMiddleware(ILogger _logger, int _maximumPageSize) : IPipelineStep
 {
-    private static readonly string[] _disallowedQueryFields = ["limit", "offset", "totalCount"];
+    private static readonly string[] _reservedQueryParameters =
+    [
+        "limit",
+        "offset",
+        "totalCount",
+        .. ChangeVersionParameterValidator.ReservedParameterNames,
+    ];
 
     /// <summary>
     /// Finds and sets PaginationParameters on the requestInfo by parsing the client request.
@@ -172,8 +179,36 @@ internal class ValidateQueryMiddleware(ILogger _logger, int _maximumPageSize) : 
             return;
         }
 
+        ChangeVersionValidationResult changeVersionResult = ChangeVersionParameterValidator.Validate(
+            requestInfo.FrontendRequest.QueryParameters
+        );
+
+        if (changeVersionResult.Errors.Count > 0)
+        {
+            _logger.LogDebug(
+                "Change-version parameter validation error - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+
+            requestInfo.FrontendResponse = new FrontendResponse(
+                StatusCode: 400,
+                Body: ForParameterValidation(
+                    [.. changeVersionResult.Errors],
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: []
+            );
+            return;
+        }
+
+        requestInfo.ChangeVersionRange = changeVersionResult.Range;
+
         IEnumerable<KeyValuePair<string, string>> nonPaginationQueryTerms =
-            requestInfo.FrontendRequest.QueryParameters.ExceptBy(_disallowedQueryFields, (term) => term.Key);
+            requestInfo.FrontendRequest.QueryParameters.ExceptBy(
+                _reservedQueryParameters,
+                (term) => term.Key,
+                StringComparer.OrdinalIgnoreCase
+            );
 
         QueryField[] possibleQueryFields = requestInfo.ResourceSchema.QueryFields.ToArray();
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -92,6 +92,13 @@ internal class RequestInfo(
     public QueryElement[] QueryElements { get; set; } = [];
 
     /// <summary>
+    /// The parsed and validated change-version window from the minChangeVersion /
+    /// maxChangeVersion query parameters. ChangeVersionRange.None when neither is
+    /// supplied. Set by ValidateQueryMiddleware before query-field matching.
+    /// </summary>
+    public ChangeVersionRange ChangeVersionRange { get; set; } = ChangeVersionRange.None;
+
+    /// <summary>
     /// Collection of authorization strategy filters, each specifying
     /// collection of filters and filter operator
     /// </summary>

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -41,6 +41,8 @@ public static class FailureResponse
         $"{_typePrefix}:system:configuration:security";
     private static readonly string _tagMismatchRequestTypePrefix = $"{_typePrefix}:optimistic-lock-failed";
     private static readonly string _dataPolicyEnforcedType = $"{_typePrefix}:data-policy-enforced";
+    private static readonly string _parameterValidationFailedType =
+        $"{_badRequestTypePrefix}:parameter-validation-failed";
 
     internal static JsonObject CreateBaseJsonObject(
         string detail,
@@ -97,6 +99,17 @@ public static class FailureResponse
             status: 400,
             correlationId: traceId.Value,
             validationErrors: validationErrors,
+            errors: errors
+        );
+
+    public static JsonNode ForParameterValidation(string[] errors, TraceId traceId) =>
+        CreateBaseJsonObject(
+            detail: "Parameters supplied to the request were invalid.",
+            type: _parameterValidationFailedType,
+            title: "Parameter Validation Failed",
+            status: 400,
+            correlationId: traceId.Value,
+            validationErrors: [],
             errors: errors
         );
 


### PR DESCRIPTION
## Summary

Implements DMS-1181: shared validation of the `minChangeVersion` / `maxChangeVersion` query parameters for the live resource and descriptor GET-many pipeline, preserving the ODS-compatible ProblemDetails shape from `change-queries.md`.

- Adds `ChangeVersionRange` (Core.External/Model): parsed range with nullable `long` bounds (matching the relational `bigint` change-version storage) and a `None` no-bounds value.
- Adds `ChangeVersionParameterValidator` (Core/ChangeQueries): a pure, dependency-free validator that parses each bound as `long >= 0` with case-insensitive parameter lookup, enforces `min <= max`, and returns the parsed range plus a deterministically-ordered error list (min parse error, then max parse error, then inverted-range error only when both parsed). Exposes `ReservedParameterNames` for callers. Built so the future `/deletes` and `/keyChanges` endpoints reuse it rather than duplicating logic.
- Adds `FailureResponse.ForParameterValidation`: ProblemDetails with type `urn:ed-fi:api:bad-request:parameter-validation-failed`, title `Parameter Validation Failed`, detail `Parameters supplied to the request were invalid.`, status 400, messages in the flat `errors` array.
- Wires the validator into `ValidateQueryMiddleware`: runs after pagination validation, returns the 400 ProblemDetails on failure, stores the parsed range on `RequestInfo.ChangeVersionRange`, and excludes the two reserved parameters from ordinary query-field matching case-insensitively.

### Out of scope (deferred)
- Backend SQL / live GET-many range filtering and threading the range into the backend query contracts (DMS-1182).
- `/deletes` and `/keyChanges` endpoint behavior (DMS-1186+).
- Snapshot-header validation, feature-disabled ProblemDetails, authorization changes.

## Test Plan
- [x] `ChangeVersionParameterValidatorTests` — valid ranges, missing bounds, non-numeric and negative values, inverted range, error ordering, long width above Int32, case-insensitive keys (25 tests).
- [x] `ValidateQueryMiddlewareTests` — invalid min/max and inverted range each return the 400 parameter-validation-failed ProblemDetails; valid range sets `RequestInfo.ChangeVersionRange`; reserved params (mixed case) are not treated as invalid query fields; pre-existing pagination/query-field fixtures unaffected.
- [x] Full `EdFi.DataManagementService.Core.Tests.Unit` project green (2549 passed, 0 failed).
