### PR TITLE
[DMS-1210] Restore Sample and Homograph smoke-test coverage on relational backend

### DIFF
--- a/.github/workflows/build-populated-template.yml
+++ b/.github/workflows/build-populated-template.yml
@@ -92,11 +92,27 @@ jobs:
           $useRelationalBackend = [bool]::Parse('${{ inputs.use_relational_backend }}')
           $verifyRestore = [bool]::Parse('${{ inputs.verify_restore }}')
           $requirePopulatedData = [bool]::Parse('${{ inputs.require_populated_data }}')
+          $publishPackage = [bool]::Parse('${{ inputs.publish_package }}')
           $environmentFile = '${{ inputs.environment_file }}'
+          $packageName = '${{ inputs.package_name }}'
 
-          if ($useRelationalBackend -and $environmentFile -ne './.env.template.relational') {
-            throw "use_relational_backend requires environment_file './.env.template.relational'; got '$environmentFile'."
+          $relationalEnvFiles = @('./.env.template.relational', './.env.smoke.relational')
+          if ($useRelationalBackend -and $environmentFile -notin $relationalEnvFiles) {
+            throw "use_relational_backend requires environment_file to be one of: $($relationalEnvFiles -join ', '); got '$environmentFile'."
           }
+
+          # The four-package smoke surface (DS52+TPDM+Sample+Homograph) is an in-run
+          # smoke artifact only. It must never publish under the product template
+          # contract, and must not reuse a product package name.
+          if ($environmentFile -eq './.env.smoke.relational') {
+            if ($publishPackage) {
+              throw "environment_file './.env.smoke.relational' is smoke-only and must not be published; set publish_package to false."
+            }
+            if ($packageName -notlike 'EdFi.Dms.Smoke.Template.PostgreSQL*') {
+              throw "environment_file './.env.smoke.relational' requires a smoke package_name (prefix 'EdFi.Dms.Smoke.Template.PostgreSQL'); got '$packageName'."
+            }
+          }
+
           if ($requirePopulatedData -and -not $verifyRestore) {
             throw "require_populated_data requires verify_restore."
           }

--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -82,48 +82,6 @@ jobs:
       - name: Add Kafka hostname to /etc/hosts
         run: echo "127.0.0.1 dms-kafka1" | sudo tee -a /etc/hosts
 
-      - name: Run legacy End to End Tests - IdentityProvider (${{ matrix.identityprovider }})
-        id: legacy_e2e
-        if: success()
-        continue-on-error: true
-        run: ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@relational-backend'
-
-      - name: Export Legacy Docker Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        run: |
-          $logDir = "${{ github.workspace }}/logs/legacy"
-          Remove-Item -Path $logDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $logDir -Force | Out-Null
-
-          $containers = @(docker ps -a --format "{{.Names}}" | Sort-Object)
-
-          if ($containers.Count -eq 0) {
-              Write-Host "No Docker containers found for log export."
-              exit 0
-          }
-
-          foreach ($container in $containers) {
-              $logPath = Join-Path $logDir "$container.log"
-              docker logs $container > $logPath 2>&1
-          }
-
-      - name: Upload Legacy Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
-        with:
-          name: scheduled-build-logs-${{ matrix.identityprovider }}-legacy
-          path: |
-            ${{ github.workspace }}/logs/legacy
-          retention-days: 10
-
-      - name: Upload Legacy End to End Test Results
-        if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
-        with:
-          name: scheduled-build-e2e-results-${{ matrix.identityprovider }}-legacy
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.legacy.trx
-          if-no-files-found: ignore
-
       - name: Run relational End to End Tests - IdentityProvider (${{ matrix.identityprovider }})
         id: relational_e2e
         if: success()
@@ -166,12 +124,11 @@ jobs:
           path: TestResults/EdFi.DataManagementService.Tests.E2E.relational.trx
           if-no-files-found: ignore
 
-      - name: Fail if an E2E lane failed
-        if: always() && (steps.legacy_e2e.outcome == 'failure' || steps.relational_e2e.outcome == 'failure')
+      - name: Fail if relational E2E failed
+        if: always() && steps.relational_e2e.outcome == 'failure'
         run: |
-          Write-Host "Legacy lane outcome: ${{ steps.legacy_e2e.outcome }}"
           Write-Host "Relational lane outcome: ${{ steps.relational_e2e.outcome }}"
-          throw "One or more E2E lanes failed."
+          throw "Relational E2E failed."
 
   build-and-start-dms:
     name: Build and Start DMS, Download OpenAPI Specs

--- a/.github/workflows/scheduled-pre-image-test.yml
+++ b/.github/workflows/scheduled-pre-image-test.yml
@@ -47,48 +47,6 @@ jobs:
         id: build_step
         run: ./build-dms.ps1 Build -Configuration Release -IdentityProvider ${{matrix.identityprovider}}
 
-      - name: Run legacy End to End Tests
-        id: legacy_e2e
-        if: success()
-        continue-on-error: true
-        run: ./build-dms.ps1 E2ETest -UsePublishedImage -Configuration Release -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@relational-backend'
-
-      - name: Export Legacy Docker Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        run: |
-          $logDir = "${{ github.workspace }}/logs/legacy"
-          Remove-Item -Path $logDir -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path $logDir -Force | Out-Null
-
-          $containers = @(docker ps -a --format "{{.Names}}" | Sort-Object)
-
-          if ($containers.Count -eq 0) {
-              Write-Host "No Docker containers found for log export."
-              exit 0
-          }
-
-          foreach ($container in $containers) {
-              $logPath = Join-Path $logDir "$container.log"
-              docker logs $container > $logPath 2>&1
-          }
-
-      - name: Upload Legacy Logs
-        if: always() && steps.legacy_e2e.outcome == 'failure'
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
-        with:
-          name: scheduled-pre-image-logs-${{ matrix.identityprovider }}-legacy
-          path: |
-            ${{ github.workspace }}/logs/legacy
-          retention-days: 10
-
-      - name: Upload Legacy End to End Test Results
-        if: always()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
-        with:
-          name: scheduled-pre-image-e2e-results-${{ matrix.identityprovider }}-legacy
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.legacy.trx
-          if-no-files-found: ignore
-
       - name: Run relational End to End Tests
         id: relational_e2e
         if: success()
@@ -131,12 +89,11 @@ jobs:
           path: TestResults/EdFi.DataManagementService.Tests.E2E.relational.trx
           if-no-files-found: ignore
 
-      - name: Fail if an E2E lane failed
-        if: always() && (steps.legacy_e2e.outcome == 'failure' || steps.relational_e2e.outcome == 'failure')
+      - name: Fail if relational E2E failed
+        if: always() && steps.relational_e2e.outcome == 'failure'
         run: |
-          Write-Host "Legacy lane outcome: ${{ steps.legacy_e2e.outcome }}"
           Write-Host "Relational lane outcome: ${{ steps.relational_e2e.outcome }}"
-          throw "One or more E2E lanes failed."
+          throw "Relational E2E failed."
 
       - name: Notify Slack on success
         if: success() && github.event_name != 'workflow_dispatch'
@@ -144,7 +101,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "✅ Scheduled pre image tests passed for identityprovider=${{ matrix.identityprovider }} across legacy and relational lanes."
+              "text": "✅ Scheduled pre image tests passed for identityprovider=${{ matrix.identityprovider }} on the relational lane."
             }
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -155,13 +112,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "❌ Scheduled pre image tests result: ${{ job.status }}\nIdentityProvider: ${{ matrix.identityprovider }}\nLegacy lane: ${{ steps.legacy_e2e.outcome }}\nRelational lane: ${{ steps.relational_e2e.outcome }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": "❌ Scheduled pre image tests result: ${{ job.status }}\nIdentityProvider: ${{ matrix.identityprovider }}\nRelational lane: ${{ steps.relational_e2e.outcome }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "❌ Scheduled pre image tests result: ${{ job.status }}\n*Identity Provider:* ${{ matrix.identityprovider }}\n*Legacy Lane:* ${{ steps.legacy_e2e.outcome }}\n*Relational Lane:* ${{ steps.relational_e2e.outcome }}\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Commit Message:* ${{ github.event.head_commit.message || 'No commit message available' }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "❌ Scheduled pre image tests result: ${{ job.status }}\n*Identity Provider:* ${{ matrix.identityprovider }}\n*Relational Lane:* ${{ steps.relational_e2e.outcome }}\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Commit Message:* ${{ github.event.head_commit.message || 'No commit message available' }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -244,11 +244,15 @@ jobs:
           ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll" -OAuthUrl "http://localhost:8080/oauth/token"
         working-directory: eng/smoke_test/
 
-      # The published ODS SDK sweep (EdFi.OdsApi.Sdk) exercises the full ODS resource
-      # surface, including the Sample and Homograph extensions. This relational smoke
-      # path serves only the Core (DS52) + TPDM product surface, so that sweep would
-      # 404 on Sample/Homograph resources. ODS SDK smoke coverage is reintroduced once
-      # the Sample/Homograph smoke surface is restored.
+      - name: Run NonDestructive ODS SDK Tests
+        run: |
+          ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkNamespace "EdFi.OdsApi.Sdk" -OAuthUrl "http://localhost:8080/oauth/token"
+        working-directory: eng/smoke_test/
+
+      - name: Run Destructive ODS SDK Tests
+        run: |
+          ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkNamespace "EdFi.OdsApi.Sdk" -OAuthUrl "http://localhost:8080/oauth/token"
+        working-directory: eng/smoke_test/
 
       - name: Export Docker Logs on Failure
         if: failure()
@@ -289,7 +293,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "✅ *Scheduled Smoke Tests - SUCCESS*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Tests Run:* DMS NonDestructiveAPI, DMS NonDestructiveSDK, DMS DestructiveSDK\n*Backend:* Relational\n*Extensions:* Core (DS52), TPDM\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "✅ *Scheduled Smoke Tests - SUCCESS*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Tests Run:* DMS NonDestructiveAPI, DMS NonDestructiveSDK, DMS DestructiveSDK, ODS NonDestructiveSDK, ODS DestructiveSDK\n*Backend:* Relational\n*Extensions:* Core (DS52), TPDM, Sample, Homograph\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]
@@ -309,7 +313,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "❌ *Scheduled Smoke Tests - FAILURE*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Tests:* NonDestructiveAPI, NonDestructiveSDK, DestructiveSDK\n*Backend:* Relational\n*Extensions:* Core (DS52), TPDM\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "❌ *Scheduled Smoke Tests - FAILURE*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Tests:* DMS NonDestructiveAPI, DMS NonDestructiveSDK, DMS DestructiveSDK, ODS NonDestructiveSDK, ODS DestructiveSDK\n*Backend:* Relational\n*Extensions:* Core (DS52), TPDM, Sample, Homograph\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: ./.github/workflows/build-populated-template.yml
     with:
       standard_version: "5.2.0"
-      package_name: "EdFi.Dms.Populated.Template.PostgreSQL.5.2.0"
+      package_name: "EdFi.Dms.Smoke.Template.PostgreSQL.5.2.0"
       manifest_file: "_manifest/spdx_2.2/manifest.spdx.json"
       provenance_file: "populated.template.intoto.jsonl"
       # The smoke test consumes the template artifact built in this run; nothing is
@@ -33,7 +33,7 @@ jobs:
       # the template package workflows (tag/release and explicit dispatch opt-in).
       publish_package: false
       use_relational_backend: true
-      environment_file: "./.env.template.relational"
+      environment_file: "./.env.smoke.relational"
       verify_restore: true
       require_populated_data: true
     secrets:
@@ -99,18 +99,18 @@ jobs:
       - name: Download Populated Template Package artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 #v4.1.8
         with:
-          name: "EdFi.Dms.Populated.Template.PostgreSQL.5.2.0-NuGet"
+          name: "EdFi.Dms.Smoke.Template.PostgreSQL.5.2.0-NuGet"
           path: ${{ github.workspace }}/template-package
 
-      # The smoke environment serves the same Core (DS52) + TPDM surface the populated
-      # template was built from. The dms.EffectiveSchema fingerprint requires the running
-      # schema packages and the restored database to match exactly, so the smoke test
-      # reuses the template build's environment file. Sample and Homograph remain covered
-      # by the relational E2E suite (.env.e2e.relational).
-      - name: Start DMS on the relational backend with Core and TPDM (SmokeTest)
+      # The smoke environment serves the four-package DS52 + TPDM + Sample + Homograph
+      # surface the published ODS SDK sweep expects. The dms.EffectiveSchema fingerprint
+      # requires the running schema packages and the restored database to match exactly,
+      # so the smoke test reuses the same .env.smoke.relational the in-run template was
+      # built from. This is smoke coverage only; the product template stays Core+TPDM.
+      - name: Start DMS on the relational backend with Core, TPDM, Sample, and Homograph (SmokeTest)
         run: |
           $env:LOG_LEVEL="Warning"
-          ./start-local-dms.ps1 -EnvironmentFile "./.env.template.relational" -EnableConfig
+          ./start-local-dms.ps1 -EnvironmentFile "./.env.smoke.relational" -EnableConfig
         working-directory: eng/docker-compose/
 
       - name: Wait for the Configuration Service to be ready
@@ -147,7 +147,7 @@ jobs:
         run: |
           Import-Module ../Dms-Management.psm1 -Force
           Import-Module ./env-utility.psm1 -Force
-          $envValues = ReadValuesFromEnvFile "./.env.template.relational"
+          $envValues = ReadValuesFromEnvFile "./.env.smoke.relational"
           Add-CmsClient -CmsUrl "http://localhost:8081" -ClientId "data-store-admin" -ClientSecret "ValidClientSecret1234567890!Abcd" -DisplayName "Data Store Setup Administrator"
           $configToken = Get-CmsToken -CmsUrl "http://localhost:8081" -ClientId "data-store-admin" -ClientSecret "ValidClientSecret1234567890!Abcd"
           $dataStoreId = Add-DataStore -CmsUrl "http://localhost:8081" -AccessToken $configToken -PostgresPassword $envValues.POSTGRES_PASSWORD -PostgresDbName $env:SMOKE_DATABASE_NAME -Name "Smoke Test Data Store" -DataStoreType "SmokeTest"

--- a/eng/Package-Management.psm1
+++ b/eng/Package-Management.psm1
@@ -256,19 +256,14 @@ function Get-SampleData {
     Diagnostic override of the repo pin.
 #>
 function Get-BulkLoadClient {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidDefaultValueSwitchParameter', '', Justification = 'The pinned BulkLoadClient build is published to the dev feed view before promotion to EdFi@Release, so resolution must default to the dev view; the exact three-part pin keeps the result deterministic and -PreRelease:$false restores release-view resolution.')]
     param (
         # Diagnostic override of the repo-pinned version. Defaults to the shared pin.
         [string]
         $PackageVersion = $script:PinnedBulkLoadClientVersion,
 
-        # Resolve from the dev (EdFi) feed view by default: the pinned build is
-        # published there but not yet promoted to the EdFi@Release view. The dev view
-        # is a superset of the release view and the exact three-part pin cannot float,
-        # so resolution stays deterministic. Pass -PreRelease:$false to require the
-        # release view once the pinned version has been promoted.
+        # Enable usage of prereleases
         [Switch]
-        $PreRelease = $true
+        $PreRelease
     )
 
     Get-NugetPackage -PackageName "EdFi.Suite3.BulkLoadClient.Console" `

--- a/eng/Package-Management.psm1
+++ b/eng/Package-Management.psm1
@@ -256,14 +256,19 @@ function Get-SampleData {
     Diagnostic override of the repo pin.
 #>
 function Get-BulkLoadClient {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidDefaultValueSwitchParameter', '', Justification = 'The pinned BulkLoadClient build is published to the dev feed view before promotion to EdFi@Release, so resolution must default to the dev view; the exact three-part pin keeps the result deterministic and -PreRelease:$false restores release-view resolution.')]
     param (
         # Diagnostic override of the repo-pinned version. Defaults to the shared pin.
         [string]
         $PackageVersion = $script:PinnedBulkLoadClientVersion,
 
-        # Enable usage of prereleases
+        # Resolve from the dev (EdFi) feed view by default: the pinned build is
+        # published there but not yet promoted to the EdFi@Release view. The dev view
+        # is a superset of the release view and the exact three-part pin cannot float,
+        # so resolution stays deterministic. Pass -PreRelease:$false to require the
+        # release view once the pinned version has been promoted.
         [Switch]
-        $PreRelease
+        $PreRelease = $true
     )
 
     Get-NugetPackage -PackageName "EdFi.Suite3.BulkLoadClient.Console" `

--- a/eng/Package-Management.psm1
+++ b/eng/Package-Management.psm1
@@ -15,7 +15,7 @@ if (-not [Net.ServicePointManager]::SecurityProtocol.HasFlag([Net.SecurityProtoc
 # templates, sample-data loaders). Exactly three parts; never a partial like "7.3",
 # which would float to the newest matching feed build. Bumps must be reviewed against
 # the BulkLoadClient XML flag preflight and invocation shape.
-$script:PinnedBulkLoadClientVersion = "7.3.20144"
+$script:PinnedBulkLoadClientVersion = "7.3.20162"
 
 <#
 .SYNOPSIS

--- a/eng/docker-compose/.env.smoke.relational
+++ b/eng/docker-compose/.env.smoke.relational
@@ -1,0 +1,190 @@
+# Relational-backend environment for the SCHEDULED SMOKE TEST ONLY. The smoke
+# workflow builds an in-run populated template from this file, restores that same
+# artifact, and starts DMS from this file so the dms.EffectiveSchema fingerprint
+# check passes (the running schema packages and the restored database must match
+# exactly).
+#
+# SCHEMA_PACKAGES is the four-package surface DS52 + TPDM + Sample + Homograph so
+# the smoke run advertises the Sample/Homograph endpoints the published ODS SDK
+# sweep expects. This is smoke coverage only: the artifact built from this file is
+# never published to the product template feed (build-populated-template.yml
+# rejects publish_package=true and any non-smoke package_name for this env file).
+# The published product template stays Core+TPDM via .env.template.relational.
+#
+# Loaded sample data remains Core/TPDM-compatible (the bulk-load step loads only
+# *.ed-fi.xml Grand Bend data); Sample/Homograph tables may be empty and GetAll
+# returns valid empty 200. Sample XML inline-array field fidelity is out of scope.
+
+# -----------------
+# Postgres database
+# -----------------
+POSTGRES_PASSWORD=abcdefgh1!
+POSTGRES_DB_NAME=edfi_datamanagementservice
+POSTGRES_PORT=5435
+RELATIONAL_E2E_DATABASE_NAME=edfi_datamanagementservice_template_relational
+
+# ----------------
+# Name of the database template package for setting up initial data
+# ----------------
+DATABASE_TEMPLATE_PACKAGE=EdFi.Dms.Smoke.Template.PostgreSql.5.2.0
+DMS_IMAGE_TAG=pre
+
+# -----
+# Kafka
+# -----
+
+# Variables for Kafka UI
+KAFKA_PORT=9092
+KAFKA_UI_PORT=8088
+
+# Variables for Kafka connect
+CONNECT_SOURCE_PORT=8083
+CONNECT_SINK_PORT=8085
+
+# ---
+# Identity Provider Configuration
+# ---
+KEYCLOAK_OAUTH_TOKEN_ENDPOINT=http://dms-keycloak:8080/realms/edfi/protocol/openid-connect/token
+KEYCLOAK_DMS_JWT_AUTHORITY=http://dms-keycloak:8080/realms/edfi
+KEYCLOAK_DMS_JWT_METADATA_ADDRESS=http://dms-keycloak:8080/realms/edfi/.well-known/openid-configuration
+
+SELF_CONTAINED_OAUTH_TOKEN_ENDPOINT=http://dms-config-service:8081/connect/token
+SELF_CONTAINED_DMS_JWT_AUTHORITY=http://dms-config-service:8081
+SELF_CONTAINED_DMS_JWT_METADATA_ADDRESS=http://dms-config-service:8081/.well-known/openid-configuration
+
+# --------
+# Keycloak
+# --------
+
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=admin
+KEYCLOAK_PORT=8045
+
+DMS_DATASTORE_CACHE_EXPIRATION_SECONDS=600
+DMS_DATASTORE_CACHE_REFRESH_ENABLED=true
+# ---
+# DMS
+# ---
+DMS_HTTP_PORTS=8080
+OAUTH_TOKEN_ENDPOINT=http://dms-config-service:8081/connect/token
+NEED_DATABASE_SETUP=true
+USE_RELATIONAL_BACKEND=true
+DMS_DEPLOY_DATABASE_ON_STARTUP=false
+BYPASS_STRING_COERCION=false
+ALLOW_IDENTITY_UPDATE_OVERRIDES=
+MAXIMUM_PAGE_SIZE=500
+PATH_BASE=api
+USE_REVERSE_PROXY_HEADERS=false
+DMS_STARTUP_STATUS_FILE_PATH=/tmp/dms-startup-status.json
+USE_API_SCHEMA_PATH=true
+API_SCHEMA_PATH=/app/ApiSchema
+DMS_ENABLE_MANAGEMENT_ENDPOINTS=true
+DMS_ENABLE_CLAIMSET_RELOAD=true
+DOMAINS_EXCLUDED_FROM_OPEN_API=
+
+# JWT Authentication
+DMS_JWT_AUTHORITY=http://dms-config-service:8081
+DMS_JWT_AUDIENCE=account
+DMS_JWT_METADATA_ADDRESS=http://dms-config-service:8081/.well-known/openid-configuration
+DMS_JWT_REQUIRE_HTTPS_METADATA=false
+DMS_JWT_ROLE_CLAIM_TYPE=http://schemas.microsoft.com/ws/2008/06/identity/claims/role
+DMS_JWT_CLIENT_ROLE=dms-client
+DMS_JWT_CLOCK_SKEW_SECONDS=30
+DMS_JWT_REFRESH_INTERVAL_MINUTES=60
+DMS_JWT_AUTOMATIC_REFRESH_INTERVAL_HOURS=24
+
+# INFORMATION, WARNING
+LOG_LEVEL=DEBUG
+
+MASK_REQUEST_BODY_IN_LOGS=true
+CORRELATION_ID_HEADER=correlationid
+DMS_DATASTORE=postgresql
+DMS_QUERYHANDLER=postgresql
+
+DATABASE_CONNECTION_STRING=host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=${POSTGRES_DB_NAME};NoResetOnClose=true;
+# RepeatableRead, Snapshot
+DATABASE_ISOLATION_LEVEL=ReadCommitted
+
+# DATABASE_CONNECTION_STRING_ADMIN allows for alternate credentials with elevated permissions for creating database objects
+DATABASE_CONNECTION_STRING_ADMIN=host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=${POSTGRES_DB_NAME};NoResetOnClose=true;
+
+# Resilience parameters
+FAILURE_RATIO=0.01
+SAMPLING_DURATION_SECONDS=10
+MINIMUM_THROUGHPUT=2
+BREAK_DURATION_SECONDS=30
+
+# DMS connecting to Configuration Service
+CONFIG_SERVICE_URL=http://dms-config-service:8081
+CONFIG_SERVICE_CLIENT_ID=CMSReadOnlyAccess
+CONFIG_SERVICE_CLIENT_SECRET=ValidClientSecret1234567890!Abcd
+CONFIG_SERVICE_CLIENT_SCOPE=edfi_admin_api/readonly_access
+CACHE_EXPIRATION_MINUTES=10
+DMS_MULTI_TENANCY=false
+ROUTE_QUALIFIER_SEGMENTS=
+
+SCHEMA_PACKAGES='[
+  {
+    "version": "1.0.328",
+    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
+    "name": "EdFi.DataStandard52.ApiSchema"
+  },
+  {
+    "version": "1.0.328",
+    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
+    "name": "EdFi.TPDM.ApiSchema"
+  },
+  {
+    "version": "1.0.328",
+    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
+    "name": "EdFi.Sample.ApiSchema",
+    "extensionName": "Sample"
+  },
+  {
+    "version": "1.0.328",
+    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
+    "name": "EdFi.Homograph.ApiSchema",
+    "extensionName": "Homograph"
+  }
+]'
+
+# --------------
+# Config Service
+# --------------
+
+DMS_CONFIG_ASPNETCORE_HTTP_PORTS=8081
+DMS_CONFIG_DATASTORE=postgresql
+DMS_CONFIG_DATABASE_CONNECTION_STRING=host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=${POSTGRES_DB_NAME};NoResetOnClose=true;
+DMS_CONFIG_DATABASE_ENCRYPTION_KEY=secret!_32_chars_xxxxxxxxxxxxxx
+DMS_CONFIG_IDENTITY_ALLOW_REGISTRATION=true
+DMS_CONFIG_IDENTITY_SERVICE_ROLE=cms-client
+DMS_CONFIG_IDENTITY_CLIENT_ROLE=dms-client
+DMS_CONFIG_IDENTITY_AUTHORITY=${DMS_JWT_AUTHORITY}
+DMS_CONFIG_IDENTITY_AUDIENCE=${DMS_JWT_AUDIENCE}
+DMS_CONFIG_IDENTITY_CLIENT_ID=DmsConfigurationService
+DMS_CONFIG_IDENTITY_CLIENT_SECRET=ValidClientSecret1234567890!Abcd
+DMS_CONFIG_IDENTITY_CLIENT_SECRET_MINIMUM_LENGTH=32
+DMS_CONFIG_IDENTITY_CLIENT_SECRET_MAXIMUM_LENGTH=128
+DMS_CONFIG_IDENTITY_SCOPE=edfi_admin_api/full_access
+DMS_CONFIG_IDENTITY_REQUIRE_HTTPS=false
+DMS_CONFIG_IDENTITY_ROLE_CLAIM_TYPE=${DMS_JWT_ROLE_CLAIM_TYPE}
+DMS_CONFIG_LOG_LEVEL=Information
+DMS_CONFIG_DEPLOY_DATABASE=true
+DMS_CONFIG_PATH_BASE=config
+DMS_CONFIG_USE_REVERSE_PROXY_HEADERS=false
+DMS_CONFIG_TOKEN_TIMEOUT_SECONDS=30
+DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING=true
+DMS_CONFIG_CLAIMS_SOURCE=Hybrid
+DMS_CONFIG_CLAIMS_DIRECTORY=/app/additional-claims
+DMS_CONFIG_IDENTITY_ENCRYPTION_KEY=QWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXo0NTY3ODkwMTIz
+DMS_CONFIG_IDENTITY_HASHING_ITERATIONS=210000
+DMS_CONFIG_IDENTITY_PROVIDER=self-contained
+DMS_CONFIG_ENABLE_APPLICATION_RESET_ENDPOINT=true
+DMS_CONFIG_MULTI_TENANCY=false
+
+# --------------
+# DMS Swagger UI
+# --------------
+DMS_SWAGGER_UI_PORT=8082
+DMS_SWAGGER_UI_URL=http://localhost:${DMS_SWAGGER_UI_PORT}
+DMS_SWAGGER_UI_ENABLE_CUSTOM_DOMAINS=true

--- a/eng/docker-compose/.env.smoke.relational
+++ b/eng/docker-compose/.env.smoke.relational
@@ -125,25 +125,25 @@ ROUTE_QUALIFIER_SEGMENTS=
 
 SCHEMA_PACKAGES='[
   {
-    "version": "1.0.328",
+    "version": "1.0.332",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
     "name": "EdFi.DataStandard52.ApiSchema"
   },
   {
-    "version": "1.0.328",
+    "version": "1.0.332",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
-    "name": "EdFi.TPDM.ApiSchema"
+    "name": "EdFi.DataStandard52.TPDM.ApiSchema"
   },
   {
-    "version": "1.0.328",
+    "version": "1.0.332",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
-    "name": "EdFi.Sample.ApiSchema",
+    "name": "EdFi.DataStandard52.Sample.ApiSchema",
     "extensionName": "Sample"
   },
   {
-    "version": "1.0.328",
+    "version": "1.0.332",
     "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
-    "name": "EdFi.Homograph.ApiSchema",
+    "name": "EdFi.DataStandard52.Homograph.ApiSchema",
     "extensionName": "Homograph"
   }
 ]'

--- a/eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1
@@ -2043,7 +2043,7 @@ EdFi.BulkLoadClient.Console fake
         It "Get-BulkLoadClientPinnedVersion returns the exact repo pin" {
             # Tripwire: bumping the shared pin is a deliberate change that must be reviewed
             # against the BulkLoadClient XML flag preflight and invocation shape.
-            Get-BulkLoadClientPinnedVersion | Should -Be "7.3.20144"
+            Get-BulkLoadClientPinnedVersion | Should -Be "7.3.20162"
         }
 
         It "Get-BulkLoadClient resolves the shared pin when no version is supplied" {

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -54,7 +54,7 @@ if ($SdkPath) {
 # pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
 # DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
 # {SdkNamespace}.Client.HostConfiguration type.
-$path = Get-SmokeTestTool -PackageVersion '7.3.20173' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20178' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -45,7 +45,11 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.20162' -PreRelease
+# SmokeTest.Console 7.3.20162's SdkConfigurationFactory requires a
+# {SdkNamespace}.Client.HostConfiguration type that only SDKs from the newer
+# Ed-Fi SDK generator carry. The in-run DMS TestSdk (stock openapi-generator)
+# and the pinned EdFi.OdsApi.Sdk 7.3.10132 both lack it, so stay on 7.3.10008.
+$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -45,7 +45,7 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20162' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -45,11 +45,16 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-# SmokeTest.Console 7.3.20162's SdkConfigurationFactory requires a
-# {SdkNamespace}.Client.HostConfiguration type that only SDKs from the newer
-# Ed-Fi SDK generator carry. The in-run DMS TestSdk (stock openapi-generator)
-# and the pinned EdFi.OdsApi.Sdk 7.3.10132 both lack it, so stay on 7.3.10008.
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+# SmokeTest.Console reflects over the generated SDK to find each resource's verb
+# methods and builds its API client from the SDK's configuration type. This pin
+# carries the two behaviors the four-package smoke surface needs: it maps one
+# resource per POST method, so Homograph's homonym resources (Contact, School,
+# Staff, Student, StudentSchoolAssociation) that share a core OpenAPI tag and land
+# on the same generated Api class no longer collide; and it falls back to the
+# pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
+# DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
+# {SdkNamespace}.Client.HostConfiguration type.
+$path = Get-SmokeTestTool -PackageVersion '7.3.20173' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-DestructiveSdkTests.ps1
@@ -54,7 +54,7 @@ if ($SdkPath) {
 # pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
 # DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
 # {SdkNamespace}.Client.HostConfiguration type.
-$path = Get-SmokeTestTool -PackageVersion '7.3.20178' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20178'
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -54,7 +54,7 @@ if ($SdkPath) {
 # pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
 # DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
 # {SdkNamespace}.Client.HostConfiguration type.
-$path = Get-SmokeTestTool -PackageVersion '7.3.20173' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20178' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -45,7 +45,11 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.20162' -PreRelease
+# SmokeTest.Console 7.3.20162's SdkConfigurationFactory requires a
+# {SdkNamespace}.Client.HostConfiguration type that only SDKs from the newer
+# Ed-Fi SDK generator carry. The in-run DMS TestSdk (stock openapi-generator)
+# and the pinned EdFi.OdsApi.Sdk 7.3.10132 both lack it, so stay on 7.3.10008.
+$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -45,7 +45,7 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20162' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -45,11 +45,16 @@ if ($SdkPath) {
   $sdkDllPath = Get-ApiSdkDll
 }
 
-# SmokeTest.Console 7.3.20162's SdkConfigurationFactory requires a
-# {SdkNamespace}.Client.HostConfiguration type that only SDKs from the newer
-# Ed-Fi SDK generator carry. The in-run DMS TestSdk (stock openapi-generator)
-# and the pinned EdFi.OdsApi.Sdk 7.3.10132 both lack it, so stay on 7.3.10008.
-$path = Get-SmokeTestTool -PackageVersion '7.3.10008' -PreRelease
+# SmokeTest.Console reflects over the generated SDK to find each resource's verb
+# methods and builds its API client from the SDK's configuration type. This pin
+# carries the two behaviors the four-package smoke surface needs: it maps one
+# resource per POST method, so Homograph's homonym resources (Contact, School,
+# Staff, Student, StudentSchoolAssociation) that share a core OpenAPI tag and land
+# on the same generated Api class no longer collide; and it falls back to the
+# pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
+# DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
+# {SdkNamespace}.Client.HostConfiguration type.
+$path = Get-SmokeTestTool -PackageVersion '7.3.20173' -PreRelease
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
+++ b/eng/smoke_test/Invoke-NonDestructiveSdkTests.ps1
@@ -54,7 +54,7 @@ if ($SdkPath) {
 # pre-host-builder SDK configuration for stock openapi-generator SDKs (the in-run
 # DMS TestSdk and EdFi.OdsApi.Sdk 7.3.10132), which lack the newer
 # {SdkNamespace}.Client.HostConfiguration type.
-$path = Get-SmokeTestTool -PackageVersion '7.3.20178' -PreRelease
+$path = Get-SmokeTestTool -PackageVersion '7.3.20178'
 
 $parameters = @{
   BaseUrl = $BaseUrl

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -146,7 +146,7 @@ function Get-SmokeTestCredentials {
 
         # Step 4: Create vendor using Dms-Management module
         Write-Host "Creating vendor..."
-        $vendorId = Add-Vendor -CmsUrl $ConfigServiceUrl -Company $VendorName -ContactName "Smoke Test Contact" -ContactEmailAddress "smoketest@example.com" -NamespacePrefixes "uri://ed-fi.org,uri://gbisd.edu,uri://tpdm.ed-fi.org" -AccessToken $configToken -Tenant $Tenant
+        $vendorId = Add-Vendor -CmsUrl $ConfigServiceUrl -Company $VendorName -ContactName "Smoke Test Contact" -ContactEmailAddress "smoketest@example.com" -NamespacePrefixes "uri://ed-fi.org,uri://gbisd.edu,uri://tpdm.ed-fi.org,uri://sample.ed-fi.org" -AccessToken $configToken -Tenant $Tenant
 
         Write-Host "Vendor created with ID: $vendorId"
 

--- a/eng/smoke_test/modules/SmokeTest.psm1
+++ b/eng/smoke_test/modules/SmokeTest.psm1
@@ -77,7 +77,8 @@ function Invoke-SmokeTestUtility {
     Write-Output $ToolPath $options
     $host.UI.RawUI.ForegroundColor = $previousForegroundColor
 
-    $path = (Join-Path -Path ($ToolPath).Trim() -ChildPath "tools/net8.0/any/EdFi.SmokeTest.Console.dll")
+    $path = (Join-Path -Path ($ToolPath).Trim() -ChildPath "tools/net*/any/EdFi.SmokeTest.Console.dll")
+    $path = Resolve-Path $path
     &dotnet $path $options
 }
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
@@ -9,7 +9,6 @@ Feature: The Discovery API provides information about the application version, s
                   """
                   {
                     "applicationName": "Ed-Fi API",
-                    "informationalVersion": "8.0.0",
                     "dataModels": [
                       {
                         "name": "Ed-Fi",

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -1261,9 +1261,15 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             expectedBody = ReplacePlaceholders(expectedBody, responseJson);
             JsonNode expectedBodyJson = JsonNode.Parse(expectedBody)!;
 
-            // Remove version as it varies between environments
+            // Remove version and the top-level informationalVersion as they vary by build:
+            // locally/CI-built images fall back to the Directory.Build.props value, while
+            // published images carry a MinVer-derived version baked in at build time. The
+            // schema-driven informationalVersion values nested under dataModels are stable and
+            // remain asserted.
             (responseJson as JsonObject)?.Remove("version");
             (expectedBodyJson as JsonObject)?.Remove("version");
+            (responseJson as JsonObject)?.Remove("informationalVersion");
+            (expectedBodyJson as JsonObject)?.Remove("informationalVersion");
 
             // Normalize OAuth URLs - accept both internal Docker and external localhost URLs
             NormalizeOAuthUrl(responseJson);


### PR DESCRIPTION
## Summary

Restores Sample and Homograph generated-SDK smoke endpoint sweep coverage for the relational scheduled smoke path.

- Adds a smoke-only four-package relational environment (`DS52 + TPDM + Sample + Homograph`).
- Points the scheduled smoke workflow at the smoke-only relational environment/template package.
- Keeps product/template publication guarded against accidentally publishing the smoke-only package.
- Adds the Sample namespace prefix to smoke credentials so the generated SDK sweep can authorize Sample endpoints.

## Base / dependency

Rebased onto `main` (`b9934026`). The now-merged DMS-1212 (#1007) and DMS-1213 (#1008) commits have been dropped from the stack; only the unmerged DMS-1159 smoke-test stack (15 commits) remains beneath the 6 DMS-1210 commits, because DMS-1210 edits workflow/env files introduced by that stack. The diff vs `main` is the pure smoke/template/workflow surface plus the DMS-1159 relational write-flattener fix. Rebase again once the DMS-1159 stack lands if a mainline-only diff is required.

## Test Plan

- Not rerun locally during the rebase/PR retarget.
- Existing branch workflow history includes `scheduled-smoke-test.yml` validation on `DMS-1210` before this rebase; PR CI should now run against `main` with DMS-1209 included.