### PR TITLE
[DMS-1213] Relational document reconstitution renders date identity fields inside reference objects as date-times

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/ProjectionPlanContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/Plans/ProjectionPlanContracts.cs
@@ -111,9 +111,11 @@ public sealed record ReferenceIdentityProjectionBinding
 /// </summary>
 /// <param name="ReferenceJsonPath">Reference identity field path in the materialized JSON object.</param>
 /// <param name="ColumnOrdinal">Zero-based hydration select-list ordinal for this field's value column.</param>
+/// <param name="ScalarType">Relational scalar type of the projected column, used for typed JSON value conversion.</param>
 public sealed record ReferenceIdentityProjectionFieldOrdinal(
     JsonPathExpression ReferenceJsonPath,
-    int ColumnOrdinal
+    int ColumnOrdinal,
+    RelationalScalarType ScalarType
 );
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterLinkEmissionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterLinkEmissionTests.cs
@@ -323,7 +323,8 @@ public class Given_DocumentReconstituter_With_Document_Reference_Link_Injection
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _schoolReferenceSchoolIdPath,
-                            ColumnOrdinal: 2
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int32)
                         ),
                     ]
                 ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
@@ -1037,6 +1037,242 @@ public class Given_DocumentReconstituter_With_Reference
 }
 
 [TestFixture]
+public class Given_DocumentReconstituter_With_A_Reference_Identity_Date_Field_Read_As_DateTime
+{
+    private JsonNode _result = null!;
+
+    private static readonly DbSchemaName _schema = new("edfi");
+    private static readonly DbTableName _tableName = new(_schema, "Grade");
+
+    private static readonly JsonPathExpression _rootScope = new("$", []);
+
+    private static readonly JsonPathExpression _referencePath = new(
+        "$.studentSectionAssociationReference",
+        [new JsonPathSegment.Property("studentSectionAssociationReference")]
+    );
+
+    private static readonly JsonPathExpression _beginDatePath = new(
+        "$.studentSectionAssociationReference.beginDate",
+        [
+            new JsonPathSegment.Property("studentSectionAssociationReference"),
+            new JsonPathSegment.Property("beginDate"),
+        ]
+    );
+
+    private static readonly QualifiedResourceName _targetResource = new("Ed-Fi", "StudentSectionAssociation");
+
+    [SetUp]
+    public void SetUp()
+    {
+        var columns = new List<DbColumnModel>
+        {
+            new(
+                ColumnName: new DbColumnName("DocumentId"),
+                Kind: ColumnKind.ParentKeyPart,
+                ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                IsNullable: false,
+                SourceJsonPath: null,
+                TargetResource: null
+            ),
+            new(
+                ColumnName: new DbColumnName("StudentSectionAssociation_DocumentId"),
+                Kind: ColumnKind.DocumentFk,
+                ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                IsNullable: false,
+                SourceJsonPath: null,
+                TargetResource: _targetResource
+            ),
+            new(
+                ColumnName: new DbColumnName("StudentSectionAssociationReference_BeginDate"),
+                Kind: ColumnKind.Scalar,
+                ScalarType: new RelationalScalarType(ScalarKind.Date),
+                IsNullable: false,
+                SourceJsonPath: _beginDatePath,
+                TargetResource: null
+            ),
+        };
+
+        var tableModel = new DbTableModel(
+            Table: _tableName,
+            JsonScope: _rootScope,
+            Key: new TableKey(
+                "PK_Grade",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns: columns,
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+        var refPlan = new ReferenceIdentityProjectionTablePlan(
+            Table: _tableName,
+            BindingsInOrder:
+            [
+                new ReferenceIdentityProjectionBinding(
+                    IsIdentityComponent: true,
+                    ReferenceObjectPath: _referencePath,
+                    TargetResource: _targetResource,
+                    FkColumnOrdinal: 1,
+                    IdentityFieldOrdinalsInOrder:
+                    [
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            ReferenceJsonPath: _beginDatePath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Date)
+                        ),
+                    ]
+                ),
+            ]
+        );
+
+        // PostgreSQL/MSSQL date columns hydrate as CLR DateTime — the regression input.
+        object?[] row = [1L, 10L, new DateTime(2024, 8, 1, 0, 0, 0, DateTimeKind.Unspecified)];
+
+        var tableRows = new HydratedTableRows(tableModel, [row]);
+
+        _result = DocumentReconstituter.Reconstitute(
+            documentId: 1L,
+            tableRowsInDependencyOrder: [tableRows],
+            referenceProjectionPlans: [refPlan],
+            descriptorProjectionSources: [],
+            descriptorUriLookup: new Dictionary<long, string>()
+        );
+    }
+
+    [Test]
+    public void It_should_emit_beginDate_as_date_only()
+    {
+        _result["studentSectionAssociationReference"]!["beginDate"]!
+            .GetValue<string>()
+            .Should()
+            .Be("2024-08-01");
+    }
+}
+
+[TestFixture]
+public class Given_DocumentReconstituter_With_A_Reference_Identity_Time_Field_Read_As_TimeSpan
+{
+    private JsonNode _result = null!;
+
+    private static readonly DbSchemaName _schema = new("edfi");
+    private static readonly DbTableName _tableName = new(_schema, "SectionTimeSlot");
+
+    private static readonly JsonPathExpression _rootScope = new("$", []);
+
+    private static readonly JsonPathExpression _referencePath = new(
+        "$.classPeriodReference",
+        [new JsonPathSegment.Property("classPeriodReference")]
+    );
+
+    private static readonly JsonPathExpression _startTimePath = new(
+        "$.classPeriodReference.startTime",
+        [new JsonPathSegment.Property("classPeriodReference"), new JsonPathSegment.Property("startTime")]
+    );
+
+    private static readonly QualifiedResourceName _targetResource = new("Ed-Fi", "ClassPeriod");
+
+    [SetUp]
+    public void SetUp()
+    {
+        var columns = new List<DbColumnModel>
+        {
+            new(
+                ColumnName: new DbColumnName("DocumentId"),
+                Kind: ColumnKind.ParentKeyPart,
+                ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                IsNullable: false,
+                SourceJsonPath: null,
+                TargetResource: null
+            ),
+            new(
+                ColumnName: new DbColumnName("ClassPeriod_DocumentId"),
+                Kind: ColumnKind.DocumentFk,
+                ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                IsNullable: false,
+                SourceJsonPath: null,
+                TargetResource: _targetResource
+            ),
+            new(
+                ColumnName: new DbColumnName("ClassPeriodReference_StartTime"),
+                Kind: ColumnKind.Scalar,
+                ScalarType: new RelationalScalarType(ScalarKind.Time),
+                IsNullable: false,
+                SourceJsonPath: _startTimePath,
+                TargetResource: null
+            ),
+        };
+
+        var tableModel = new DbTableModel(
+            Table: _tableName,
+            JsonScope: _rootScope,
+            Key: new TableKey(
+                "PK_SectionTimeSlot",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns: columns,
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [new DbColumnName("DocumentId")],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+        var refPlan = new ReferenceIdentityProjectionTablePlan(
+            Table: _tableName,
+            BindingsInOrder:
+            [
+                new ReferenceIdentityProjectionBinding(
+                    IsIdentityComponent: true,
+                    ReferenceObjectPath: _referencePath,
+                    TargetResource: _targetResource,
+                    FkColumnOrdinal: 1,
+                    IdentityFieldOrdinalsInOrder:
+                    [
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            ReferenceJsonPath: _startTimePath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Time)
+                        ),
+                    ]
+                ),
+            ]
+        );
+
+        // MSSQL time columns hydrate as CLR TimeSpan — unsupported by untyped conversion.
+        object?[] row = [1L, 10L, new TimeSpan(8, 30, 0)];
+
+        var tableRows = new HydratedTableRows(tableModel, [row]);
+
+        _result = DocumentReconstituter.Reconstitute(
+            documentId: 1L,
+            tableRowsInDependencyOrder: [tableRows],
+            referenceProjectionPlans: [refPlan],
+            descriptorProjectionSources: [],
+            descriptorUriLookup: new Dictionary<long, string>()
+        );
+    }
+
+    [Test]
+    public void It_should_emit_startTime_as_time_only()
+    {
+        _result["classPeriodReference"]!["startTime"]!.GetValue<string>().Should().Be("08:30:00");
+    }
+}
+
+[TestFixture]
 public class Given_DocumentReconstituter_With_Descriptor
 {
     private JsonNode _result = null!;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReconstituterTests.cs
@@ -996,7 +996,8 @@ public class Given_DocumentReconstituter_With_Reference
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _schoolReferenceSchoolIdPath,
-                            ColumnOrdinal: 2
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int32)
                         ),
                     ]
                 ),
@@ -3279,7 +3280,8 @@ public class Given_DocumentReconstituter_With_Null_Optional_Reference
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _schoolReferenceSchoolIdPath,
-                            ColumnOrdinal: 2
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int32)
                         ),
                     ]
                 ),
@@ -3518,11 +3520,13 @@ public class Given_DocumentReconstituter_With_Physical_Order_Different_From_Comp
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _alphaReferenceNamespacePath,
-                            ColumnOrdinal: 4
+                            ColumnOrdinal: 4,
+                            ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 50)
                         ),
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _alphaReferenceCodePath,
-                            ColumnOrdinal: 6
+                            ColumnOrdinal: 6,
+                            ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 50)
                         ),
                     ]
                 ),
@@ -4467,7 +4471,11 @@ file static class PageBasedDocumentReconstituterTestData
                         FkColumnOrdinal: 2,
                         IdentityFieldOrdinalsInOrder:
                         [
-                            new ReferenceIdentityProjectionFieldOrdinal(localEducationAgencyIdPath, 3),
+                            new ReferenceIdentityProjectionFieldOrdinal(
+                                localEducationAgencyIdPath,
+                                3,
+                                new RelationalScalarType(ScalarKind.Int32)
+                            ),
                         ]
                     ),
                 ]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ExternalPlanContractsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ExternalPlanContractsTests.cs
@@ -666,11 +666,13 @@ public class Given_ExternalPlanContracts
                             [
                                 new ExternalPlans.ReferenceIdentityProjectionFieldOrdinal(
                                     schoolYearPath,
-                                    ColumnOrdinal: 9
+                                    ColumnOrdinal: 9,
+                                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
                                 ),
                                 new ExternalPlans.ReferenceIdentityProjectionFieldOrdinal(
                                     schoolIdPath,
-                                    ColumnOrdinal: 8
+                                    ColumnOrdinal: 8,
+                                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
                                 ),
                             ]
                         ),
@@ -688,7 +690,8 @@ public class Given_ExternalPlanContracts
                             [
                                 new ExternalPlans.ReferenceIdentityProjectionFieldOrdinal(
                                     schoolIdPath,
-                                    ColumnOrdinal: 4
+                                    ColumnOrdinal: 4,
+                                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
                                 ),
                             ]
                         ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/focused-stable-key/positive/extension-child-collections/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/focused-stable-key/positive/extension-child-collections/expected/mappingset.manifest.json
@@ -770,7 +770,8 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$._ext.sample.addresses[*]._ext.sample.sponsorReferences[*].programReference.programName",
-                        "column_ordinal": 5
+                        "column_ordinal": 5,
+                        "scalar_kind": "string"
                       }
                     ]
                   }
@@ -1562,7 +1563,8 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$._ext.sample.addresses[*]._ext.sample.sponsorReferences[*].programReference.programName",
-                        "column_ordinal": 5
+                        "column_ordinal": 5,
+                        "scalar_kind": "string"
                       }
                     ]
                   }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/minimal/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/minimal/expected/mappingset.manifest.json
@@ -442,7 +442,8 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$.schoolReference.schoolId",
-                        "column_ordinal": 2
+                        "column_ordinal": 2,
+                        "scalar_kind": "int32"
                       }
                     ]
                   }
@@ -1108,7 +1109,8 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$.schoolReference.schoolId",
-                        "column_ordinal": 2
+                        "column_ordinal": 2,
+                        "scalar_kind": "int32"
                       }
                     ]
                   }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
@@ -187,15 +187,18 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$.sessionTermReference.schoolId",
-                        "column_ordinal": 2
+                        "column_ordinal": 2,
+                        "scalar_kind": "int32"
                       },
                       {
                         "reference_json_path": "$.sessionTermReference.schoolYear",
-                        "column_ordinal": 3
+                        "column_ordinal": 3,
+                        "scalar_kind": "int32"
                       },
                       {
                         "reference_json_path": "$.sessionTermReference.sessionName",
-                        "column_ordinal": 4
+                        "column_ordinal": 4,
+                        "scalar_kind": "string"
                       }
                     ]
                   }
@@ -565,15 +568,18 @@
                     "identity_field_ordinals_in_order": [
                       {
                         "reference_json_path": "$.sessionTermReference.schoolId",
-                        "column_ordinal": 2
+                        "column_ordinal": 2,
+                        "scalar_kind": "int32"
                       },
                       {
                         "reference_json_path": "$.sessionTermReference.schoolYear",
-                        "column_ordinal": 3
+                        "column_ordinal": 3,
+                        "scalar_kind": "int32"
                       },
                       {
                         "reference_json_path": "$.sessionTermReference.sessionName",
-                        "column_ordinal": 4
+                        "column_ordinal": 4,
+                        "scalar_kind": "string"
                       }
                     ]
                   }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/LinkSubtreeStripperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/LinkSubtreeStripperTests.cs
@@ -215,7 +215,8 @@ public class Given_LinkSubtreeStripper
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _schoolReferenceSchoolIdPath,
-                            ColumnOrdinal: 2
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int32)
                         ),
                     ]
                 ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MappingSetManifestJsonEmitter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MappingSetManifestJsonEmitter.cs
@@ -719,6 +719,7 @@ internal static class MappingSetManifestJsonEmitter
                 writer.WriteStartObject();
                 writer.WriteString("reference_json_path", fieldOrdinal.ReferenceJsonPath.Canonical);
                 writer.WriteNumber("column_ordinal", fieldOrdinal.ColumnOrdinal);
+                writer.WriteString("scalar_kind", ToScalarKindToken(fieldOrdinal.ScalarType.Kind));
                 writer.WriteEndObject();
             }
 
@@ -933,7 +934,7 @@ internal static class MappingSetManifestJsonEmitter
         };
     }
 
-    private static string ToScalarKindToken(ScalarKind scalarKind)
+    internal static string ToScalarKindToken(ScalarKind scalarKind)
     {
         return scalarKind switch
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MappingSetManifestJsonEmitterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/MappingSetManifestJsonEmitterTests.cs
@@ -1645,7 +1645,10 @@ public class Given_MappingSetManifestJsonEmitter
                         .IdentityFieldOrdinalsInOrder.Select(
                             fieldOrdinal => new ReferenceIdentityProjectionFieldOrdinalSummary(
                                 ReferenceJsonPath: fieldOrdinal.ReferenceJsonPath.Canonical,
-                                ColumnOrdinal: fieldOrdinal.ColumnOrdinal
+                                ColumnOrdinal: fieldOrdinal.ColumnOrdinal,
+                                ScalarKind: MappingSetManifestJsonEmitter.ToScalarKindToken(
+                                    fieldOrdinal.ScalarType.Kind
+                                )
                             )
                         )
                         .ToArray()
@@ -1776,7 +1779,8 @@ public class Given_MappingSetManifestJsonEmitter
     {
         return new ReferenceIdentityProjectionFieldOrdinalSummary(
             ReferenceJsonPath: RequireString(fieldOrdinal, "reference_json_path"),
-            ColumnOrdinal: RequireInt(fieldOrdinal, "column_ordinal")
+            ColumnOrdinal: RequireInt(fieldOrdinal, "column_ordinal"),
+            ScalarKind: RequireString(fieldOrdinal, "scalar_kind")
         );
     }
 
@@ -2319,7 +2323,8 @@ public class Given_MappingSetManifestJsonEmitter
 
     private sealed record ReferenceIdentityProjectionFieldOrdinalSummary(
         string ReferenceJsonPath,
-        int ColumnOrdinal
+        int ColumnOrdinal,
+        string ScalarKind
     );
 
     private sealed record DescriptorProjectionPlanSummary(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractCodec.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractCodec.cs
@@ -89,7 +89,8 @@ internal static class NormalizedPlanContractCodec
                             IdentityFieldOrdinalsInOrder: binding.IdentityFieldOrdinalsInOrder.Select(
                                 fieldOrdinal => new ReferenceIdentityProjectionFieldOrdinalDto(
                                     ReferenceJsonPath: fieldOrdinal.ReferenceJsonPath.Canonical,
-                                    ColumnOrdinal: fieldOrdinal.ColumnOrdinal
+                                    ColumnOrdinal: fieldOrdinal.ColumnOrdinal,
+                                    ScalarType: EncodeScalarType(fieldOrdinal.ScalarType)
                                 )
                             )
                         )
@@ -612,7 +613,11 @@ internal static class NormalizedPlanContractCodec
 
                     fieldOrdinals[fieldIndex] = new ExternalPlans.ReferenceIdentityProjectionFieldOrdinal(
                         ReferenceJsonPath: referenceJsonPath,
-                        ColumnOrdinal: columnOrdinal
+                        ColumnOrdinal: columnOrdinal,
+                        ScalarType: DecodeScalarType(
+                            fieldDto.ScalarType,
+                            $"{fieldArgument}.{nameof(ReferenceIdentityProjectionFieldOrdinalDto.ScalarType)}"
+                        )
                     );
                 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractCodecTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractCodecTests.cs
@@ -2441,11 +2441,13 @@ public class Given_NormalizedPlanContractCodec : WritePlanCompilerTestBase
                             [
                                 new ReferenceIdentityProjectionFieldOrdinal(
                                     ReferenceJsonPath: Path("$.schoolReference.schoolId"),
-                                    ColumnOrdinal: 3
+                                    ColumnOrdinal: 3,
+                                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
                                 ),
                                 new ReferenceIdentityProjectionFieldOrdinal(
                                     ReferenceJsonPath: Path("$.schoolReference.schoolYear"),
-                                    ColumnOrdinal: 4
+                                    ColumnOrdinal: 4,
+                                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
                                 ),
                             ]
                         ),
@@ -2458,7 +2460,8 @@ public class Given_NormalizedPlanContractCodec : WritePlanCompilerTestBase
                             [
                                 new ReferenceIdentityProjectionFieldOrdinal(
                                     ReferenceJsonPath: Path("$.calendarReference.calendarCode"),
-                                    ColumnOrdinal: 6
+                                    ColumnOrdinal: 6,
+                                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 50)
                                 ),
                             ]
                         ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractDtos.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractDtos.cs
@@ -553,7 +553,8 @@ internal sealed record ReferenceIdentityProjectionBindingDto
 
 internal sealed record ReferenceIdentityProjectionFieldOrdinalDto(
     string ReferenceJsonPath,
-    int ColumnOrdinal
+    int ColumnOrdinal,
+    RelationalScalarTypeDto ScalarType
 );
 
 internal sealed record DescriptorProjectionPlanDto

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractDtosTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/NormalizedPlanContractDtosTests.cs
@@ -140,11 +140,13 @@ public class Given_NormalizedPlanContractDtos
                             [
                                 new ReferenceIdentityProjectionFieldOrdinalDto(
                                     ReferenceJsonPath: "$.schoolReference.schoolId",
-                                    ColumnOrdinal: 3
+                                    ColumnOrdinal: 3,
+                                    ScalarType: new RelationalScalarTypeDto(NormalizedScalarKind.Int32)
                                 ),
                                 new ReferenceIdentityProjectionFieldOrdinalDto(
                                     ReferenceJsonPath: "$.schoolReference.schoolYear",
-                                    ColumnOrdinal: 4
+                                    ColumnOrdinal: 4,
+                                    ScalarType: new RelationalScalarTypeDto(NormalizedScalarKind.Int32)
                                 ),
                             ]
                         ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
@@ -586,6 +586,69 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
     }
 
     [Test]
+    public void It_should_populate_reference_identity_field_scalar_types_from_the_hydration_columns()
+    {
+        var tableModelsByTable = _pgsqlProjectionReadPlan.TablePlansInDependencyOrder.ToDictionary(
+            static tablePlan => tablePlan.TableModel.Table,
+            static tablePlan => tablePlan.TableModel
+        );
+
+        var fieldOrdinalsWithTables = _pgsqlProjectionReadPlan
+            .ReferenceIdentityProjectionPlansInDependencyOrder.SelectMany(projectionPlan =>
+                projectionPlan.BindingsInOrder.SelectMany(binding =>
+                    binding.IdentityFieldOrdinalsInOrder.Select(fieldOrdinal =>
+                        (FieldOrdinal: fieldOrdinal, TableModel: tableModelsByTable[projectionPlan.Table])
+                    )
+                )
+            )
+            .ToArray();
+
+        fieldOrdinalsWithTables.Should().NotBeEmpty();
+        fieldOrdinalsWithTables
+            .Should()
+            .AllSatisfy(pair =>
+                pair.FieldOrdinal.ScalarType.Should()
+                    .Be(pair.TableModel.Columns[pair.FieldOrdinal.ColumnOrdinal].ScalarType)
+            );
+    }
+
+    [Test]
+    public void It_should_fail_fast_when_a_projected_reference_identity_column_lacks_a_scalar_type()
+    {
+        var act = () =>
+            new ReadPlanCompiler(SqlDialect.Pgsql).Compile(
+                CreateModelWithNullReferenceIdentityColumnScalarType(_projectionResourceModel)
+            );
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage(
+                "Cannot compile reference identity projection plan for 'edfi.StudentProjection': grouped reference-identity binding '$.schoolReference.schoolId' for reference '$.schoolReference' representative column 'School_RefSchoolId' does not declare a scalar type."
+            );
+    }
+
+    [Test]
+    public void It_should_reject_a_reference_identity_field_scalar_type_that_differs_from_the_column()
+    {
+        var mutatedReadPlan = CreateReadPlanWithReferenceProjectionFieldScalarType(
+            _pgsqlProjectionReadPlan,
+            new RelationalScalarType(ScalarKind.Boolean)
+        );
+
+        var act = () =>
+            ReadPlanProjectionContractValidator.ValidateOrThrow(
+                mutatedReadPlan,
+                reason => new InvalidOperationException(reason)
+            );
+
+        act.Should()
+            .Throw<InvalidOperationException>()
+            .WithMessage(
+                "reference identity projection field '$.schoolReference.schoolId' at index '0' for reference '$.schoolReference' on table 'edfi.StudentProjection' has ScalarType 'Boolean', but column 'School_RefSchoolId' declares 'Int32'"
+            );
+    }
+
+    [Test]
     public void It_should_emit_null_DocumentReferenceLookup_when_model_has_no_document_reference_bindings()
     {
         _pgsqlRootOnlyReadPlan.DocumentReferenceLookup.Should().BeNull();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanProjectionMutationHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanProjectionMutationHelper.cs
@@ -216,6 +216,70 @@ internal static class ReadPlanProjectionMutationHelper
         };
     }
 
+    public static RelationalResourceModel CreateModelWithNullReferenceIdentityColumnScalarType(
+        RelationalResourceModel model
+    )
+    {
+        var binding = model.DocumentReferenceBindings[0];
+        var identityColumn = binding.IdentityBindings[0].Column;
+
+        var tables = model
+            .TablesInDependencyOrder.Select(table =>
+                table.Table.Equals(binding.Table)
+                    ? table with
+                    {
+                        Columns =
+                        [
+                            .. table.Columns.Select(column =>
+                                column.ColumnName.Equals(identityColumn)
+                                    ? column with
+                                    {
+                                        ScalarType = null,
+                                    }
+                                    : column
+                            ),
+                        ],
+                    }
+                    : table
+            )
+            .ToArray();
+
+        return model with
+        {
+            Root = tables.Single(table => table.Table.Equals(model.Root.Table)),
+            TablesInDependencyOrder = [.. tables],
+        };
+    }
+
+    public static ResourceReadPlan CreateReadPlanWithReferenceProjectionFieldScalarType(
+        ResourceReadPlan readPlan,
+        RelationalScalarType scalarType
+    )
+    {
+        var projectionTablePlan = readPlan.ReferenceIdentityProjectionPlansInDependencyOrder.Single();
+        var binding = projectionTablePlan.BindingsInOrder.Single();
+        var identityFieldOrdinals = binding.IdentityFieldOrdinalsInOrder.ToArray();
+
+        identityFieldOrdinals[0] = identityFieldOrdinals[0] with { ScalarType = scalarType };
+
+        return readPlan with
+        {
+            ReferenceIdentityProjectionPlansInDependencyOrder =
+            [
+                projectionTablePlan with
+                {
+                    BindingsInOrder =
+                    [
+                        binding with
+                        {
+                            IdentityFieldOrdinalsInOrder = [.. identityFieldOrdinals],
+                        },
+                    ],
+                },
+            ],
+        };
+    }
+
     public static ResourceReadPlan CreateReadPlanWithSwappedReferenceProjectionFields(
         ResourceReadPlan readPlan
     )

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReferenceIdentityProjectorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReferenceIdentityProjectorTests.cs
@@ -40,7 +40,11 @@ public class Given_ReferenceIdentityProjector_With_Concrete_Reference
             FkColumnOrdinal: 1,
             IdentityFieldOrdinalsInOrder:
             [
-                new ReferenceIdentityProjectionFieldOrdinal(_schoolIdPath, ColumnOrdinal: 2),
+                new ReferenceIdentityProjectionFieldOrdinal(
+                    _schoolIdPath,
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                ),
             ]
         );
 
@@ -120,7 +124,11 @@ public class Given_ReferenceIdentityProjector_With_Abstract_Reference
             FkColumnOrdinal: 1,
             IdentityFieldOrdinalsInOrder:
             [
-                new ReferenceIdentityProjectionFieldOrdinal(_educationOrgIdPath, ColumnOrdinal: 2),
+                new ReferenceIdentityProjectionFieldOrdinal(
+                    _educationOrgIdPath,
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                ),
             ]
         );
 
@@ -177,7 +185,8 @@ public class Given_ReferenceIdentityProjector_With_Null_Fk
                             new JsonPathSegment.Property("schoolId"),
                         ]
                     ),
-                    ColumnOrdinal: 2
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
                 ),
             ]
         );
@@ -229,7 +238,8 @@ public class Given_ReferenceIdentityProjector_With_Multiple_References_On_Same_R
                             new JsonPathSegment.Property("schoolId"),
                         ]
                     ),
-                    ColumnOrdinal: 2
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
                 ),
             ]
         );
@@ -249,7 +259,8 @@ public class Given_ReferenceIdentityProjector_With_Multiple_References_On_Same_R
                             new JsonPathSegment.Property("calendarCode"),
                         ]
                     ),
-                    ColumnOrdinal: 4
+                    ColumnOrdinal: 4,
+                    ScalarType: new RelationalScalarType(ScalarKind.String)
                 ),
             ]
         );
@@ -323,9 +334,21 @@ public class Given_ReferenceIdentityProjector_With_Multiple_Identity_Fields
             FkColumnOrdinal: 1,
             IdentityFieldOrdinalsInOrder:
             [
-                new ReferenceIdentityProjectionFieldOrdinal(_schoolIdPath, ColumnOrdinal: 2),
-                new ReferenceIdentityProjectionFieldOrdinal(_schoolYearPath, ColumnOrdinal: 3),
-                new ReferenceIdentityProjectionFieldOrdinal(_sessionNamePath, ColumnOrdinal: 4),
+                new ReferenceIdentityProjectionFieldOrdinal(
+                    _schoolIdPath,
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                ),
+                new ReferenceIdentityProjectionFieldOrdinal(
+                    _schoolYearPath,
+                    ColumnOrdinal: 3,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32)
+                ),
+                new ReferenceIdentityProjectionFieldOrdinal(
+                    _sessionNamePath,
+                    ColumnOrdinal: 4,
+                    ScalarType: new RelationalScalarType(ScalarKind.String)
+                ),
             ]
         );
 
@@ -446,7 +469,11 @@ public class Given_ReferenceIdentityProjector_ProjectTable_With_Grouped_Results
                     FkColumnOrdinal: 1,
                     IdentityFieldOrdinalsInOrder:
                     [
-                        new ReferenceIdentityProjectionFieldOrdinal(_schoolIdPath, ColumnOrdinal: 2),
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            _schoolIdPath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                        ),
                     ]
                 ),
             ]
@@ -696,7 +723,8 @@ public class Given_Project_With_Collection_Scope_Row
                             new JsonPathSegment.Property("codeValue"),
                         ]
                     ),
-                    ColumnOrdinal: 4
+                    ColumnOrdinal: 4,
+                    ScalarType: new RelationalScalarType(ScalarKind.String)
                 ),
             ]
         );
@@ -866,7 +894,11 @@ public class Given_ProjectPage_With_Root_Table_Projections
                     FkColumnOrdinal: 1,
                     IdentityFieldOrdinalsInOrder:
                     [
-                        new ReferenceIdentityProjectionFieldOrdinal(_schoolIdPath, ColumnOrdinal: 2),
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            _schoolIdPath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                        ),
                     ]
                 ),
             ]
@@ -1181,7 +1213,11 @@ public class Given_ProjectPage_With_Mixed_Root_And_Collection_Plans
                     FkColumnOrdinal: 1,
                     IdentityFieldOrdinalsInOrder:
                     [
-                        new ReferenceIdentityProjectionFieldOrdinal(_schoolIdPath, ColumnOrdinal: 2),
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            _schoolIdPath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int64)
+                        ),
                     ]
                 ),
             ]
@@ -1277,7 +1313,8 @@ public class Given_ReferenceIdentityProjector_With_NonNull_Fk_But_Null_Identity_
                             new JsonPathSegment.Property("schoolId"),
                         ]
                     ),
-                    ColumnOrdinal: 2
+                    ColumnOrdinal: 2,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64)
                 ),
             ]
         );
@@ -1375,7 +1412,11 @@ public class Given_ProjectTable_With_RootExtension_Table
                     FkColumnOrdinal: 1,
                     IdentityFieldOrdinalsInOrder:
                     [
-                        new ReferenceIdentityProjectionFieldOrdinal(_mentorIdPath, ColumnOrdinal: 2),
+                        new ReferenceIdentityProjectionFieldOrdinal(
+                            _mentorIdPath,
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 32)
+                        ),
                     ]
                 ),
             ]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReferenceIdentityProjectorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReferenceIdentityProjectorTests.cs
@@ -376,6 +376,21 @@ public class Given_ReferenceIdentityProjector_With_Multiple_Identity_Fields
         present.FieldsInOrder[2].ReferenceJsonPath.Canonical.Should().Be("$.sessionReference.sessionName");
         present.FieldsInOrder[2].Value.Should().Be("Fall");
     }
+
+    [Test]
+    public void It_should_carry_the_field_ordinal_scalar_type_on_each_projected_field()
+    {
+        var present = (ReferenceProjectionResult.Present)_result;
+
+        present
+            .FieldsInOrder.Select(static field => field.ScalarType)
+            .Should()
+            .Equal(
+                new RelationalScalarType(ScalarKind.Int64),
+                new RelationalScalarType(ScalarKind.Int32),
+                new RelationalScalarType(ScalarKind.String)
+            );
+    }
 }
 
 [TestFixture]

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReconstituter.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReconstituter.cs
@@ -483,7 +483,7 @@ public static class DocumentReconstituter
                 field.ReferenceJsonPath,
                 present.ReferenceObjectPath
             );
-            fieldParent[fieldPropertyName] = ConvertToJsonValue(field.Value);
+            fieldParent[fieldPropertyName] = ConvertToJsonValue(field.Value, field.ScalarType);
         }
 
         EmitReferenceLink(referenceObject, row, binding, tablePlan, pageReconstitutionContext);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanProjectionContractValidator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReadPlanProjectionContractValidator.cs
@@ -610,6 +610,14 @@ internal static class ReadPlanProjectionContractValidator
             );
         }
 
+        if (fieldOrdinal.ScalarType != fieldColumnModel.ScalarType)
+        {
+            throw createException(
+                $"reference identity projection field '{fieldOrdinal.ReferenceJsonPath.Canonical}' at index '{fieldIndex}' for reference '{referenceObjectPath.Canonical}' on table '{table}' has ScalarType "
+                    + $"'{FormatScalarType(fieldOrdinal.ScalarType)}', but column '{fieldColumnModel.ColumnName.Value}' declares '{FormatScalarType(fieldColumnModel.ScalarType)}'"
+            );
+        }
+
         if (authoritativeLogicalField.MemberColumnsInOrder.Contains(fieldColumnModel.ColumnName))
         {
             return;
@@ -814,6 +822,17 @@ internal static class ReadPlanProjectionContractValidator
     {
         var paths = formattedPaths.ToArray();
         return paths.Length == 0 ? "<none>" : string.Join(", ", paths);
+    }
+
+    private static string FormatScalarType(RelationalScalarType? scalarType)
+    {
+        return scalarType switch
+        {
+            null => "<null>",
+            { Decimal: { } facets } => $"{scalarType.Kind}({facets.Precision},{facets.Scale})",
+            { MaxLength: { } maxLength } => $"{scalarType.Kind}({maxLength})",
+            _ => scalarType.Kind.ToString(),
+        };
     }
 
     private static bool DescriptorSourcesMatch(DescriptorEdgeSource actual, DescriptorEdgeSource expected)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjectionPlanCompiler.cs
@@ -70,8 +70,17 @@ internal static class ReferenceIdentityProjectionPlanCompiler
                                 $"Cannot compile reference identity projection plan for '{binding.Table}': document-reference binding '{binding.ReferenceObjectPath.Canonical}' FK column '{missingColumn.Value}' does not exist in hydration select-list columns."
                             )
                         ),
-                        IdentityFieldOrdinalsInOrder: logicalFieldsInOrder.Select(
-                            logicalField => new ReferenceIdentityProjectionFieldOrdinal(
+                        IdentityFieldOrdinalsInOrder: logicalFieldsInOrder.Select(logicalField =>
+                        {
+                            var representativeColumn = ProjectionMetadataResolver.ResolveTableColumnOrThrow(
+                                tableModel,
+                                logicalField.RepresentativeBindingColumn,
+                                missingColumn => new InvalidOperationException(
+                                    $"Cannot compile reference identity projection plan for '{binding.Table}': grouped reference-identity binding '{logicalField.ReferenceJsonPath.Canonical}' for reference '{binding.ReferenceObjectPath.Canonical}' representative column '{missingColumn.Value}' does not exist in table columns."
+                                )
+                            );
+
+                            return new ReferenceIdentityProjectionFieldOrdinal(
                                 ReferenceJsonPath: logicalField.ReferenceJsonPath,
                                 ColumnOrdinal: ProjectionMetadataResolver.ResolveHydrationColumnOrdinalOrThrow(
                                     columnOrdinals,
@@ -79,9 +88,13 @@ internal static class ReferenceIdentityProjectionPlanCompiler
                                     missingColumn => new InvalidOperationException(
                                         $"Cannot compile reference identity projection plan for '{binding.Table}': grouped reference-identity binding '{logicalField.ReferenceJsonPath.Canonical}' for reference '{binding.ReferenceObjectPath.Canonical}' representative column '{missingColumn.Value}' does not exist in hydration select-list columns."
                                     )
-                                )
-                            )
-                        )
+                                ),
+                                ScalarType: representativeColumn.ScalarType
+                                    ?? throw new InvalidOperationException(
+                                        $"Cannot compile reference identity projection plan for '{binding.Table}': grouped reference-identity binding '{logicalField.ReferenceJsonPath.Canonical}' for reference '{binding.ReferenceObjectPath.Canonical}' representative column '{logicalField.RepresentativeBindingColumn.Value}' does not declare a scalar type."
+                                    )
+                            );
+                        })
                     );
                 })
                 .ToArray();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjector.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ReferenceIdentityProjector.cs
@@ -9,12 +9,17 @@ using EdFi.DataManagementService.Backend.External.Plans;
 namespace EdFi.DataManagementService.Backend.Plans;
 
 /// <summary>
-/// A single projected reference identity field: the JSON path under the reference object
-/// and its CLR value from the hydrated row buffer.
+/// A single projected reference identity field: the JSON path under the reference object,
+/// its CLR value from the hydrated row buffer, and the projected column's scalar type.
 /// </summary>
 /// <param name="ReferenceJsonPath">The identity field path within the reference object.</param>
 /// <param name="Value">The CLR value read from the hydrated row buffer.</param>
-public sealed record ProjectedReferenceField(JsonPathExpression ReferenceJsonPath, object Value);
+/// <param name="ScalarType">Relational scalar type of the projected column, used for typed JSON value conversion.</param>
+public sealed record ProjectedReferenceField(
+    JsonPathExpression ReferenceJsonPath,
+    object Value,
+    RelationalScalarType ScalarType
+);
 
 /// <summary>
 /// The projection result for a single reference binding on a hydrated row.
@@ -88,7 +93,11 @@ public static class ReferenceIdentityProjector
                         + $"(path '{fieldOrdinal.ReferenceJsonPath.Canonical}') is null "
                         + "but FK column is non-null — CHECK constraint may be violated."
                 );
-            fields[i] = new ProjectedReferenceField(fieldOrdinal.ReferenceJsonPath, value);
+            fields[i] = new ProjectedReferenceField(
+                fieldOrdinal.ReferenceJsonPath,
+                value,
+                fieldOrdinal.ScalarType
+            );
         }
 
         return new ReferenceProjectionResult.Present(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -11619,7 +11619,8 @@ public class Given_RelationalDocumentStoreRepositoryTests
                                 [
                                     new ReferenceIdentityProjectionFieldOrdinal(
                                         new JsonPathExpression(studentPath, []),
-                                        ColumnOrdinal: 2
+                                        ColumnOrdinal: 2,
+                                        ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 32)
                                     ),
                                 ]
                             ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
@@ -995,7 +995,8 @@ public class Given_RelationalReadMaterializer_With_Link_Injection_And_External_R
                     [
                         new ReferenceIdentityProjectionFieldOrdinal(
                             ReferenceJsonPath: _schoolReferenceSchoolIdPath,
-                            ColumnOrdinal: 2
+                            ColumnOrdinal: 2,
+                            ScalarType: new RelationalScalarType(ScalarKind.Int32)
                         ),
                     ]
                 ),


### PR DESCRIPTION
## Summary

Relational GET reconstitution emitted date-typed identity fields inside reference objects as date-times (`"beginDate": "2024-08-01T00:00:00Z"` instead of `"2024-08-01"`), because `DocumentReconstituter.EmitReferenceObject` converted reference identity values without a `RelationalScalarType` while root scalars use the typed conversion path. OpenAPI types these fields as `format: date`, so strictly typed generated SDK clients fail deserialization (observed in scheduled smoke run 27073862668 on `EdFiGrade` and `EdFiStudentAssessmentRegistration`).

- **Commit 1 — plan-contract metadata:** `ReferenceIdentityProjectionFieldOrdinal` gains a required, non-nullable `RelationalScalarType`. The read-plan compiler populates it from the representative projected column and fails fast when a projected column declares no scalar type (DescriptorFk identity members always declare `Int64`, so descriptor-valued reference identity fields compile unchanged). `ReadPlanProjectionContractValidator` asserts the compiled field scalar type equals the column model's at the compiled ordinal. The mapping-set manifest emitter writes a `scalar_kind` token per identity field entry and the five mapping-set manifest goldens are regenerated (mechanical `scalar_kind` additions only); the normalized plan contract codec round-trips the full scalar type.
- **Commit 2 — rendering fix:** `ProjectedReferenceField` carries the scalar type through projection, and `EmitReferenceObject` passes it to `ConvertToJsonValue` — the same typed conversion root scalars already use. `Date` identity fields hydrated as CLR `DateTime` (PG/MSSQL `date` columns) now render as `yyyy-MM-dd`; `Time` identity fields hydrated as `TimeSpan` (MSSQL `time`) now render as `HH:mm:ss` instead of throwing. Absent-reference handling (null FK), field ordering, and descriptor URI overwrite behavior are unchanged.

## Test Plan

- [x] New reconstituter regression fixtures, proven red before the fix: reference identity `Date` field hydrated as CLR `DateTime` renders `"2024-08-01"`; reference identity `Time` field hydrated as `TimeSpan` renders `"08:30:00"`
- [x] New compiler tests: every compiled field ordinal's scalar type equals the hydration column's; fail-fast on a projected column with null scalar type
- [x] New validator test: scalar type mismatch between compiled plan and column model is rejected
- [x] New projector test: scalar types carry from compiled field ordinals onto projected fields
- [x] Golden determinism: regenerated via `UPDATE_GOLDENS=1`, clean re-run green; DS-5.2 golden spot-checked (`$.studentSectionAssociationReference.beginDate` → `"scalar_kind": "date"`, descriptor identity entries → `"int64"`)
- [x] `EdFi.DataManagementService.Backend.Plans.Tests.Unit`: 1268/1268; `EdFi.DataManagementService.Backend.Tests.Unit`: 1683/1683; full `src/dms` solution build clean; CSharpier formatted