### PR TITLE
[DMS-1155] Document DS-qualified ApiSchema extension package ID convention

### DIFF
--- a/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
@@ -206,6 +206,11 @@ Extension packages use the same shape. The schema file should be named `ApiSchem
 contract even if MetaEd originally emitted `ApiSchema-EXTENSION.json`; the package manifest and schema
 content identify whether the project is core or extension.
 
+Published ApiSchema package IDs are Data-Standard-qualified. The core package is
+`EdFi.DataStandard52.ApiSchema`, and extension packages follow the `EdFi.DataStandard52.ApiSchema.<Project>`
+convention (for example `EdFi.DataStandard52.ApiSchema.Sample`, `EdFi.DataStandard52.ApiSchema.Homograph`,
+and `EdFi.DataStandard52.ApiSchema.TPDM`), where `<Project>` is the MetaEd project name.
+
 The package should contain no `lib/` or `ref/` entries. It may include docs and license files:
 
 ```text
@@ -219,7 +224,7 @@ Example package manifest:
 ```json
 {
   "version": 1,
-  "packageId": "EdFi.Sample.ApiSchema",
+  "packageId": "EdFi.DataStandard52.ApiSchema.Sample",
   "projectName": "Sample",
   "projectEndpointName": "sample",
   "isExtensionProject": true,

--- a/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
@@ -211,6 +211,10 @@ Published ApiSchema package IDs are Data-Standard-qualified. The core package is
 convention (for example `EdFi.DataStandard52.ApiSchema.Sample`, `EdFi.DataStandard52.ApiSchema.Homograph`,
 and `EdFi.DataStandard52.ApiSchema.TPDM`), where `<Project>` is the MetaEd project name.
 
+This is the canonical DMS-916 target package identity convention. Some current repository package references
+and `SCHEMA_PACKAGES` examples still use legacy unqualified extension IDs such as `EdFi.Sample.ApiSchema`,
+`EdFi.Homograph.ApiSchema`, and `EdFi.TPDM.ApiSchema` until the Story 04/06 migration updates those consumers.
+
 The package should contain no `lib/` or `ref/` entries. It may include docs and license files:
 
 ```text

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -556,7 +556,7 @@ For each extension in `-Extensions`, bootstrap resolves the schema package and a
 fragment metadata from the configured artifact sources. The seed phase owns a separate seed catalog that may
 define an optional built-in seed data package for the same extension name:
 
-1. **Schema package** (e.g., `EdFi.Sample.ApiSchema`) - determines API surface
+1. **Schema package** (e.g., `EdFi.DataStandard52.ApiSchema.Sample`) - determines API surface
 2. **Security fragment** (e.g., `004-sample-extension-claimset.json`) - determines authorization rules
 3. **Optional built-in seed data package** (when present in the seed catalog) - determines bootstrap-managed
    sample data
@@ -1650,7 +1650,7 @@ seed-catalog concern rather than a schema-selection concern.
 The `-Extensions` parameter is the single developer-facing control for enabling extensions. Passing it triggers three coordinated actions automatically - the developer does not need to configure each concern separately:
 
 1. **ApiSchema files staged host-side (Section 3)** - The script resolves the extension's NuGet schema
-   package (e.g., `EdFi.Sample.ApiSchema`) on the host, stages the resulting file in
+   package (e.g., `EdFi.DataStandard52.ApiSchema.Sample`) on the host, stages the resulting file in
    `eng/docker-compose/.bootstrap/ApiSchema/`, and includes that staged file in the exact set later hashed
    and mounted/read by DMS.
 
@@ -1904,8 +1904,8 @@ A minimal acceptable console shape is:
 Bootstrap-DMS: Starting...
 
 [prepare-dms-schema]                                       (0.4s)
-  Core:  EdFi.DataStandard52.ApiSchema 1.0.328
-  Ext:   EdFi.Sample.ApiSchema         1.0.328
+  Core:  EdFi.DataStandard52.ApiSchema        1.0.328
+  Ext:   EdFi.DataStandard52.ApiSchema.Sample 1.0.328
 [prepare-dms-claims]                                       (0.2s)
   Hybrid mode: 1 security fragment(s) staged
 [start-local-dms -InfraOnly]                              (13.7s)

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -393,9 +393,8 @@ Modes 1 and 2 cover the vast majority of development workflows. Use these for da
 **Mode 1 - Default (core Ed-Fi only)**
 
 Omit `-Extensions` entirely. In the target package-backed flow, bootstrap resolves only the standard core
-Data Standard ApiSchema asset package (e.g. `EdFi.DataStandard52.ApiSchema`; **exact package name must be
-confirmed against the NuGet feed before Story 06 implementation begins**, not Story 00 or Story
-01) host-side, extracts it into an isolated package-specific temporary directory, normalizes its asset payload into
+Data Standard ApiSchema asset package (`EdFi.DataStandard52.ApiSchema`) host-side, extracts it into an
+isolated package-specific temporary directory, normalizes its asset payload into
 `eng/docker-compose/.bootstrap/ApiSchema/`, and computes the expected `EffectiveSchemaHash` from the
 normalized core schema file. The target package payload is asset-only as defined in
 [`apischema-container.md`](apischema-container.md); publishing that package shape is tracked separately in
@@ -1905,7 +1904,7 @@ Bootstrap-DMS: Starting...
 
 [prepare-dms-schema]                                       (0.4s)
   Core:  EdFi.DataStandard52.ApiSchema        1.0.328
-  Ext:   EdFi.DataStandard52.ApiSchema.Sample 1.0.328
+  Ext:   EdFi.DataStandard52.ApiSchema.Sample 1.0.154
 [prepare-dms-claims]                                       (0.2s)
   Hybrid mode: 1 security fragment(s) staged
 [start-local-dms -InfraOnly]                              (13.7s)
@@ -1938,6 +1937,9 @@ Summary
   ----------------------------------------------
   Total                                   216.0s
 ```
+
+> The core and extension ApiSchema packages are versioned independently and may not share a version (the
+> versions above are illustrative); bootstrap resolves each package to its own configured feed version.
 
 CI environments may suppress color output. The summary table is always emitted on both success and failure;
 on failure the failing phase name and error are printed before the summary.

--- a/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
@@ -52,7 +52,11 @@ both materialize to the same workspace before runtime starts.
   `.bootstrap/ApiSchema` is mounted/read by DMS, and `.bootstrap/claims` is mounted/read by Config Service for
   the same root bootstrap manifest.
 - Existing non-bootstrap behavior may keep a compatibility path for assembly-bundled content when
-  `UseApiSchemaPath=false`, but that path is not the DMS-916 bootstrap contract.
+  `UseApiSchemaPath=false`, but that path is not the DMS-916 bootstrap contract. That legacy path discovers
+  assemblies with a `*.ApiSchema.dll` glob and derives served filenames from the assembly name, so it does not
+  match MetaEd's Data-Standard-qualified package assemblies (for example
+  `EdFi.DataStandard52.ApiSchema.Sample.dll`); consuming the qualified packages relies on the file-based
+  workspace contract delivered here, with package resolution owned by Story 06.
 - Unit or integration coverage proves that metadata/specification JSON and XSD endpoints work from a
   file-based staged workspace with no `*.ApiSchema.dll` files present.
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md
@@ -53,10 +53,10 @@ both materialize to the same workspace before runtime starts.
   the same root bootstrap manifest.
 - Existing non-bootstrap behavior may keep a compatibility path for assembly-bundled content when
   `UseApiSchemaPath=false`, but that path is not the DMS-916 bootstrap contract. That legacy path discovers
-  assemblies with a `*.ApiSchema.dll` glob and derives served filenames from the assembly name, so it does not
-  match MetaEd's Data-Standard-qualified package assemblies (for example
-  `EdFi.DataStandard52.ApiSchema.Sample.dll`); consuming the qualified packages relies on the file-based
-  workspace contract delivered here, with package resolution owned by Story 06.
+  assemblies with a `*.ApiSchema.dll` glob and derives served filenames from the assembly name. Asset-only
+  Data-Standard-qualified packages contain no `*.ApiSchema.dll` assemblies for that glob to find, so consuming
+  those qualified packages relies on the file-based workspace contract delivered here, with package resolution
+  owned by Story 06.
 - Unit or integration coverage proves that metadata/specification JSON and XSD endpoints work from a
   file-based staged workspace with no `*.ApiSchema.dll` files present.
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/05-metaed-apischema-asset-packaging.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/05-metaed-apischema-asset-packaging.md
@@ -35,10 +35,10 @@ same workspace.
   ```
 
 - Extension packages use the same package contract as core packages.
-- Published package IDs are Data-Standard-qualified: the core package is `EdFi.DataStandard52.ApiSchema` and
-  extension packages follow the `EdFi.DataStandard52.ApiSchema.<Project>` convention (for example
-  `EdFi.DataStandard52.ApiSchema.Sample`, `EdFi.DataStandard52.ApiSchema.Homograph`, and
-  `EdFi.DataStandard52.ApiSchema.TPDM`).
+- Published package IDs use the canonical Data-Standard-qualified convention defined in
+  [`../../design-docs/bootstrap/apischema-container.md`](../../design-docs/bootstrap/apischema-container.md):
+  the core package is `EdFi.DataStandard52.ApiSchema`, and extension packages follow
+  `EdFi.DataStandard52.ApiSchema.<Project>`.
 - The package schema file is named `ApiSchema.json` in the package contract. If MetaEd generation produces
   `ApiSchema-EXTENSION.json`, packaging normalizes it to `ApiSchema.json`; the package manifest and schema
   content identify whether the project is core or extension.

--- a/reference/design/backend-redesign/epics/16-bootstrap/05-metaed-apischema-asset-packaging.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/05-metaed-apischema-asset-packaging.md
@@ -35,6 +35,10 @@ same workspace.
   ```
 
 - Extension packages use the same package contract as core packages.
+- Published package IDs are Data-Standard-qualified: the core package is `EdFi.DataStandard52.ApiSchema` and
+  extension packages follow the `EdFi.DataStandard52.ApiSchema.<Project>` convention (for example
+  `EdFi.DataStandard52.ApiSchema.Sample`, `EdFi.DataStandard52.ApiSchema.Homograph`, and
+  `EdFi.DataStandard52.ApiSchema.TPDM`).
 - The package schema file is named `ApiSchema.json` in the package contract. If MetaEd generation produces
   `ApiSchema-EXTENSION.json`, packaging normalizes it to `ApiSchema.json`; the package manifest and schema
   content identify whether the project is core or extension.

--- a/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
@@ -40,11 +40,14 @@ filesystem inputs.
   fail fast before Docker operations start.
 - `-Extensions` and `-ApiSchemaPath` are mutually exclusive. Supplying both fails fast with guidance to use
   standard mode for package-backed extensions or expert mode for a custom schema directory.
-- Package-backed resolution uses the configured NuGet feed and package/version defaults. The package-identity
-  convention is Data-Standard-qualified: the core package is `EdFi.DataStandard52.ApiSchema` and extension
-  packages follow `EdFi.DataStandard52.ApiSchema.<Project>` (for example `EdFi.DataStandard52.ApiSchema.Sample`,
-  `EdFi.DataStandard52.ApiSchema.Homograph`, and `EdFi.DataStandard52.ApiSchema.TPDM`). Version defaults are
-  documented and validated against the feed during implementation.
+- Package-backed resolution uses the configured NuGet feed and package/version defaults. Package IDs use the
+  canonical Data-Standard-qualified convention defined in
+  [`../../design-docs/bootstrap/apischema-container.md`](../../design-docs/bootstrap/apischema-container.md):
+  the core package is `EdFi.DataStandard52.ApiSchema`, and extension packages follow
+  `EdFi.DataStandard52.ApiSchema.<Project>`. Version defaults are documented and validated against the feed
+  during implementation.
+- Current repository package references and `SCHEMA_PACKAGES` examples may still use legacy unqualified
+  extension IDs until the Story 04/06 migration updates those consumers.
 - Package materialization rejects invalid package payloads before finalizing the staged workspace:
   - missing asset-only ApiSchema payload,
   - missing or malformed package manifest,
@@ -74,9 +77,9 @@ filesystem inputs.
 
 ## Tasks
 
-1. Define package-backed schema resolution for standard mode: core package identity/version defaults,
-   extension package identity convention or metadata source, namespace prefixes, and the security fragment
-   lookup keys shared with claims staging.
+1. Wire standard-mode package-backed schema resolution to the package identity convention defined above: core
+   package version defaults, namespace prefixes, and the security fragment lookup keys shared with claims
+   staging.
 2. Update `prepare-dms-schema.ps1` so standard mode is valid when `-ApiSchemaPath` is omitted:
    core-only when `-Extensions` is omitted, and core plus selected extensions when it is supplied.
 3. Preserve `-ApiSchemaPath` as the expert direct-filesystem path from Story 00 and enforce mutual

--- a/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
@@ -40,9 +40,11 @@ filesystem inputs.
   fail fast before Docker operations start.
 - `-Extensions` and `-ApiSchemaPath` are mutually exclusive. Supplying both fails fast with guidance to use
   standard mode for package-backed extensions or expert mode for a custom schema directory.
-- Package-backed resolution uses the configured NuGet feed and package/version defaults. The exact core
-  package ID, extension package identity convention or metadata source, and version defaults are documented
-  and validated against the feed during implementation.
+- Package-backed resolution uses the configured NuGet feed and package/version defaults. The package-identity
+  convention is Data-Standard-qualified: the core package is `EdFi.DataStandard52.ApiSchema` and extension
+  packages follow `EdFi.DataStandard52.ApiSchema.<Project>` (for example `EdFi.DataStandard52.ApiSchema.Sample`,
+  `EdFi.DataStandard52.ApiSchema.Homograph`, and `EdFi.DataStandard52.ApiSchema.TPDM`). Version defaults are
+  documented and validated against the feed during implementation.
 - Package materialization rejects invalid package payloads before finalizing the staged workspace:
   - missing asset-only ApiSchema payload,
   - missing or malformed package manifest,


### PR DESCRIPTION
## Summary

MetaEd publishes ApiSchema extension packages under a Data-Standard-qualified ID convention
(`EdFi.DataStandard52.ApiSchema.<Project>`, e.g. `.Sample`, `.Homograph`, `.TPDM`), parallel to the core
`EdFi.DataStandard52.ApiSchema` package. This aligns the bootstrap design docs and the affected bootstrap
stories with that published convention.

This is a documentation-only change. No package references, environment files, runtime defaults, or tests are
modified.

## Changes

**Design docs**
- `apischema-container.md` — DS-qualify the Published NuGet Shape `packageId` example and add a paragraph
  documenting the package-ID convention (core `EdFi.DataStandard52.ApiSchema`, extensions
  `EdFi.DataStandard52.ApiSchema.<Project>`).
- `bootstrap-design.md` — DS-qualify the target-design extension examples (the `-Extensions` schema-package
  illustrations and the console mock-up). The §3.1 "Current State" SCHEMA_PACKAGES block is left unchanged
  because it is explicitly non-normative and mirrors the current `.env.example`.

**Stories**
- `05-metaed-apischema-asset-packaging.md` — record the published DS-qualified package-ID convention.
- `06-package-backed-standard-schema-selection.md` — replace the package-identity-convention placeholder with
  the validated convention; version defaults remain to be validated during implementation.
- `04-apischema-runtime-content-loading.md` — note that the legacy `*.ApiSchema.dll` glob and
  assembly-name-derived filenames do not match the qualified package assemblies.

## Out of scope

The DMS-side migration to consume these package IDs (central package references, `env-utility.psm1`,
`.env*`, runtime assembly discovery, and XSD metadata endpoints) is owned by Story 04 (runtime content
loading) and Story 06 (bootstrap package resolution), not by this story.