### PR TITLE
[DMS-1157] Add specificationVersion to CMS info endpoint

### DIFF
--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Information/ApiInformation.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/Information/ApiInformation.cs
@@ -12,7 +12,8 @@ public class ApiInformation
         string applicationName,
         string informationalVersion,
         string build,
-        ApiUrls urls
+        ApiUrls urls,
+        string specificationVersion
     )
     {
         Version = version;
@@ -20,6 +21,7 @@ public class ApiInformation
         InformationalVersion = informationalVersion;
         Build = build;
         Urls = urls;
+        SpecificationVersion = specificationVersion;
     }
 
     public string Version { get; }
@@ -31,6 +33,8 @@ public class ApiInformation
     public string Build { get; }
 
     public ApiUrls Urls { get; }
+
+    public string SpecificationVersion { get; }
 }
 
 public class ApiUrls

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Configuration/AppSettingsValidatorTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Configuration/AppSettingsValidatorTests.cs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Configuration;
+
+[TestFixture]
+public class Given_AppSettingsValidator
+{
+    private AppSettingsValidator _validator = null!;
+
+    [SetUp]
+    public void SetUp() => _validator = new AppSettingsValidator();
+
+    private static AppSettings ValidSettings() =>
+        new()
+        {
+            Datastore = "postgresql",
+            IdentityProvider = "keycloak",
+            SpecificationVersion = "v3",
+        };
+
+    [Test]
+    public void It_should_succeed_when_all_settings_are_valid()
+    {
+        var result = _validator.Validate(null, ValidSettings());
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [TestCase("")]
+    [TestCase("   ")]
+    public void It_should_fail_when_specification_version_is_missing_or_whitespace(string version)
+    {
+        var settings = ValidSettings();
+        settings.SpecificationVersion = version;
+
+        var result = _validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("Missing required AppSettings value: SpecificationVersion");
+    }
+
+    [Test]
+    public void It_should_fail_when_specification_version_is_invalid()
+    {
+        var settings = ValidSettings();
+        settings.SpecificationVersion = "v99";
+
+        var result = _validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.FailureMessage.Should().Contain("must be one of: v1, v2, v3");
+    }
+
+    [TestCase("v1")]
+    [TestCase("v2")]
+    [TestCase("v3")]
+    [TestCase("V1")]
+    [TestCase("V2")]
+    [TestCase("V3")]
+    public void It_should_succeed_for_valid_specification_versions(string version)
+    {
+        var settings = ValidSettings();
+        settings.SpecificationVersion = version;
+
+        var result = _validator.Validate(null, settings);
+
+        result.Succeeded.Should().BeTrue();
+    }
+}

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/TenantResolutionMiddlewareTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/TenantResolutionMiddlewareTests.cs
@@ -43,6 +43,7 @@ internal class TenantResolutionMiddlewareTests
                     MultiTenancy = false,
                     Datastore = "postgresql",
                     IdentityProvider = "self-contained",
+                    SpecificationVersion = "v3",
                 }
             );
         }
@@ -113,6 +114,7 @@ internal class TenantResolutionMiddlewareTests
                     MultiTenancy = true,
                     Datastore = "postgresql",
                     IdentityProvider = "self-contained",
+                    SpecificationVersion = "v3",
                 }
             );
         }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
@@ -127,6 +127,38 @@ public class InformationModuleTests
     }
 
     [Test]
+    public async Task Information_Endpoint_Normalizes_SpecificationVersion_To_Lowercase()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:SpecificationVersion"] = "V2" }
+                    );
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/");
+        var content = await response.Content.ReadAsStringAsync();
+        var jsonDoc = JsonDocument.Parse(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        jsonDoc
+            .RootElement.TryGetProperty("specificationVersion", out var specificationVersion)
+            .Should()
+            .BeTrue();
+        specificationVersion.GetString().Should().Be("v2");
+    }
+
+    [Test]
     public async Task When_PathBase_Provided_Information_Endpoint_Returns_Ok_Response()
     {
         // Arrange

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/InformationModuleTests.cs
@@ -60,6 +60,11 @@ public class InformationModuleTests
         build.GetString().Should().NotBeNullOrEmpty();
         jsonDoc.RootElement.TryGetProperty("urls", out var urls).Should().BeTrue();
         urls.TryGetProperty("openApiMetadata", out _).Should().BeTrue();
+        jsonDoc
+            .RootElement.TryGetProperty("specificationVersion", out var specificationVersion)
+            .Should()
+            .BeTrue();
+        specificationVersion.GetString().Should().BeOneOf("v1", "v2", "v3");
     }
 
     [Test]
@@ -87,6 +92,38 @@ public class InformationModuleTests
             .BeTrue(
                 because: $"build value '{buildValue}' should match the four-part numeric version pattern"
             );
+    }
+
+    [Test]
+    public async Task Information_Endpoint_Returns_SpecificationVersion_From_Config()
+    {
+        // Arrange
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:SpecificationVersion"] = "v2" }
+                    );
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/");
+        var content = await response.Content.ReadAsStringAsync();
+        var jsonDoc = JsonDocument.Parse(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        jsonDoc
+            .RootElement.TryGetProperty("specificationVersion", out var specificationVersion)
+            .Should()
+            .BeTrue();
+        specificationVersion.GetString().Should().Be("v2");
     }
 
     [Test]

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/AppSettings.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Configuration/AppSettings.cs
@@ -15,10 +15,13 @@ public class AppSettings
     public required string IdentityProvider { get; set; }
     public bool MultiTenancy { get; set; }
     public bool EnableApplicationResetEndpoint { get; set; }
+    public required string SpecificationVersion { get; set; }
 }
 
 public class AppSettingsValidator : IValidateOptions<AppSettings>
 {
+    private static readonly string[] ValidSpecificationVersions = ["v1", "v2", "v3"];
+
     public ValidateOptionsResult Validate(string? name, AppSettings options)
     {
         if (string.IsNullOrWhiteSpace(options.Datastore))
@@ -53,6 +56,23 @@ public class AppSettingsValidator : IValidateOptions<AppSettings>
         {
             return ValidateOptionsResult.Fail(
                 "AppSettings value IdentityProvider must be one of: (keycloak, self-contained)"
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(options.SpecificationVersion))
+        {
+            return ValidateOptionsResult.Fail("Missing required AppSettings value: SpecificationVersion");
+        }
+
+        if (
+            !ValidSpecificationVersions.Contains(
+                options.SpecificationVersion,
+                StringComparer.OrdinalIgnoreCase
+            )
+        )
+        {
+            return ValidateOptionsResult.Fail(
+                "AppSettings value SpecificationVersion must be one of: v1, v2, v3"
             );
         }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
@@ -22,13 +22,14 @@ public class InformationModule(IOptions<AppSettings> appSettings) : IEndpointMod
         var baseUrl =
             $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{httpContext.Request.PathBase}";
         var urls = new ApiUrls($"{baseUrl}/metadata/specifications");
+        var specificationVersion = appSettings.Value.SpecificationVersion.ToLowerInvariant();
         var response = new ApiInformation(
             ApiVersionDetails.Version,
             ApiVersionDetails.ApplicationName,
             ApiVersionDetails.InformationalVersion,
             ApiVersionDetails.Build,
             urls,
-            appSettings.Value.SpecificationVersion
+            specificationVersion
         );
         return Results.Ok(response);
     }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/InformationModule.cs
@@ -4,18 +4,20 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.DmsConfigurationService.DataModel.Model.Information;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
 using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure;
+using Microsoft.Extensions.Options;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
 
-public class InformationModule : IEndpointModule
+public class InformationModule(IOptions<AppSettings> appSettings) : IEndpointModule
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapGet("", GetInformation);
     }
 
-    private static IResult GetInformation(HttpContext httpContext)
+    private IResult GetInformation(HttpContext httpContext)
     {
         var baseUrl =
             $"{httpContext.Request.Scheme}://{httpContext.Request.Host}{httpContext.Request.PathBase}";
@@ -25,7 +27,8 @@ public class InformationModule : IEndpointModule
             ApiVersionDetails.ApplicationName,
             ApiVersionDetails.InformationalVersion,
             ApiVersionDetails.Build,
-            urls
+            urls,
+            appSettings.Value.SpecificationVersion
         );
         return Results.Ok(response);
     }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.Test.json
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.Test.json
@@ -2,7 +2,8 @@
     "AppSettings": {
         "DeployDatabaseOnStartup": false,
         "Datastore": "postgresql",
-        "EnableApplicationResetEndpoint": false
+        "EnableApplicationResetEndpoint": false,
+        "SpecificationVersion": "v3"
     },
     "DatabaseSettings": {
         "EncryptionKey": "TestEncryptionKey32CharactersLong1"

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.json
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/appsettings.json
@@ -7,7 +7,8 @@
         "EnableApplicationResetEndpoint": false,
         "PathBase": "",
         "UseReverseProxyHeaders": false,
-        "MultiTenancy": false
+        "MultiTenancy": false,
+        "SpecificationVersion": "v3"
     },
     "DatabaseSettings": {
         "DatabaseConnection": "host=localhost;port=5432;username=postgres;database=edfi_configurationservice;",

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Metadata.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Metadata.feature
@@ -15,7 +15,8 @@ Feature: Metadata endpoints
                       "build": "{*}",
                       "urls": {
                           "openApiMetadata": "{*}"
-                      }
+                      },
+                      "specificationVersion": "{*}"
                   }
                   """
               And the response contains metadata URLs
@@ -56,10 +57,10 @@ Feature: Metadata endpoints
              When a GET request is made to "/metadata/specifications"
              Then it should respond with 200
               And the OpenAPI paths should include
-                  | Path                 |
-                  | /v2/vendors          |
-                  | /v2/applications     |
-                  | /v2/claimSets        |
+                  | Path                   |
+                  | /v2/vendors            |
+                  | /v2/applications       |
+                  | /v2/claimSets          |
                   | /authorizationMetadata |
 
         Scenario: 06 Service information URLs should be accessible


### PR DESCRIPTION
- Add SpecificationVersion to AppSettings with startup validation (v2/v3)
- Add SpecificationVersion property to ApiInformation response model
- Update InformationModule to inject IOptions<AppSettings> and return specificationVersion
- Update appsettings.json and appsettings.Test.json with default value v3
- Add InformationModuleTests for specificationVersion field
- Add AppSettingsValidatorTests for validation paths
- Fix TenantResolutionMiddlewareTests for required SpecificationVersion