### PR TITLE
[DMS-1213] Enable cascading-updates E2E scenario on the relational backend

### DIFF
--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/UpdateResourcesValidation.feature
@@ -915,7 +915,8 @@ Feature: Resources "Update" Operation validations
                   }
                   """
 
-        @API-256
+        @API-256 @relational-backend
+        @relational-ci-shard-1
         Scenario: 22 Verify cascading updates on role named references
             Given the system has these "schools"
                   | schoolId | nameOfInstitution | gradeLevels                                                                      | educationOrganizationCategories                                                                                        |


### PR DESCRIPTION
## Summary

Enables one previously-excluded E2E scenario on the relational backend now that DMS-1213 (PR #1008, merged as `b9934026`) fixed date identity fields inside reference objects.

**Change (single `.feature` tag edit):** add `@relational-backend` and `@relational-ci-shard-1` to `UpdateResourcesValidation` **Scenario 22 — "Verify cascading updates on role named references"**. All sibling relational scenarios in this feature are on shard 1, and the PR CI filter requires both `@relational-backend` AND `@relational-ci-shard-N`.

## Why this scenario

Its GET/response-body assertions include **date identity fields inside reference objects**:
- `studentSectionAssociationReference.beginDate` = `"2025-01-01"`
- `grades[].gradeReference.beginDate` = `"2025-01-01"`

Before DMS-1213 the relational backend reconstituted these as date-times (`"2025-01-01T00:00:00Z"`), so the body match failed and the scenario was kept off the relational backend. A repo-wide search for bare-date values inside `*Reference` objects in expected response bodies found this as the **only** such candidate (the other hit was a POST request body in an already-tagged scenario).

## What this PR verifies

The date-rendering blocker is removed; this PR's CI run confirms whether the scenario passes end-to-end. Note it **also** exercises cascading identity updates on role-named references — an independent relational capability. If CI fails on the cascade rather than the date rendering, the tag should be reverted.

## Notes

- `.feature` tag only — no production code change. Reqnroll regenerates the gitignored `.feature.cs` from the `.feature` at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)