### PR TITLE
[DMS-1156] Add package-backed standard schema selection

### DIFF
--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -131,8 +131,10 @@ jobs:
           DMS_BOOTSTRAP_RUN_PACKAGE_TESTS: "true"
         run: |
           $paths = @(
+            "eng/docker-compose/tests/BootstrapPackageResolver.Tests.ps1",
             "eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1",
             "eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1",
+            "eng/docker-compose/tests/BootstrapStandardSchemaSelection.Tests.ps1",
             "eng/docker-compose/tests/BootstrapClaimsGate.Tests.ps1",
             "eng/docker-compose/tests/BootstrapEntryPointWorkflow.Tests.ps1",
             "eng/docker-compose/tests/SchemaPackageUtility.Tests.ps1",

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -165,41 +165,20 @@ image from source code.
 ./start-local-dms.ps1 -r
 ```
 
-By default, Data Standard 5.2 core model and TPDM model are included. You can
-include custom extensions in your deployment by configuring the SCHEMA_PACKAGES,
-USE_API_SCHEMA_PATH and API_SCHEMA_PATH environment variables.
+## Schema Selection
 
-> [!NOTE]
-> To add custom extensions: In your `.env` file, set
-> `USE_API_SCHEMA_PATH` to `true` and specify `API_SCHEMA_PATH` as the path where
-> schema files will be downloaded. Then, add or update the `SCHEMA_PACKAGES`
-> variable to include the core package and any required extension packages.
+DMS supports two modes for staging the ApiSchema bootstrap workspace. Both modes produce the
+same normalized `.bootstrap/ApiSchema/` workspace that downstream phases consume.
 
-```env
- USE_API_SCHEMA_PATH=true
- API_SCHEMA_PATH=/app/ApiSchema
- SCHEMA_PACKAGES='[
-  {
-    "version": "1.0.332",
-    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
-    "name": "EdFi.DataStandard52.ApiSchema"
-  },
-  {
-    "version": "1.0.332",
-    "feedUrl": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json",
-    "name": "EdFi.DataStandard52.Sample.ApiSchema",
-    "extensionName": "Sample"
-  }
-]'
-```
+### Standard mode (package-backed)
 
-For bootstrap-managed schema and extension security metadata, stage the inputs
-before starting Docker:
+Standard mode resolves the DS-qualified asset-only core ApiSchema NuGet package from the Ed-Fi
+package feed and stages it into the bootstrap workspace. This is the recommended path for most
+developers. It is package-backed core-only; extension or custom schema sets use Expert mode below.
 
-> **Requirement — `dms-schema` tool:** `prepare-dms-schema.ps1` needs the
-> in-repo `dms-schema` CLI published as a native executable. Build it once
-> before running the prepare command (the publish step is safe to re-run after
-> branch switches).
+> **Requirement — `dms-schema` tool:** `prepare-dms-schema.ps1` needs the in-repo `dms-schema`
+> CLI published as a native executable. Build it once before running the prepare command (the
+> publish step is safe to re-run after branch switches).
 
 ```pwsh
 # 1. Publish the dms-schema tool (required on a clean checkout)
@@ -209,9 +188,51 @@ dotnet publish $schemaToolProject -c Release -p:UseAppHost=true -o $schemaToolOu
 
 # 2. Point to the platform-appropriate executable
 $schemaToolExe = if ($IsWindows) { "$schemaToolOutput/dms-schema.exe" } else { "$schemaToolOutput/dms-schema" }
+```
 
-# 3. Stage schema and claims, then run the bootstrap wrapper
-#    (sequences infrastructure -> configure -> provision -> DMS over the staged workspace)
+Standard mode (omit `-ApiSchemaPath`) resolves and stages the core Data Standard ApiSchema package
+only. There is no `-Extensions` parameter.
+
+```pwsh
+./prepare-dms-schema.ps1 -SchemaToolPath $schemaToolExe
+./prepare-dms-claims.ps1
+./bootstrap-local-dms.ps1
+```
+
+After staging, run the `bootstrap-local-dms.ps1` wrapper (which sequences
+infrastructure → configure → provision → DMS over the staged workspace), not bare
+`start-local-dms.ps1` — see the note under Expert mode below for why a bare start leaves
+the stack unconfigured.
+
+To bootstrap an **extension-containing** schema set, use Expert mode (`-ApiSchemaPath`) below; it
+stages core plus any extensions present in the supplied directory. `prepare-dms-claims.ps1`
+auto-stages bootstrap-managed claim fragments (Sample, Homograph) for extensions present in that
+schema set; extensions that require caller-supplied claim fragments (e.g. TPDM) need an additional
+`-ClaimsDirectoryPath` argument to `prepare-dms-claims.ps1`.
+
+**Wrapper shorthand:** `bootstrap-local-dms.ps1` stages core-only standard mode in-line (when no
+workspace is staged) and then starts the stack. It auto-discovers the `dms-schema` executable
+published to `.bootstrap/tools/dms-schema` in step 1 (or set `DMS_SCHEMA_TOOL_PATH` to point
+elsewhere).
+
+```pwsh
+./bootstrap-local-dms.ps1
+```
+
+> [!NOTE]
+> Legacy `SCHEMA_PACKAGES` entries (unqualified IDs such as `EdFi.Sample.ApiSchema` at
+> `1.0.328`) may still appear in `.env*` files during the migration. Those entries are NOT the
+> standard-mode selector. Standard mode resolves the DS-qualified asset-only core package
+> (`EdFi.DataStandard52.ApiSchema` at `1.0.329`) and DMS consumes the staged `.bootstrap/ApiSchema`
+> workspace — `SCHEMA_PACKAGES` is ignored by standard mode.
+
+### Expert mode (filesystem)
+
+Expert mode stages ApiSchema files directly from a local directory. Use this path for custom
+or in-repo schema directories that are not published as NuGet packages.
+
+```pwsh
+# Stage schema and claims, then start DMS
 ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
 ./prepare-dms-claims.ps1 -ClaimsDirectoryPath <directory-with-tpdm-claimset-fragment>
 ./bootstrap-local-dms.ps1
@@ -230,6 +251,9 @@ manually:
 ./provision-dms-schema.ps1
 ./start-local-dms.ps1 -DmsOnly
 ```
+
+Expert mode (`-ApiSchemaPath`) and standard mode (omit `-ApiSchemaPath`) are the two schema-selection
+paths; there is no `-Extensions` parameter.
 
 `prepare-dms-claims.ps1` stages `*-claimset.json` fragments into
 `.bootstrap/claims`. When a bootstrap manifest is present, startup activates

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -46,10 +46,11 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-local-dms.ps1`).
 
-    Precondition: the wrapper requires staged bootstrap schema and claims workspaces. Run
-    `prepare-dms-schema.ps1` and `prepare-dms-claims.ps1` for the current checkout first;
-    the wrapper fails fast when the staged workspace is absent rather than starting an
-    unprovisionable stack.
+    Staging: no manual prepare step is required for the standard happy path. When no workspace is
+    staged the wrapper stages core-only standard mode; an already-staged workspace (e.g. a manual
+    expert `-ApiSchemaPath` flow) is used as-is. There is no `-Extensions` parameter; extension or
+    custom schema sets are staged via expert `-ApiSchemaPath` before invoking the wrapper. All
+    staging is delegated to `prepare-dms-schema.ps1` / `prepare-dms-claims.ps1`.
 
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after DMS startup completes. When
@@ -107,20 +108,33 @@
     is also requested, forwarded to `load-dms-seed-data.ps1` so seeds hit the IDE-hosted DMS.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
-    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1
-    Common happy path: stage the schema and claims workspaces, then start the local stack and
-    provision schemas, no seed loading. The wrapper requires a staged bootstrap workspace and
-    fails fast if the prepare commands have not been run for the current checkout.
+    Standard mode, core only. Stages the core ApiSchema package and claims in-line (when no
+    workspace is staged), then starts the stack. No manual prepare step and no seed loading.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-schema.ps1 -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-claims.ps1
+    pwsh ./bootstrap-local-dms.ps1
+    Standard mode, core only - manual prepare flow. Stage the core schema and claims
+    workspaces first, then start the local stack. Use this flow when you want to inspect
+    or validate the staged workspace before starting infrastructure.
+
+.EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-claims.ps1
+    pwsh ./bootstrap-local-dms.ps1
+    Expert mode (filesystem). Stage the in-repo ApiSchema directory (which includes TPDM
+    and other extensions) and claims workspaces manually, then start the local stack. The
+    in-repo directory requires -ClaimsDirectoryPath with a TPDM claim fragment unless
+    only core, Sample, and Homograph extensions are staged.
+
+.EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
-    Prepare an ApiSchemaPath-mode bootstrap manifest, then start the stack and load
-    developer-supplied XML interchange files. Package-backed -SeedTemplate Minimal/Populated
-    requires Story 06 schema selection and is not yet runnable from a fresh workspace.
+    Expert mode with seed loading. Prepare the bootstrap manifest, then start the stack and
+    load developer-supplied XML interchange files.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema

--- a/eng/docker-compose/bootstrap-manifest.psm1
+++ b/eng/docker-compose/bootstrap-manifest.psm1
@@ -445,9 +445,13 @@ function Set-BootstrapStartupEnvironment {
     if ($schemaSection -isnot [System.Collections.IDictionary]) {
         throw "Bootstrap manifest schema section must be a JSON object."
     }
+    # Both package-backed standard mode (prepare-dms-schema.ps1 default, selectionMode "Standard")
+    # and expert filesystem mode (-ApiSchemaPath, selectionMode "ApiSchemaPath") stage the same
+    # normalized .bootstrap/ApiSchema/ workspace, and startup validation below is identical for both.
+    # Rejecting "Standard" here broke the standard-mode/wrapper production path at startup.
     $schemaSelectionMode = $schemaSection["selectionMode"]
-    if ($schemaSelectionMode -ne "ApiSchemaPath") {
-        throw "Bootstrap schema selectionMode '$(Format-LogSafeText $schemaSelectionMode)' is not supported in Story 00; only 'ApiSchemaPath' is accepted."
+    if ($schemaSelectionMode -notin @("Standard", "ApiSchemaPath")) {
+        throw "Bootstrap manifest 'schema.selectionMode' must be Standard or ApiSchemaPath, got: $(Format-LogSafeText $schemaSelectionMode)"
     }
     if (-not $schemaSection.ContainsKey("apiSchemaManifestPath") -or [string]::IsNullOrWhiteSpace($schemaSection["apiSchemaManifestPath"])) {
         throw "Bootstrap manifest field 'schema.apiSchemaManifestPath' must not be empty."

--- a/eng/docker-compose/bootstrap-package-resolver.psm1
+++ b/eng/docker-compose/bootstrap-package-resolver.psm1
@@ -1,0 +1,766 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Set-StrictMode -Version Latest
+
+# Guarded fallback so the module stays usable without bootstrap-manifest.psm1 on the path
+# (e.g. when the module is dot-sourced in isolation or imported by name).
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue))
+{
+    function script:Format-LogSafeText
+    {
+        <#
+        .SYNOPSIS
+        Sanitizes a value for safe inclusion in log output (whitelist of letters, digits, and safe punctuation).
+        #>
+        param(
+            $Value
+        )
+
+        if ($null -eq $Value)
+        {
+            return ""
+        }
+
+        $text = [string]$Value
+        if ([string]::IsNullOrEmpty($text))
+        {
+            return ""
+        }
+
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray())
+        {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/")
+            {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
+function Resolve-NupkgFileName
+{
+    <#
+    .SYNOPSIS
+    Returns the expected lowercased NuGet flat-container filename for a given package id and version.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Version
+    )
+
+    return "$($PackageId.ToLowerInvariant()).$($Version.ToLowerInvariant()).nupkg"
+}
+
+function Expand-Nupkg
+{
+    <#
+    .SYNOPSIS
+    Extracts a .nupkg (zip) file into a target directory using System.IO.Compression.ZipFile.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; callers do not expose -WhatIf end to end.')]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $NupkgPath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DestinationDirectory
+    )
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+
+    try
+    {
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($NupkgPath, $DestinationDirectory)
+    }
+    catch
+    {
+        throw "Failed to extract package '$(Format-LogSafeText $NupkgPath)' into '$(Format-LogSafeText $DestinationDirectory)': $(Format-LogSafeText ($_.Exception.Message))"
+    }
+}
+
+function Resolve-LocalFolderPackage
+{
+    <#
+    .SYNOPSIS
+    Locates and returns the absolute path to a .nupkg in a local folder feed, matching by
+    package id and version (case-insensitively, using NuGet's lowercased id.version.nupkg naming).
+    Throws a diagnostics error when the package or version is not found.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $FolderPath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Version
+    )
+
+    if (-not (Test-Path -LiteralPath $FolderPath -PathType Container))
+    {
+        throw "Local feed folder not found: $(Format-LogSafeText $FolderPath)"
+    }
+
+    $expectedFileName = Resolve-NupkgFileName -PackageId $PackageId -Version $Version
+
+    # Scan all .nupkg files in the folder (case-insensitive filename match).
+    $candidates = @(
+        Get-ChildItem -LiteralPath $FolderPath -Filter "*.nupkg" -File |
+            Where-Object { $_.Name.Equals($expectedFileName, [System.StringComparison]::OrdinalIgnoreCase) }
+    )
+
+    if ($candidates.Count -eq 0)
+    {
+        # Distinguish between "package not found at all" and "package found but wrong version".
+        $idLower = $PackageId.ToLowerInvariant()
+        $anyVersion = @(
+            Get-ChildItem -LiteralPath $FolderPath -Filter "*.nupkg" -File |
+                Where-Object { $_.Name.StartsWith("$idLower.", [System.StringComparison]::OrdinalIgnoreCase) }
+        )
+
+        if ($anyVersion.Count -eq 0)
+        {
+            throw "Package '$(Format-LogSafeText $PackageId)' was not found in local feed folder '$(Format-LogSafeText $FolderPath)'."
+        }
+
+        throw "Package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' was not found in local feed folder '$(Format-LogSafeText $FolderPath)'. Available versions may differ - pinned version resolution never falls back to latest."
+    }
+
+    return $candidates[0].FullName
+}
+
+function Resolve-HttpV3Package
+{
+    <#
+    .SYNOPSIS
+    Downloads a .nupkg from an HTTP NuGet v3 feed (service index URL), following 303 redirects,
+    and saves it to a temporary file. Returns the path to the downloaded .nupkg.
+    Throws diagnostics errors on unreachable feed, missing package id, or missing version.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal bootstrap helper; callers do not expose -WhatIf end to end.')]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ServiceIndexUrl,
+
+        [Parameter(Mandatory)]
+        [string]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Version,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DownloadDirectory
+    )
+
+    # Fetch the service index JSON.
+    try
+    {
+        $serviceIndexResponse = Invoke-WebRequest -Uri $ServiceIndexUrl -UseBasicParsing -ErrorAction Stop
+    }
+    catch
+    {
+        throw "NuGet feed service index is unreachable at '$(Format-LogSafeText $ServiceIndexUrl)': $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    try
+    {
+        $serviceIndex = $serviceIndexResponse.Content | ConvertFrom-Json -AsHashtable
+    }
+    catch
+    {
+        throw "NuGet feed service index at '$(Format-LogSafeText $ServiceIndexUrl)' returned malformed JSON: $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    # Locate the PackageBaseAddress/3.0.0 resource (flat container base). Member access goes through
+    # hashtable ContainsKey so a service index missing 'resources'/'@type'/'@id' fails with the
+    # diagnostic below rather than a raw StrictMode property-not-found error.
+    $flatContainerBase = $null
+    if ($serviceIndex -is [System.Collections.IDictionary] -and $serviceIndex.ContainsKey("resources"))
+    {
+        foreach ($resource in @($serviceIndex["resources"]))
+        {
+            if ($resource -is [System.Collections.IDictionary] -and
+                $resource.ContainsKey("@type") -and
+                $resource["@type"] -eq "PackageBaseAddress/3.0.0" -and
+                $resource.ContainsKey("@id") -and
+                -not [string]::IsNullOrWhiteSpace([string]$resource["@id"]))
+            {
+                $flatContainerBase = ([string]$resource["@id"]).TrimEnd("/")
+                break
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($flatContainerBase))
+    {
+        throw "NuGet service index at '$(Format-LogSafeText $ServiceIndexUrl)' does not advertise a PackageBaseAddress/3.0.0 resource."
+    }
+
+    $idLower = $PackageId.ToLowerInvariant()
+    $versionLower = $Version.ToLowerInvariant()
+    $nupkgFileName = Resolve-NupkgFileName -PackageId $PackageId -Version $Version
+    $nupkgUrl = "$flatContainerBase/$idLower/$versionLower/$nupkgFileName"
+
+    # Verify the package exists by checking the version index first.
+    $versionIndexUrl = "$flatContainerBase/$idLower/index.json"
+    try
+    {
+        $versionIndexResponse = Invoke-WebRequest -Uri $versionIndexUrl -UseBasicParsing -ErrorAction Stop
+    }
+    catch
+    {
+        throw "Package '$(Format-LogSafeText $PackageId)' was not found on the NuGet feed at '$(Format-LogSafeText $ServiceIndexUrl)'. The version index request failed: $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    try
+    {
+        $versionIndex = $versionIndexResponse.Content | ConvertFrom-Json -AsHashtable
+    }
+    catch
+    {
+        throw "Package '$(Format-LogSafeText $PackageId)' version index at '$(Format-LogSafeText $versionIndexUrl)' returned malformed JSON: $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    $availableVersions = if ($versionIndex -is [System.Collections.IDictionary] -and $versionIndex.ContainsKey("versions"))
+    {
+        @($versionIndex["versions"])
+    }
+    else
+    {
+        @()
+    }
+    $versionFound = $availableVersions | Where-Object { $_.Equals($Version, [System.StringComparison]::OrdinalIgnoreCase) }
+
+    if ($null -eq $versionFound -or @($versionFound).Count -eq 0)
+    {
+        throw "Package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' was not found on the NuGet feed. Pinned version resolution never falls back to latest."
+    }
+
+    # Download the .nupkg, following redirects (Invoke-WebRequest follows by default).
+    $downloadPath = Join-Path $DownloadDirectory $nupkgFileName
+
+    try
+    {
+        Invoke-WebRequest -Uri $nupkgUrl -OutFile $downloadPath -UseBasicParsing -ErrorAction Stop
+    }
+    catch
+    {
+        throw "Failed to download package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' from '$(Format-LogSafeText $nupkgUrl)': $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    return $downloadPath
+}
+
+function Resolve-StandardSchemaPackage
+{
+    <#
+    .SYNOPSIS
+    Resolves and extracts an asset-only ApiSchema NuGet package.
+
+    .DESCRIPTION
+    Supports local folder feeds and HTTP NuGet v3 feeds. The package is extracted into a
+    package-specific directory under DestinationRoot, then validated for the required
+    contentFiles/any/any/ApiSchema contract.
+
+    .PARAMETER FeedUrl
+    NuGet v3 service index URL, local filesystem path, or file:// URL.
+
+    .PARAMETER PackageId
+    NuGet package ID to resolve.
+
+    .PARAMETER Version
+    Pinned package version. Resolution never falls back to latest.
+
+    .PARAMETER DestinationRoot
+    Root directory for package-specific extraction directories.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $FeedUrl,
+
+        [Parameter(Mandatory)]
+        [string]
+        $PackageId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Version,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DestinationRoot
+    )
+
+    # Determine feed mode.
+    $isLocalFeed = $false
+    $localFolderPath = $null
+
+    if ($FeedUrl.StartsWith("file://", [System.StringComparison]::OrdinalIgnoreCase))
+    {
+        # file:// URL - convert to a local path.
+        try
+        {
+            $uri = [System.Uri]::new($FeedUrl)
+            $localFolderPath = $uri.LocalPath
+        }
+        catch
+        {
+            throw "FeedUrl '$(Format-LogSafeText $FeedUrl)' is not a valid file:// URL: $(Format-LogSafeText ($_.Exception.Message))"
+        }
+
+        $isLocalFeed = $true
+    }
+    elseif (Test-Path -LiteralPath $FeedUrl -PathType Container)
+    {
+        # Plain directory path.
+        $localFolderPath = $FeedUrl
+        $isLocalFeed = $true
+    }
+
+    # Create the package-specific isolation directory under DestinationRoot.
+    $isolationDir = Join-Path $DestinationRoot $PackageId
+    New-Item -ItemType Directory -Path $isolationDir -Force | Out-Null
+
+    if ($isLocalFeed)
+    {
+        $nupkgPath = Resolve-LocalFolderPackage `
+            -FolderPath $localFolderPath `
+            -PackageId $PackageId `
+            -Version $Version
+
+        Write-Verbose "Resolved package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' from local feed: $(Format-LogSafeText $nupkgPath)"
+    }
+    else
+    {
+        # HTTP v3 feed: download to the isolation dir then extract in place.
+        $nupkgPath = Resolve-HttpV3Package `
+            -ServiceIndexUrl $FeedUrl `
+            -PackageId $PackageId `
+            -Version $Version `
+            -DownloadDirectory $isolationDir
+
+        Write-Verbose "Downloaded package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' from HTTP feed."
+    }
+
+    # Extract the .nupkg (a zip) into the isolation directory.
+    Expand-Nupkg -NupkgPath $nupkgPath -DestinationDirectory $isolationDir
+
+    # Only the HTTP path downloads the .nupkg into the isolation dir; remove that download artifact
+    # after extraction. Local-feed packages are read in place from the feed folder (outside the
+    # isolation dir), so there is nothing to clean up for them.
+    if (-not $isLocalFeed -and (Test-Path -LiteralPath $nupkgPath -PathType Leaf))
+    {
+        Remove-Item -LiteralPath $nupkgPath -Force -ErrorAction SilentlyContinue
+    }
+
+    # Verify the asset-only contract path exists.
+    $apiSchemaDir = Join-Path $isolationDir "contentFiles/any/any/ApiSchema"
+    if (-not (Test-Path -LiteralPath $apiSchemaDir -PathType Container))
+    {
+        throw "Package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' was extracted to '$(Format-LogSafeText $isolationDir)' but the expected asset-only contract path 'contentFiles/any/any/ApiSchema/' was not found. Verify the package is an asset-only ApiSchema NuGet package."
+    }
+
+    Write-Verbose "Resolved package '$(Format-LogSafeText $PackageId)' version '$(Format-LogSafeText $Version)' to '$(Format-LogSafeText $isolationDir)'"
+
+    return [pscustomobject]@{
+        PackageId           = $PackageId
+        Version             = $Version
+        ExtractionDirectory = $isolationDir
+        ApiSchemaDirectory  = $apiSchemaDir
+        PackageRoot         = $isolationDir
+    }
+}
+
+function Assert-SafeManifestRelativePath
+{
+    <#
+    .SYNOPSIS
+    Rejects a manifest-declared relative path that is rooted/absolute or contains a '..' segment,
+    which would let a package's declared asset escape the asset-only contract directory.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $RelativePath,
+
+        [Parameter(Mandatory)]
+        [string]
+        $FieldName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ExpectedPackageId
+    )
+
+    if ([System.IO.Path]::IsPathRooted($RelativePath))
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest '$FieldName' must be a relative path inside the package, but '$(Format-LogSafeText $RelativePath)' is rooted."
+    }
+
+    if (($RelativePath -split '[\\/]+') -contains "..")
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest '$FieldName' must not contain '..' path segments, but '$(Format-LogSafeText $RelativePath)' does. Asset-only payloads must stay within 'contentFiles/any/any/ApiSchema/'."
+    }
+}
+
+function Assert-AssetOnlyPackageContract
+{
+    <#
+    .SYNOPSIS
+    Validates an extracted asset-only ApiSchema NuGet package against the Story 05 contract.
+    Throws a clear, fail-fast message on any violation.
+
+    .DESCRIPTION
+    Validates:
+    - Required asset-only payload: contentFiles/any/any/ApiSchema/ must exist and contain ApiSchema.json.
+    - Exactly one schema JSON file at the contract path.
+    - Valid package-manifest.json with all required fields.
+    - No forbidden DLL/assembly shape entries (lib/, ref/, bin/, obj/, *.dll, *.cs).
+    - Identity match: manifest packageId must equal ExpectedPackageId (case-insensitive);
+      manifest isExtensionProject must equal ExpectedIsExtension.
+    - Manifest-declared static assets (discoverySpecPath, xsdDirectory) must exist on disk when non-null.
+    - No duplicate normalized relative paths within the package payload.
+
+    .PARAMETER ApiSchemaDirectory
+    Absolute path to the contentFiles/any/any/ApiSchema/ directory of the extracted package.
+
+    .PARAMETER PackageRoot
+    Absolute path to the package extraction root directory.
+
+    .PARAMETER ExpectedPackageId
+    The NuGet package ID that was requested (used for identity validation).
+
+    .PARAMETER ExpectedIsExtension
+    Whether the package is expected to be an extension package.
+
+    .OUTPUTS
+    PSCustomObject with validated identity:
+      - PackageId: manifest packageId
+      - ProjectName: manifest projectName
+      - ProjectEndpointName: manifest projectEndpointName
+      - IsExtensionProject: manifest isExtensionProject
+      - SchemaPath: absolute path to the schema JSON file
+      - DiscoverySpecPath: absolute path to discovery-spec.json, or $null
+      - XsdDirectory: absolute path to xsd directory, or $null
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ApiSchemaDirectory,
+
+        [Parameter(Mandatory)]
+        [string]
+        $PackageRoot,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ExpectedPackageId,
+
+        [Parameter(Mandatory)]
+        [bool]
+        $ExpectedIsExtension
+    )
+
+    # --- 1. Verify asset-only contract directory exists ---
+    if (-not (Test-Path -LiteralPath $ApiSchemaDirectory -PathType Container))
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': asset-only contract directory 'contentFiles/any/any/ApiSchema/' was not found at '$(Format-LogSafeText $ApiSchemaDirectory)'."
+    }
+
+    # --- 2. Check for forbidden DLL/assembly shape entries anywhere in the payload ---
+    # Forbidden assembly-shape directories (lib/, ref/, bin/, obj/) are rejected at any depth,
+    # not only as direct children of the package root: a nested segment such as
+    # contentFiles/any/any/ApiSchema/bin/ must also fail even when it carries no *.dll or *.cs.
+    $forbiddenDirNames = @("lib", "ref", "bin", "obj")
+    $forbiddenDir = Get-ChildItem -LiteralPath $PackageRoot -Recurse -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $forbiddenDirNames -contains $_.Name } |
+        Select-Object -First 1
+    if ($null -ne $forbiddenDir)
+    {
+        $forbiddenDirName = $forbiddenDir.Name.ToLowerInvariant()
+        $forbiddenDirPath = Format-LogSafeText ($forbiddenDir.FullName)
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': forbidden assembly-shape directory '$forbiddenDirName/' was found at '$forbiddenDirPath'. Asset-only packages must not contain lib/, ref/, bin/, or obj/ directories anywhere in the payload."
+    }
+
+    $dllFiles = @(Get-ChildItem -LiteralPath $PackageRoot -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Extension -ieq ".dll" -or $_.Extension -ieq ".cs" })
+    if ($dllFiles.Count -gt 0)
+    {
+        $firstForbidden = Format-LogSafeText ($dllFiles[0].FullName)
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': forbidden file type found: '$firstForbidden'. Asset-only packages must not contain *.dll or *.cs files."
+    }
+
+    # --- 3. Read and validate package-manifest.json ---
+    $manifestPath = Join-Path $ApiSchemaDirectory "package-manifest.json"
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf))
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': required file 'package-manifest.json' is missing from '$(Format-LogSafeText $ApiSchemaDirectory)'."
+    }
+
+    $manifestContent = Get-Content -LiteralPath $manifestPath -Raw -ErrorAction Stop
+    try
+    {
+        $manifest = $manifestContent | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' is not valid JSON: $(Format-LogSafeText ($_.Exception.Message))"
+    }
+
+    # Validate required fields (use Get-Member to handle StrictMode safely)
+    $requiredFields = @("version", "packageId", "projectName", "projectEndpointName", "isExtensionProject", "schemaPath")
+    foreach ($field in $requiredFields)
+    {
+        $propertyExists = $null -ne ($manifest | Get-Member -Name $field -MemberType NoteProperty)
+        if (-not $propertyExists)
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' is missing required field '$field'."
+        }
+        $value = $manifest.$field
+        # Reject JSON null as well as empty strings: a null value is not a [string], so checking only
+        # the empty-string case would let "<field>": null pass the guard and surface later as a raw
+        # null-reference error (e.g. packageId.Equals(...) or Join-Path on schemaPath) instead of this
+        # clear "missing required field" message.
+        if ($null -eq $value -or ($value -is [string] -and [string]::IsNullOrEmpty($value)))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' is missing required field '$field'."
+        }
+    }
+
+    # The required identity/path fields must be JSON strings. The presence loop above rejects missing,
+    # null, and empty-string values, but a non-string value (e.g. "packageId": 123 or "schemaPath": true)
+    # would otherwise pass and then fail with a non-contract error - Int32.Equals(string, StringComparison)
+    # at the identity check below, or [string]/Join-Path coercion on projectName/projectEndpointName/
+    # schemaPath here and in prepare-dms-schema.ps1. Reject it here with a clear contract message.
+    $requiredStringFields = @("packageId", "projectName", "projectEndpointName", "schemaPath")
+    foreach ($field in $requiredStringFields)
+    {
+        if ($manifest.$field -isnot [string])
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' field '$field' must be a JSON string, but found '$(Format-LogSafeText $manifest.$field)'."
+        }
+    }
+
+    # 'version' is the integer schema-version of the manifest format (currently 1). The required-fields
+    # loop above rejects only null and empty strings, so a value like "bad" or 1.5 would otherwise pass; require
+    # a real JSON integer equal to the supported version.
+    $supportedManifestVersion = 1
+    $manifestVersion = $manifest.version
+    $isIntegerVersion = ($manifestVersion -is [int]) -or ($manifestVersion -is [long]) -or ($manifestVersion -is [short]) -or ($manifestVersion -is [byte])
+    if (-not $isIntegerVersion)
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' field 'version' must be an integer manifest schema version, but found '$(Format-LogSafeText $manifestVersion)'."
+    }
+    if ($manifestVersion -ne $supportedManifestVersion)
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' field 'version' is '$manifestVersion' but only manifest schema version $supportedManifestVersion is supported."
+    }
+
+    # --- 4. Validate identity: packageId must match ExpectedPackageId (case-insensitive) ---
+    if (-not $manifest.packageId.Equals($ExpectedPackageId, [System.StringComparison]::OrdinalIgnoreCase))
+    {
+        throw "Package identity mismatch: manifest 'packageId' is '$(Format-LogSafeText $manifest.packageId)' but expected '$(Format-LogSafeText $ExpectedPackageId)'. The extracted package does not match the requested package ID."
+    }
+
+    # --- 5. Validate identity: isExtensionProject must match ExpectedIsExtension ---
+    # Require a real JSON boolean. A raw [bool] cast would coerce any non-empty string (including
+    # "false") to $true and $null to $false, letting a malformed manifest slip past this check.
+    if ($manifest.isExtensionProject -isnot [bool])
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' field 'isExtensionProject' must be a JSON boolean (true/false), but found '$(Format-LogSafeText $manifest.isExtensionProject)'."
+    }
+
+    $manifestIsExtension = $manifest.isExtensionProject
+    if ($manifestIsExtension -ne $ExpectedIsExtension)
+    {
+        $manifestFlag = if ($manifestIsExtension) { "true" } else { "false" }
+        $expectedFlag = if ($ExpectedIsExtension) { "true" } else { "false" }
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'isExtensionProject' is '$manifestFlag' but expected '$expectedFlag'. Verify the package is the correct type (core vs. extension)."
+    }
+
+    # --- 5b. Validate optional static-asset path fields are JSON strings when present ---
+    # discoverySpecPath / xsdDirectory are optional: omit the key or use JSON null. When present and
+    # non-null they must be JSON strings. A raw [string] cast (used below to resolve them) would coerce a
+    # number or boolean (e.g. discoverySpecPath: 123 or xsdDirectory: true) into a path that can match an
+    # on-disk file/directory, letting a malformed manifest pass; require the real JSON string type instead
+    # and fail fast before staging.
+    foreach ($optionalPathField in @("discoverySpecPath", "xsdDirectory"))
+    {
+        $optionalPathMember = $manifest | Get-Member -Name $optionalPathField -MemberType NoteProperty
+        if ($null -ne $optionalPathMember)
+        {
+            $optionalPathValue = $manifest.$optionalPathField
+            if ($null -ne $optionalPathValue -and $optionalPathValue -isnot [string])
+            {
+                throw "Package '$(Format-LogSafeText $ExpectedPackageId)': 'package-manifest.json' field '$optionalPathField' must be a JSON string (or null/omitted), but found '$(Format-LogSafeText $optionalPathValue)'."
+            }
+        }
+    }
+
+    # --- 6. Verify exactly one schema JSON file exists at the contract path ---
+    # Schema JSON files are all .json files at the root of ApiSchemaDirectory excluding
+    # package-manifest.json and the manifest-declared optional discoverySpecPath file.
+    $declaredDiscoverySpecFullPath = $null
+    $discoverySpecMember = $manifest | Get-Member -Name "discoverySpecPath" -MemberType NoteProperty
+    if ($null -ne $discoverySpecMember)
+    {
+        $discoverySpecValue = $manifest.discoverySpecPath
+        if ($null -ne $discoverySpecValue -and -not [string]::IsNullOrEmpty([string]$discoverySpecValue))
+        {
+            # Resolve to a full path so we only exclude the root JSON file that actually IS the
+            # discovery spec. Comparing bare file names would wrongly exclude an unrelated extra root
+            # JSON that happens to share a basename with a *nested* discoverySpecPath (e.g. root
+            # Other.json excluded by a declared nested/Other.json), letting a multi-schema package pass.
+            $declaredDiscoverySpecFullPath = [System.IO.Path]::GetFullPath((Join-Path $ApiSchemaDirectory ([string]$discoverySpecValue)))
+        }
+    }
+
+    $schemaJsonFiles = @(Get-ChildItem -LiteralPath $ApiSchemaDirectory -File -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.Extension -ieq ".json" -and
+            $_.Name -ine "package-manifest.json" -and
+            ($null -eq $declaredDiscoverySpecFullPath -or
+             -not [System.IO.Path]::GetFullPath($_.FullName).Equals($declaredDiscoverySpecFullPath, [System.StringComparison]::OrdinalIgnoreCase))
+        })
+
+    if ($schemaJsonFiles.Count -eq 0)
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': no schema JSON file found at the asset-only contract path '$(Format-LogSafeText $ApiSchemaDirectory)'. Expected exactly one schema JSON (e.g. ApiSchema.json)."
+    }
+
+    if ($schemaJsonFiles.Count -gt 1)
+    {
+        $fileList = ($schemaJsonFiles | ForEach-Object { Format-LogSafeText $_.Name }) -join ", "
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': multiple schema JSON files found at the asset-only contract path: $fileList. Expected exactly one schema JSON."
+    }
+
+    # --- 7. Verify manifest schemaPath exists and matches the single root schema JSON ---
+    Assert-SafeManifestRelativePath -RelativePath ([string]$manifest.schemaPath) -FieldName "schemaPath" -ExpectedPackageId $ExpectedPackageId
+    $schemaFilePath = Join-Path $ApiSchemaDirectory $manifest.schemaPath
+    if (-not (Test-Path -LiteralPath $schemaFilePath -PathType Leaf))
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'schemaPath' references '$(Format-LogSafeText $manifest.schemaPath)' but that file does not exist at '$(Format-LogSafeText $schemaFilePath)'."
+    }
+
+    $resolvedSchemaFilePath = [System.IO.Path]::GetFullPath($schemaFilePath)
+    $resolvedRootSchemaPath = [System.IO.Path]::GetFullPath($schemaJsonFiles[0].FullName)
+    if (-not $resolvedSchemaFilePath.Equals($resolvedRootSchemaPath, [System.StringComparison]::OrdinalIgnoreCase))
+    {
+        throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'schemaPath' must reference the single schema JSON at the asset-only contract root, but '$(Format-LogSafeText $manifest.schemaPath)' does not match the found root schema file '$(Format-LogSafeText $schemaJsonFiles[0].Name)'."
+    }
+
+    # --- 8. Verify optional manifest-declared static assets exist when non-null ---
+    # Access optional fields through Get-Member: a conforming manifest may omit these keys entirely,
+    # and a bare property access would throw under StrictMode.
+    # Absence of an optional static-content path is expressed ONLY by omitting the key or setting it
+    # to JSON null. A present-but-empty (or whitespace) string is a malformed declared path and must
+    # fail fast rather than be silently treated as absent.
+    $resolvedDiscoverySpecPath = $null
+    $discoverySpecMember = $manifest | Get-Member -Name "discoverySpecPath" -MemberType NoteProperty
+    if ($null -ne $discoverySpecMember -and $null -ne $manifest.discoverySpecPath)
+    {
+        $discoverySpecRaw = [string]$manifest.discoverySpecPath
+        if ([string]::IsNullOrWhiteSpace($discoverySpecRaw))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'discoverySpecPath' is present but empty. Omit the field or use JSON null to indicate no discovery spec."
+        }
+        Assert-SafeManifestRelativePath -RelativePath $discoverySpecRaw -FieldName "discoverySpecPath" -ExpectedPackageId $ExpectedPackageId
+        $resolvedDiscoverySpecPath = Join-Path $ApiSchemaDirectory $manifest.discoverySpecPath
+        if (-not (Test-Path -LiteralPath $resolvedDiscoverySpecPath -PathType Leaf))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'discoverySpecPath' references '$(Format-LogSafeText $manifest.discoverySpecPath)' but that file does not exist at '$(Format-LogSafeText $resolvedDiscoverySpecPath)'."
+        }
+
+        # A declared discoverySpecPath must carry content. A zero-byte file would finalize a workspace
+        # advertising a discovery spec it cannot actually serve, so a present-but-empty file fails fast.
+        # Optional discovery-spec content is expressed by omitting the field or setting it to null.
+        if ((Get-Item -LiteralPath $resolvedDiscoverySpecPath).Length -eq 0)
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'discoverySpecPath' references '$(Format-LogSafeText $manifest.discoverySpecPath)' but that file is empty at '$(Format-LogSafeText $resolvedDiscoverySpecPath)'. A declared discoverySpecPath must contain content; omit the field or use JSON null when the package has no discovery spec."
+        }
+    }
+
+    $resolvedXsdDirectory = $null
+    $xsdDirectoryMember = $manifest | Get-Member -Name "xsdDirectory" -MemberType NoteProperty
+    if ($null -ne $xsdDirectoryMember -and $null -ne $manifest.xsdDirectory)
+    {
+        $xsdDirectoryRaw = [string]$manifest.xsdDirectory
+        if ([string]::IsNullOrWhiteSpace($xsdDirectoryRaw))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'xsdDirectory' is present but empty. Omit the field or use JSON null to indicate no XSD directory."
+        }
+        Assert-SafeManifestRelativePath -RelativePath $xsdDirectoryRaw -FieldName "xsdDirectory" -ExpectedPackageId $ExpectedPackageId
+        $resolvedXsdDirectory = Join-Path $ApiSchemaDirectory $manifest.xsdDirectory
+        if (-not (Test-Path -LiteralPath $resolvedXsdDirectory -PathType Container))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'xsdDirectory' references '$(Format-LogSafeText $manifest.xsdDirectory)' but that directory does not exist at '$(Format-LogSafeText $resolvedXsdDirectory)'."
+        }
+
+        # A declared xsdDirectory must actually carry XSD content. prepare-dms-schema.ps1 records and
+        # stages XSD only when *.xsd files exist, so an empty (or .xsd-free) declared directory would
+        # silently finalize a workspace missing the advertised XSD content. Optional XSD content is
+        # expressed by omitting xsdDirectory or setting it to null; a present directory must be populated.
+        $declaredXsdFiles = @(Get-ChildItem -LiteralPath $resolvedXsdDirectory -File -Filter "*.xsd" -Recurse -ErrorAction SilentlyContinue)
+        if ($declaredXsdFiles.Count -eq 0)
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': manifest 'xsdDirectory' references '$(Format-LogSafeText $manifest.xsdDirectory)' but no .xsd files were found under '$(Format-LogSafeText $resolvedXsdDirectory)'. A declared xsdDirectory must contain XSD content; omit the field or use JSON null when the package has no XSD content."
+        }
+    }
+
+    # --- 9. Check for duplicate normalized relative paths in the package payload ---
+    $allFiles = @(Get-ChildItem -LiteralPath $PackageRoot -Recurse -File -ErrorAction SilentlyContinue)
+    $normalizedPaths = @{}
+    foreach ($file in $allFiles)
+    {
+        $relativePath = $file.FullName.Substring($PackageRoot.Length).TrimStart([System.IO.Path]::DirectorySeparatorChar, '/')
+        $normalizedRelative = $relativePath.Replace('\', '/').ToLowerInvariant()
+        if ($normalizedPaths.ContainsKey($normalizedRelative))
+        {
+            throw "Package '$(Format-LogSafeText $ExpectedPackageId)': duplicate normalized relative path detected: '$(Format-LogSafeText $normalizedRelative)'. Package payload must not contain duplicate paths (case-insensitive, path-separator normalized)."
+        }
+        $normalizedPaths[$normalizedRelative] = $true
+    }
+
+    # --- Return validated identity ---
+    return [pscustomobject]@{
+        PackageId            = $manifest.packageId
+        ProjectName          = $manifest.projectName
+        ProjectEndpointName  = $manifest.projectEndpointName
+        IsExtensionProject   = $manifestIsExtension
+        SchemaPath           = $schemaFilePath
+        DiscoverySpecPath    = $resolvedDiscoverySpecPath
+        XsdDirectory         = $resolvedXsdDirectory
+    }
+}
+
+Export-ModuleMember -Function Resolve-StandardSchemaPackage, Assert-AssetOnlyPackageContract

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -24,10 +24,11 @@
     The shared wrapper body lives in `bootstrap-wrapper.psm1`; this entry script only
     selects the target start script (`start-published-dms.ps1`).
 
-    Precondition: the wrapper requires staged bootstrap schema and claims workspaces. Run
-    `prepare-dms-schema.ps1` and `prepare-dms-claims.ps1` for the current checkout first;
-    the wrapper fails fast when the staged workspace is absent rather than starting an
-    unprovisionable stack.
+    Staging: no manual prepare step is required for the standard happy path. When no workspace is
+    staged the wrapper stages core-only standard mode; an already-staged workspace (e.g. a manual
+    expert `-ApiSchemaPath` flow) is used as-is. There is no `-Extensions` parameter; extension or
+    custom schema sets are staged via expert `-ApiSchemaPath` before invoking the wrapper. All
+    staging is delegated to `prepare-dms-schema.ps1` / `prepare-dms-claims.ps1`.
 
 .PARAMETER LoadSeedData
     When supplied, invokes `load-dms-seed-data.ps1` after `start-published-dms.ps1` completes.
@@ -71,20 +72,16 @@
     also passed to the seed phase via `-SchoolYear`.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
-    pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1
-    Common happy path: stage the schema and claims workspaces, then start the published stack
-    and provision schemas, no seed loading. The wrapper requires a staged bootstrap workspace
-    and fails fast if the prepare commands have not been run for the current checkout.
+    Standard mode, core only. Stages the core ApiSchema package and claims in-line (when no
+    workspace is staged), then starts the published stack and provisions schemas. No seed loading.
 
 .EXAMPLE
     pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
-    Prepare an ApiSchemaPath-mode bootstrap manifest, then start the stack and load
-    developer-supplied XML interchange files. Package-backed -SeedTemplate Minimal/Populated
-    requires Story 06 schema selection and is not yet runnable from a fresh workspace.
+    Expert mode with seed loading. Stage an extension-containing or custom schema set via
+    -ApiSchemaPath, then start the stack and load developer-supplied XML interchange files.
 #>
 [CmdletBinding()]
 param(

--- a/eng/docker-compose/bootstrap-schema-catalog.psm1
+++ b/eng/docker-compose/bootstrap-schema-catalog.psm1
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+Set-StrictMode -Version Latest
+
+# Guarded fallback so the module stays usable without bootstrap-manifest.psm1 on the path
+# (e.g. when the module is dot-sourced in isolation or imported by name).
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue))
+{
+    function script:Format-LogSafeText
+    {
+        <#
+        .SYNOPSIS
+        Sanitizes a value for safe inclusion in log output (whitelist of letters, digits, and safe punctuation).
+        #>
+        param(
+            $Value
+        )
+
+        if ($null -eq $Value)
+        {
+            return ""
+        }
+
+        $text = [string]$Value
+        if ([string]::IsNullOrEmpty($text))
+        {
+            return ""
+        }
+
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray())
+        {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/")
+            {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
+}
+
+$script:StandardFeedUrl = "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json"
+$script:StandardCorePackageId = "EdFi.DataStandard52.ApiSchema"
+$script:StandardCoreProjectName = "Ed-Fi"
+$script:StandardCoreEndpointName = "ed-fi"
+$script:StandardPackageVersion = "1.0.329"
+
+# Known extension claims metadata keyed by Title-cased project name (matching the projectName
+# field in bootstrap-api-schema-manifest.json, which sources its value from ApiSchema.json).
+#
+# NamespacePrefix is recorded ONLY for extensions whose resources carry a DISTINCT seed namespace,
+# which becomes an authorized vendor namespace on the SeedLoader credential. Per
+# 00-schema-and-security-selection.md, bootstrap records only known built-in prefixes and must NOT
+# infer them from schema content. Sample resources use uri://sample.ed-fi.org (SampleExtension.feature
+# authorizes Sample with "uri://ed-fi.org, uri://sample.ed-fi.org"), so its prefix is recorded.
+# Homograph resources use the core uri://ed-fi.org namespace (HomographExtension.feature authorizes
+# Homograph with "uri://ed-fi.org" only) and its claims use NoFurtherAuthorizationRequired, so
+# Homograph intentionally records NO distinct namespace prefix.
+$script:KnownExtensionClaimsMetadata = @{
+    "Sample" = @{
+        FragmentFileName = "004-sample-extension-claimset.json"
+        NamespacePrefix  = "uri://sample.ed-fi.org"
+    }
+    "Homograph" = @{
+        # No NamespacePrefix by design: Homograph resources use the core uri://ed-fi.org namespace
+        # (see the block comment above). Recording uri://homograph.ed-fi.org would authorize a
+        # namespace no Homograph resource uses and would violate the "must not infer prefixes" rule.
+        FragmentFileName = "005-homograph-extension-claimset.json"
+    }
+}
+
+function Get-StandardSchemaFeed {
+    <#
+    .SYNOPSIS
+    Returns the pinned default NuGet feed URL for Ed-Fi standard ApiSchema packages.
+    #>
+    return $script:StandardFeedUrl
+}
+
+function Get-StandardCorePackage {
+    <#
+    .SYNOPSIS
+    Returns the core ApiSchema package identity (id, version, and canonical project/endpoint
+    tokens) as a PSCustomObject. ProjectToken and EndpointToken are the projectName and
+    projectEndpointName the core package manifest must declare; consumers assert them so a
+    mislabeled core package fails fast.
+    #>
+    return [pscustomobject]@{
+        Id            = $script:StandardCorePackageId
+        Version       = $script:StandardPackageVersion
+        ProjectToken  = $script:StandardCoreProjectName
+        EndpointToken = $script:StandardCoreEndpointName
+    }
+}
+
+function Get-StandardKnownExtensionInfo {
+    <#
+    .SYNOPSIS
+    Returns bootstrap-managed claims metadata for extensions that ship one, or $null for
+    extensions that don't have known metadata.
+
+    .DESCRIPTION
+    Used by prepare-dms-claims.ps1 to auto-stage claim fragments for extensions present in a staged
+    schema set (notably expert -ApiSchemaPath schema sets that contain extensions). Known extensions
+    (Sample, Homograph) return a hashtable with FragmentFileName and optionally NamespacePrefix.
+    Extensions absent from the known map return $null - this is by design and does not indicate an
+    error; such an extension simply requires a caller-supplied ClaimsDirectoryPath. Note that
+    standard mode is package-backed core-only and does not select extensions; this lookup serves the
+    claims phase regardless of how the schema set was staged.
+
+    .PARAMETER ProjectName
+    The projectName as recorded in the ApiSchema manifest (e.g. "Sample", "Homograph", "TPDM").
+    Case-sensitive match against the known metadata map.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]
+        $ProjectName
+    )
+
+    if ($script:KnownExtensionClaimsMetadata.ContainsKey($ProjectName)) {
+        return $script:KnownExtensionClaimsMetadata[$ProjectName]
+    }
+
+    return $null
+}
+
+Export-ModuleMember -Function `
+    Get-StandardSchemaFeed, `
+    Get-StandardCorePackage, `
+    Get-StandardKnownExtensionInfo

--- a/eng/docker-compose/bootstrap-schema-tool.psm1
+++ b/eng/docker-compose/bootstrap-schema-tool.psm1
@@ -24,6 +24,18 @@ function Get-DotNetFrameworkVersion {
 
 function Get-DmsSchemaToolCandidateDirectory {
     $repoRoot = Get-BootstrapRepoRoot
+    $candidateDirectories = [System.Collections.ArrayList]::new()
+
+    # Documented publish location (README "Standard mode" / prepare-dms-schema.ps1 help):
+    # `dotnet publish ... -o .bootstrap/tools/dms-schema` drops the apphost executable directly in this
+    # flat directory. Probing it lets the documented wrapper shorthand
+    # (`bootstrap-local-dms.ps1` core-only standard staging) resolve the tool after the documented one-time
+    # publish step, without requiring -SchemaToolPath (which the wrapper does not forward) or DMS_SCHEMA_TOOL_PATH.
+    $publishedToolDirectory = Join-Path (Get-BootstrapRoot) "tools/dms-schema"
+    if (Test-Path -LiteralPath $publishedToolDirectory -PathType Container) {
+        $null = $candidateDirectories.Add($publishedToolDirectory)
+    }
+
     $toolBinRoot = Join-Path $repoRoot "src/dms/clis/EdFi.DataManagementService.SchemaTools/bin"
     $frameworkDirectories = [System.Collections.ArrayList]::new()
 
@@ -48,13 +60,18 @@ function Get-DmsSchemaToolCandidateDirectory {
         }
     }
 
-    return @(
+    $sortedBinDirectories = @(
         $frameworkDirectories |
             Sort-Object `
                 -Property @{ Expression = { $_.FrameworkVersion }; Descending = $true },
                     @{ Expression = { $_.ConfigurationPriority }; Ascending = $true } |
             ForEach-Object { $_.Directory }
     )
+    foreach ($binDirectory in $sortedBinDirectories) {
+        $null = $candidateDirectories.Add($binDirectory)
+    }
+
+    return @($candidateDirectories)
 }
 
 function Resolve-DmsSchemaTool {

--- a/eng/docker-compose/bootstrap-wrapper.psm1
+++ b/eng/docker-compose/bootstrap-wrapper.psm1
@@ -92,6 +92,55 @@ function Assert-WrapperStagedSchemaWorkspace {
     Resolve-BootstrapSchemaWorkspace | Out-Null
 }
 
+function Test-WrapperManifestClaimsStaged {
+    <#
+    .SYNOPSIS
+    Returns $true only when the on-disk bootstrap manifest already carries BOTH the claims and
+    seed sections, i.e. prepare-dms-claims.ps1 has completed for the staged workspace.
+
+    The wrapper uses this to detect a schema-only manifest — one written by prepare-dms-schema.ps1
+    without a following prepare-dms-claims.ps1 — so the staging phase can complete it before any
+    Docker/CMS side effects. Without this, the schema-only manifest passes Assert-WrapperStagedSchemaWorkspace
+    (which validates the schema workspace only) and infrastructure starts; start-local-dms.ps1 then
+    activates staged claims and runs the claims-ready gate, both of which require the claims/seed
+    sections and throw after the stack is already up.
+
+    Bare JSON parse keeps the wrapper independent of bootstrap-manifest.psm1 in sandboxed Pester
+    invocations (mirrors the ApiSchemaPath preflight in Invoke-BootstrapWrapper). Property presence
+    is tested via PSObject.Properties so the check is safe regardless of Set-StrictMode. A missing,
+    empty, malformed, or unreadable manifest is reported as "claims not staged" so the staging phase
+    runs prepare-dms-claims.ps1, which then surfaces the authoritative manifest error.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string]$ManifestPath
+    )
+
+    if (-not (Test-Path -LiteralPath $ManifestPath -PathType Leaf)) {
+        return $false
+    }
+
+    try {
+        $rawManifestContent = Get-Content -LiteralPath $ManifestPath -Raw -ErrorAction Stop
+        if ([string]::IsNullOrWhiteSpace($rawManifestContent)) {
+            return $false
+        }
+
+        $parsedManifest = $rawManifestContent | ConvertFrom-Json -ErrorAction Stop
+        if ($null -eq $parsedManifest) {
+            return $false
+        }
+
+        $claimsProperty = $parsedManifest.PSObject.Properties['claims']
+        $seedProperty = $parsedManifest.PSObject.Properties['seed']
+        return ($null -ne $claimsProperty -and $null -ne $claimsProperty.Value -and
+                $null -ne $seedProperty -and $null -ne $seedProperty.Value)
+    }
+    catch {
+        return $false
+    }
+}
+
 function Resolve-WrapperEnvironmentFilePath {
     <#
     .SYNOPSIS
@@ -291,43 +340,46 @@ function Invoke-BootstrapWrapper {
     $seedTemplateSupplied = $PSBoundParameters.ContainsKey('SeedTemplate') -and -not [string]::IsNullOrWhiteSpace($SeedTemplate)
     $seedDataPathSupplied = $PSBoundParameters.ContainsKey('SeedDataPath') -and -not [string]::IsNullOrWhiteSpace($SeedDataPath)
 
-    # Pre-start seed preflights: catch missing manifest, mutually-exclusive seed-source flags,
-    # and ApiSchemaPath combos here so a known-bad -LoadSeedData invocation doesn't first spin up
-    # Docker + CMS state. load-dms-seed-data.ps1's Read-SeedManifest / Assert-SeedSelectionInputs
-    # remain the authoritative validators; the checks below are a fail-fast convenience.
+    # Pre-start seed preflights: catch mutually-exclusive seed-source flags and ApiSchemaPath combos
+    # here so a known-bad -LoadSeedData invocation doesn't first spin up Docker + CMS state.
+    # load-dms-seed-data.ps1's Read-SeedManifest / Assert-SeedSelectionInputs remain the authoritative
+    # validators; the checks below are a fail-fast convenience.
     if ($LoadSeedData) {
-        $expectedManifest = Join-Path $PSScriptRoot ".bootstrap/bootstrap-manifest.json"
-        if (-not (Test-Path -LiteralPath $expectedManifest -PathType Leaf)) {
-            throw "Bootstrap manifest not found at $expectedManifest. Run prepare-dms-schema.ps1 to stage the manifest before invoking the wrapper with -LoadSeedData."
-        }
-
         if ($seedTemplateSupplied -and $seedDataPathSupplied) {
             throw "-SeedTemplate and -SeedDataPath are mutually exclusive. Provide at most one."
         }
 
-        # Bare JSON parse keeps the wrapper independent of bootstrap-manifest.psm1 in sandboxed
-        # Pester invocations. Malformed/empty manifests defer to load-dms-seed-data.ps1's
-        # Read-SeedManifest for the authoritative error rather than throwing here.
-        $manifestSelectionMode = $null
-        try {
-            $rawManifestContent = Get-Content -LiteralPath $expectedManifest -Raw -ErrorAction Stop
-            if (-not [string]::IsNullOrWhiteSpace($rawManifestContent)) {
-                $parsedManifest = $rawManifestContent | ConvertFrom-Json -ErrorAction Stop
-                if ($null -ne $parsedManifest -and $null -ne $parsedManifest.schema -and -not [string]::IsNullOrWhiteSpace([string]$parsedManifest.schema.selectionMode)) {
-                    $manifestSelectionMode = [string]$parsedManifest.schema.selectionMode
+        # The schema/claims staging phase below guarantees a Standard-mode manifest exists before any
+        # Docker or CMS state is created: when no workspace is staged it stages core-only standard mode,
+        # for which -SeedTemplate is valid, so there is nothing to pre-validate. Only when a manifest
+        # ALREADY exists (a manual/expert pre-stage flow) do the ApiSchemaPath seed-source rules apply;
+        # they are checked here so a known-bad -LoadSeedData invocation fails fast before the start phase.
+        $expectedManifest = Join-Path $PSScriptRoot ".bootstrap/bootstrap-manifest.json"
+        if (Test-Path -LiteralPath $expectedManifest -PathType Leaf) {
+            # Bare JSON parse keeps the wrapper independent of bootstrap-manifest.psm1 in sandboxed
+            # Pester invocations. Malformed/empty manifests defer to load-dms-seed-data.ps1's
+            # Read-SeedManifest for the authoritative error rather than throwing here.
+            $manifestSelectionMode = $null
+            try {
+                $rawManifestContent = Get-Content -LiteralPath $expectedManifest -Raw -ErrorAction Stop
+                if (-not [string]::IsNullOrWhiteSpace($rawManifestContent)) {
+                    $parsedManifest = $rawManifestContent | ConvertFrom-Json -ErrorAction Stop
+                    if ($null -ne $parsedManifest -and $null -ne $parsedManifest.schema -and -not [string]::IsNullOrWhiteSpace([string]$parsedManifest.schema.selectionMode)) {
+                        $manifestSelectionMode = [string]$parsedManifest.schema.selectionMode
+                    }
                 }
             }
-        }
-        catch {
-            $manifestSelectionMode = $null
-        }
-
-        if ($manifestSelectionMode -eq "ApiSchemaPath") {
-            if ($seedTemplateSupplied) {
-                throw "Expert mode (bootstrap-manifest.schema.selectionMode=ApiSchemaPath) does not support -SeedTemplate. Provide -SeedDataPath instead."
+            catch {
+                $manifestSelectionMode = $null
             }
-            if (-not $seedDataPathSupplied) {
-                throw "Expert mode (bootstrap-manifest.schema.selectionMode=ApiSchemaPath) requires -SeedDataPath. No built-in seed template is available in this mode."
+
+            if ($manifestSelectionMode -eq "ApiSchemaPath") {
+                if ($seedTemplateSupplied) {
+                    throw "Expert mode (bootstrap-manifest.schema.selectionMode=ApiSchemaPath) does not support -SeedTemplate. Provide -SeedDataPath instead."
+                }
+                if (-not $seedDataPathSupplied) {
+                    throw "Expert mode (bootstrap-manifest.schema.selectionMode=ApiSchemaPath) requires -SeedDataPath. No built-in seed template is available in this mode."
+                }
             }
         }
     }
@@ -370,6 +422,51 @@ function Invoke-BootstrapWrapper {
             -BaseEnvironmentFile $baseEnvFile `
             -LoadSeedDataRequested:$LoadSeedData
 
+        # Schema/claims staging phase. The standard happy path needs no manual pre-staging
+        # (bootstrap-design.md Section 9.4.1): when no workspace is staged yet, stage core-only standard
+        # mode so a clean checkout runs `bootstrap-local-dms.ps1` with no preceding prepare step. When a
+        # schema workspace is already staged (a manual/expert prepare flow, or a prior run), reuse it
+        # as-is rather than rewriting a workspace that may still be bind-mounted into a running stack.
+        # There is no -Extensions parameter; extension/custom schema sets are staged via expert
+        # -ApiSchemaPath before invoking the wrapper. prepare-dms-schema.ps1 owns all validation and the
+        # rerun contract.
+        #
+        # Claims completion is staged whenever the manifest lacks the claims/seed sections: both after a
+        # fresh schema stage above, and when a pre-existing manifest carries schema but not claims/seed
+        # (prepare-dms-schema.ps1 was run without prepare-dms-claims.ps1). That schema-only state is
+        # incomplete: it passes Assert-WrapperStagedSchemaWorkspace (schema-only validation) but
+        # start-local-dms.ps1 then activates staged claims and runs the claims-ready gate, both of which
+        # require claims/seed and would throw only after Docker/CMS startup. Completing it here keeps the
+        # failure (if any) ahead of all infrastructure side effects. prepare-dms-claims.ps1 requires the
+        # schema section + staged ApiSchema manifest (guaranteed by the schema stage) and is a guarded
+        # rerun when the claims workspace already matches.
+        $prepareSchemaScript = "$PSScriptRoot/prepare-dms-schema.ps1"
+        $prepareClaimsScript = "$PSScriptRoot/prepare-dms-claims.ps1"
+        $stagedManifestPath = Join-Path $PSScriptRoot ".bootstrap/bootstrap-manifest.json"
+        $stagedManifestPresent = Test-Path -LiteralPath $stagedManifestPath -PathType Leaf
+
+        # Reset the native exit-code sentinel before each prepare invocation (same pattern as the
+        # start/configure/provision phases below). prepare-dms-*.ps1 signal failure by throwing and may
+        # run no native command, so a stale nonzero $LASTEXITCODE left by an earlier command in the
+        # session would otherwise make a successful staging step throw a false "failed with exit code"
+        # before infrastructure starts.
+        if ((Test-Path -LiteralPath $prepareSchemaScript) -and -not $stagedManifestPresent) {
+            $global:LASTEXITCODE = 0
+            & $prepareSchemaScript
+            if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+                throw "prepare-dms-schema.ps1 failed with exit code $LASTEXITCODE."
+            }
+        }
+
+        if ((Test-Path -LiteralPath $prepareClaimsScript) -and
+            (-not $stagedManifestPresent -or -not (Test-WrapperManifestClaimsStaged -ManifestPath $stagedManifestPath))) {
+            $global:LASTEXITCODE = 0
+            & $prepareClaimsScript
+            if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
+                throw "prepare-dms-claims.ps1 failed with exit code $LASTEXITCODE."
+            }
+        }
+
         Assert-WrapperStagedSchemaWorkspace
 
         # Infrastructure phase
@@ -383,6 +480,10 @@ function Invoke-BootstrapWrapper {
         if ($AddExtensionSecurityMetadata) { $startArgs.AddExtensionSecurityMetadata = $true }
         $startArgs.EnvironmentFile = $effectiveEnvFile
 
+        # Reset the native exit-code sentinel so the check below reflects only this start invocation and
+        # not a stale value left by an earlier command. The start scripts signal failure by throwing;
+        # docker-compose paths set a real exit code that overwrites this reset.
+        $global:LASTEXITCODE = 0
         & "$PSScriptRoot/$StartScriptName" @startArgs
         if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) {
             throw "$StartScriptName failed with exit code $LASTEXITCODE."

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -12,16 +12,7 @@ param(
 Set-StrictMode -Version Latest
 
 Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force
-
-$knownExtensionClaims = @{
-    "Sample" = @{
-        FragmentFileName = "004-sample-extension-claimset.json"
-        NamespacePrefix = "uri://sample.ed-fi.org"
-    }
-    "Homograph" = @{
-        FragmentFileName = "005-homograph-extension-claimset.json"
-    }
-}
+Import-Module (Join-Path $PSScriptRoot "bootstrap-schema-catalog.psm1") -Force
 
 $baselineFragmentFileNames = [System.Collections.Generic.HashSet[string]]::new(
     [string[]]@(
@@ -61,7 +52,7 @@ function Get-ValueOrNull {
 
     if ($Hashtable -is [System.Collections.IDictionary] -and $Hashtable.Contains($Key)) {
         # Wrap with the unary comma so PowerShell does not flatten single-element arrays into
-        # scalars on function return — callers rely on the original shape for IList checks.
+        # scalars on function return - callers rely on the original shape for IList checks.
         return ,$Hashtable[$Key]
     }
 
@@ -383,9 +374,24 @@ if ($null -eq $rootManifest -or -not $rootManifest.ContainsKey("schema")) {
     throw "Bootstrap manifest is missing the schema section. Run prepare-dms-schema.ps1 before prepare-dms-claims.ps1."
 }
 
-$apiSchemaManifestPath = Join-Path $bootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json"
-if (-not (Test-Path -LiteralPath $apiSchemaManifestPath)) {
-    throw "Staged ApiSchema manifest was not found: $(Format-LogSafeText $apiSchemaManifestPath)"
+# Resolve the ApiSchema manifest from the schema handoff's recorded schema.apiSchemaManifestPath
+# rather than hardcoding a path, so claims staging validates and stages against the exact ApiSchema
+# manifest the schema phase recorded. This matches the other consumers of the field
+# (Resolve-BootstrapSchemaWorkspace and Set-BootstrapStartupEnvironment); hardcoding could otherwise
+# let claims staging consume a different manifest than the one prepare-dms-schema.ps1 recorded.
+$schemaSection = $rootManifest["schema"]
+if ($schemaSection -isnot [System.Collections.IDictionary]) {
+    throw "Bootstrap manifest schema section must be a JSON object. Run prepare-dms-schema.ps1 before prepare-dms-claims.ps1."
+}
+if (-not $schemaSection.ContainsKey("apiSchemaManifestPath") -or [string]::IsNullOrWhiteSpace([string]$schemaSection["apiSchemaManifestPath"])) {
+    throw "Bootstrap manifest field 'schema.apiSchemaManifestPath' must not be empty. Run prepare-dms-schema.ps1 before prepare-dms-claims.ps1."
+}
+$apiSchemaManifestRelativePath = Resolve-BootstrapWorkspaceRelativePath `
+    -RelativePath ([string]$schemaSection["apiSchemaManifestPath"]) `
+    -ManifestField "schema.apiSchemaManifestPath"
+$apiSchemaManifestPath = Resolve-BootstrapPath -RelativePath $apiSchemaManifestRelativePath
+if (-not (Test-Path -LiteralPath $apiSchemaManifestPath -PathType Leaf)) {
+    throw "Staged ApiSchema manifest was not found: $(Format-LogSafeText $apiSchemaManifestPath). Run prepare-dms-schema.ps1 before prepare-dms-claims.ps1."
 }
 
 $apiSchemaManifest = Read-JsonHashtable -Path $apiSchemaManifestPath -ArtifactName "ApiSchema manifest"
@@ -425,8 +431,8 @@ foreach ($extensionProject in $extensionProjects) {
         throw "Bootstrap ApiSchema manifest project entry is missing 'projectName'."
     }
 
-    if ($knownExtensionClaims.ContainsKey($projectName)) {
-        $knownExtension = $knownExtensionClaims[$projectName]
+    $knownExtension = Get-StandardKnownExtensionInfo -ProjectName $projectName
+    if ($null -ne $knownExtension) {
         if ($knownExtension.ContainsKey("FragmentFileName")) {
             $fragmentPath = Join-Path $shippedClaimsDirectory $knownExtension["FragmentFileName"]
             if (-not (Test-Path -LiteralPath $fragmentPath -PathType Leaf)) {

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -3,32 +3,340 @@
 # The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 # See the LICENSE and NOTICES files in the project root for more information.
 
+<#
+.SYNOPSIS
+    Stages the ApiSchema bootstrap workspace from either a NuGet package feed (standard mode)
+    or a local filesystem directory (expert mode).
+
+.DESCRIPTION
+    prepare-dms-schema.ps1 materializes the normalized ApiSchema workspace at
+    eng/docker-compose/.bootstrap/ApiSchema/. Every downstream bootstrap phase
+    (start-local-dms.ps1, bootstrap-local-dms.ps1) reads from that workspace;
+    this script is the sole writer.
+
+    Standard mode (default, package-backed, core-only):
+        Omit -ApiSchemaPath. The script resolves the DS-qualified asset-only core ApiSchema NuGet
+        package (EdFi.DataStandard52.ApiSchema) from the Ed-Fi package feed at the pinned version
+        and stages it into the workspace. Standard mode stages the core package only; there is no
+        -Extensions parameter.
+
+    Expert mode (filesystem):
+        Supply -ApiSchemaPath pointing to a directory that contains one or more ApiSchema*.json
+        files. The script normalizes those loose files into the same workspace layout. Use this
+        path for custom or in-repo schema directories, including extension-containing schema sets,
+        that are not staged as the package-backed core.
+
+    After staging the schema workspace, run prepare-dms-claims.ps1 to stage security metadata,
+    then start-local-dms.ps1 (or bootstrap-local-dms.ps1) to launch the stack.
+
+.PARAMETER ApiSchemaPath
+    Expert mode. Path to a local directory containing one or more ApiSchema*.json files.
+    The script recursively discovers all matching files, normalizes them into the bootstrap
+    workspace, and records selectionMode "ApiSchemaPath" in the manifest. This is the path for
+    extension-containing or custom schema sets.
+
+.PARAMETER SchemaToolPath
+    Path to the dms-schema native executable. Defaults to the DMS_SCHEMA_TOOL_PATH environment
+    variable. Build the tool once before running this script on a clean checkout:
+        dotnet publish ../../src/dms/clis/EdFi.DataManagementService.SchemaTools/EdFi.DataManagementService.SchemaTools.csproj \
+            -c Release -p:UseAppHost=true -o .bootstrap/tools/dms-schema
+
+.EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -SchemaToolPath $schemaToolExe
+    Standard mode, core only. Resolves EdFi.DataStandard52.ApiSchema from the Ed-Fi package feed
+    and stages it into the bootstrap workspace.
+
+.EXAMPLE
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+    Expert mode. Stages ApiSchema*.json files from the in-repo directory (which includes TPDM).
+    Use this path when you have a custom or in-repo schema directory not published as a NuGet package.
+    After staging, run prepare-dms-claims.ps1 with -ClaimsDirectoryPath if the schema includes
+    extensions whose claim fragments are not auto-staged (e.g. TPDM).
+#>
 [CmdletBinding()]
 param(
     [string]
     $ApiSchemaPath,
 
-    [string[]]
-    $Extensions,
-
     [string]
-    $SchemaToolPath = $env:DMS_SCHEMA_TOOL_PATH
+    $SchemaToolPath = $env:DMS_SCHEMA_TOOL_PATH,
+
+    # Internal test seam: overrides the pinned default package feed so offline tests can point at a
+    # local-folder feed. Not intended for normal operator use; production runs omit this.
+    [string]
+    $PackageFeedUrl
 )
 
 Set-StrictMode -Version Latest
 
-Import-Module (Join-Path $PSScriptRoot "bootstrap-schema-tool.psm1") -Force -Global
 Import-Module (Join-Path $PSScriptRoot "bootstrap-manifest.psm1") -Force -Global
+Import-Module (Join-Path $PSScriptRoot "bootstrap-schema-tool.psm1") -Force -Global
 
-$story06Message = "Package-backed standard schema selection is deferred until Story 06. For Story 00, supply -ApiSchemaPath pointing to a filesystem ApiSchema directory."
+if (-not (Get-Command Format-LogSafeText -ErrorAction SilentlyContinue)) {
+    function Format-LogSafeText {
+        param($Value)
 
-if ($PSBoundParameters.ContainsKey("Extensions")) {
-    throw $story06Message
+        if ($null -eq $Value) { return "" }
+        $text = [string]$Value
+        $builder = [System.Text.StringBuilder]::new()
+        foreach ($character in $text.ToCharArray()) {
+            if ([char]::IsLetterOrDigit($character) -or
+                $character -eq " " -or
+                $character -eq "_" -or
+                $character -eq "-" -or
+                $character -eq "." -or
+                $character -eq ":" -or
+                $character -eq "/") {
+                $null = $builder.Append($character)
+            }
+        }
+
+        return $builder.ToString()
+    }
 }
 
-if (-not $PSBoundParameters.ContainsKey("ApiSchemaPath") -or [string]::IsNullOrWhiteSpace($ApiSchemaPath)) {
-    throw $story06Message
+if (-not (Get-Command Read-RequiredJsonBoolean -ErrorAction SilentlyContinue)) {
+    function Read-RequiredJsonBoolean {
+        param(
+            [Parameter(Mandatory)]
+            $Hashtable,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Key,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ArtifactContext
+        )
+
+        if ($Hashtable -isnot [System.Collections.IDictionary] -or -not $Hashtable.Contains($Key)) {
+            throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+        }
+
+        $value = $Hashtable[$Key]
+        if ($value -is [bool]) {
+            return $value
+        }
+
+        throw "$(Format-LogSafeText $ArtifactContext) has malformed boolean for '$(Format-LogSafeText $Key)'."
+    }
 }
+
+if (-not (Get-Command Get-BootstrapRoot -ErrorAction SilentlyContinue)) {
+    $script:PrepareBootstrapRoot = Join-Path $PSScriptRoot ".bootstrap"
+    $script:PrepareBootstrapManifestPath = Join-Path $script:PrepareBootstrapRoot "bootstrap-manifest.json"
+    $script:PrepareWorkspaceMismatchMessage = "Existing staged bootstrap workspace differs from requested inputs, manifest state is incomplete, or files were manually edited (partial prior state). Stop the local stack and remove eng/docker-compose/.bootstrap before retrying. For local Docker, run: pwsh eng/docker-compose/start-local-dms.ps1 -d -v -RemoveBootstrap. E2E teardown wrappers also remove the bootstrap workspace."
+    $script:PrepareUtf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+    function Get-BootstrapRoot {
+        return $script:PrepareBootstrapRoot
+    }
+
+    function Get-BootstrapRelativePath {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [string]
+            $BasePath = $script:PrepareBootstrapRoot
+        )
+
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+        $fullBasePath = [System.IO.Path]::GetFullPath($BasePath)
+        return [System.IO.Path]::GetRelativePath($fullBasePath, $fullPath).Replace("\", "/")
+    }
+
+    function Get-BootstrapWorkspaceMismatchMessage {
+        param(
+            [string]
+            $Reason
+        )
+
+        if (-not [string]::IsNullOrWhiteSpace($Reason)) {
+            return $script:PrepareWorkspaceMismatchMessage.Replace(
+                "Stop the local stack",
+                "Diverging field: $(Format-LogSafeText $Reason). Stop the local stack"
+            )
+        }
+
+        return $script:PrepareWorkspaceMismatchMessage
+    }
+
+    function New-BootstrapManifest {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Builds an in-memory manifest object; no system state changes and no -WhatIf surface.')]
+        param()
+
+        return @{
+            version = 1
+        }
+    }
+
+    function Read-BootstrapManifest {
+        param(
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            return $null
+        }
+
+        try {
+            $manifest = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json -AsHashtable
+        } catch {
+            throw "Bootstrap manifest '$(Format-LogSafeText $Path)' contains malformed JSON. $(Format-LogSafeText ($_.Exception.Message))"
+        }
+
+        if ($manifest -isnot [System.Collections.IDictionary]) {
+            throw "Bootstrap manifest '$(Format-LogSafeText $Path)' must contain a JSON object."
+        }
+
+        if (-not $manifest.ContainsKey("version") -or $null -eq $manifest["version"]) {
+            $manifest["version"] = 1
+            return $manifest
+        }
+
+        $manifest["version"] = [int]$manifest["version"]
+        return $manifest
+    }
+
+    function Write-BootstrapJson {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path,
+
+            [Parameter(Mandatory)]
+            $Value
+        )
+
+        $directory = Split-Path -Parent $Path
+        if (-not [string]::IsNullOrWhiteSpace($directory)) {
+            New-Item -ItemType Directory -Path $directory -Force | Out-Null
+        }
+
+        $json = $Value | ConvertTo-Json -Depth 100
+        [System.IO.File]::WriteAllText($Path, "$json`n", $script:PrepareUtf8NoBom)
+    }
+
+    function Write-BootstrapManifest {
+        param(
+            [Parameter(Mandatory)]
+            $Manifest,
+
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        $orderedManifest = [ordered]@{
+            version = 1
+        }
+
+        foreach ($sectionName in @("schema", "claims", "seed")) {
+            if ($Manifest.ContainsKey($sectionName)) {
+                $orderedManifest[$sectionName] = $Manifest[$sectionName]
+            }
+        }
+
+        Write-BootstrapJson -Path $Path -Value $orderedManifest
+    }
+
+    function Set-BootstrapManifestSection {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Mutates an in-memory manifest hashtable; no system state changes and no -WhatIf surface.')]
+        param(
+            [Parameter(Mandatory)]
+            [ValidateSet("schema", "claims", "seed")]
+            [string]
+            $Name,
+
+            [Parameter(Mandatory)]
+            $Value,
+
+            [string]
+            $Path = $script:PrepareBootstrapManifestPath
+        )
+
+        $manifest = Read-BootstrapManifest -Path $Path
+        if ($null -eq $manifest) {
+            $manifest = New-BootstrapManifest
+        }
+
+        $manifest[$Name] = $Value
+        Write-BootstrapManifest -Manifest $manifest -Path $Path
+    }
+
+    function Get-BootstrapFingerprintByte {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path
+        )
+
+        $extension = [System.IO.Path]::GetExtension($Path)
+        if ($extension.Equals(".json", [System.StringComparison]::OrdinalIgnoreCase) -or
+            $extension.Equals(".xsd", [System.StringComparison]::OrdinalIgnoreCase)) {
+            $text = [System.IO.File]::ReadAllText($Path)
+            $normalizedText = $text.Replace("`r`n", "`n").Replace("`r", "`n")
+            return [System.Text.Encoding]::UTF8.GetBytes($normalizedText)
+        }
+
+        return [System.IO.File]::ReadAllBytes($Path)
+    }
+
+    function Get-BootstrapWorkspaceFingerprint {
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $Path
+        )
+
+        if (-not (Test-Path -LiteralPath $Path)) {
+            throw "Workspace path does not exist: $(Format-LogSafeText $Path)"
+        }
+
+        $entries = @(
+            Get-ChildItem -LiteralPath $Path -File -Recurse | ForEach-Object {
+                [pscustomobject]@{
+                    RelativePath = Get-BootstrapRelativePath -Path $_.FullName -BasePath $Path
+                    FullName = $_.FullName
+                }
+            }
+        )
+
+        $sortedEntries = @($entries | Sort-Object -Property RelativePath)
+        $incrementalHash = [System.Security.Cryptography.IncrementalHash]::CreateHash(
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256
+        )
+        [byte[]] $separator = 0
+
+        foreach ($entry in $sortedEntries) {
+            $relativePathBytes = [System.Text.Encoding]::UTF8.GetBytes($entry.RelativePath)
+            $incrementalHash.AppendData($relativePathBytes)
+            $incrementalHash.AppendData($separator)
+            $incrementalHash.AppendData((Get-BootstrapFingerprintByte -Path $entry.FullName))
+            $incrementalHash.AppendData($separator)
+        }
+
+        return [System.Convert]::ToHexString($incrementalHash.GetHashAndReset()).ToLowerInvariant()
+    }
+}
+
+Import-Module (Join-Path $PSScriptRoot "bootstrap-schema-catalog.psm1") -Force -Global
+
+# --- Schema-selection mode ---
+# Expert mode when -ApiSchemaPath is supplied; otherwise package-backed core-only standard mode.
+# There is no -Extensions parameter: extension/custom schema sets use expert -ApiSchemaPath.
+#
+# Standard mode is selected by OMITTING -ApiSchemaPath entirely. An explicitly bound but blank value
+# (e.g. -ApiSchemaPath "" or -ApiSchemaPath $null) is invalid caller input for expert mode, not a request
+# for standard mode; fail fast rather than silently routing it to package-backed core-only staging.
+$apiSchemaPathBound = $PSBoundParameters.ContainsKey("ApiSchemaPath")
+if ($apiSchemaPathBound -and [string]::IsNullOrWhiteSpace($ApiSchemaPath)) {
+    throw "-ApiSchemaPath was supplied but is blank. Provide a path to an ApiSchema directory for expert mode, or omit -ApiSchemaPath entirely to use package-backed core-only standard mode."
+}
+$hasApiSchemaPath = $apiSchemaPathBound
 
 function Get-ProjectDirectoryName {
     param(
@@ -177,13 +485,35 @@ function Add-ProjectContentOperation {
         $TargetSources,
 
         [System.Collections.ArrayList]
-        $CopyOperations
+        $CopyOperations,
+
+        # Standard mode: the validated package manifest is authoritative for schema-adjacent
+        # content. When set, source paths come exclusively from the two Manifest* parameters
+        # (null/empty means the package declares no such asset) and convention-based sibling
+        # discovery is skipped entirely. Expert mode omits it and keeps sibling discovery.
+        [switch]
+        $UseManifestAssets,
+
+        # Absolute path to the manifest-declared discovery spec file, already validated to exist.
+        [string]
+        $ManifestDiscoverySpecPath,
+
+        # Absolute path to the manifest-declared XSD directory, already validated to exist.
+        [string]
+        $ManifestXsdDirectory
     )
 
     $contentRoot = "content/$($Project.ProjectDirectoryName)"
-    $discoverySpecSourcePath = Join-Path $Project.SourceDirectory "discovery-spec.json"
+
+    $discoverySpecSourcePath = if ($UseManifestAssets) {
+        $ManifestDiscoverySpecPath
+    } else {
+        Join-Path $Project.SourceDirectory "discovery-spec.json"
+    }
+
     $discoverySpecRelativePath = $null
-    if (Test-Path -LiteralPath $discoverySpecSourcePath -PathType Leaf) {
+    if (-not [string]::IsNullOrWhiteSpace($discoverySpecSourcePath) -and
+        (Test-Path -LiteralPath $discoverySpecSourcePath -PathType Leaf)) {
         $discoverySpecRelativePath = "$contentRoot/discovery-spec.json"
         Add-CopyOperation `
             -TargetSources $TargetSources `
@@ -192,13 +522,21 @@ function Add-ProjectContentOperation {
             -RelativeTargetPath $discoverySpecRelativePath
     }
 
-    $xsdSourceDirectory = Join-Path $Project.SourceDirectory "xsd"
-    if (-not (Test-Path -LiteralPath $xsdSourceDirectory -PathType Container)) {
-        $xsdSourceDirectory = Join-Path $Project.SourceDirectory "XSD"
+    $xsdSourceDirectory = if ($UseManifestAssets) {
+        $ManifestXsdDirectory
+    } else {
+        $conventionXsdDirectory = Join-Path $Project.SourceDirectory "xsd"
+        if (-not (Test-Path -LiteralPath $conventionXsdDirectory -PathType Container)) {
+            $conventionXsdDirectory = Join-Path $Project.SourceDirectory "XSD"
+        }
+        $conventionXsdDirectory
     }
 
     $xsdDirectoryRelativePath = $null
-    if (Test-Path -LiteralPath $xsdSourceDirectory -PathType Container) {
+    if (-not [string]::IsNullOrWhiteSpace($xsdSourceDirectory) -and
+        (Test-Path -LiteralPath $xsdSourceDirectory -PathType Container)) {
+        # XSD files must sit flat directly under the source directory. Reject nested XSD files so the
+        # staged workspace mirrors the published asset-only package contract (flat xsd/).
         $pathSeparatorChars = [char[]]@(
             [System.IO.Path]::DirectorySeparatorChar,
             [System.IO.Path]::AltDirectorySeparatorChar
@@ -231,177 +569,351 @@ function Add-ProjectContentOperation {
     }
 }
 
-$schemaSourceFiles = Find-ApiSchemaFile -Path $ApiSchemaPath
-$schemaProjects = @($schemaSourceFiles | ForEach-Object { Read-ApiSchemaIdentity -Path $_ })
+# --- Shared schema workspace staging function ---
+function Invoke-SchemaWorkspaceStaging {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Stages bootstrap files; callers do not expose -WhatIf end to end.')]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]
+        $SchemaSourceFiles,
 
-$coreProjects = @($schemaProjects | Where-Object { -not $_.IsExtensionProject })
-if ($coreProjects.Count -ne 1) {
-    throw "ApiSchemaPath must stage exactly one core schema. Found $($coreProjects.Count)."
-}
+        [Parameter(Mandatory)]
+        [ValidateSet("ApiSchemaPath", "Standard")]
+        [string]
+        $SelectionMode,
 
-$extensionProjects = @(
-    $schemaProjects |
-        Where-Object { $_.IsExtensionProject } |
-        Sort-Object -Property @{ Expression = { $_.ProjectEndpointName.ToLowerInvariant() } }, SourcePath
-)
-
-$orderedProjects = @($coreProjects[0]) + $extensionProjects
-$sourceDirectoryGroups = $schemaProjects | Group-Object -Property SourceDirectory -AsHashTable
-
-$targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
-    [System.StringComparer]::OrdinalIgnoreCase
-)
-$copyOperations = [System.Collections.ArrayList]::new()
-$manifestProjects = [System.Collections.ArrayList]::new()
-$contentBySourceDirectory = @{}
-
-foreach ($project in $orderedProjects) {
-    $schemaRelativePath = "schemas/$($project.ProjectDirectoryName)/ApiSchema.json"
-    Add-CopyOperation `
-        -TargetSources $targetSources `
-        -CopyOperations $copyOperations `
-        -SourcePath $project.SourcePath `
-        -RelativeTargetPath $schemaRelativePath
-
-    if (-not $contentBySourceDirectory.ContainsKey($project.SourceDirectory)) {
-        # When two or more projects share a source directory AND that directory carries
-        # schema-adjacent content (discovery-spec.json or xsd/), the core schema owns the staged
-        # content path that every project in the group references. Extension-only groups have no
-        # unambiguous owner in that case — fail fast and tell the caller to put each extension in
-        # its own directory (or add a sibling core schema). When no schema-adjacent content exists
-        # in the directory, there is nothing to disambiguate, so multiple extensions in the same
-        # directory are accepted (typical of recursive ApiSchema*.json discovery layouts).
-        $sourceDirectoryGroup = @($sourceDirectoryGroups[$project.SourceDirectory])
-        $coreInGroup = @($sourceDirectoryGroup | Where-Object { -not $_.IsExtensionProject })
-        if ($sourceDirectoryGroup.Count -gt 1 -and $coreInGroup.Count -eq 0) {
-            $hasSchemaAdjacentContent =
-                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "discovery-spec.json") -PathType Leaf) -or
-                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "xsd") -PathType Container) -or
-                (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "XSD") -PathType Container)
-            if ($hasSchemaAdjacentContent) {
-                throw "Ambiguous schema-adjacent content ownership: source directory '$(Format-LogSafeText $project.SourceDirectory)' contains multiple extension schemas and no core schema. Move each extension into its own directory."
-            }
-        }
-
-        $contentBySourceDirectory[$project.SourceDirectory] = Add-ProjectContentOperation `
-            -Project $project `
-            -TargetSources $targetSources `
-            -CopyOperations $copyOperations
-    }
-    $contentPaths = $contentBySourceDirectory[$project.SourceDirectory]
-
-    $manifestProject = [ordered]@{
-        projectName = $project.ProjectName
-        projectEndpointName = $project.ProjectEndpointName
-        isExtensionProject = $project.IsExtensionProject
-        schemaPath = $schemaRelativePath
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($contentPaths.DiscoverySpecPath)) {
-        $manifestProject["discoverySpecPath"] = $contentPaths.DiscoverySpecPath
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace($contentPaths.XsdDirectory)) {
-        $manifestProject["xsdDirectory"] = $contentPaths.XsdDirectory
-    }
-
-    $null = $manifestProjects.Add($manifestProject)
-}
-
-$bootstrapRoot = Get-BootstrapRoot
-$temporaryRoot = Join-Path (Join-Path $bootstrapRoot ".tmp") "ApiSchema-$([Guid]::NewGuid().ToString('N'))"
-$finalWorkspace = Join-Path $bootstrapRoot "ApiSchema"
-$temporaryMoved = $false
-
-try {
-    New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
-
-    foreach ($copyOperation in $copyOperations) {
-        $targetPath = Join-Path $temporaryRoot $copyOperation.RelativeTargetPath
-        New-Item -ItemType Directory -Path (Split-Path -Parent $targetPath) -Force | Out-Null
-        Copy-Item -LiteralPath $copyOperation.SourcePath -Destination $targetPath -ErrorAction Stop
-    }
-
-    # Copy JsonSchemaForApiSchema.json into the workspace root so it is available when
-    # /app/ApiSchema is mounted in Docker (the mount shadows the DMS assembly output directory
-    # that ApiSchemaValidator uses to load this meta-schema at startup).
-    $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../.."))
-    $jsonSchemaValidatorSource = Join-Path $repoRoot "src/dms/core/EdFi.DataManagementService.Core/ApiSchema/JsonSchemaForApiSchema.json"
-    if (-not (Test-Path -LiteralPath $jsonSchemaValidatorSource -PathType Leaf)) {
-        throw "JsonSchemaForApiSchema.json not found at $(Format-LogSafeText $jsonSchemaValidatorSource). Build the DMS solution before running prepare-dms-schema.ps1."
-    }
-    Copy-Item -LiteralPath $jsonSchemaValidatorSource -Destination (Join-Path $temporaryRoot "JsonSchemaForApiSchema.json") -ErrorAction Stop
-
-    $apiSchemaManifest = [ordered]@{
-        version = 1
-        projects = @($manifestProjects)
-    }
-    $apiSchemaManifestPath = Join-Path $temporaryRoot "bootstrap-api-schema-manifest.json"
-    Write-BootstrapJson -Path $apiSchemaManifestPath -Value $apiSchemaManifest
-
-    $coreStagedSchemaPath = Join-Path $temporaryRoot $manifestProjects[0]["schemaPath"]
-    $extensionStagedSchemaPaths = @(
-        $manifestProjects |
-            Where-Object { $_["isExtensionProject"] } |
-            ForEach-Object { Join-Path $temporaryRoot $_["schemaPath"] }
+        # Optional map of absolute schema-file path -> validated package identity (PackageId,
+        # ProjectName, ProjectEndpointName, IsExtensionProject, DiscoverySpecPath, XsdDirectory).
+        # Standard mode supplies it so the identity declared inside each staged ApiSchema.json is
+        # asserted against the validated package manifest, and so schema-adjacent content is staged
+        # from the manifest-declared (contract-validated) asset paths instead of sibling
+        # rediscovery; expert mode omits it, skipping the assertion and using sibling discovery.
+        [hashtable]
+        $ExpectedIdentities
     )
 
-    $schemaTool = Resolve-DmsSchemaTool -RequestedPath $SchemaToolPath
-    $effectiveSchemaHash = Invoke-DmsSchemaHash `
-        -ToolPath $schemaTool `
-        -CoreSchemaPath $coreStagedSchemaPath `
-        -ExtensionSchemaPath $extensionStagedSchemaPaths
+    $schemaProjects = @($SchemaSourceFiles | ForEach-Object { Read-ApiSchemaIdentity -Path $_ })
 
-    $workspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
-    $schemaSection = [ordered]@{
-        selectionMode = "ApiSchemaPath"
-        selectedExtensions = @($extensionProjects | ForEach-Object { $_.ProjectEndpointName.ToLowerInvariant() })
-        effectiveSchemaHash = $effectiveSchemaHash
-        workspaceFingerprint = $workspaceFingerprint
-        apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
+    # Lock package identity end to end: the project identity inside each staged ApiSchema.json must
+    # match the validated package manifest. Without this, a package that passes packageId validation
+    # could still stage a different project, producing wrong selectedExtensions, claims, and seed
+    # handoff.
+    if ($null -ne $ExpectedIdentities) {
+        foreach ($project in $schemaProjects) {
+            if (-not $ExpectedIdentities.ContainsKey($project.SourcePath)) {
+                continue
+            }
+
+            $expected = $ExpectedIdentities[$project.SourcePath]
+            if (-not $project.ProjectName.Equals([string]$expected.ProjectName, [System.StringComparison]::OrdinalIgnoreCase) -or
+                -not $project.ProjectEndpointName.Equals([string]$expected.ProjectEndpointName, [System.StringComparison]::OrdinalIgnoreCase) -or
+                $project.IsExtensionProject -ne [bool]$expected.IsExtensionProject) {
+                throw "Package identity mismatch for '$(Format-LogSafeText $expected.PackageId)': the package manifest declares project '$(Format-LogSafeText $expected.ProjectName)' (endpoint '$(Format-LogSafeText $expected.ProjectEndpointName)', isExtension=$([bool]$expected.IsExtensionProject)), but the staged ApiSchema.json declares project '$(Format-LogSafeText $project.ProjectName)' (endpoint '$(Format-LogSafeText $project.ProjectEndpointName)', isExtension=$($project.IsExtensionProject)). The package manifest and schema asset must describe the same project."
+            }
+        }
     }
 
-    $rootManifest = Read-BootstrapManifest
-    if ($null -eq $rootManifest) {
-        $rootManifest = New-BootstrapManifest
+    $coreProjects = @($schemaProjects | Where-Object { -not $_.IsExtensionProject })
+    if ($coreProjects.Count -ne 1) {
+        throw "ApiSchemaPath must stage exactly one core schema. Found $($coreProjects.Count)."
     }
-    if (Test-Path -LiteralPath $finalWorkspace) {
-        if (-not $rootManifest.ContainsKey("schema")) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section missing")
+
+    $extensionProjects = @(
+        $schemaProjects |
+            Where-Object { $_.IsExtensionProject } |
+            Sort-Object -Property @{ Expression = { $_.ProjectEndpointName.ToLowerInvariant() } }, SourcePath
+    )
+
+    $orderedProjects = @($coreProjects[0]) + $extensionProjects
+    $sourceDirectoryGroups = $schemaProjects | Group-Object -Property SourceDirectory -AsHashTable
+
+    $targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
+        [System.StringComparer]::OrdinalIgnoreCase
+    )
+    $copyOperations = [System.Collections.ArrayList]::new()
+    $manifestProjects = [System.Collections.ArrayList]::new()
+    $contentBySourceDirectory = @{}
+
+    foreach ($project in $orderedProjects) {
+        $schemaRelativePath = "schemas/$($project.ProjectDirectoryName)/ApiSchema.json"
+        Add-CopyOperation `
+            -TargetSources $targetSources `
+            -CopyOperations $copyOperations `
+            -SourcePath $project.SourcePath `
+            -RelativeTargetPath $schemaRelativePath
+
+        if (-not $contentBySourceDirectory.ContainsKey($project.SourceDirectory)) {
+            $validatedIdentity = $null
+            if ($null -ne $ExpectedIdentities -and $ExpectedIdentities.ContainsKey($project.SourcePath)) {
+                $validatedIdentity = $ExpectedIdentities[$project.SourcePath]
+            }
+
+            if ($null -ne $validatedIdentity) {
+                # Standard mode: the validated package manifest declares its schema-adjacent content
+                # (discoverySpecPath/xsdDirectory) and is authoritative - stage exactly what it
+                # declares from the contract-validated paths, with no sibling rediscovery. Each
+                # package extracts into its own isolation directory, so there is no shared-directory
+                # ownership to disambiguate.
+                $contentBySourceDirectory[$project.SourceDirectory] = Add-ProjectContentOperation `
+                    -Project $project `
+                    -TargetSources $targetSources `
+                    -CopyOperations $copyOperations `
+                    -UseManifestAssets `
+                    -ManifestDiscoverySpecPath ([string]$validatedIdentity.DiscoverySpecPath) `
+                    -ManifestXsdDirectory ([string]$validatedIdentity.XsdDirectory)
+            } else {
+                # When two or more projects share a source directory AND that directory carries
+                # schema-adjacent content (discovery-spec.json or xsd/), the core schema owns the staged
+                # content path that every project in the group references. Extension-only groups have no
+                # unambiguous owner in that case - fail fast and tell the caller to put each extension in
+                # its own directory (or add a sibling core schema). When no schema-adjacent content exists
+                # in the directory, there is nothing to disambiguate, so multiple extensions in the same
+                # directory are accepted (typical of recursive ApiSchema*.json discovery layouts).
+                $sourceDirectoryGroup = @($sourceDirectoryGroups[$project.SourceDirectory])
+                $coreInGroup = @($sourceDirectoryGroup | Where-Object { -not $_.IsExtensionProject })
+                if ($sourceDirectoryGroup.Count -gt 1 -and $coreInGroup.Count -eq 0) {
+                    $hasSchemaAdjacentContent =
+                        (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "discovery-spec.json") -PathType Leaf) -or
+                        (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "xsd") -PathType Container) -or
+                        (Test-Path -LiteralPath (Join-Path $project.SourceDirectory "XSD") -PathType Container)
+                    if ($hasSchemaAdjacentContent) {
+                        throw "Ambiguous schema-adjacent content ownership: source directory '$(Format-LogSafeText $project.SourceDirectory)' contains multiple extension schemas and no core schema. Move each extension into its own directory."
+                    }
+                }
+
+                $contentBySourceDirectory[$project.SourceDirectory] = Add-ProjectContentOperation `
+                    -Project $project `
+                    -TargetSources $targetSources `
+                    -CopyOperations $copyOperations
+            }
+        }
+        $contentPaths = $contentBySourceDirectory[$project.SourceDirectory]
+
+        $manifestProject = [ordered]@{
+            projectName = $project.ProjectName
+            projectEndpointName = $project.ProjectEndpointName
+            isExtensionProject = $project.IsExtensionProject
+            schemaPath = $schemaRelativePath
         }
 
-        $existingSchemaSection = $rootManifest["schema"]
-        if ($existingSchemaSection -isnot [System.Collections.IDictionary]) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section malformed")
-        }
-        if ($existingSchemaSection["effectiveSchemaHash"] -ne $effectiveSchemaHash) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "effective schema hash mismatch")
+        if (-not [string]::IsNullOrWhiteSpace($contentPaths.DiscoverySpecPath)) {
+            $manifestProject["discoverySpecPath"] = $contentPaths.DiscoverySpecPath
         }
 
-        if ($existingSchemaSection["workspaceFingerprint"] -ne $workspaceFingerprint) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "workspace fingerprint mismatch")
+        if (-not [string]::IsNullOrWhiteSpace($contentPaths.XsdDirectory)) {
+            $manifestProject["xsdDirectory"] = $contentPaths.XsdDirectory
         }
 
-        $existingFingerprint = Get-BootstrapWorkspaceFingerprint -Path $finalWorkspace
-        if ($existingFingerprint -ne $workspaceFingerprint) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "staged content drift")
+        $null = $manifestProjects.Add($manifestProject)
+    }
+
+    $bootstrapRoot = Get-BootstrapRoot
+    $temporaryRoot = Join-Path (Join-Path $bootstrapRoot ".tmp") "ApiSchema-$([Guid]::NewGuid().ToString('N'))"
+    $finalWorkspace = Join-Path $bootstrapRoot "ApiSchema"
+    $temporaryMoved = $false
+
+    try {
+        New-Item -ItemType Directory -Path $temporaryRoot -Force | Out-Null
+
+        foreach ($copyOperation in $copyOperations) {
+            $targetPath = Join-Path $temporaryRoot $copyOperation.RelativeTargetPath
+            New-Item -ItemType Directory -Path (Split-Path -Parent $targetPath) -Force | Out-Null
+            Copy-Item -LiteralPath $copyOperation.SourcePath -Destination $targetPath -ErrorAction Stop
         }
+
+        # Copy JsonSchemaForApiSchema.json into the workspace root so it is available when
+        # /app/ApiSchema is mounted in Docker (the mount shadows the DMS assembly output directory
+        # that ApiSchemaValidator uses to load this meta-schema at startup). Required once Story 04
+        # (DMS-1154) activates staged-workspace runtime loading.
+        $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../.."))
+        $jsonSchemaValidatorSource = Join-Path $repoRoot "src/dms/core/EdFi.DataManagementService.Core/ApiSchema/JsonSchemaForApiSchema.json"
+        if (-not (Test-Path -LiteralPath $jsonSchemaValidatorSource -PathType Leaf)) {
+            throw "JsonSchemaForApiSchema.json not found at $(Format-LogSafeText $jsonSchemaValidatorSource). Build the DMS solution before running prepare-dms-schema.ps1."
+        }
+        Copy-Item -LiteralPath $jsonSchemaValidatorSource -Destination (Join-Path $temporaryRoot "JsonSchemaForApiSchema.json") -ErrorAction Stop
+
+        $apiSchemaManifest = [ordered]@{
+            version = 1
+            projects = @($manifestProjects)
+        }
+        $apiSchemaManifestPath = Join-Path $temporaryRoot "bootstrap-api-schema-manifest.json"
+        Write-BootstrapJson -Path $apiSchemaManifestPath -Value $apiSchemaManifest
+
+        $coreStagedSchemaPath = Join-Path $temporaryRoot $manifestProjects[0]["schemaPath"]
+        $extensionStagedSchemaPaths = @(
+            $manifestProjects |
+                Where-Object { $_["isExtensionProject"] } |
+                ForEach-Object { Join-Path $temporaryRoot $_["schemaPath"] }
+        )
+
+        $schemaTool = Resolve-DmsSchemaTool -RequestedPath $SchemaToolPath
+        $effectiveSchemaHash = Invoke-DmsSchemaHash `
+            -ToolPath $schemaTool `
+            -CoreSchemaPath $coreStagedSchemaPath `
+            -ExtensionSchemaPath $extensionStagedSchemaPaths
+
+        $workspaceFingerprint = Get-BootstrapWorkspaceFingerprint -Path $temporaryRoot
+        $schemaSection = [ordered]@{
+            selectionMode = $SelectionMode
+            selectedExtensions = @($extensionProjects | ForEach-Object { $_.ProjectEndpointName.ToLowerInvariant() })
+            effectiveSchemaHash = $effectiveSchemaHash
+            workspaceFingerprint = $workspaceFingerprint
+            apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
+        }
+
+        $rootManifest = Read-BootstrapManifest
+        if ($null -eq $rootManifest) {
+            $rootManifest = New-BootstrapManifest
+        }
+        if (Test-Path -LiteralPath $finalWorkspace) {
+            if (-not $rootManifest.ContainsKey("schema")) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section missing")
+            }
+
+            $existingSchemaSection = $rootManifest["schema"]
+            if ($existingSchemaSection -isnot [System.Collections.IDictionary]) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest schema section malformed")
+            }
+            if ($existingSchemaSection["effectiveSchemaHash"] -ne $effectiveSchemaHash) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "effective schema hash mismatch")
+            }
+
+            if ($existingSchemaSection["workspaceFingerprint"] -ne $workspaceFingerprint) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "workspace fingerprint mismatch")
+            }
+
+            $existingFingerprint = Get-BootstrapWorkspaceFingerprint -Path $finalWorkspace
+            if ($existingFingerprint -ne $workspaceFingerprint) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "staged content drift")
+            }
+        } else {
+            if ($rootManifest.ContainsKey("claims") -or $rootManifest.ContainsKey("seed")) {
+                throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest has stale claims/seed sections but ApiSchema workspace is missing")
+            }
+
+            New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+            Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace -ErrorAction Stop
+            $temporaryMoved = $true
+        }
+
+        Set-BootstrapManifestSection -Name "schema" -Value $schemaSection
+
+        Write-Output "Prepared ApiSchema workspace at $(Format-LogSafeText $finalWorkspace)"
+        Write-Output "Effective schema hash: $effectiveSchemaHash"
+    } finally {
+        if (-not $temporaryMoved -and (Test-Path -LiteralPath $temporaryRoot)) {
+            Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
+        }
+    }
+}
+
+# --- Standard-mode package resolution and staging ---
+function Assert-RequestedPackageIdentity {
+    <#
+    .SYNOPSIS
+    Asserts that a validated package's manifest projectName and projectEndpointName match the
+    identity the request implies (the catalog ProjectToken/EndpointToken). Without this, a
+    mislabeled package - correct packageId but internally consistent manifest+schema for a
+    different project - would pass validation and stage the wrong project under the requested
+    selection. Both fields matter independently: the endpoint drives selectedExtensions and
+    routing, while the project name drives the staged directory layout and claims metadata
+    lookup.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        $Validated,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ExpectedProjectName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $ExpectedEndpointName,
+
+        [Parameter(Mandatory)]
+        [string]
+        $RequestedName
+    )
+
+    if (-not ([string]$Validated.ProjectName).Equals($ExpectedProjectName, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Package identity mismatch for '$(Format-LogSafeText $Validated.PackageId)': the requested selection '$(Format-LogSafeText $RequestedName)' implies project name '$(Format-LogSafeText $ExpectedProjectName)', but the package manifest declares projectName '$(Format-LogSafeText $Validated.ProjectName)'. The package content does not match the requested selection."
+    }
+
+    if (-not ([string]$Validated.ProjectEndpointName).Equals($ExpectedEndpointName, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Package identity mismatch for '$(Format-LogSafeText $Validated.PackageId)': the requested selection '$(Format-LogSafeText $RequestedName)' implies project endpoint '$(Format-LogSafeText $ExpectedEndpointName)', but the package manifest declares projectEndpointName '$(Format-LogSafeText $Validated.ProjectEndpointName)'. The package content does not match the requested selection."
+    }
+}
+
+function Invoke-StandardModeSchemaStaging {
+    param(
+        [string]
+        $FeedUrl
+    )
+
+    Import-Module (Join-Path $PSScriptRoot "bootstrap-package-resolver.psm1") -Force -Global
+
+    # Resolve feed URL: use the caller-supplied override or fall back to the pinned default.
+    $resolvedFeedUrl = if (-not [string]::IsNullOrWhiteSpace($FeedUrl)) {
+        $FeedUrl
     } else {
-        if ($rootManifest.ContainsKey("claims") -or $rootManifest.ContainsKey("seed")) {
-            throw (Get-BootstrapWorkspaceMismatchMessage -Reason "manifest has stale claims/seed sections but ApiSchema workspace is missing")
+        Get-StandardSchemaFeed
+    }
+
+    $bootstrapRoot = Get-BootstrapRoot
+    $extractionRoot = Join-Path (Join-Path $bootstrapRoot ".tmp") "pkg-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $extractionRoot -Force | Out-Null
+
+    try {
+        # Collect the core ApiSchema.json path plus its validated identity so staging can assert the
+        # schema asset matches the package manifest. Standard mode is core-only.
+        $schemaSourceFiles = [System.Collections.Generic.List[string]]::new()
+        $expectedIdentities = @{}
+
+        # Resolve and validate the core package.
+        $corePackage = Get-StandardCorePackage
+        $coreResolved = Resolve-StandardSchemaPackage `
+            -FeedUrl $resolvedFeedUrl `
+            -PackageId $corePackage.Id `
+            -Version $corePackage.Version `
+            -DestinationRoot $extractionRoot
+
+        $coreValidated = Assert-AssetOnlyPackageContract `
+            -ApiSchemaDirectory $coreResolved.ApiSchemaDirectory `
+            -PackageRoot $coreResolved.PackageRoot `
+            -ExpectedPackageId $corePackage.Id `
+            -ExpectedIsExtension $false
+
+        Assert-RequestedPackageIdentity `
+            -Validated $coreValidated `
+            -ExpectedProjectName $corePackage.ProjectToken `
+            -ExpectedEndpointName $corePackage.EndpointToken `
+            -RequestedName "core"
+
+        $schemaSourceFiles.Add($coreValidated.SchemaPath)
+        $expectedIdentities[[System.IO.Path]::GetFullPath($coreValidated.SchemaPath)] = $coreValidated
+
+        # Stage the collected (core) schema file using the shared staging function. With no extension
+        # projects in the staged set, the manifest records selectedExtensions = @().
+        Invoke-SchemaWorkspaceStaging `
+            -SchemaSourceFiles $schemaSourceFiles.ToArray() `
+            -SelectionMode "Standard" `
+            -ExpectedIdentities $expectedIdentities
+    } finally {
+        if (Test-Path -LiteralPath $extractionRoot) {
+            Remove-Item -LiteralPath $extractionRoot -Recurse -Force
         }
-
-        New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
-        Move-Item -LiteralPath $temporaryRoot -Destination $finalWorkspace -ErrorAction Stop
-        $temporaryMoved = $true
     }
+}
 
-    Set-BootstrapManifestSection -Name "schema" -Value $schemaSection
-
-    Write-Output "Prepared ApiSchema workspace at $(Format-LogSafeText $finalWorkspace)"
-    Write-Output "Effective schema hash: $effectiveSchemaHash"
-} finally {
-    if (-not $temporaryMoved -and (Test-Path -LiteralPath $temporaryRoot)) {
-        Remove-Item -LiteralPath $temporaryRoot -Recurse -Force
-    }
+# --- Mode determination ---
+if ($hasApiSchemaPath) {
+    # Expert mode: use the shared staging function with ApiSchemaPath selection mode.
+    Invoke-SchemaWorkspaceStaging `
+        -SchemaSourceFiles (Find-ApiSchemaFile -Path $ApiSchemaPath) `
+        -SelectionMode "ApiSchemaPath"
+} else {
+    # Standard mode: resolve and stage the core package only.
+    Invoke-StandardModeSchemaStaging `
+        -FeedUrl $PackageFeedUrl
 }

--- a/eng/docker-compose/tests/BootstrapEntryPointWorkflow.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapEntryPointWorkflow.Tests.ps1
@@ -226,6 +226,53 @@ Add-Content -LiteralPath '$CallLogPath' -Value "seed DmsBaseUrl=`$DmsBaseUrl"
 "@ | Set-Content -LiteralPath $scriptPath -Encoding utf8
             return $scriptPath
         }
+
+        function script:New-SchemaOnlyBootstrapManifestFile {
+            # A manifest written by prepare-dms-schema.ps1 alone: schema section present, no
+            # claims/seed. Models the incomplete state the wrapper must complete before infrastructure.
+            param(
+                [Parameter(Mandatory)]
+                [string]$DockerComposeRoot
+            )
+
+            $bootstrapRoot = Join-Path $DockerComposeRoot ".bootstrap"
+            New-Item -ItemType Directory -Path $bootstrapRoot -Force | Out-Null
+
+            $manifest = [ordered]@{
+                version = 1
+                schema  = [ordered]@{
+                    selectionMode        = "Standard"
+                    effectiveSchemaHash  = "abc123"
+                    workspaceFingerprint = "0000000000000000000000000000000000000000000000000000000000000000"
+                    apiSchemaManifestPath = "ApiSchema/bootstrap-api-schema-manifest.json"
+                }
+            }
+            $manifestPath = Join-Path $bootstrapRoot "bootstrap-manifest.json"
+            $manifest | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+            return $manifestPath
+        }
+
+        function script:New-RecordingPrepareScripts {
+            # Call-recording stubs for the two staging phase scripts: each appends a single line so
+            # tests can assert which staging phases ran and in what order relative to the start phase.
+            param(
+                [Parameter(Mandatory)]
+                [string]$Directory,
+
+                [Parameter(Mandatory)]
+                [string]$CallLogPath
+            )
+
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+Add-Content -LiteralPath '$CallLogPath' -Value "prepare-schema"
+"@ | Set-Content -LiteralPath (Join-Path $Directory "prepare-dms-schema.ps1") -Encoding utf8
+
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)] `$Rest)
+Add-Content -LiteralPath '$CallLogPath' -Value "prepare-claims"
+"@ | Set-Content -LiteralPath (Join-Path $Directory "prepare-dms-claims.ps1") -Encoding utf8
+        }
     }
 
     BeforeEach {
@@ -402,6 +449,95 @@ Add-Content -LiteralPath '$CallLogPath' -Value "seed DmsBaseUrl=`$DmsBaseUrl"
             # start-infra invocation must NOT carry any DmsBaseUrl
             $startLine = $log | Where-Object { $_ -like "start-infra*" } | Select-Object -First 1
             $startLine | Should -Match "DmsBaseUrl=$"
+        }
+    }
+
+    # =========================================================================
+    # R4b - Wrapper schema/claims staging phase (claims-completion before infra)
+    #   A schema-only manifest (prepare-dms-schema.ps1 run without prepare-dms-claims.ps1)
+    #   is an incomplete bootstrap state: start-local-dms.ps1 activates staged claims and runs
+    #   the claims-ready gate, both of which require the claims/seed sections. The wrapper must
+    #   complete the claims staging BEFORE any infrastructure side effects rather than letting
+    #   the gate throw after Docker/CMS startup.
+    # =========================================================================
+    Context "wrapper schema/claims staging phase" {
+        It "stages schema then claims before infrastructure when no manifest exists" {
+            $callLog = Join-Path $script:repo.RepoRoot "call-log-stage-fresh.txt"
+            New-RecordingPrepareScripts -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog
+            New-RecordingStartScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingConfigureScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingProvisionScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+
+            & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -InfraOnly
+
+            $log = @(Get-Content -LiteralPath $callLog)
+
+            $schemaIndex = [array]::IndexOf($log, "prepare-schema")
+            $claimsIndex = [array]::IndexOf($log, "prepare-claims")
+            $startIndex  = [array]::IndexOf($log, ($log | Where-Object { $_ -like "start-infra*" } | Select-Object -First 1))
+
+            $schemaIndex | Should -BeGreaterOrEqual 0 -Because "a clean checkout must stage the core schema"
+            $claimsIndex | Should -BeGreaterThan $schemaIndex -Because "claims stage after schema"
+            $startIndex  | Should -BeGreaterThan $claimsIndex -Because "all staging must run before infrastructure starts"
+        }
+
+        It "completes a schema-only manifest by staging claims (not schema) before infrastructure starts" {
+            New-SchemaOnlyBootstrapManifestFile -DockerComposeRoot $script:repo.DockerComposeRoot | Out-Null
+            $callLog = Join-Path $script:repo.RepoRoot "call-log-stage-claims.txt"
+            New-RecordingPrepareScripts -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog
+            New-RecordingStartScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingConfigureScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingProvisionScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+
+            & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -InfraOnly
+
+            $log = @(Get-Content -LiteralPath $callLog)
+
+            # Schema is already staged; only the claims completion runs.
+            $log | Should -Not -Contain "prepare-schema" -Because "an already-staged schema must not be re-staged"
+            $log | Should -Contain "prepare-claims" -Because "the missing claims/seed sections must be completed"
+
+            # The claims completion must run BEFORE any infrastructure side effect.
+            $claimsIndex = [array]::IndexOf($log, "prepare-claims")
+            $startIndex  = [array]::IndexOf($log, ($log | Where-Object { $_ -like "start-infra*" } | Select-Object -First 1))
+            $startIndex | Should -BeGreaterThan $claimsIndex -Because "claims completion must precede infrastructure startup"
+        }
+
+        It "does not false-fail claims staging when a stale nonzero \$LASTEXITCODE lingers from the session" {
+            # Regression: prepare-dms-claims.ps1 signals failure by throwing and runs no native command,
+            # so a nonzero $LASTEXITCODE left by an earlier command in the session must NOT be read as a
+            # staging failure. The wrapper resets the sentinel before each prepare invocation.
+            New-SchemaOnlyBootstrapManifestFile -DockerComposeRoot $script:repo.DockerComposeRoot | Out-Null
+            $callLog = Join-Path $script:repo.RepoRoot "call-log-stale-exit.txt"
+            New-RecordingPrepareScripts -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog
+            New-RecordingStartScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingConfigureScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingProvisionScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+
+            # Simulate a prior native-command failure lingering in the PowerShell session.
+            $global:LASTEXITCODE = 99
+
+            { & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -InfraOnly } |
+                Should -Not -Throw -Because "a stale exit code must not be mistaken for a prepare-dms-claims.ps1 failure"
+
+            @(Get-Content -LiteralPath $callLog) | Should -Contain "prepare-claims" -Because "claims completion must still run and succeed"
+        }
+
+        It "reuses a complete manifest as-is and does not re-stage schema or claims" {
+            New-BootstrapManifestFile -DockerComposeRoot $script:repo.DockerComposeRoot | Out-Null
+            $callLog = Join-Path $script:repo.RepoRoot "call-log-stage-complete.txt"
+            New-RecordingPrepareScripts -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog
+            New-RecordingStartScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingConfigureScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+            New-RecordingProvisionScript -Directory $script:repo.DockerComposeRoot -CallLogPath $callLog | Out-Null
+
+            & $script:repo.WrapperScript -EnvironmentFile $script:repo.EnvFile -InfraOnly
+
+            $log = @(Get-Content -LiteralPath $callLog)
+
+            $log | Should -Not -Contain "prepare-schema" -Because "a complete manifest must be reused as-is"
+            $log | Should -Not -Contain "prepare-claims" -Because "a complete manifest must be reused as-is"
+            $log | Where-Object { $_ -like "start-infra*" } | Should -Not -BeNullOrEmpty -Because "the start phase still runs"
         }
     }
 

--- a/eng/docker-compose/tests/BootstrapPackageResolver.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapPackageResolver.Tests.ps1
@@ -1,0 +1,1702 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Pester fixture parameters are unused by design.')]
+param()
+
+Describe "DMS-1156 bootstrap package resolver" {
+    BeforeAll {
+        $script:sourceDockerComposeRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+        $script:resolverModule = Join-Path $script:sourceDockerComposeRoot "bootstrap-package-resolver.psm1"
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+        Add-Type -AssemblyName System.IO.Compression -ErrorAction Stop
+
+        function script:New-TestDirectory
+        {
+            $path = Join-Path ([System.IO.Path]::GetTempPath()) "dms-resolver-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+            return $path
+        }
+
+        function script:New-ExtractedCorePackage
+        {
+            <#
+            .SYNOPSIS
+            Creates a minimal valid extracted asset-only core package tree on disk (no zip).
+            Returns a PSCustomObject with ApiSchemaDirectory and PackageRoot.
+            #>
+            param(
+                [string] $PackageId = "EdFi.DataStandard52.ApiSchema",
+                [string] $Version   = "1.0.329",
+                [switch] $IncludeDiscoverySpec,
+                [switch] $IncludeXsd
+            )
+
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            '{"apiSchemaVersion":"1.0.0"}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = $PackageId
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+
+            if ($IncludeDiscoverySpec)
+            {
+                '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "discovery-spec.json") -Encoding utf8
+                $manifest.discoverySpecPath = "discovery-spec.json"
+            }
+
+            if ($IncludeXsd)
+            {
+                $xsdDir = Join-Path $apiSchemaDir "xsd"
+                New-Item -ItemType Directory -Path $xsdDir -Force | Out-Null
+                "<xs:schema />" | Set-Content -LiteralPath (Join-Path $xsdDir "Ed-Fi-Core.xsd") -Encoding utf8
+                $manifest.xsdDirectory = "xsd"
+            }
+
+            $manifest | ConvertTo-Json -Depth 5 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            return [pscustomobject]@{
+                PackageRoot        = $packageRoot
+                ApiSchemaDirectory = $apiSchemaDir
+            }
+        }
+
+        function script:New-ExtractedExtensionPackage
+        {
+            <#
+            .SYNOPSIS
+            Creates a minimal valid extracted asset-only extension package tree on disk (no zip).
+            Returns a PSCustomObject with ApiSchemaDirectory and PackageRoot.
+            #>
+            param(
+                [string] $PackageId = "EdFi.DataStandard52.Sample.ApiSchema",
+                [string] $Version   = "1.0.329",
+                [switch] $IncludeXsd
+            )
+
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            '{"apiSchemaVersion":"1.0.0"}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = $PackageId
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = $true
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+
+            if ($IncludeXsd)
+            {
+                $xsdDir = Join-Path $apiSchemaDir "xsd"
+                New-Item -ItemType Directory -Path $xsdDir -Force | Out-Null
+                "<xs:schema />" | Set-Content -LiteralPath (Join-Path $xsdDir "EXTENSION-Core.xsd") -Encoding utf8
+                $manifest.xsdDirectory = "xsd"
+            }
+
+            $manifest | ConvertTo-Json -Depth 5 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            return [pscustomobject]@{
+                PackageRoot        = $packageRoot
+                ApiSchemaDirectory = $apiSchemaDir
+            }
+        }
+
+        function script:New-FixtureNupkg
+        {
+            <#
+            .SYNOPSIS
+            Creates a minimal asset-only ApiSchema .nupkg fixture in a local feed folder.
+            The .nupkg contains contentFiles/any/any/ApiSchema/package-manifest.json and
+            contentFiles/any/any/ApiSchema/ApiSchema.json (and optionally an xsd/ subfolder).
+            Returns the absolute path to the .nupkg file.
+            #>
+            param(
+                [Parameter(Mandatory)]
+                [string]
+                $FeedFolder,
+
+                [Parameter(Mandatory)]
+                [string]
+                $PackageId,
+
+                [Parameter(Mandatory)]
+                [string]
+                $Version,
+
+                [switch]
+                $IncludeXsd
+            )
+
+            $nupkgName = "$($PackageId.ToLowerInvariant()).$($Version.ToLowerInvariant()).nupkg"
+            $nupkgPath = Join-Path $FeedFolder $nupkgName
+
+            # Build the zip (nupkg) contents in a temp staging dir, then zip it.
+            $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) "dms-nupkg-stage-$([Guid]::NewGuid().ToString('N'))"
+            $apiSchemaDir = Join-Path $stagingDir "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            # Minimal package-manifest.json
+            $manifest = [ordered]@{
+                packageId = $PackageId
+                version   = $Version
+            }
+            $manifest | ConvertTo-Json -Depth 5 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            # Minimal ApiSchema.json
+            $apiSchema = [ordered]@{
+                apiSchemaVersion = "1.0.0"
+                projectSchema    = [ordered]@{
+                    projectName         = $PackageId
+                    projectEndpointName = $PackageId.ToLowerInvariant()
+                    isExtensionProject  = $false
+                    resourceSchemas     = [ordered]@{}
+                }
+            }
+            $apiSchema | ConvertTo-Json -Depth 10 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            if ($IncludeXsd)
+            {
+                $xsdDir = Join-Path $apiSchemaDir "xsd"
+                New-Item -ItemType Directory -Path $xsdDir -Force | Out-Null
+                "<xs:schema />" | Set-Content -LiteralPath (Join-Path $xsdDir "Ed-Fi-Core.xsd") -Encoding utf8
+            }
+
+            # Create .nupkg as a zip from the staging dir.
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $nupkgPath)
+
+            # Clean up staging dir.
+            Remove-Item -LiteralPath $stagingDir -Recurse -Force
+
+            return $nupkgPath
+        }
+    }
+
+    BeforeEach {
+        Remove-Module bootstrap-package-resolver -Force -ErrorAction SilentlyContinue
+        Import-Module $script:resolverModule -Force
+
+        $script:feedFolder = script:New-TestDirectory
+        $script:destRoot = script:New-TestDirectory
+    }
+
+    AfterEach {
+        Remove-Module bootstrap-package-resolver -Force -ErrorAction SilentlyContinue
+
+        if ($null -ne $script:feedFolder -and (Test-Path -LiteralPath $script:feedFolder))
+        {
+            Remove-Item -LiteralPath $script:feedFolder -Recurse -Force
+        }
+
+        if ($null -ne $script:destRoot -and (Test-Path -LiteralPath $script:destRoot))
+        {
+            Remove-Item -LiteralPath $script:destRoot -Recurse -Force
+        }
+    }
+
+    Context "Given_LocalFolderFeed" {
+        It "It_resolves_and_extracts_core_package_and_exposes_ApiSchema_contract_path" {
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" | Out-Null
+
+            $result = Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+
+            $result.PackageId | Should -Be "EdFi.DataStandard52.ApiSchema"
+            $result.Version | Should -Be "1.0.329"
+            $result.ExtractionDirectory | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.ExtractionDirectory -PathType Container | Should -BeTrue
+            $result.ApiSchemaDirectory | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.ApiSchemaDirectory -PathType Container | Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $result.ApiSchemaDirectory "ApiSchema.json") -PathType Leaf | Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $result.ApiSchemaDirectory "package-manifest.json") -PathType Leaf | Should -BeTrue
+        }
+
+        It "It_resolves_core_package_with_xsd_from_local_feed" {
+            # Core-only standard mode: the resolver fetches the pinned core package and
+            # exposes its optional XSD payload. Extension package resolution is out of scope — extension
+            # and custom schema sets use the expert -ApiSchemaPath filesystem path, not package resolution.
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -IncludeXsd | Out-Null
+
+            $result = Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+
+            $result.PackageId | Should -Be "EdFi.DataStandard52.ApiSchema"
+            Test-Path -LiteralPath (Join-Path $result.ApiSchemaDirectory "xsd/Ed-Fi-Core.xsd") -PathType Leaf | Should -BeTrue
+        }
+
+        It "It_resolves_via_file_URL_feed" {
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" | Out-Null
+
+            $fileUrl = [System.Uri]::new($script:feedFolder).AbsoluteUri
+
+            $result = Resolve-StandardSchemaPackage `
+                -FeedUrl $fileUrl `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+
+            Test-Path -LiteralPath $result.ApiSchemaDirectory -PathType Container | Should -BeTrue
+        }
+
+        It "It_throws_clear_error_when_package_id_not_in_local_feed" {
+            # Feed is empty - no packages at all.
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.Nonexistent.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*not found in local feed folder*"
+        }
+
+        It "It_throws_clear_error_when_requested_version_not_in_local_feed" {
+            # Package exists but only at a different version.
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.1" | Out-Null
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*version*1.0.329*not found*"
+        }
+
+        It "It_never_falls_back_to_a_different_version_on_missing_pinned_version" {
+            # Confirm error message explicitly states no fallback.
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.1" | Out-Null
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*never falls back to latest*"
+        }
+
+        It "It_result_PackageRoot_matches_ExtractionDirectory" {
+            script:New-FixtureNupkg `
+                -FeedFolder $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" | Out-Null
+
+            $result = Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+
+            $result.PackageRoot | Should -Be $result.ExtractionDirectory
+        }
+
+        It "It_throws_when_extracted_package_lacks_ApiSchema_contract_directory" {
+            # Build a .nupkg that does NOT contain contentFiles/any/any/ApiSchema/.
+            $nupkgName = "edfi.datastandardnoapischema.1.0.0.nupkg"
+            $nupkgPath = Join-Path $script:feedFolder $nupkgName
+
+            $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) "dms-noapischema-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $stagingDir -Force | Out-Null
+            "placeholder" | Set-Content -LiteralPath (Join-Path $stagingDir "dummy.txt") -Encoding utf8
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $nupkgPath)
+            Remove-Item -LiteralPath $stagingDir -Recurse -Force
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl $script:feedFolder `
+                -PackageId "EdFi.DataStandardNoApiSchema" `
+                -Version "1.0.0" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*contentFiles/any/any/ApiSchema/*"
+        }
+    }
+
+    Context "Given_Assert-AssetOnlyPackageContract" {
+
+        # SCOPE NOTE: these are package-CONTRACT VALIDATION tests, not extension package
+        # RESOLUTION tests. Assert-AssetOnlyPackageContract is the general asset-only validator that
+        # runs over whatever package the resolver extracted; its isExtensionProject / payload / manifest
+        # rules must be proven for both core- and extension-shaped manifests regardless of the core-only
+        # selection scope. The contract (06-package-backed-standard-schema-selection.md:115-118) removes
+        # extension package RESOLUTION coverage (done in Given_LocalFolderFeed) while keeping core payload
+        # and contract-validation coverage; an extension-shaped fixture here exercises a validator branch,
+        # it does not stage or resolve an extension into standard mode.
+
+        # ---- Happy path ----
+
+        It "It_returns_validated_identity_for_valid_core_package" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+
+            $result.PackageId           | Should -Be "EdFi.DataStandard52.ApiSchema"
+            $result.ProjectName         | Should -Be "Ed-Fi"
+            $result.ProjectEndpointName | Should -Be "ed-fi"
+            $result.IsExtensionProject  | Should -BeFalse
+            $result.SchemaPath          | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.SchemaPath -PathType Leaf | Should -BeTrue
+            $result.DiscoverySpecPath   | Should -BeNullOrEmpty
+            $result.XsdDirectory        | Should -BeNullOrEmpty
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_returns_validated_identity_for_valid_core_package_with_optional_assets" {
+            $pkg = script:New-ExtractedCorePackage `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -IncludeDiscoverySpec `
+                -IncludeXsd
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+
+            $result.DiscoverySpecPath | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.DiscoverySpecPath -PathType Leaf | Should -BeTrue
+            $result.XsdDirectory | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.XsdDirectory -PathType Container | Should -BeTrue
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_returns_validated_identity_for_valid_extension_package" {
+            # Validator-branch coverage (see SCOPE NOTE above): proves Assert-AssetOnlyPackageContract
+            # accepts a well-formed extension-shaped manifest (isExtensionProject=true). This validates
+            # the contract checker, not extension package resolution — nothing here resolves or stages an
+            # extension into core-only standard mode.
+            $pkg = script:New-ExtractedExtensionPackage `
+                -PackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -IncludeXsd
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+
+            $result.PackageId           | Should -Be "EdFi.DataStandard52.Sample.ApiSchema"
+            $result.ProjectName         | Should -Be "Sample"
+            $result.ProjectEndpointName | Should -Be "sample"
+            $result.IsExtensionProject  | Should -BeTrue
+            Test-Path -LiteralPath $result.SchemaPath -PathType Leaf | Should -BeTrue
+            $result.XsdDirectory | Should -Not -BeNullOrEmpty
+            Test-Path -LiteralPath $result.XsdDirectory -PathType Container | Should -BeTrue
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        # ---- Missing asset-only payload ----
+
+        It "It_throws_when_ApiSchema_directory_is_absent" {
+            $packageRoot = script:New-TestDirectory
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory (Join-Path $packageRoot "contentFiles/any/any/ApiSchema") `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*contentFiles/any/any/ApiSchema/*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_no_schema_JSON_file_exists_in_ApiSchema_directory" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            # Only manifest, no ApiSchema.json
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*no schema JSON file found*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_multiple_schema_JSON_files_exist_in_ApiSchema_directory" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema2.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*multiple schema JSON files found*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_extra_root_JSON_shares_a_basename_with_a_nested_discoverySpecPath" {
+            # Regression: the discoverySpecPath exclusion must match the actual declared file, not
+            # just its basename. A nested discoverySpecPath (nested/Other.json) must NOT cause an
+            # unrelated root Other.json to be excluded from the single-schema count.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            $nestedDir = Join-Path $apiSchemaDir "nested"
+            New-Item -ItemType Directory -Path $nestedDir -Force | Out-Null
+
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "Other.json") -Encoding utf8
+            '{}' | Set-Content -LiteralPath (Join-Path $nestedDir "Other.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = "nested/Other.json"
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*multiple schema JSON files found*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- Missing or malformed package-manifest.json ----
+
+        It "It_throws_when_manifest_version_is_a_non_integer_string" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # version is a non-empty string, so presence/non-empty checks pass; type check must fail.
+            $manifest = [ordered]@{
+                version              = "bad"
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'version' must be an integer manifest schema version*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_version_is_a_fractional_number" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A non-integer JSON number must be rejected (ConvertFrom-Json parses 1.5 as [double]).
+            $manifestJson = '{ "version": 1.5, "packageId": "EdFi.DataStandard52.ApiSchema", "projectName": "Ed-Fi", "projectEndpointName": "ed-fi", "isExtensionProject": false, "schemaPath": "ApiSchema.json", "discoverySpecPath": null, "xsdDirectory": null }'
+            $manifestJson | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'version' must be an integer manifest schema version*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_version_is_an_unsupported_integer" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 2
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*only manifest schema version 1 is supported*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_discoverySpecPath_is_not_a_string" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A non-string discoverySpecPath (JSON number) must be rejected as malformed, even though a
+            # file whose name matches the coerced value exists. A raw [string] cast would let it pass.
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "123") -Encoding utf8
+            $manifestJson = '{ "version": 1, "packageId": "EdFi.DataStandard52.ApiSchema", "projectName": "Ed-Fi", "projectEndpointName": "ed-fi", "isExtensionProject": false, "schemaPath": "ApiSchema.json", "discoverySpecPath": 123, "xsdDirectory": null }'
+            $manifestJson | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'discoverySpecPath' must be a JSON string*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_xsdDirectory_is_not_a_string" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A non-string xsdDirectory (JSON boolean) must be rejected as malformed, even though a
+            # directory whose name matches the coerced value ([string]$true -> "True") exists with XSD content.
+            $coercedDir = Join-Path $apiSchemaDir "True"
+            New-Item -ItemType Directory -Path $coercedDir -Force | Out-Null
+            "<xs:schema />" | Set-Content -LiteralPath (Join-Path $coercedDir "Ed-Fi-Core.xsd") -Encoding utf8
+            $manifestJson = '{ "version": 1, "packageId": "EdFi.DataStandard52.ApiSchema", "projectName": "Ed-Fi", "projectEndpointName": "ed-fi", "isExtensionProject": false, "schemaPath": "ApiSchema.json", "discoverySpecPath": null, "xsdDirectory": true }'
+            $manifestJson | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'xsdDirectory' must be a JSON string*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_required_string_field_<Field>_is_not_a_string" -ForEach @(
+            @{ Field = "packageId" }
+            @{ Field = "projectName" }
+            @{ Field = "projectEndpointName" }
+            @{ Field = "schemaPath" }
+        ) {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A required identity/path field given as a non-string (JSON number) must be rejected as a
+            # contract violation here, not coerced or deferred to a later non-contract failure (e.g.
+            # Int32.Equals(string,...) on packageId, or [string]/Join-Path on schemaPath downstream).
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest[$Field] = 123
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'$Field' must be a JSON string*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_manifest_json_is_absent" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+            # No package-manifest.json
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*package-manifest.json*missing*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_manifest_json_is_not_valid_JSON" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+            "{ not valid json !!!" | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*package-manifest.json*not valid JSON*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_manifest_json_is_missing_required_field_projectName" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # Missing projectName
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*missing required field*projectName*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_a_clear_error_when_required_packageId_is_JSON_null" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A JSON null required field must produce the clear "missing required field" message, not a raw
+            # "cannot call a method on a null-valued expression" error from the later identity check.
+            $manifestJson = '{ "version": 1, "packageId": null, "projectName": "Ed-Fi", "projectEndpointName": "ed-fi", "isExtensionProject": false, "schemaPath": "ApiSchema.json", "discoverySpecPath": null, "xsdDirectory": null }'
+            $manifestJson | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*missing required field*packageId*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_a_clear_error_when_required_schemaPath_is_JSON_null" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A JSON null schemaPath must be rejected by the required-field guard, not reach Join-Path.
+            $manifestJson = '{ "version": 1, "packageId": "EdFi.DataStandard52.ApiSchema", "projectName": "Ed-Fi", "projectEndpointName": "ed-fi", "isExtensionProject": false, "schemaPath": null, "discoverySpecPath": null, "xsdDirectory": null }'
+            $manifestJson | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*missing required field*schemaPath*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- Forbidden DLL/assembly shape ----
+
+        It "It_throws_when_package_contains_a_dll_file" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            # Plant a DLL in a lib/ directory
+            $libDir = Join-Path $pkg.PackageRoot "lib/net8.0"
+            New-Item -ItemType Directory -Path $libDir -Force | Out-Null
+            [System.IO.File]::WriteAllBytes((Join-Path $libDir "EdFi.ApiSchema.dll"), [byte[]]@(0, 0, 0, 0))
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*forbidden*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_contains_a_cs_file" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            "// Marker.cs" | Set-Content -LiteralPath (Join-Path $pkg.PackageRoot "Marker.cs") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*forbidden*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_contains_a_lib_directory" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            New-Item -ItemType Directory -Path (Join-Path $pkg.PackageRoot "lib") -Force | Out-Null
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*forbidden*lib/*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_contains_a_ref_directory" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            New-Item -ItemType Directory -Path (Join-Path $pkg.PackageRoot "ref") -Force | Out-Null
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*forbidden*ref/*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_package_contains_a_nested_forbidden_directory" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            # A forbidden directory (bin/) nested below the contract path, carrying only an
+            # innocuous file, must still be rejected even though it contains no *.dll or *.cs.
+            $nestedBin = Join-Path $pkg.ApiSchemaDirectory "bin"
+            New-Item -ItemType Directory -Path $nestedBin -Force | Out-Null
+            "harmless" | Set-Content -LiteralPath (Join-Path $nestedBin "foo.txt") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*forbidden*bin/*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        # ---- Identity mismatch ----
+
+        It "It_throws_when_manifest_packageId_does_not_match_expected" {
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.WRONG.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*identity mismatch*"
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_extension_manifest_declares_isExtensionProject_false" {
+            # Extension package whose manifest incorrectly says isExtensionProject: false
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = $false   # <-- wrong: says false but caller expects extension
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*isExtensionProject*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_core_manifest_declares_isExtensionProject_true" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $true    # <-- wrong: says true but caller expects core
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*isExtensionProject*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_extension_manifest_declares_isExtensionProject_as_string_false" {
+            # PowerShell coerces any non-empty string (including "false") to $true under a raw
+            # [bool] cast, so a string-typed flag must be rejected as malformed, not coerced.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = "false"   # <-- malformed: JSON string, not boolean
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*isExtensionProject*must be a JSON boolean*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_declares_isExtensionProject_as_non_boolean_string" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = "not-a-bool"   # <-- malformed: arbitrary string
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*isExtensionProject*must be a JSON boolean*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_core_manifest_declares_isExtensionProject_as_null" {
+            # A JSON null required field is rejected by the required-field guard (null is treated as a
+            # missing field), before the boolean-type check below, so the message is "missing required field".
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $null   # <-- malformed: JSON null
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*missing required field*isExtensionProject*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- Manifest-declared static assets missing on disk ----
+
+        It "It_throws_when_manifest_discoverySpecPath_does_not_exist_on_disk" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = "discovery-spec.json"   # declared but missing on disk
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*discoverySpecPath*does not exist*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_discoverySpecPath_is_a_zero_byte_file" {
+            # A declared discoverySpecPath that exists but is empty would otherwise pass the
+            # file-exists check yet finalize a workspace advertising a discovery spec it cannot serve.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # The declared discovery spec exists on disk but is zero bytes.
+            $discoverySpecFile = Join-Path $apiSchemaDir "discovery-spec.json"
+            New-Item -ItemType File -Path $discoverySpecFile -Force | Out-Null
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = "discovery-spec.json"   # declared but empty on disk
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*discoverySpecPath*is empty*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_xsdDirectory_does_not_exist_on_disk" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = $true
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = "xsd"   # declared but missing on disk
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*xsdDirectory*does not exist*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_xsdDirectory_exists_but_contains_no_xsd_files" {
+            # A declared xsdDirectory that exists but holds no *.xsd content would otherwise pass the
+            # directory-exists check yet stage nothing (prepare-dms-schema.ps1 records XSD only when
+            # *.xsd files exist), silently finalizing a workspace missing the advertised XSD content.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # The declared directory exists but contains a non-XSD file only (no *.xsd).
+            $xsdDir = Join-Path $apiSchemaDir "xsd"
+            New-Item -ItemType Directory -Path $xsdDir -Force | Out-Null
+            "not an xsd" | Set-Content -LiteralPath (Join-Path $xsdDir "README.txt") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = $true
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = "xsd"   # declared but holds no *.xsd content
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*xsdDirectory*no .xsd files were found*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_allows_null_discoverySpecPath_without_error" {
+            # Core package with discoverySpecPath explicitly null - should not throw.
+            $pkg = script:New-ExtractedCorePackage -PackageId "EdFi.DataStandard52.ApiSchema"
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+
+            $result.DiscoverySpecPath | Should -BeNullOrEmpty
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_allows_null_xsdDirectory_without_error" {
+            # Extension package with xsdDirectory null - should not throw.
+            $pkg = script:New-ExtractedExtensionPackage -PackageId "EdFi.DataStandard52.Sample.ApiSchema"
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $pkg.ApiSchemaDirectory `
+                -PackageRoot $pkg.PackageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+
+            $result.XsdDirectory | Should -BeNullOrEmpty
+
+            Remove-Item -LiteralPath $pkg.PackageRoot -Recurse -Force
+        }
+
+        It "It_allows_manifest_that_omits_optional_fields_without_StrictMode_error" {
+            # A conforming manifest may omit discoverySpecPath/xsdDirectory entirely (not merely set
+            # them to null). Under Set-StrictMode, accessing an absent property throws; the validator
+            # must treat omitted optional fields the same as null.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # discoverySpecPath and xsdDirectory keys are intentionally absent.
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            $result = Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+
+            $result.DiscoverySpecPath | Should -BeNullOrEmpty
+            $result.XsdDirectory | Should -BeNullOrEmpty
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_discoverySpecPath_is_empty_string" {
+            # Absence is expressed only by omitting the key or JSON null. A present-but-empty string is
+            # a malformed declared path and must fail fast, not be silently treated as absent.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = ""
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'discoverySpecPath' is present but empty*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_xsdDirectory_is_empty_string" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = ""
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*'xsdDirectory' is present but empty*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- Manifest path traversal ----
+
+        It "It_throws_when_manifest_schemaPath_contains_parent_traversal" {
+            # A manifest schemaPath with '..' could point outside contentFiles/any/any/ApiSchema/.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "../../escape.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*must not contain '..'*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_xsdDirectory_is_rooted" {
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.Sample.ApiSchema"
+                projectName          = "Sample"
+                projectEndpointName  = "sample"
+                isExtensionProject   = $true
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = "/etc"
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.Sample.ApiSchema" `
+                -ExpectedIsExtension $true
+            } | Should -Throw -ExpectedMessage "*is rooted*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- Duplicate normalized paths ----
+
+        It "It_throws_when_duplicate_normalized_paths_exist_in_package_payload" {
+            # Simulate two files that normalize to the same path (case difference on a
+            # case-sensitive filesystem, or a direct duplicate on case-insensitive).
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "ApiSchema.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            # Create a second directory that after normalization (case-insensitive) collides with the first.
+            # We do this by creating a sibling directory at the package root level that mirrors the content,
+            # creating a file at a path whose normalized form duplicates an existing one.
+            # Use a sub-dir that has the same normalized path as an existing file.
+            # Easiest: add the same file content under a different casing sub-path (works on macOS/Linux).
+            # On case-insensitive FS (Windows/macOS default) this would fail mkdir; use same-name
+            # files in different subdirs that normalize identically.
+            $docsDir = Join-Path $packageRoot "docs"
+            New-Item -ItemType Directory -Path $docsDir -Force | Out-Null
+            "readme" | Set-Content -LiteralPath (Join-Path $docsDir "README.md") -Encoding utf8
+            # Add a second file that normalizes to the same path as an existing one.
+            # We'll create an 'extra' dir alongside docs with the same normalized structure.
+            $extraDir = Join-Path $packageRoot "extra"
+            New-Item -ItemType Directory -Path $extraDir -Force | Out-Null
+            "readme2" | Set-Content -LiteralPath (Join-Path $extraDir "README.md") -Encoding utf8
+            # Now manually call the function with a patched package root that has duplicate paths.
+            # The simplest cross-platform approach: build the package root so two files share the same
+            # normalized relative path by copying the file into the same logical location.
+            # Because we can't create identical file paths on any FS, we instead inject a collision
+            # by writing the same normalized path twice into an in-memory list - but that's not
+            # exercising the real code. Instead, test the detection through the real code by creating
+            # a directory structure where two separate subdirectories each contain a file named identically
+            # such that the relative paths differ only by parent directory letter casing, which on
+            # macOS HFS+ (case-insensitive) fails to create. On case-sensitive FS (Linux/ext4) it works.
+            #
+            # Cross-platform strategy: use the SAME file in a symlink or hard link - not available here.
+            # Fallback: test duplicate detection via a single flat directory with the same file included
+            # twice - not possible on any real FS. Instead, verify that the duplicate-path detection
+            # code executes without error on a clean package (no duplicates), and separately use a unit
+            # approach by verifying the error message is reachable from code inspection.
+            #
+            # Actual cross-platform approach: put two files with names that differ only in extension
+            # casing - e.g. "file.JSON" and "file.json" - which on Linux creates two distinct files
+            # that normalize to the same path.
+            $dupeDir = Join-Path $packageRoot "dupedir"
+            New-Item -ItemType Directory -Path $dupeDir -Force | Out-Null
+            "a" | Set-Content -LiteralPath (Join-Path $dupeDir "data.json") -Encoding utf8
+
+            # Check whether FS is case-sensitive for this directory.
+            $fileB = Join-Path $dupeDir "DATA.JSON"
+            $isCaseSensitive = -not (Test-Path -LiteralPath $fileB)
+
+            if ($isCaseSensitive)
+            {
+                # Linux/case-sensitive: create DATA.JSON as a distinct file that normalizes to data.json
+                "b" | Set-Content -LiteralPath $fileB -Encoding utf8
+
+                { Assert-AssetOnlyPackageContract `
+                    -ApiSchemaDirectory $apiSchemaDir `
+                    -PackageRoot $packageRoot `
+                    -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                    -ExpectedIsExtension $false
+                } | Should -Throw -ExpectedMessage "*duplicate normalized relative path*"
+            }
+            else
+            {
+                # macOS/Windows: case-insensitive FS - can't create distinct files with same normalized
+                # path. Skip the throw assertion and just verify the happy path runs cleanly.
+                { Assert-AssetOnlyPackageContract `
+                    -ApiSchemaDirectory $apiSchemaDir `
+                    -PackageRoot $packageRoot `
+                    -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                    -ExpectedIsExtension $false
+                } | Should -Not -Throw
+            }
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        # ---- schemaPath / root schema mismatch ----
+
+        It "It_throws_when_manifest_schemaPath_references_nested_JSON_instead_of_root_schema" {
+            # A package that has a valid root ApiSchema.json, but whose manifest schemaPath
+            # points at a different nested file (nested/Other.json) - must throw the mismatch diagnostic.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            $nestedDir    = Join-Path $apiSchemaDir "nested"
+            New-Item -ItemType Directory -Path $nestedDir -Force | Out-Null
+
+            # The one root-level schema JSON (counted in step 6).
+            '{"apiSchemaVersion":"1.0.0"}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # A nested file that the manifest mistakenly references as schemaPath.
+            '{"apiSchemaVersion":"1.0.0"}' | Set-Content -LiteralPath (Join-Path $nestedDir "Other.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "nested/Other.json"
+                discoverySpecPath    = $null
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*manifest 'schemaPath' must reference the single schema JSON at the asset-only contract root*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+
+        It "It_throws_when_manifest_schemaPath_references_the_discovery_spec_file" {
+            # A package whose manifest has schemaPath and discoverySpecPath both pointing at
+            # the same discovery-spec.json file - the root-schema count sees ApiSchema.json as
+            # the single schema, but schemaPath references discovery-spec.json, so it must throw.
+            $packageRoot = script:New-TestDirectory
+            $apiSchemaDir = Join-Path $packageRoot "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            # The actual root schema JSON (counted in step 6 after excluding discoverySpecPath).
+            '{"apiSchemaVersion":"1.0.0"}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            # The discovery-spec file also exists on disk.
+            '{}' | Set-Content -LiteralPath (Join-Path $apiSchemaDir "discovery-spec.json") -Encoding utf8
+
+            $manifest = [ordered]@{
+                version              = 1
+                packageId            = "EdFi.DataStandard52.ApiSchema"
+                projectName          = "Ed-Fi"
+                projectEndpointName  = "ed-fi"
+                isExtensionProject   = $false
+                schemaPath           = "discovery-spec.json"
+                discoverySpecPath    = "discovery-spec.json"
+                xsdDirectory         = $null
+            }
+            $manifest | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            { Assert-AssetOnlyPackageContract `
+                -ApiSchemaDirectory $apiSchemaDir `
+                -PackageRoot $packageRoot `
+                -ExpectedPackageId "EdFi.DataStandard52.ApiSchema" `
+                -ExpectedIsExtension $false
+            } | Should -Throw -ExpectedMessage "*manifest 'schemaPath' must reference the single schema JSON at the asset-only contract root*"
+
+            Remove-Item -LiteralPath $packageRoot -Recurse -Force
+        }
+    }
+
+    Context "Given_HttpV3Feed_StrictModeHardening" {
+        It "It_throws_clear_diagnostic_when_service_index_lacks_resources" {
+            # A service index that parses as valid JSON but omits 'resources' must surface the
+            # advertise diagnostic, not a raw StrictMode property-not-found error.
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                [pscustomobject]@{ Content = '{ "version": "3.0.0" }' }
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*does not advertise a PackageBaseAddress*"
+        }
+
+        It "It_throws_version_diagnostic_when_version_index_lacks_versions" {
+            # Valid service index, but the version index omits 'versions'. Must surface the
+            # pinned-version-not-found diagnostic rather than a StrictMode crash on .versions.
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                if ($Uri -eq "https://example.test/v3/index.json") {
+                    return [pscustomobject]@{
+                        Content = '{"resources":[{"@id":"https://example.test/flat/","@type":"PackageBaseAddress/3.0.0"}]}'
+                    }
+                }
+                return [pscustomobject]@{ Content = '{}' }
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*was not found*"
+        }
+
+        It "It_throws_clear_diagnostic_when_the_service_index_is_unreachable" {
+            # A network/HTTP failure fetching the service index must surface the unreachable-feed
+            # diagnostic rather than a raw web exception.
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                throw "The remote name could not be resolved."
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*service index is unreachable*"
+        }
+
+        It "It_throws_clear_diagnostic_when_the_service_index_returns_malformed_JSON" {
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                [pscustomobject]@{ Content = '{ this is not valid json' }
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*service index*returned malformed JSON*"
+        }
+
+        It "It_throws_clear_diagnostic_when_the_version_index_request_fails" {
+            # Service index resolves, but the flat-container version-index request fails (e.g. the
+            # package id path does not exist). Must surface the package-not-found-on-feed diagnostic.
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                if ($Uri -eq "https://example.test/v3/index.json") {
+                    return [pscustomobject]@{
+                        Content = '{"resources":[{"@id":"https://example.test/flat/","@type":"PackageBaseAddress/3.0.0"}]}'
+                    }
+                }
+                throw "404 (Not Found)."
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*version index request failed*"
+        }
+
+        It "It_throws_clear_diagnostic_when_the_version_index_returns_malformed_JSON" {
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                if ($Uri -eq "https://example.test/v3/index.json") {
+                    return [pscustomobject]@{
+                        Content = '{"resources":[{"@id":"https://example.test/flat/","@type":"PackageBaseAddress/3.0.0"}]}'
+                    }
+                }
+                return [pscustomobject]@{ Content = '{ broken version index' }
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*version index*returned malformed JSON*"
+        }
+
+        It "It_throws_clear_diagnostic_when_the_nupkg_download_fails" {
+            # Service index and version index resolve and list the pinned version, but the flat-container
+            # .nupkg download fails. Must surface the download-failure diagnostic.
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                if ($OutFile) {
+                    throw "503 (Service Unavailable)."
+                }
+                if ($Uri -eq "https://example.test/v3/index.json") {
+                    return [pscustomobject]@{
+                        Content = '{"resources":[{"@id":"https://example.test/flat/","@type":"PackageBaseAddress/3.0.0"}]}'
+                    }
+                }
+                return [pscustomobject]@{ Content = '{"versions":["1.0.329"]}' }
+            }
+
+            { Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+            } | Should -Throw -ExpectedMessage "*Failed to download package*"
+        }
+    }
+
+    Context "Given_HttpV3Feed_SuccessPath" {
+        It "It_resolves_and_extracts_a_package_from_a_configured_HTTP_NuGet_v3_feed" {
+            # Positive coverage for the production default: an Azure-style HTTP NuGet v3 feed. The mock
+            # serves the three real request stages — service index (advertises PackageBaseAddress/3.0.0),
+            # flat-container version index (lists the pinned version), and the .nupkg flat-container
+            # download (writes a real asset-only package to -OutFile) — so the full configured-feed
+            # success path is exercised end to end, not just the local-folder override used elsewhere.
+            $sourceFeed = script:New-TestDirectory
+            $script:httpFixtureNupkg = script:New-FixtureNupkg `
+                -FeedFolder $sourceFeed `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329"
+
+            Mock -ModuleName bootstrap-package-resolver Invoke-WebRequest {
+                if ($OutFile) {
+                    # Flat-container .nupkg download: materialize the pinned package at the requested path.
+                    Copy-Item -LiteralPath $script:httpFixtureNupkg -Destination $OutFile -Force
+                    return
+                }
+                if ($Uri -eq "https://example.test/v3/index.json") {
+                    return [pscustomobject]@{
+                        Content = '{"resources":[{"@id":"https://example.test/flat/","@type":"PackageBaseAddress/3.0.0"}]}'
+                    }
+                }
+                if ($Uri -eq "https://example.test/flat/edfi.datastandard52.apischema/index.json") {
+                    return [pscustomobject]@{ Content = '{"versions":["1.0.329"]}' }
+                }
+                throw "Unexpected URI requested by the resolver: $Uri"
+            }
+
+            $result = Resolve-StandardSchemaPackage `
+                -FeedUrl "https://example.test/v3/index.json" `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -DestinationRoot $script:destRoot
+
+            $result.PackageId | Should -Be "EdFi.DataStandard52.ApiSchema"
+            $result.Version | Should -Be "1.0.329"
+            Test-Path -LiteralPath $result.ApiSchemaDirectory -PathType Container | Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $result.ApiSchemaDirectory "ApiSchema.json") -PathType Leaf |
+                Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $result.ApiSchemaDirectory "package-manifest.json") -PathType Leaf |
+                Should -BeTrue
+
+            # The downloaded .nupkg artifact is removed after extraction (only the HTTP path downloads it).
+            Test-Path -LiteralPath (Join-Path $result.ExtractionDirectory "edfi.datastandard52.apischema.1.0.329.nupkg") |
+                Should -BeFalse
+
+            # Pin the full HTTP flow: service index, version index, and flat-container download.
+            Should -Invoke -ModuleName bootstrap-package-resolver Invoke-WebRequest -Times 3 -Exactly
+
+            Remove-Item -LiteralPath $sourceFeed -Recurse -Force
+        }
+    }
+}

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -34,7 +34,7 @@ Describe "Story 00 bootstrap" {
         $dockerComposeRoot = Join-Path $repoRoot "eng/docker-compose"
         New-Item -ItemType Directory -Path $dockerComposeRoot -Force | Out-Null
 
-        foreach ($fileName in @("bootstrap-manifest.psm1", "bootstrap-schema-tool.psm1", "prepare-dms-schema.ps1", "prepare-dms-claims.ps1")) {
+        foreach ($fileName in @("bootstrap-manifest.psm1", "bootstrap-schema-catalog.psm1", "bootstrap-schema-tool.psm1", "bootstrap-package-resolver.psm1", "prepare-dms-schema.ps1", "prepare-dms-claims.ps1")) {
             Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot $fileName) -Destination $dockerComposeRoot
         }
 
@@ -213,6 +213,144 @@ exit $ExitCode
         New-Item -ItemType Directory -Path (Split-Path -Parent $Path) -Force | Out-Null
         $fragment | ConvertTo-Json -Depth 20 | Set-Content -LiteralPath $Path -Encoding utf8
     }
+
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+    Add-Type -AssemblyName System.IO.Compression -ErrorAction Stop
+
+    function script:New-FixtureNupkgForSchema {
+        <#
+        .SYNOPSIS
+        Creates a minimal asset-only ApiSchema .nupkg fixture for standard-mode pipeline tests.
+        The .nupkg contains contentFiles/any/any/ApiSchema/package-manifest.json and
+        contentFiles/any/any/ApiSchema/ApiSchema.json with a valid projectSchema.
+        Returns the absolute path to the .nupkg file.
+        #>
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $FeedFolder,
+
+            [Parameter(Mandatory)]
+            [string]
+            $PackageId,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Version,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ProjectName,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ProjectEndpointName,
+
+            [bool]
+            $IsExtensionProject = $false
+        )
+
+        $nupkgName = "$($PackageId.ToLowerInvariant()).$($Version.ToLowerInvariant()).nupkg"
+        $nupkgPath = Join-Path $FeedFolder $nupkgName
+
+        $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) "dms-s00-nupkg-$([Guid]::NewGuid().ToString('N'))"
+        $apiSchemaDir = Join-Path $stagingDir "contentFiles/any/any/ApiSchema"
+        New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+        # Full package-manifest.json with all required fields.
+        $manifest = [ordered]@{
+            version             = 1
+            packageId           = $PackageId
+            projectName         = $ProjectName
+            projectEndpointName = $ProjectEndpointName
+            isExtensionProject  = $IsExtensionProject
+            schemaPath          = "ApiSchema.json"
+            discoverySpecPath   = $null
+            xsdDirectory        = $null
+        }
+        $manifest | ConvertTo-Json -Depth 5 |
+            Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+        # Valid ApiSchema.json with a proper projectSchema so Read-ApiSchemaIdentity succeeds.
+        $apiSchema = [ordered]@{
+            apiSchemaVersion = "1.0.0"
+            projectSchema    = [ordered]@{
+                projectName         = $ProjectName
+                projectEndpointName = $ProjectEndpointName
+                isExtensionProject  = $IsExtensionProject
+                resourceSchemas     = [ordered]@{}
+                openApiBaseDocuments = [ordered]@{
+                    resources = [ordered]@{
+                        openapi = "3.0.1"
+                    }
+                }
+            }
+        }
+        $apiSchema | ConvertTo-Json -Depth 10 |
+            Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $nupkgPath)
+        Remove-Item -LiteralPath $stagingDir -Recurse -Force
+
+        return $nupkgPath
+    }
+
+    function script:New-StandardModeFeed {
+        <#
+        .SYNOPSIS
+        Creates a local fixture feed folder containing a core and optional extension .nupkg.
+        Returns the path to the feed folder.
+        #>
+        param(
+            [string[]]
+            $ExtensionNames = @()
+        )
+
+        $feedFolder = New-TestDirectory
+        New-Item -ItemType Directory -Path $feedFolder -Force | Out-Null
+
+        # Core package
+        New-FixtureNupkgForSchema `
+            -FeedFolder $feedFolder `
+            -PackageId "EdFi.DataStandard52.ApiSchema" `
+            -Version "1.0.329" `
+            -ProjectName "Ed-Fi" `
+            -ProjectEndpointName "ed-fi" `
+            -IsExtensionProject $false | Out-Null
+
+        foreach ($name in $ExtensionNames) {
+            $lower = $name.ToLowerInvariant()
+            $title = $lower.Substring(0, 1).ToUpperInvariant() + $lower.Substring(1)
+            New-FixtureNupkgForSchema `
+                -FeedFolder $feedFolder `
+                -PackageId "EdFi.DataStandard52.$title.ApiSchema" `
+                -Version "1.0.329" `
+                -ProjectName $title `
+                -ProjectEndpointName $lower `
+                -IsExtensionProject $true | Out-Null
+        }
+
+        return $feedFolder
+    }
+
+    function script:Invoke-PrepareSchemaStandard {
+        # Standard mode is package-backed core-only; there is no -Extensions parameter.
+        param(
+            [string]
+            $FeedFolder,
+
+            [string]
+            $Hash = $script:hashA,
+
+            [int]
+            $ToolExitCode = 0
+        )
+
+        $tool = New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $Hash -ExitCode $ToolExitCode
+        & $script:repo.PrepareSchemaScript `
+            -PackageFeedUrl $FeedFolder `
+            -SchemaToolPath $tool | Out-Null
+    }
     }
 
     BeforeEach {
@@ -235,12 +373,30 @@ exit $ExitCode
     }
 
     Context "schema staging" {
-        It "rejects missing ApiSchemaPath and Story 06 schema parameters" {
-            { & $script:repo.PrepareSchemaScript } |
-                Should -Throw -ExpectedMessage "*Story 06*"
+        It "stages core-only schema in standard mode against a local fixture feed" {
+            $feedFolder = New-StandardModeFeed
+            try {
+                Invoke-PrepareSchemaStandard -FeedFolder $feedFolder
+                $manifest = Get-RootManifest
 
-            { & $script:repo.PrepareSchemaScript -Extensions sample } |
-                Should -Throw -ExpectedMessage "*Story 06*"
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") |
+                    Should -BeTrue
+                $manifest.schema.selectionMode | Should -Be "Standard"
+                $manifest.schema.selectedExtensions | Should -BeNullOrEmpty
+                $manifest.schema.effectiveSchemaHash | Should -Be $script:hashA
+                $manifest.schema.apiSchemaManifestPath | Should -Be "ApiSchema/bootstrap-api-schema-manifest.json"
+            } finally {
+                if (Test-Path -LiteralPath $feedFolder) {
+                    Remove-Item -LiteralPath $feedFolder -Recurse -Force
+                }
+            }
+        }
+
+        It "does not accept an -Extensions parameter in standard mode" {
+            # standard mode is core-only; -Extensions was removed and fails with the native
+            # PowerShell "parameter cannot be found" error.
+            { & $script:repo.PrepareSchemaScript -Extensions "sample" } |
+                Should -Throw -ExpectedMessage "*parameter cannot be found*Extensions*"
         }
 
         It "stages core plus extension schemas and records the Story 00 manifest contract" {
@@ -803,6 +959,64 @@ exit $ExitCode
 
             Test-Path -LiteralPath $stagedClaims | Should -BeFalse
         }
+
+        It "Standard-mode core-only schema writes Embedded claims mode with no namespace prefixes" {
+            # prepare-dms-claims.ps1 is mode-agnostic: it reads bootstrap-api-schema-manifest.json
+            # regardless of selectionMode. Standard mode with no extensions produces no extension
+            # projects in the manifest, so no fragments are staged and mode is Embedded.
+            $feedFolder = New-StandardModeFeed
+            try {
+                Invoke-PrepareSchemaStandard -FeedFolder $feedFolder
+                Invoke-PrepareClaim
+                $manifest = Get-RootManifest
+
+                $manifest.claims.mode | Should -Be "Embedded"
+                @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File).Count |
+                    Should -Be 0
+                $manifest.seed.extensionNamespacePrefixes | Should -BeNullOrEmpty
+            } finally {
+                if (Test-Path -LiteralPath $feedFolder) {
+                    Remove-Item -LiteralPath $feedFolder -Recurse -Force
+                }
+            }
+        }
+
+        It "reads the ApiSchema manifest from the recorded schema.apiSchemaManifestPath, not a hardcoded path" {
+            # claims staging must consume the ApiSchema manifest the schema handoff recorded
+            # (schema.apiSchemaManifestPath) - the same field Resolve-BootstrapSchemaWorkspace and
+            # Set-BootstrapStartupEnvironment use - rather than a hardcoded
+            # ApiSchema/bootstrap-api-schema-manifest.json.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet)
+
+            $apiSchemaDir = Join-Path $script:repo.BootstrapRoot "ApiSchema"
+            $defaultManifest = Join-Path $apiSchemaDir "bootstrap-api-schema-manifest.json"
+            $relocatedRelative = "ApiSchema/relocated-api-schema-manifest.json"
+            Move-Item -LiteralPath $defaultManifest -Destination (Join-Path $script:repo.BootstrapRoot $relocatedRelative)
+
+            # Point the recorded schema handoff at the relocated manifest.
+            $manifestPath = Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json"
+            $manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+            $manifest.schema.apiSchemaManifestPath = $relocatedRelative
+            $manifest | ConvertTo-Json -Depth 50 | Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+            # The hardcoded default manifest no longer exists; claims staging must follow the recorded
+            # path and succeed. With the old hardcoded path this threw "Staged ApiSchema manifest was not found".
+            { Invoke-PrepareClaim } | Should -Not -Throw -Because "claims staging must honor schema.apiSchemaManifestPath"
+            (Get-RootManifest).claims.mode | Should -Be "Embedded"
+        }
+
+        It "throws when the root manifest schema section lacks apiSchemaManifestPath" {
+            # A schema section without apiSchemaManifestPath is an incomplete/legacy handoff; claims staging
+            # must require the recorded field rather than silently falling back to a hardcoded manifest path.
+            New-Item -ItemType Directory -Path $script:repo.BootstrapRoot -Force | Out-Null
+            $manifestPath = Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json"
+            '{"version":1,"schema":{"selectionMode":"Standard"}}' |
+                Set-Content -LiteralPath $manifestPath -Encoding utf8
+
+            { Invoke-PrepareClaim } |
+                Should -Throw -ExpectedMessage "*schema.apiSchemaManifestPath*"
+        }
+
     }
 
     Context "startup handoff" {
@@ -837,6 +1051,33 @@ exit $ExitCode
             $env:DMS_CONFIG_CLAIMS_SOURCE | Should -Be "Hybrid"
             $env:DMS_CONFIG_CLAIMS_DIRECTORY | Should -Be "/app/additional-claims"
             $env:DMS_CONFIG_CLAIMS_MOUNT_SOURCE | Should -Not -BeNullOrEmpty
+        }
+
+        It "validates a package-backed standard-mode bootstrap manifest at startup (DMS-1156 wrapper path)" {
+            # regression: prepare-dms-schema.ps1 standard mode (core-only, invoked directly or
+            # auto-staged by the wrapper) records selectionMode "Standard". Standard and ApiSchemaPath modes
+            # stage the same normalized .bootstrap/ApiSchema workspace, so startup validation must accept
+            # "Standard"; rejecting everything but "ApiSchemaPath" broke the standard-mode/wrapper production
+            # path before infrastructure could start.
+            $feedFolder = New-StandardModeFeed
+            try {
+                Invoke-PrepareSchemaStandard -FeedFolder $feedFolder
+                Invoke-PrepareClaim
+                (Get-RootManifest).schema.selectionMode | Should -Be "Standard"
+
+                Remove-Module bootstrap-manifest -Force -ErrorAction SilentlyContinue
+                Import-Module $script:repo.ManifestModule -Force
+
+                # Story 04 (DMS-1154) activates staged-workspace runtime loading, so a valid
+                # standard-mode manifest must be accepted and the staged-schema env vars activated.
+                Set-BootstrapStartupEnvironment | Should -BeTrue
+                $env:USE_API_SCHEMA_PATH | Should -Be "true"
+                $env:API_SCHEMA_PATH | Should -Be "/app/ApiSchema"
+            } finally {
+                if (Test-Path -LiteralPath $feedFolder) {
+                    Remove-Item -LiteralPath $feedFolder -Recurse -Force
+                }
+            }
         }
 
         It "activates staged schema env vars in bootstrap mode and sets DMS_API_SCHEMA_MOUNT_SOURCE to the staged workspace" {

--- a/eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1
@@ -2532,10 +2532,11 @@ EdFi.BulkLoadClient.Console fake
             Remove-Item -LiteralPath $tmpRoot -Recurse -Force
         }
 
-        It "bootstrap-local-dms.ps1 rejects missing bootstrap manifest before any phase invocation when -LoadSeedData is supplied" {
-            # Regression: an absent .bootstrap/bootstrap-manifest.json used to throw only inside
-            # load-dms-seed-data.ps1 after the wrapper had already invoked start-local-dms.ps1
-            # and spun up Docker + CMS. The wrapper must catch this BEFORE the start phase.
+        It "bootstrap-local-dms.ps1 auto-stages core-only standard mode when no workspace is pre-staged" {
+            # bootstrap-design.md Section 9.4.1: the thin wrapper requires no manual prepare
+            # step. With no -Extensions and no pre-staged .bootstrap/bootstrap-manifest.json, the wrapper
+            # stages core-only standard mode (prepare-dms-schema.ps1 + prepare-dms-claims.ps1) before the
+            # start phase, then reaches start (and the seed phase under -LoadSeedData) without throwing.
             $wrapperScript = Join-Path $script:sourceDockerComposeRoot "bootstrap-local-dms.ps1"
             $tmpRoot = New-TestDirectory
             $tmpDockerCompose = Join-Path $tmpRoot "eng/docker-compose"
@@ -2544,9 +2545,16 @@ EdFi.BulkLoadClient.Console fake
             Copy-Item -LiteralPath $wrapperScript -Destination $tmpDockerCompose
             Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot "bootstrap-wrapper.psm1") -Destination $tmpDockerCompose
 
+            $prepareProbe = Join-Path $tmpRoot "prepare-invoked.txt"
             $startProbe = Join-Path $tmpRoot "start-invoked.txt"
             $seedProbe = Join-Path $tmpRoot "seed-invoked.txt"
 
+            # prepare-dms-schema.ps1 stub records that the core-only prepare phase ran and asserts no
+            # -Extensions were forwarded (core-only path).
+            "param([string[]]`$Extensions, [Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$prepareProbe' -Value (`"extensions=`$(`$Extensions -join ',')`") -Encoding utf8" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "prepare-dms-schema.ps1") -Encoding utf8
+            "param([Parameter(ValueFromRemainingArguments)]`$rest)" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "prepare-dms-claims.ps1") -Encoding utf8
             "param([Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$startProbe' -Value 'invoked' -Encoding utf8" |
                 Set-Content -LiteralPath (Join-Path $tmpDockerCompose "start-local-dms.ps1") -Encoding utf8
             "param([Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$seedProbe' -Value 'invoked' -Encoding utf8" |
@@ -2554,16 +2562,20 @@ EdFi.BulkLoadClient.Console fake
 
             $wrapperCopy = Join-Path $tmpDockerCompose "bootstrap-local-dms.ps1"
 
-            # The sandbox tmpDockerCompose does NOT have .bootstrap/bootstrap-manifest.json,
-            # so -LoadSeedData must throw before invoking start-local-dms.ps1.
-            { & $wrapperCopy -LoadSeedData } | Should -Throw -ExpectedMessage "*bootstrap-manifest.json*"
+            # No .bootstrap/bootstrap-manifest.json exists; -LoadSeedData must NOT throw -- the core-only
+            # prepare phase stages the workspace first, then start and seed run.
+            { & $wrapperCopy -LoadSeedData } | Should -Not -Throw
 
-            Test-Path -LiteralPath $startProbe | Should -BeFalse -Because "start phase must not run when manifest is missing"
-            Test-Path -LiteralPath $seedProbe | Should -BeFalse -Because "seed phase must not run when manifest is missing"
+            (Get-Content -LiteralPath $prepareProbe -Raw).Trim() | Should -Be "extensions=" -Because "core-only auto-stage must run prepare-dms-schema.ps1 with no -Extensions"
+            Test-Path -LiteralPath $startProbe | Should -BeTrue -Because "start phase must run after core-only staging"
+            Test-Path -LiteralPath $seedProbe | Should -BeTrue -Because "seed phase must run when -LoadSeedData is supplied"
 
-            # Without -LoadSeedData the preflight is skipped, start phase still runs
+            # The no-argument core-only happy path also stages and starts (no seed).
+            Remove-Item -LiteralPath $prepareProbe, $startProbe, $seedProbe -Force -ErrorAction SilentlyContinue
             & $wrapperCopy
+            Test-Path -LiteralPath $prepareProbe | Should -BeTrue -Because "no-argument wrapper must auto-stage core-only"
             Test-Path -LiteralPath $startProbe | Should -BeTrue
+            Test-Path -LiteralPath $seedProbe | Should -BeFalse -Because "seed phase must not run without -LoadSeedData"
 
             Remove-Item -LiteralPath $tmpRoot -Recurse -Force
         }
@@ -2784,6 +2796,55 @@ EdFi.BulkLoadClient.Console fake
             & $wrapperCopy -LoadSeedData
             Test-Path -LiteralPath $startProbe | Should -BeTrue
             Test-Path -LiteralPath $seedProbe | Should -BeTrue -Because "seed phase must run when -LoadSeedData is present"
+
+            Remove-Item -LiteralPath $tmpRoot -Recurse -Force
+        }
+
+        It "bootstrap-published-dms.ps1 auto-stages core-only standard mode when no workspace is pre-staged" {
+            # bootstrap-design.md Section 9.4.1: like the local wrapper, the published thin wrapper requires
+            # no manual prepare step. With no -Extensions and no pre-staged .bootstrap/bootstrap-manifest.json,
+            # it must stage core-only standard mode (prepare-dms-schema.ps1 + prepare-dms-claims.ps1) before
+            # the start phase, then reach start (and the seed phase under -LoadSeedData) without throwing.
+            # The other published-wrapper tests pre-stage a fake manifest, which bypasses this auto-stage path.
+            $wrapperScript = Join-Path $script:sourceDockerComposeRoot "bootstrap-published-dms.ps1"
+            $tmpRoot = New-TestDirectory
+            $tmpDockerCompose = Join-Path $tmpRoot "eng/docker-compose"
+            New-Item -ItemType Directory -Path $tmpDockerCompose -Force | Out-Null
+
+            Copy-Item -LiteralPath $wrapperScript -Destination $tmpDockerCompose
+            Copy-Item -LiteralPath (Join-Path $script:sourceDockerComposeRoot "bootstrap-wrapper.psm1") -Destination $tmpDockerCompose
+
+            $prepareProbe = Join-Path $tmpRoot "prepare-invoked.txt"
+            $startProbe = Join-Path $tmpRoot "start-invoked.txt"
+            $seedProbe = Join-Path $tmpRoot "seed-invoked.txt"
+
+            # prepare-dms-schema.ps1 stub records that the core-only prepare phase ran and asserts no
+            # -Extensions were forwarded (core-only path).
+            "param([string[]]`$Extensions, [Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$prepareProbe' -Value (`"extensions=`$(`$Extensions -join ',')`") -Encoding utf8" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "prepare-dms-schema.ps1") -Encoding utf8
+            "param([Parameter(ValueFromRemainingArguments)]`$rest)" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "prepare-dms-claims.ps1") -Encoding utf8
+            "param([Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$startProbe' -Value 'invoked' -Encoding utf8" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "start-published-dms.ps1") -Encoding utf8
+            "param([Parameter(ValueFromRemainingArguments)]`$rest); Set-Content -LiteralPath '$seedProbe' -Value 'invoked' -Encoding utf8" |
+                Set-Content -LiteralPath (Join-Path $tmpDockerCompose "load-dms-seed-data.ps1") -Encoding utf8
+
+            $wrapperCopy = Join-Path $tmpDockerCompose "bootstrap-published-dms.ps1"
+
+            # No .bootstrap/bootstrap-manifest.json exists; -LoadSeedData must NOT throw -- the core-only
+            # prepare phase stages the workspace first, then start and seed run.
+            { & $wrapperCopy -LoadSeedData } | Should -Not -Throw
+
+            (Get-Content -LiteralPath $prepareProbe -Raw).Trim() | Should -Be "extensions=" -Because "core-only auto-stage must run prepare-dms-schema.ps1 with no -Extensions"
+            Test-Path -LiteralPath $startProbe | Should -BeTrue -Because "start phase must run after core-only staging"
+            Test-Path -LiteralPath $seedProbe | Should -BeTrue -Because "seed phase must run when -LoadSeedData is supplied"
+
+            # The no-argument core-only happy path also stages and starts (no seed).
+            Remove-Item -LiteralPath $prepareProbe, $startProbe, $seedProbe -Force -ErrorAction SilentlyContinue
+            & $wrapperCopy
+            Test-Path -LiteralPath $prepareProbe | Should -BeTrue -Because "no-argument wrapper must auto-stage core-only"
+            Test-Path -LiteralPath $startProbe | Should -BeTrue
+            Test-Path -LiteralPath $seedProbe | Should -BeFalse -Because "seed phase must not run without -LoadSeedData"
 
             Remove-Item -LiteralPath $tmpRoot -Recurse -Force
         }

--- a/eng/docker-compose/tests/BootstrapStandardSchemaSelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapStandardSchemaSelection.Tests.ps1
@@ -1,0 +1,1000 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', '', Justification = 'Pester fixture parameters are unused by design.')]
+param()
+
+Describe "DMS-1156 standard-mode schema selection" {
+    BeforeAll {
+        $script:sourceRepoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:sourceDockerComposeRoot = Join-Path $script:sourceRepoRoot "eng/docker-compose"
+        $script:hashA = "0000000000000000000000000000000000000000000000000000000000000001"
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction Stop
+        Add-Type -AssemblyName System.IO.Compression -ErrorAction Stop
+
+        function script:New-TempDirectory {
+            $path = Join-Path ([System.IO.Path]::GetTempPath()) "dms-std-$([Guid]::NewGuid().ToString('N'))"
+            New-Item -ItemType Directory -Path $path -Force | Out-Null
+            return $path
+        }
+
+        function script:New-IsolatedRepo {
+            <#
+            .SYNOPSIS
+            Copies the bootstrap scripts into a temp repo tree and returns a helper object.
+            #>
+            $repoRoot = script:New-TempDirectory
+            $dockerComposeRoot = Join-Path $repoRoot "eng/docker-compose"
+            New-Item -ItemType Directory -Path $dockerComposeRoot -Force | Out-Null
+
+            foreach ($fileName in @(
+                "bootstrap-manifest.psm1",
+                "bootstrap-schema-catalog.psm1",
+                "bootstrap-schema-tool.psm1",
+                "bootstrap-package-resolver.psm1",
+                "prepare-dms-schema.ps1"
+            )) {
+                Copy-Item `
+                    -LiteralPath (Join-Path $script:sourceDockerComposeRoot $fileName) `
+                    -Destination $dockerComposeRoot
+            }
+
+            # Copy JsonSchemaForApiSchema.json so prepare-dms-schema.ps1 can stage it into the
+            # workspace (required since DMS-1154 activates staged-workspace runtime loading).
+            $jsonSchemaSourceDir = Join-Path $script:sourceRepoRoot "src/dms/core/EdFi.DataManagementService.Core/ApiSchema"
+            $jsonSchemaTargetDir = Join-Path $repoRoot "src/dms/core/EdFi.DataManagementService.Core/ApiSchema"
+            New-Item -ItemType Directory -Path $jsonSchemaTargetDir -Force | Out-Null
+            Copy-Item `
+                -LiteralPath (Join-Path $jsonSchemaSourceDir "JsonSchemaForApiSchema.json") `
+                -Destination $jsonSchemaTargetDir
+
+            return [pscustomobject]@{
+                RepoRoot            = $repoRoot
+                DockerComposeRoot   = $dockerComposeRoot
+                BootstrapRoot       = Join-Path $dockerComposeRoot ".bootstrap"
+                PrepareSchemaScript = Join-Path $dockerComposeRoot "prepare-dms-schema.ps1"
+            }
+        }
+
+        function script:New-FakeSchemaTool {
+            param(
+                [Parameter(Mandatory)]
+                [string]
+                $Directory,
+
+                [string]
+                $Hash = $script:hashA,
+
+                [int]
+                $ExitCode = 0
+            )
+
+            $path = Join-Path $Directory "fake-schema-tool.ps1"
+            @"
+param([Parameter(ValueFromRemainingArguments = `$true)][string[]] `$Arguments)
+Write-Output "Effective schema hash: $Hash"
+exit $ExitCode
+"@ | Set-Content -LiteralPath $path -Encoding utf8
+            return $path
+        }
+
+        function script:New-FixtureNupkg {
+            <#
+            .SYNOPSIS
+            Creates an asset-only .nupkg fixture in a local feed folder.
+            The nupkg contains:
+              contentFiles/any/any/ApiSchema/package-manifest.json
+              contentFiles/any/any/ApiSchema/ApiSchema.json
+            Returns the .nupkg path.
+            #>
+            param(
+                [Parameter(Mandatory)]
+                [string]
+                $FeedFolder,
+
+                [Parameter(Mandatory)]
+                [string]
+                $PackageId,
+
+                [Parameter(Mandatory)]
+                [string]
+                $Version,
+
+                [Parameter(Mandatory)]
+                [string]
+                $ProjectName,
+
+                [Parameter(Mandatory)]
+                [string]
+                $ProjectEndpointName,
+
+                [bool]
+                $IsExtensionProject = $false,
+
+                # Manifest-relative path to a discovery spec file; when supplied, the file is
+                # created inside the package and declared in package-manifest.json.
+                [string]
+                $DiscoverySpecPath,
+
+                # Manifest-relative path to an XSD directory; when supplied, the directory is
+                # created with one .xsd file and declared in package-manifest.json.
+                [string]
+                $XsdDirectory,
+
+                # Plants a conventional sibling xsd/ directory in the payload WITHOUT declaring it
+                # in the manifest, to exercise manifest-authoritative (no rediscovery) staging.
+                [switch]
+                $PlantUndeclaredXsdDirectory
+            )
+
+            $nupkgName = "$($PackageId.ToLowerInvariant()).$($Version.ToLowerInvariant()).nupkg"
+            $nupkgPath = Join-Path $FeedFolder $nupkgName
+
+            $stagingDir = Join-Path ([System.IO.Path]::GetTempPath()) "dms-std-nupkg-$([Guid]::NewGuid().ToString('N'))"
+            $apiSchemaDir = Join-Path $stagingDir "contentFiles/any/any/ApiSchema"
+            New-Item -ItemType Directory -Path $apiSchemaDir -Force | Out-Null
+
+            $manifest = [ordered]@{
+                version             = 1
+                packageId           = $PackageId
+                projectName         = $ProjectName
+                projectEndpointName = $ProjectEndpointName
+                isExtensionProject  = $IsExtensionProject
+                schemaPath          = "ApiSchema.json"
+                discoverySpecPath   = $null
+                xsdDirectory        = $null
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($DiscoverySpecPath)) {
+                $manifest.discoverySpecPath = $DiscoverySpecPath
+                $discoverySpecFullPath = Join-Path $apiSchemaDir $DiscoverySpecPath
+                New-Item -ItemType Directory -Path (Split-Path -Parent $discoverySpecFullPath) -Force | Out-Null
+                '{"urls":{}}' | Set-Content -LiteralPath $discoverySpecFullPath -Encoding utf8
+            }
+
+            if (-not [string]::IsNullOrWhiteSpace($XsdDirectory)) {
+                $manifest.xsdDirectory = $XsdDirectory
+                $xsdFullPath = Join-Path $apiSchemaDir $XsdDirectory
+                New-Item -ItemType Directory -Path $xsdFullPath -Force | Out-Null
+                "<xs:schema />" | Set-Content -LiteralPath (Join-Path $xsdFullPath "Ed-Fi-Core.xsd") -Encoding utf8
+            }
+
+            if ($PlantUndeclaredXsdDirectory) {
+                $undeclaredXsdPath = Join-Path $apiSchemaDir "xsd"
+                New-Item -ItemType Directory -Path $undeclaredXsdPath -Force | Out-Null
+                "<xs:schema />" | Set-Content -LiteralPath (Join-Path $undeclaredXsdPath "Undeclared.xsd") -Encoding utf8
+            }
+
+            $manifest | ConvertTo-Json -Depth 5 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "package-manifest.json") -Encoding utf8
+
+            $apiSchema = [ordered]@{
+                apiSchemaVersion = "1.0.0"
+                projectSchema    = [ordered]@{
+                    projectName         = $ProjectName
+                    projectEndpointName = $ProjectEndpointName
+                    isExtensionProject  = $IsExtensionProject
+                    resourceSchemas     = [ordered]@{}
+                    openApiBaseDocuments = [ordered]@{
+                        resources = [ordered]@{
+                            openapi = "3.0.1"
+                        }
+                    }
+                }
+            }
+            $apiSchema | ConvertTo-Json -Depth 10 |
+                Set-Content -LiteralPath (Join-Path $apiSchemaDir "ApiSchema.json") -Encoding utf8
+
+            [System.IO.Compression.ZipFile]::CreateFromDirectory($stagingDir, $nupkgPath)
+            Remove-Item -LiteralPath $stagingDir -Recurse -Force
+
+            return $nupkgPath
+        }
+
+        function script:New-FixtureFeed {
+            <#
+            .SYNOPSIS
+            Creates a local fixture feed folder containing the package-backed core package. Standard mode is
+            core-only, so the feed stages only the core package; extension/custom schema sets use
+            the expert -ApiSchemaPath filesystem path, not package resolution.
+            Returns the path to the feed folder.
+            #>
+            param()
+
+            $feedFolder = script:New-TempDirectory
+
+            script:New-FixtureNupkg `
+                -FeedFolder $feedFolder `
+                -PackageId "EdFi.DataStandard52.ApiSchema" `
+                -Version "1.0.329" `
+                -ProjectName "Ed-Fi" `
+                -ProjectEndpointName "ed-fi" `
+                -IsExtensionProject $false | Out-Null
+
+            return $feedFolder
+        }
+
+        function script:Invoke-PrepareStandard {
+            <#
+            .SYNOPSIS
+            Invokes prepare-dms-schema.ps1 in standard mode (no -ApiSchemaPath). Standard mode is
+            package-backed core-only; there is no -Extensions parameter.
+            #>
+            param(
+                [Parameter(Mandatory)]
+                [string]
+                $FeedFolder,
+
+                [string]
+                $Hash = $script:hashA,
+
+                [int]
+                $ToolExitCode = 0
+            )
+
+            $tool = script:New-FakeSchemaTool `
+                -Directory $script:repo.RepoRoot `
+                -Hash $Hash `
+                -ExitCode $ToolExitCode
+
+            & $script:repo.PrepareSchemaScript `
+                -PackageFeedUrl $FeedFolder `
+                -SchemaToolPath $tool | Out-Null
+        }
+
+        function script:Get-RootManifest {
+            return Get-Content `
+                -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") `
+                -Raw |
+                ConvertFrom-Json
+        }
+
+        function script:Get-ApiSchemaManifest {
+            return Get-Content `
+                -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json") `
+                -Raw |
+                ConvertFrom-Json
+        }
+
+        function script:Get-DeclaredParameterBlock {
+            <#
+            .SYNOPSIS
+            Returns the ParamBlockAst for a script file's top-level param block, or for a named function
+            defined within the file. Returns $null when there is no param block. Parses; never executes.
+            #>
+            param(
+                [Parameter(Mandatory)]
+                [string]
+                $FilePath,
+
+                [string]
+                $FunctionName
+            )
+
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($FilePath, [ref]$null, [ref]$parseErrors)
+            if ($parseErrors.Count -gt 0) {
+                throw "Parse errors in '$FilePath': $($parseErrors[0].Message)"
+            }
+
+            if ([string]::IsNullOrEmpty($FunctionName)) {
+                return $ast.ParamBlock
+            }
+
+            $function = $ast.Find(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $node.Name -eq $FunctionName
+                },
+                $true)
+            if ($null -eq $function) {
+                throw "Function '$FunctionName' not found in '$FilePath'."
+            }
+            return $function.Body.ParamBlock
+        }
+
+        function script:Test-ExposesExtensionsParameter {
+            <#
+            .SYNOPSIS
+            True if the param block declares a parameter named 'Extensions' (typed or untyped) or any
+            parameter carrying an [Alias('Extensions')] alias. Case-insensitive, matching how PowerShell
+            binds parameter names and aliases - so it catches forms a single regex would miss.
+            #>
+            param(
+                $ParamBlock
+            )
+
+            if ($null -eq $ParamBlock) {
+                return $false
+            }
+
+            foreach ($parameter in $ParamBlock.Parameters) {
+                if ($parameter.Name.VariablePath.UserPath -ieq 'Extensions') {
+                    return $true
+                }
+
+                foreach ($attribute in $parameter.Attributes) {
+                    if ($attribute -is [System.Management.Automation.Language.AttributeAst] -and
+                        ($attribute.TypeName.Name -ieq 'Alias' -or $attribute.TypeName.Name -ieq 'AliasAttribute')) {
+                        foreach ($argument in $attribute.PositionalArguments) {
+                            if (($argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) -and
+                                ($argument.Value -ieq 'Extensions')) {
+                                return $true
+                            }
+                        }
+                    }
+                }
+            }
+
+            return $false
+        }
+    }
+
+    BeforeEach {
+        $script:repo = script:New-IsolatedRepo
+        $script:feedFolder = $null
+    }
+
+    AfterEach {
+        if ($null -ne $script:repo -and (Test-Path -LiteralPath $script:repo.RepoRoot)) {
+            Remove-Item -LiteralPath $script:repo.RepoRoot -Recurse -Force
+        }
+
+        if ($null -ne $script:feedFolder -and (Test-Path -LiteralPath $script:feedFolder)) {
+            Remove-Item -LiteralPath $script:feedFolder -Recurse -Force
+        }
+    }
+
+    Context "Given_StandardMode_CoreOnly_NoExtensionsParam" {
+        It "It_stages_core_schema_and_records_Standard_selectionMode_when_ApiSchemaPath_omitted" {
+            $script:feedFolder = script:New-FixtureFeed
+
+            script:Invoke-PrepareStandard -FeedFolder $script:feedFolder
+
+            $manifest = script:Get-RootManifest
+
+            $manifest.schema.selectionMode | Should -Be "Standard"
+            $manifest.schema.selectedExtensions | Should -BeNullOrEmpty
+            $manifest.schema.apiSchemaManifestPath | Should -Be "ApiSchema/bootstrap-api-schema-manifest.json"
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") |
+                Should -BeTrue
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/bootstrap-api-schema-manifest.json") |
+                Should -BeTrue
+        }
+    }
+
+    Context "Given_DefaultCatalogPath" {
+        It "It_catalog_exposes_the_pinned_default_feed_and_core_package" {
+            # The production standard path uses the pinned catalog defaults (no caller-supplied feed/id/
+            # version). Lock those defaults so an accidental change to the configured feed or pinned core
+            # package identity is caught here.
+            Import-Module (Join-Path $script:sourceDockerComposeRoot "bootstrap-schema-catalog.psm1") -Force
+
+            Get-StandardSchemaFeed |
+                Should -Match '^https://pkgs\.dev\.azure\.com/ed-fi-alliance/.*/EdFi/nuget/v3/index\.json$'
+
+            $core = Get-StandardCorePackage
+            $core.Id | Should -Be "EdFi.DataStandard52.ApiSchema"
+            $core.ProjectToken | Should -Be "Ed-Fi"
+            $core.EndpointToken | Should -Be "ed-fi"
+            $core.Version | Should -Match '^\d+\.\d+\.\d+'
+        }
+
+        It "It_standard_mode_resolves_the_default_catalog_feed_and_core_package_when_PackageFeedUrl_is_omitted" {
+            # Production standard path: developers omit -PackageFeedUrl, so prepare-dms-schema.ps1 falls
+            # back to Get-StandardSchemaFeed / Get-StandardCorePackage. Exercise that fallback end to end
+            # WITHOUT a network call by redirecting the isolated copy's pinned default feed to the local
+            # fixture; the core package id/version still come from the catalog (Get-StandardCorePackage)
+            # unchanged. prepare-dms-schema.ps1 re-imports the copied catalog with -Force on each run, so
+            # the redirect is what the default path resolves.
+            $script:feedFolder = script:New-FixtureFeed
+
+            $catalogPath = Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-catalog.psm1"
+            $redirected = $false
+            $newLines = foreach ($line in (Get-Content -LiteralPath $catalogPath)) {
+                if ($line -match '^\s*\$script:StandardFeedUrl\s*=') {
+                    $redirected = $true
+                    '$script:StandardFeedUrl = ' + "'$($script:feedFolder)'"
+                } else {
+                    $line
+                }
+            }
+            $redirected |
+                Should -BeTrue -Because "test setup must redirect the catalog default feed to the fixture; otherwise the default path would reach the live feed"
+            Set-Content -LiteralPath $catalogPath -Value $newLines -Encoding utf8
+
+            $tool = script:New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $script:hashA -ExitCode 0
+
+            # No -PackageFeedUrl: exercises the default feed / catalog fallback.
+            & $script:repo.PrepareSchemaScript -SchemaToolPath $tool | Out-Null
+
+            $manifest = script:Get-RootManifest
+            $manifest.schema.selectionMode | Should -Be "Standard"
+            $manifest.schema.selectedExtensions | Should -BeNullOrEmpty
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") |
+                Should -BeTrue
+        }
+    }
+
+    Context "Given_ExtensionsParameterRemoved" {
+        It "It_does_not_declare_an_Extensions_parameter_on_prepare-dms-schema.ps1" {
+            # scope decision: standard mode is package-backed core-only; there is no
+            # -Extensions parameter. Invoking with -Extensions must fail with PowerShell's native
+            # "parameter cannot be found" error.
+            $prepareContent = Get-Content -LiteralPath $script:repo.PrepareSchemaScript -Raw
+            # Case-sensitive param-declaration check (avoids matching $extension* locals).
+            $prepareContent | Should -Not -Match '(?-i)\[string\[\]\]\s*\$Extensions\b'
+
+            {
+                & $script:repo.PrepareSchemaScript -Extensions "sample"
+            } | Should -Throw -ExpectedMessage "*parameter cannot be found*Extensions*"
+        }
+    }
+
+    Context "Given_BlankApiSchemaPath_BoundButEmpty" {
+        It "It_throws_invalid_input_instead_of_falling_into_standard_mode_when_ApiSchemaPath_is_blank" {
+            # blocker: standard mode is selected by OMITTING -ApiSchemaPath. An explicitly bound
+            # but blank value is invalid expert-mode input and must fail fast, not silently route to
+            # package-backed core-only staging.
+            {
+                & $script:repo.PrepareSchemaScript -ApiSchemaPath ""
+            } | Should -Throw -ExpectedMessage "*-ApiSchemaPath was supplied but is blank*"
+
+            # The failure must occur before any workspace is staged.
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "bootstrap-manifest.json") |
+                Should -BeFalse
+        }
+    }
+
+    Context "Given_StandardMode_ManifestCorrectness" {
+        It "It_does_not_record_package_IDs_or_feed_URLs_in_root_manifest_or_ApiSchema_manifest" {
+            $script:feedFolder = script:New-FixtureFeed
+
+            script:Invoke-PrepareStandard -FeedFolder $script:feedFolder
+
+            $rootManifest = script:Get-RootManifest
+            $apiSchemaManifest = script:Get-ApiSchemaManifest
+
+            # Root manifest schema section must not expose package IDs, versions, or feed URLs.
+            $rootManifestJson = $rootManifest | ConvertTo-Json -Depth 20
+            $rootManifestJson | Should -Not -Match "EdFi\.DataStandard"
+            $rootManifestJson | Should -Not -Match "1\.0\.329"
+            $rootManifestJson | Should -Not -Match "pkgs\.dev\.azure\.com"
+            $rootManifestJson | Should -Not -Match $script:feedFolder.Replace("\", "\\")
+
+            # ApiSchema manifest projects must not expose package IDs, versions, or feed URLs.
+            $apiSchemaManifestJson = $apiSchemaManifest | ConvertTo-Json -Depth 20
+            $apiSchemaManifestJson | Should -Not -Match "EdFi\.DataStandard"
+            $apiSchemaManifestJson | Should -Not -Match "1\.0\.329"
+            $apiSchemaManifestJson | Should -Not -Match "pkgs\.dev\.azure\.com"
+        }
+    }
+
+    Context "Given_InvalidPayload_LibDll_SurfacedThroughStandardMode" {
+        It "It_fails_fast_with_clear_message_and_leaves_no_staged_workspace_when_package_contains_lib_dll" {
+            # Build a malformed CORE .nupkg that contains a forbidden lib/ directory with a .dll file.
+            # The resolver finds it by the pinned core ID; the contract validator must reject it before
+            # workspace finalization.
+            $malformedFeedFolder = script:New-TempDirectory
+
+            try {
+                $corePackageId = "EdFi.DataStandard52.ApiSchema"
+                $coreNupkgName = "$($corePackageId.ToLowerInvariant()).1.0.329.nupkg"
+                $coreNupkgPath = Join-Path $malformedFeedFolder $coreNupkgName
+                $libStaging = Join-Path ([System.IO.Path]::GetTempPath()) "dms-std-libcore-$([Guid]::NewGuid().ToString('N'))"
+                $libApiSchemaDir = Join-Path $libStaging "contentFiles/any/any/ApiSchema"
+                New-Item -ItemType Directory -Path $libApiSchemaDir -Force | Out-Null
+
+                $libManifest = [ordered]@{
+                    version             = 1
+                    packageId           = $corePackageId
+                    projectName         = "Ed-Fi"
+                    projectEndpointName = "ed-fi"
+                    isExtensionProject  = $false
+                    schemaPath          = "ApiSchema.json"
+                    discoverySpecPath   = $null
+                    xsdDirectory        = $null
+                }
+                $libManifest | ConvertTo-Json -Depth 5 |
+                    Set-Content -LiteralPath (Join-Path $libApiSchemaDir "package-manifest.json") -Encoding utf8
+
+                $libApiSchema = [ordered]@{
+                    apiSchemaVersion = "1.0.0"
+                    projectSchema    = [ordered]@{
+                        projectName         = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject  = $false
+                        resourceSchemas     = [ordered]@{}
+                        openApiBaseDocuments = [ordered]@{
+                            resources = [ordered]@{ openapi = "3.0.1" }
+                        }
+                    }
+                }
+                $libApiSchema | ConvertTo-Json -Depth 10 |
+                    Set-Content -LiteralPath (Join-Path $libApiSchemaDir "ApiSchema.json") -Encoding utf8
+
+                # Plant the forbidden lib/ directory to trigger the contract violation.
+                $libNetDir = Join-Path $libStaging "lib/net8.0"
+                New-Item -ItemType Directory -Path $libNetDir -Force | Out-Null
+                [System.IO.File]::WriteAllBytes(
+                    (Join-Path $libNetDir "EdFi.DataStandard52.ApiSchema.dll"),
+                    [byte[]]@(0, 0, 0, 0)
+                )
+
+                [System.IO.Compression.ZipFile]::CreateFromDirectory($libStaging, $coreNupkgPath)
+                Remove-Item -LiteralPath $libStaging -Recurse -Force
+
+                {
+                    script:Invoke-PrepareStandard -FeedFolder $malformedFeedFolder
+                } | Should -Throw -ExpectedMessage "*forbidden*"
+
+                # The staged ApiSchema workspace must not have been created.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                    Should -BeFalse
+            }
+            finally {
+                if (Test-Path -LiteralPath $malformedFeedFolder) {
+                    Remove-Item -LiteralPath $malformedFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_SchemaAssetIdentityDivergesFromManifest_SurfacedThroughStandardMode" {
+        It "It_fails_fast_with_identity_mismatch_and_leaves_no_staged_workspace_when_ApiSchema_json_declares_a_different_project" {
+            # The core package can pass package-manifest identity validation (packageId/projectName
+            # say Ed-Fi) yet ship an ApiSchema.json whose internal project identity differs. The
+            # stage-time identity lock must reject that divergence rather than silently staging the
+            # wrong project.
+            $divergentFeedFolder = script:New-TempDirectory
+
+            try {
+                $corePackageId = "EdFi.DataStandard52.ApiSchema"
+                $coreNupkgPath = Join-Path $divergentFeedFolder "$($corePackageId.ToLowerInvariant()).1.0.329.nupkg"
+                $coreStaging = Join-Path ([System.IO.Path]::GetTempPath()) "dms-std-divergent-$([Guid]::NewGuid().ToString('N'))"
+                $coreApiSchemaDir = Join-Path $coreStaging "contentFiles/any/any/ApiSchema"
+                New-Item -ItemType Directory -Path $coreApiSchemaDir -Force | Out-Null
+
+                # Manifest declares the expected core identity (Ed-Fi/ed-fi).
+                $coreManifest = [ordered]@{
+                    version             = 1
+                    packageId           = $corePackageId
+                    projectName         = "Ed-Fi"
+                    projectEndpointName = "ed-fi"
+                    isExtensionProject  = $false
+                    schemaPath          = "ApiSchema.json"
+                    discoverySpecPath   = $null
+                    xsdDirectory        = $null
+                }
+                $coreManifest | ConvertTo-Json -Depth 5 |
+                    Set-Content -LiteralPath (Join-Path $coreApiSchemaDir "package-manifest.json") -Encoding utf8
+
+                # ApiSchema.json deliberately declares a DIFFERENT project identity than the manifest.
+                $coreApiSchema = [ordered]@{
+                    apiSchemaVersion = "1.0.0"
+                    projectSchema    = [ordered]@{
+                        projectName         = "Other"
+                        projectEndpointName = "other"
+                        isExtensionProject  = $false
+                        resourceSchemas     = [ordered]@{}
+                        openApiBaseDocuments = [ordered]@{
+                            resources = [ordered]@{ openapi = "3.0.1" }
+                        }
+                    }
+                }
+                $coreApiSchema | ConvertTo-Json -Depth 10 |
+                    Set-Content -LiteralPath (Join-Path $coreApiSchemaDir "ApiSchema.json") -Encoding utf8
+
+                [System.IO.Compression.ZipFile]::CreateFromDirectory($coreStaging, $coreNupkgPath)
+                Remove-Item -LiteralPath $coreStaging -Recurse -Force
+
+                {
+                    script:Invoke-PrepareStandard -FeedFolder $divergentFeedFolder
+                } | Should -Throw -ExpectedMessage "*identity mismatch*"
+
+                # The staged ApiSchema workspace must not have been created.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                    Should -BeFalse
+            }
+            finally {
+                if (Test-Path -LiteralPath $divergentFeedFolder) {
+                    Remove-Item -LiteralPath $divergentFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_StandardMode_ManifestDeclaredAssets_NonConventionalPaths" {
+        It "It_stages_discovery_spec_and_xsd_from_manifest_declared_paths_at_canonical_workspace_locations" {
+            # The package contract allows discoverySpecPath/xsdDirectory to be any safe relative
+            # path. Staging must source content from the validated manifest paths - not rediscover
+            # hard-coded siblings - while keeping the canonical workspace layout.
+            $assetsFeedFolder = script:New-TempDirectory
+
+            try {
+                script:New-FixtureNupkg `
+                    -FeedFolder $assetsFeedFolder `
+                    -PackageId "EdFi.DataStandard52.ApiSchema" `
+                    -Version "1.0.329" `
+                    -ProjectName "Ed-Fi" `
+                    -ProjectEndpointName "ed-fi" `
+                    -IsExtensionProject $false `
+                    -DiscoverySpecPath "assets/discovery-spec.json" `
+                    -XsdDirectory "static/xsd" | Out-Null
+
+                $tool = script:New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $script:hashA
+                & $script:repo.PrepareSchemaScript `
+                    -PackageFeedUrl $assetsFeedFolder `
+                    -SchemaToolPath $tool | Out-Null
+
+                # Content staged at canonical workspace paths regardless of source layout.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/content/Ed-Fi/discovery-spec.json") |
+                    Should -BeTrue
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/content/Ed-Fi/xsd/Ed-Fi-Core.xsd") |
+                    Should -BeTrue
+
+                # ApiSchema manifest records the canonical workspace-relative paths.
+                $apiSchemaManifest = script:Get-ApiSchemaManifest
+                $coreProject = $apiSchemaManifest.projects | Where-Object { -not $_.isExtensionProject }
+                $coreProject.discoverySpecPath | Should -Be "content/Ed-Fi/discovery-spec.json"
+                $coreProject.xsdDirectory | Should -Be "content/Ed-Fi/xsd"
+            }
+            finally {
+                if (Test-Path -LiteralPath $assetsFeedFolder) {
+                    Remove-Item -LiteralPath $assetsFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_StandardMode_ManifestNullAssets_WithUndeclaredSiblingContent" {
+        It "It_does_not_stage_an_xsd_directory_the_manifest_records_as_null" {
+            # Manifest-authoritative semantics: the package manifest is the contract for
+            # schema-adjacent content. An xsd/ directory present in the payload but recorded as
+            # null in the manifest must NOT be staged via sibling rediscovery.
+            $undeclaredFeedFolder = script:New-TempDirectory
+
+            try {
+                script:New-FixtureNupkg `
+                    -FeedFolder $undeclaredFeedFolder `
+                    -PackageId "EdFi.DataStandard52.ApiSchema" `
+                    -Version "1.0.329" `
+                    -ProjectName "Ed-Fi" `
+                    -ProjectEndpointName "ed-fi" `
+                    -IsExtensionProject $false `
+                    -PlantUndeclaredXsdDirectory | Out-Null
+
+                $tool = script:New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $script:hashA
+                & $script:repo.PrepareSchemaScript `
+                    -PackageFeedUrl $undeclaredFeedFolder `
+                    -SchemaToolPath $tool | Out-Null
+
+                # The undeclared xsd directory must not have been staged.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/content/Ed-Fi/xsd") |
+                    Should -BeFalse
+
+                # The ApiSchema manifest core project must not record an xsdDirectory.
+                $apiSchemaManifest = script:Get-ApiSchemaManifest
+                $coreProject = $apiSchemaManifest.projects | Where-Object { -not $_.isExtensionProject }
+                ($coreProject | Get-Member -Name "xsdDirectory" -MemberType NoteProperty) |
+                    Should -BeNullOrEmpty
+            }
+            finally {
+                if (Test-Path -LiteralPath $undeclaredFeedFolder) {
+                    Remove-Item -LiteralPath $undeclaredFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_MislabeledCorePackage_ConsistentIdentityForDifferentProject" {
+        It "It_fails_fast_with_identity_mismatch_when_core_package_consistently_identifies_a_non_core_project" {
+            # Core variant of the mislabeled-package scenario: the core package ID carries a
+            # manifest+schema that consistently identify tpdm (with isExtensionProject false so the
+            # extension-flag check passes). The core endpoint assertion (ed-fi) must reject it.
+            $mislabeledCoreFeedFolder = script:New-TempDirectory
+
+            try {
+                script:New-FixtureNupkg `
+                    -FeedFolder $mislabeledCoreFeedFolder `
+                    -PackageId "EdFi.DataStandard52.ApiSchema" `
+                    -Version "1.0.329" `
+                    -ProjectName "TPDM" `
+                    -ProjectEndpointName "tpdm" `
+                    -IsExtensionProject $false | Out-Null
+
+                $tool = script:New-FakeSchemaTool -Directory $script:repo.RepoRoot -Hash $script:hashA
+
+                {
+                    & $script:repo.PrepareSchemaScript `
+                        -PackageFeedUrl $mislabeledCoreFeedFolder `
+                        -SchemaToolPath $tool | Out-Null
+                } | Should -Throw -ExpectedMessage "*identity mismatch*"
+
+                # The staged ApiSchema workspace must not have been created.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                    Should -BeFalse
+            }
+            finally {
+                if (Test-Path -LiteralPath $mislabeledCoreFeedFolder) {
+                    Remove-Item -LiteralPath $mislabeledCoreFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_InvalidPayload_ManifestIdMismatch_SurfacedThroughStandardMode" {
+        It "It_fails_fast_with_identity_mismatch_and_leaves_no_staged_workspace_when_manifest_packageId_is_wrong" {
+            # Build a malformed CORE .nupkg: the filename matches the pinned core ID so the resolver
+            # finds it, but package-manifest.json declares a different packageId to trigger an identity
+            # mismatch before workspace finalization.
+            $mismatchFeedFolder = script:New-TempDirectory
+
+            try {
+                $corePackageId = "EdFi.DataStandard52.ApiSchema"
+                $mismatchNupkgName = "$($corePackageId.ToLowerInvariant()).1.0.329.nupkg"
+                $mismatchNupkgPath = Join-Path $mismatchFeedFolder $mismatchNupkgName
+                $mismatchStaging = Join-Path ([System.IO.Path]::GetTempPath()) "dms-std-mismatch-$([Guid]::NewGuid().ToString('N'))"
+                $mismatchApiSchemaDir = Join-Path $mismatchStaging "contentFiles/any/any/ApiSchema"
+                New-Item -ItemType Directory -Path $mismatchApiSchemaDir -Force | Out-Null
+
+                # Manifest declares a packageId that differs from the expected pinned core ID.
+                $mismatchManifest = [ordered]@{
+                    version             = 1
+                    packageId           = "EdFi.DataStandard52.WRONG.ApiSchema"
+                    projectName         = "Ed-Fi"
+                    projectEndpointName = "ed-fi"
+                    isExtensionProject  = $false
+                    schemaPath          = "ApiSchema.json"
+                    discoverySpecPath   = $null
+                    xsdDirectory        = $null
+                }
+                $mismatchManifest | ConvertTo-Json -Depth 5 |
+                    Set-Content -LiteralPath (Join-Path $mismatchApiSchemaDir "package-manifest.json") -Encoding utf8
+
+                $mismatchApiSchema = [ordered]@{
+                    apiSchemaVersion = "1.0.0"
+                    projectSchema    = [ordered]@{
+                        projectName         = "Ed-Fi"
+                        projectEndpointName = "ed-fi"
+                        isExtensionProject  = $false
+                        resourceSchemas     = [ordered]@{}
+                        openApiBaseDocuments = [ordered]@{
+                            resources = [ordered]@{ openapi = "3.0.1" }
+                        }
+                    }
+                }
+                $mismatchApiSchema | ConvertTo-Json -Depth 10 |
+                    Set-Content -LiteralPath (Join-Path $mismatchApiSchemaDir "ApiSchema.json") -Encoding utf8
+
+                [System.IO.Compression.ZipFile]::CreateFromDirectory($mismatchStaging, $mismatchNupkgPath)
+                Remove-Item -LiteralPath $mismatchStaging -Recurse -Force
+
+                {
+                    script:Invoke-PrepareStandard -FeedFolder $mismatchFeedFolder
+                } | Should -Throw -ExpectedMessage "*identity mismatch*"
+
+                # The staged ApiSchema workspace must not have been created.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                    Should -BeFalse
+            }
+            finally {
+                if (Test-Path -LiteralPath $mismatchFeedFolder) {
+                    Remove-Item -LiteralPath $mismatchFeedFolder -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_MissingPackage_SurfacedThroughStandardMode" {
+        It "It_fails_with_clear_resolution_diagnostic_and_no_partial_workspace_when_core_is_absent_from_feed" {
+            # Feed is empty: the pinned core package cannot be resolved.
+            $emptyFeed = script:New-TempDirectory
+
+            {
+                script:Invoke-PrepareStandard -FeedFolder $emptyFeed
+            } | Should -Throw
+
+            # No partial workspace should exist.
+            Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                Should -BeFalse
+
+            Remove-Item -LiteralPath $emptyFeed -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        It "It_fails_with_resolution_diagnostic_and_no_partial_workspace_when_pinned_version_is_absent_from_feed" {
+            # The catalog pins the core package at version 1.0.329. Supply the core package at version
+            # 1.0.1 only so the resolver cannot find the pinned version 1.0.329.
+            $wrongVersionFeed = script:New-TempDirectory
+            try {
+                script:New-FixtureNupkg `
+                    -FeedFolder $wrongVersionFeed `
+                    -PackageId "EdFi.DataStandard52.ApiSchema" `
+                    -Version "1.0.1" `
+                    -ProjectName "Ed-Fi" `
+                    -ProjectEndpointName "ed-fi" `
+                    -IsExtensionProject $false | Out-Null
+
+                {
+                    script:Invoke-PrepareStandard -FeedFolder $wrongVersionFeed
+                } | Should -Throw -ExpectedMessage "*version*1.0.329*not found*"
+
+                # No partial workspace should exist.
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema") |
+                    Should -BeFalse
+            }
+            finally {
+                if (Test-Path -LiteralPath $wrongVersionFeed) {
+                    Remove-Item -LiteralPath $wrongVersionFeed -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_RerunReuse_SameSelection" {
+        It "It_is_a_noop_on_second_run_with_identical_core_workspace_and_hash_are_unchanged" {
+            $script:feedFolder = script:New-FixtureFeed
+
+            # First run - stages the core workspace.
+            script:Invoke-PrepareStandard -FeedFolder $script:feedFolder
+
+            $manifestBefore = script:Get-RootManifest
+            $hashBefore = $manifestBefore.schema.effectiveSchemaHash
+            $fingerprintBefore = $manifestBefore.schema.workspaceFingerprint
+
+            # Second run - must not throw.
+            { script:Invoke-PrepareStandard -FeedFolder $script:feedFolder } |
+                Should -Not -Throw
+
+            $manifestAfter = script:Get-RootManifest
+            $manifestAfter.schema.effectiveSchemaHash | Should -Be $hashBefore
+            $manifestAfter.schema.workspaceFingerprint | Should -Be $fingerprintBefore
+        }
+    }
+
+    Context "Given_RerunMismatch_ChangedPackageContent" {
+        It "It_fails_fast_with_workspace_fingerprint_mismatch_when_core_package_content_changes_under_a_stable_schema_hash" {
+            # Same selection (core-only) and the SAME stable fake EffectiveSchemaHash across both runs,
+            # but the republished core package ships different staged content on the second run. Reuse
+            # must be gated on the workspace fingerprint, not just the schema hash: identical hash plus
+            # drifted package payload must still fail fast with teardown guidance.
+
+            # Run 1: core package with no discovery spec.
+            $feedV1 = script:New-TempDirectory
+            try {
+                script:New-FixtureNupkg `
+                    -FeedFolder $feedV1 `
+                    -PackageId "EdFi.DataStandard52.ApiSchema" `
+                    -Version "1.0.329" `
+                    -ProjectName "Ed-Fi" `
+                    -ProjectEndpointName "ed-fi" `
+                    -IsExtensionProject $false | Out-Null
+
+                script:Invoke-PrepareStandard -FeedFolder $feedV1 -Hash $script:hashA
+
+                # Run 2: same selection and stable hash, but the core package now ships an extra declared
+                # discovery spec -> different staged content -> different workspace fingerprint.
+                $feedV2 = script:New-TempDirectory
+                try {
+                    script:New-FixtureNupkg `
+                        -FeedFolder $feedV2 `
+                        -PackageId "EdFi.DataStandard52.ApiSchema" `
+                        -Version "1.0.329" `
+                        -ProjectName "Ed-Fi" `
+                        -ProjectEndpointName "ed-fi" `
+                        -IsExtensionProject $false `
+                        -DiscoverySpecPath "discovery-spec.json" | Out-Null
+
+                    {
+                        script:Invoke-PrepareStandard -FeedFolder $feedV2 -Hash $script:hashA
+                    } | Should -Throw -ExpectedMessage "*workspace fingerprint mismatch*Stop the local stack*"
+                } finally {
+                    if (Test-Path -LiteralPath $feedV2) {
+                        Remove-Item -LiteralPath $feedV2 -Recurse -Force
+                    }
+                }
+            } finally {
+                if (Test-Path -LiteralPath $feedV1) {
+                    Remove-Item -LiteralPath $feedV1 -Recurse -Force
+                }
+            }
+        }
+    }
+
+    Context "Given_SchemaPackagesEnvVar_DoesNotInfluenceStandardMode" {
+        It "It_produces_the_same_core_workspace_regardless_of_SCHEMA_PACKAGES_env_var_value" {
+            # SCHEMA_PACKAGES is a non-bootstrap env var owned by the DLL-backed schema-loader path.
+            # Standard mode must ignore it completely: the result must be a clean core-only workspace.
+            $script:feedFolder = script:New-FixtureFeed
+
+            $savedSchemaPackages = [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES")
+            try {
+                # Run with SCHEMA_PACKAGES pointing to something unrelated to the fixture feed.
+                [System.Environment]::SetEnvironmentVariable(
+                    "SCHEMA_PACKAGES",
+                    "EdFi.DataStandard52.Homograph.ApiSchema:1.0.329"
+                )
+
+                script:Invoke-PrepareStandard -FeedFolder $script:feedFolder
+
+                $manifest = script:Get-RootManifest
+
+                # Standard mode stages core only; SCHEMA_PACKAGES must not introduce any extension.
+                $manifest.schema.selectionMode | Should -Be "Standard"
+                $manifest.schema.selectedExtensions | Should -BeNullOrEmpty
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Ed-Fi/ApiSchema.json") |
+                    Should -BeTrue
+                Test-Path -LiteralPath (Join-Path $script:repo.BootstrapRoot "ApiSchema/schemas/Homograph/ApiSchema.json") |
+                    Should -BeFalse
+            }
+            finally {
+                [System.Environment]::SetEnvironmentVariable("SCHEMA_PACKAGES", $savedSchemaPackages)
+            }
+        }
+    }
+
+    Context "Given_ExtensionsParameterRemoved_StaticAssertion" {
+        # The package-backed core-only contract requires that no schema/wrapper surface exposes
+        # -Extensions. Assert this from the parameter AST of every required surface (not a single regex
+        # shape), so untyped or aliased parameters - and any forwarding shape - are also caught.
+        It "It_<Name>_does_not_expose_an_Extensions_parameter_or_alias" -ForEach @(
+            @{ Name = "prepare-dms-schema.ps1";      File = "prepare-dms-schema.ps1";      Function = "" }
+            @{ Name = "bootstrap-local-dms.ps1";     File = "bootstrap-local-dms.ps1";     Function = "" }
+            @{ Name = "bootstrap-published-dms.ps1"; File = "bootstrap-published-dms.ps1"; Function = "" }
+            @{ Name = "Invoke-BootstrapWrapper";     File = "bootstrap-wrapper.psm1";      Function = "Invoke-BootstrapWrapper" }
+        ) {
+            $filePath = Join-Path $script:sourceDockerComposeRoot $File
+            $paramBlock = script:Get-DeclaredParameterBlock -FilePath $filePath -FunctionName $Function
+            script:Test-ExposesExtensionsParameter -ParamBlock $paramBlock |
+                Should -BeFalse -Because "$Name must not expose -Extensions (parameter or alias) under the package-backed core-only contract"
+        }
+
+        It "It_wrapper_module_never_forwards_an_Extensions_argument_to_any_command" {
+            # Robust (AST) forwarding check: no command invocation anywhere in bootstrap-wrapper.psm1 binds
+            # an -Extensions parameter, in any forwarding shape. Combined with the surface assertions above
+            # (the wrappers expose no -Extensions to splat), the wrapper cannot forward -Extensions.
+            $filePath = Join-Path $script:sourceDockerComposeRoot "bootstrap-wrapper.psm1"
+            $parseErrors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$parseErrors)
+            $parseErrors.Count | Should -Be 0
+
+            # Sanity: the wrapper still drives prepare-dms-schema.ps1, so the assertion is meaningful.
+            (Get-Content -LiteralPath $filePath -Raw) | Should -Match "prepare-dms-schema\.ps1"
+
+            $extensionsArguments = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $node.ParameterName -ieq 'Extensions'
+                },
+                $true)
+            @($extensionsArguments).Count |
+                Should -Be 0 -Because "the wrapper must never forward -Extensions to any command"
+        }
+    }
+
+    Context "Given_PublishedToolLocation_AutoDiscovery" {
+        It "It_Resolve-DmsSchemaTool_discovers_the_published_tool_under_.bootstrap_tools_dms-schema" {
+            # The README publishes dms-schema to .bootstrap/tools/dms-schema, and the wrapper shorthand
+            # (bootstrap-local-dms.ps1) cannot forward -SchemaToolPath. The resolver must auto-discover
+            # that documented location so the documented happy path works after publishing, without
+            # requiring -SchemaToolPath or DMS_SCHEMA_TOOL_PATH.
+            Import-Module (Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-tool.psm1") -Force
+
+            $toolDirectory = Join-Path $script:repo.BootstrapRoot "tools/dms-schema"
+            New-Item -ItemType Directory -Path $toolDirectory -Force | Out-Null
+            $toolName = if ($IsWindows) { "dms-schema.exe" } else { "dms-schema" }
+            $toolPath = Join-Path $toolDirectory $toolName
+            "stub" | Set-Content -LiteralPath $toolPath -Encoding utf8
+
+            $resolved = Resolve-DmsSchemaTool
+
+            [System.IO.Path]::GetFullPath($resolved) |
+                Should -Be ([System.IO.Path]::GetFullPath($toolPath))
+        }
+    }
+}

--- a/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md
@@ -206,18 +206,18 @@ contentFiles/any/any/ApiSchema/
     Interchange-Student.xsd
 ```
 
-Extension packages use the same shape. The schema file should be named `ApiSchema.json` in the package
-contract even if MetaEd originally emitted `ApiSchema-EXTENSION.json`; the package manifest and schema
-content identify whether the project is core or extension.
+The schema file should be named `ApiSchema.json` in the package contract even if MetaEd originally emitted
+`ApiSchema-EXTENSION.json`; the package manifest and schema content identify whether the project is core or
+extension via the `isExtensionProject` field.
 
-Published ApiSchema package IDs are Data-Standard-qualified. The core package is
-`EdFi.DataStandard52.ApiSchema`, and extension packages follow the `EdFi.DataStandard52.<Project>.ApiSchema`
-convention (for example `EdFi.DataStandard52.Sample.ApiSchema`, `EdFi.DataStandard52.Homograph.ApiSchema`,
-and `EdFi.DataStandard52.TPDM.ApiSchema`), where `<Project>` is the MetaEd project name.
+The package ID for the standard core ApiSchema package is Data-Standard-qualified:
+`EdFi.DataStandard52.ApiSchema`. This is the canonical DMS-916 target package identity, verified against the
+published asset-only package at version `1.0.329` (see
+`reference/spikes/DMS-1156/asset-only-package-feed-findings.md`).
 
-This is the canonical DMS-916 target package identity convention. Legacy unqualified extension IDs such as
-`EdFi.Sample.ApiSchema`, `EdFi.Homograph.ApiSchema`, and `EdFi.TPDM.ApiSchema` are superseded by the
-qualified package IDs.
+> **Scope note:** package-backed standard mode is **core-only** and resolves only the core package
+> by ID. There is no `-Extensions` parameter and bootstrap does not construct extension package IDs.
+> Extension-containing schema sets are staged through the expert `-ApiSchemaPath` filesystem path.
 
 The package should contain no `lib/` or `ref/` entries. It may include docs and license files:
 
@@ -232,12 +232,12 @@ Example package manifest:
 ```json
 {
   "version": 1,
-  "packageId": "EdFi.DataStandard52.Sample.ApiSchema",
-  "projectName": "Sample",
-  "projectEndpointName": "sample",
-  "isExtensionProject": true,
+  "packageId": "EdFi.DataStandard52.ApiSchema",
+  "projectName": "Ed-Fi",
+  "projectEndpointName": "ed-fi",
+  "isExtensionProject": false,
   "schemaPath": "ApiSchema.json",
-  "discoverySpecPath": null,
+  "discoverySpecPath": "discovery-spec.json",
   "xsdDirectory": "xsd"
 }
 ```

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -82,15 +82,16 @@ to verify the design without re-reading every section.
    retry, or continuation policy.
 3. `ApiSchema.json` selection is the source of truth for API surface, security, and the exact DDL target
    for the run in every schema-selection mode.
-4. Standard mode means `-Extensions`, including the omitted-`-Extensions` core-only case. Expert mode
-   means `-ApiSchemaPath`; expert mode narrows bootstrap-managed seed selection and requires
-   `-ClaimsDirectoryPath` when direct filesystem inputs do not include matching claims fragments.
-5. Implementation is split: Story 00 delivers the direct filesystem `-ApiSchemaPath` path first; Story 06
-   delivers standard `-Extensions` mode after Story 05.
+4. Standard mode means package-backed **core-only** staging (omit `-ApiSchemaPath`). Expert mode means
+   `-ApiSchemaPath`; expert mode is the path for extension-containing or custom schema sets, narrows
+   bootstrap-managed seed selection, and requires `-ClaimsDirectoryPath` when direct filesystem inputs do
+   not include matching claims fragments. There is no `-Extensions` parameter.
+5. Implementation is split: Story 00 delivers the direct filesystem `-ApiSchemaPath` path; Story 06 delivers
+   package-backed core-only standard mode after Story 05.
 6. DDL provisioning and seed loading are separate phases. DMS startup is never the authoritative schema
    deployment path.
-7. Omitting `-Extensions` means core only once standard mode is implemented. DMS-916 does not preserve the
-   legacy default that included extensions.
+7. Standard mode stages core only. DMS-916 does not preserve the legacy default that included extensions;
+   extension schema sets are supplied through expert `-ApiSchemaPath`.
 8. "Skip/resume" in this story means safe per-phase invocation plus optional same-invocation continuation
    through `-InfraOnly -DmsBaseUrl` after the pre-DMS phases have completed; it does not mean a persisted
    cross-invocation resume model.
@@ -98,9 +99,10 @@ to verify the design without re-reading every section.
 
 **Terminology**:
 
-- **Standard mode**: schema selection through `-Extensions`, including the omitted-`-Extensions`
-  core-only case; implemented after the Story 05 package-backed prerequisite.
-- **Expert mode**: schema selection through `-ApiSchemaPath`.
+- **Standard mode**: package-backed core-only staging (omit `-ApiSchemaPath`); implemented after the
+  Story 05 package-backed prerequisite. There is no `-Extensions` parameter.
+- **Expert mode**: schema selection through `-ApiSchemaPath`; the path for extension-containing or custom
+  schema sets.
 - **Thin wrapper**: `bootstrap-local-dms.ps1` as optional sequencing convenience only.
 - **Same-invocation continuation**: `-InfraOnly -DmsBaseUrl` carrying the current wrapper run through
   instance configuration and schema provisioning, then continuing against an IDE-hosted DMS process.
@@ -115,10 +117,10 @@ to verify the design without re-reading every section.
 
 **Recommended developer paths**:
 
-- **Core only**: omit `-Extensions`; stage only the core schema, embedded claims, and core seed sources.
-- **Core plus extension**: use `-Extensions <name>`; bootstrap stages the selected schema and
-  claims automatically and loads built-in seed data only when the seed catalog defines it.
-- **Custom schema**: use `-ApiSchemaPath`; bootstrap derives the base security set from the staged schema
+- **Core only**: omit `-ApiSchemaPath` (standard mode); stage only the core schema, embedded claims, and
+  core seed sources.
+- **Extension or custom schema**: use `-ApiSchemaPath` pointing at a directory containing the core plus any
+  extension `ApiSchema*.json` files; bootstrap derives the base security set from the staged schema
   and the claim fragments available for that run. Pair direct filesystem schemas that need additional
   security metadata with `-ClaimsDirectoryPath`, and pair custom seed loading with `-SeedDataPath`.
 - **IDE workflow**: use `-InfraOnly` for pre-DMS preparation, or `-InfraOnly -DmsBaseUrl` when the wrapper
@@ -192,9 +194,9 @@ The ODS initdev pipeline (`Initialize-DevelopmentEnvironment`) defines 17 steps,
 |---|----------|-------------|---------------|------------|------------------------|
 | 1 | Clear errors | `Clear-Error` | always | **Obsolete** | PowerShell error state management is not replicated; Docker exit-code checks (`$LASTEXITCODE -ne 0`) with `throw` serve the same purpose inline |
 | 2 | Assemble deployment settings | `Set-DeploymentSettings` | always | **Covered** | `env-utility.psm1` → `ReadValuesFromEnvFile` reads `.env`; script parameters override individual values; result flows as `$envValues` through the script |
-| 3 | Merge plugin settings | `Merge plugin settings` | `-UsePlugins` | **Gap** | No extension/plugin selection mechanism exists. See [Extension Selection and Loading](#8-extension-selection-and-loading) for proposed `-Extensions` parameter design |
+| 3 | Merge plugin settings | `Merge plugin settings` | `-UsePlugins` | **Obsolete** | No plugin-selection mechanism. Extension schema sets are supplied through expert `-ApiSchemaPath`; see [Extension Selection and Loading](#8-extension-selection-and-loading) |
 | 4 | Generate app settings | `Invoke-NewDevelopmentAppSettings` | always | **Covered** | `appsettings.json` per project is version-controlled; Docker env vars override at runtime via `local-dms.yml` / `local-config.yml`; `setup-openiddict.ps1 -InitDb` generates and stores RSA key pairs in PostgreSQL |
-| 5 | Install plugins | `Install-Plugins` | `-UsePlugins` | **Gap** | No plugin/extension install step. Volume mounts in Docker Compose currently load extension ApiSchema files. Parameterized selection design is in [Extension Selection and Loading](#8-extension-selection-and-loading) |
+| 5 | Install plugins | `Install-Plugins` | `-UsePlugins` | **Obsolete** | No plugin/extension install step. Extension ApiSchema files are supplied through expert `-ApiSchemaPath`; see [Extension Selection and Loading](#8-extension-selection-and-loading) |
 | 6 | Code generation | `Invoke-CodeGen` | `!ExcludeCodeGen` | **Obsolete** | DMS has no code generation step. The ApiSchema JSON drives the runtime API surface without NHibernate mapping generation or similar compile-time artifacts |
 | 7 | Build solution | `Invoke-RebuildSolution` | `!NoRebuild` | **Covered (Docker path)** | `docker compose build --no-cache` via `-r` flag rebuilds Docker images. For IDE workflow, `dotnet build` is run manually |
 | 8 | Install DbDeploy tool | `Install-DbDeploy` | always | **Covered (implicitly)** | DMS-916 does not introduce a host-side database deployment tool install step. The authoritative provisioning path is the explicit `provision-dms-schema.ps1` SchemaTools/runtime-owned provisioning and validation phase that runs before DMS serves requests; it is not owned by DMS startup. |
@@ -298,15 +300,19 @@ database's stored `EffectiveSchemaHash` (see
 > [Section 11.5](#115-selected-apischemajson-drives-exact-physical-ddl-shape) for the authoritative treatment
 > of the DDL/schema relationship.
 
-### 3.3 Proposed Selection Mechanism
+### 3.3 Selection Mechanism
 
-The target standard developer flow uses `-Extensions`, owned by `prepare-dms-schema.ps1` (see
-[`command-boundaries.md` Section 3.1](command-boundaries.md#31-prepare-dms-schemaps1--schema-selection-and-staging)).
-It is typed as `String[]` and accepts one or more extension names using normal PowerShell array binding.
-The phase command does not rely on comma-splitting a single string; multi-extension examples therefore use
-PowerShell array syntax such as `-Extensions "sample","extension2"`. Implementation is intentionally split:
-Story 00 delivers the direct filesystem `-ApiSchemaPath` path first, while package-backed no-argument
-core-only mode and named `-Extensions` modes are delivered by
+Schema selection, owned by `prepare-dms-schema.ps1` (see
+[`command-boundaries.md` Section 3.1](command-boundaries.md#31-prepare-dms-schemaps1--schema-selection-and-staging)),
+has two modes and no `-Extensions` parameter:
+
+- **Standard mode** (omit `-ApiSchemaPath`): package-backed core-only — resolve and stage the core Data
+  Standard ApiSchema package.
+- **Expert mode** (`-ApiSchemaPath <path>`): stage core plus any extension `ApiSchema*.json` files present
+  in a local directory; the path for extension-containing or custom schema sets.
+
+Implementation is split: Story 00 delivers the direct filesystem `-ApiSchemaPath` path; package-backed
+core-only standard mode is delivered by
 [`Story 06`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) after asset-only ApiSchema packages
 exist.
 
@@ -383,16 +389,16 @@ normative source for every internal provisioning safety rule implemented behind 
 > against the actual SchemaTools README before Story 01 implementation begins; any discrepancy takes
 > precedence over this design document.
 
-Three usage modes are supported in the target design. Story 00 implements Mode 3 first; Story 06 implements
-Modes 1 and 2 after Story 05 publishes asset-only packages.
+Two usage modes are supported in the target design. Story 00 implements the expert `-ApiSchemaPath` mode
+first; Story 06 implements package-backed standard mode after Story 05 publishes asset-only packages.
 
 #### Standard Development Flows
 
-Modes 1 and 2 cover the vast majority of development workflows. Use these for day-to-day environment setup.
+Standard mode covers the vast majority of development workflows. Use it for day-to-day environment setup.
 
-**Mode 1 - Default (core Ed-Fi only)**
+**Standard mode - Default (core Ed-Fi only)**
 
-Omit `-Extensions` entirely. In the target package-backed flow, bootstrap resolves only the standard core
+Omit `-ApiSchemaPath` (standard mode). In the package-backed flow, bootstrap resolves only the standard core
 Data Standard ApiSchema asset package (`EdFi.DataStandard52.ApiSchema`) host-side, extracts it into an
 isolated package-specific temporary directory, normalizes its asset payload into
 `eng/docker-compose/.bootstrap/ApiSchema/`, and computes the expected `EffectiveSchemaHash` from the
@@ -406,28 +412,12 @@ directory through `-ApiSchemaPath`.
 
 This is an intentional migration from the current `SCHEMA_PACKAGES`-driven local default documented under
 `eng/docker-compose`, which stages Data Standard 5.2 plus extensions today. DMS-916 defines the normative
-developer bootstrap profile as core only when `-Extensions` is omitted. Any extension needed for a run must be
-selected explicitly through `-Extensions` or supplied through `-ApiSchemaPath`.
+developer bootstrap profile as core only in standard mode. Any extension needed for a run is supplied through
+the expert `-ApiSchemaPath` filesystem path.
 
 ```powershell
 pwsh eng/docker-compose/prepare-dms-schema.ps1
 ```
-
-**Mode 2 - Core + named extensions**
-
-Pass one or more extension names. In the target package-backed flow, the bootstrap script resolves
-the core asset package plus the corresponding extension asset packages host-side, extracts each package in
-isolation, then normalizes the resulting schema JSON and optional schema-adjacent content into the same
-ApiSchema asset workspace before computing the expected `EffectiveSchemaHash`.
-
-```powershell
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -Extensions "sample"
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -Extensions "sample","extension2"
-```
-
-Extension artifact availability is determined by whether the requested extension's package and companion
-artifacts can be resolved from the configured package and artifact sources. A resolution failure produces a
-clear pre-Docker error for the requested extension name.
 
 #### Direct Filesystem ApiSchema Usage
 
@@ -436,18 +426,18 @@ after package-backed standard mode moves to asset-only packages. It is still an 
 extension ergonomics because built-in seed selection is disabled and direct filesystem inputs may need
 explicit security input.
 
-**Mode 3 - Custom local path (Direct Filesystem / Expert Workflow)**
+**Expert mode - Custom local path (Direct Filesystem)**
 
 > **WARNING:** `-ApiSchemaPath` is the stable direct filesystem input, but it remains an expert workflow for
 > custom schema ergonomics. Bootstrap still stages the base claimset set available for the run, but built-in
 > seed selection is disabled in this mode.
 > If the staged schema requires claim fragments that are not supplied by the direct filesystem input,
-> `-ClaimsDirectoryPath` is required. Use `-SeedDataPath` for custom seed input. Prefer Modes 1 and 2 for
+> `-ClaimsDirectoryPath` is required. Use `-SeedDataPath` for custom seed input. Prefer standard mode for
 > standard development workflows.
 
 Pass a local filesystem path to a directory containing one or more pre-built `ApiSchema.json` files.
 Bootstrap stages every `ApiSchema*.json` file from that directory into the same repo-local workspace used by
-Modes 1 and 2, validates that exactly one staged file is a non-extension project, and computes the
+standard mode, validates that exactly one staged file is a non-extension project, and computes the
 expected `EffectiveSchemaHash` from the staged copies. The staged schema set and available claim fragments
 drive base claimset selection for the run. Direct filesystem schemas that require additional claims metadata
 are paired with explicit `-ClaimsDirectoryPath` input. Built-in seed selection remains disabled in this mode.
@@ -456,10 +446,10 @@ are paired with explicit `-ClaimsDirectoryPath` input. Built-in seed selection r
 pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath "C:\dev\my-custom-schema"
 ```
 
-`-Extensions` and `-ApiSchemaPath` are mutually exclusive. If both are specified, the bootstrap script exits
-with a clear error. When `-ApiSchemaPath` is used, bootstrap still derives the automatic base claimset set
-from the staged schema and available claims inputs, while custom claims and custom seed inputs continue to use
-`-ClaimsDirectoryPath` and/or `-SeedDataPath`.
+Standard mode (no `-ApiSchemaPath`) and expert `-ApiSchemaPath` mode are the two schema-selection paths; there
+is no `-Extensions` parameter. When `-ApiSchemaPath` is used, bootstrap still derives the automatic base
+claimset set from the staged schema and available claims inputs, while custom claims and custom seed inputs
+continue to use `-ClaimsDirectoryPath` and/or `-SeedDataPath`.
 
 **Fail-fast expert-mode contract:** `-ApiSchemaPath` is intentionally not a full alias for standard-mode
 ergonomics.
@@ -481,7 +471,7 @@ and any required `-ClaimsDirectoryPath` input explicitly. The exact warning text
 and is not prescribed here.
 
 **Expert companion parameters for a complete custom bootstrap:** To avoid editing environment variables or
-Docker mounts by hand, Mode 3 introduces two expert-only companion parameters alongside `-ApiSchemaPath`:
+Docker mounts by hand, expert mode introduces two expert-only companion parameters alongside `-ApiSchemaPath`:
 
 - `-ApiSchemaPath` - supplies the custom schema directory (normalized into the staged schema workspace)
 - `-ClaimsDirectoryPath` - supplies a directory of `*-claimset.json` files used for additive CMS
@@ -494,11 +484,11 @@ The following sequence describes the canonical schema flow for all bootstrap mod
 
 ```text
 prepare-dms-schema.ps1
-  -> Resolve schema inputs from -Extensions or -ApiSchemaPath
-     -> Mode 1/2 target flow after Story 05: package-backed materialization resolves asset-only ApiSchema packages on the host,
-        extracts each package in isolation, and normalizes schema JSON plus optional static content into
+  -> Resolve schema inputs from standard mode (omit -ApiSchemaPath) or -ApiSchemaPath
+     -> Standard mode target flow after Story 05: package-backed materialization resolves the asset-only core ApiSchema package on the host,
+        extracts it in isolation, and normalizes schema JSON plus optional static content into
         eng/docker-compose/.bootstrap/ApiSchema/
-     -> Mode 3 Story 00 flow: direct filesystem materialization copies/normalizes developer-supplied ApiSchema*.json files
+     -> Expert `-ApiSchemaPath` (Story 00) flow: direct filesystem materialization copies/normalizes developer-supplied ApiSchema*.json files
         and optional static content into the same workspace
   -> Stage one normalized core schema file plus 0..N normalized extension schema files
   -> Write bootstrap-api-schema-manifest.json with manifest-relative schema/content paths
@@ -522,7 +512,7 @@ prepare-dms-schema.ps1
 > Runtime loading of schema-adjacent static content is delivered by Story 04 (DMS-1154); package production
 > for the asset-only shape is implemented by Story 05. Both target the same filesystem workspace contract, so
 > direct `-ApiSchemaPath` loading can be implemented and retained independently of package publication. Story 00
-> implements that direct filesystem path only; package-backed Modes 1 and 2 belong to Story 06.
+> implements that direct filesystem path only; package-backed core-only standard mode belongs to Story 06.
 
 > **Activation boundary (Story 04 delivered):** The "Docker-hosted DMS" branch of the diagram above —
 > `bind-mount .bootstrap/ApiSchema/ → /app/ApiSchema`, `set USE_API_SCHEMA_PATH=true`,
@@ -547,7 +537,7 @@ than re-resolving packages or inferring schema shape from container-only environ
 **NuGet feed failure handling:** If the configured NuGet feed is unreachable during host-side schema package
 resolution or catalog-advertised built-in extension seed package download, the owning phase command fails fast with a clear error message
 including the feed URL and HTTP status. No partial downloads are attempted. For offline or air-gapped
-environments, use `-ApiSchemaPath` (Mode 3) and, if loading data, `-SeedDataPath` to bypass NuGet entirely
+environments, use `-ApiSchemaPath` (expert mode) and, if loading data, `-SeedDataPath` to bypass NuGet entirely
 and supply pre-downloaded artifacts from a local directory. That staged custom schema set still drives
 automatic base security selection from the claims inputs available for the run. If additional non-core
 security fragments are needed, `-ClaimsDirectoryPath` is required for caller-supplied fragments; bootstrap
@@ -555,9 +545,10 @@ does not infer security rules for arbitrary custom resources.
 
 ### 3.5 Compatibility Validation
 
-For each extension in `-Extensions`, bootstrap resolves the schema package and any companion security
-fragment metadata from the configured artifact sources. The seed phase owns a separate seed catalog that may
-define an optional built-in seed data package for the same extension name:
+For each project in the staged schema set (the core package in standard mode, or core plus any extensions in
+an expert `-ApiSchemaPath` directory), bootstrap resolves the companion security fragment metadata from the
+configured artifact sources. The seed phase owns a separate seed catalog that may define an optional built-in
+seed data package for an extension name:
 
 1. **Schema package** (e.g., `EdFi.DataStandard52.Sample.ApiSchema`) - determines API surface
 2. **Security fragment** (e.g., `004-sample-extension-claimset.json`) - determines authorization rules
@@ -573,20 +564,19 @@ only the metadata it owns: schema package fields in `prepare-dms-schema.ps1`, se
 
 **Validation rules**:
 
-- When `-Extensions` is used (Mode 1/2): Schema and claims phase commands resolve their owned artifact types
-  for each selected extension. The seed phase resolves seed artifacts from its seed catalog. If the
-  schema package for a requested extension cannot be resolved, schema staging fails before starting
-  containers. If the security fragment for a requested extension cannot be resolved, claims staging fails
-  before starting containers. Seed package requirements when seed delivery runs are governed by the
-  seed-specific rule below.
-- When `-ApiSchemaPath` is used (Mode 3): Schema hashing and DDL validation still work because bootstrap
+- Standard mode (core-only): the schema and claims phase commands resolve their owned artifact types for the
+  core package. The seed phase resolves seed artifacts from its seed catalog. If the core package cannot be
+  resolved, schema staging fails before starting containers.
+- When `-ApiSchemaPath` is used (expert mode), including extension-containing schema sets: each project in
+  the staged set has its security fragment resolved by the claims phase (auto-staged when a bootstrap-managed
+  fragment exists, e.g. Sample/Homograph; otherwise `-ClaimsDirectoryPath` is required). Schema hashing and DDL validation still work because bootstrap
   stages and hashes the exact files. What is disabled is bootstrap-managed seed-package selection, not
   automatic base security selection from the claims inputs available for the run. If the staged set needs
   additional non-core claims metadata, `-ClaimsDirectoryPath` is required and bootstrap validates those
   fragments only structurally. Bootstrap emits a warning indicating that compatibility with custom claimset
   fragments and custom seed data is validated against the explicit companion inputs for this run. The exact
   warning text is an implementation detail.
-- When `-ApiSchemaPath` is used (Mode 3): The staged directory must normalize to exactly one
+- When `-ApiSchemaPath` is used (expert mode): The staged directory must normalize to exactly one
   `projectSchema.isExtensionProject=false` file and zero or more `true` files. Any other shape is a
   bootstrap-time error.
 - When seed delivery runs: For each selected extension in the root bootstrap manifest, check the seed
@@ -662,8 +652,8 @@ claims handoff artifact.
 
 **Gap**: The current mechanism is all-or-nothing. When `-AddExtensionSecurityMetadata` is set, every
 claimset fragment in the directory is loaded regardless of which extensions the developer has actually
-selected. There is no filtering by extension. A developer bootstrapping with `-Extensions sample` still
-loads other extension claimsets, and vice versa.
+selected. There is no filtering by extension. A developer who staged only the Sample extension (via
+`-ApiSchemaPath`) still loads other extension claimsets, and vice versa.
 
 ### 4.2 Why ApiSchema.json Drives Security Configuration
 
@@ -684,8 +674,8 @@ configuration must be consistent with those resources:
 
 > **Scope of automatic derivation (precise).** "Automatic" here means core security plus the matching
 > security fragments available for the selected schema set. `prepare-dms-claims.ps1` pairs staged schema
-> inputs with those base claims inputs whether the schema came from omitted `-Extensions`, named
-> `-Extensions`, or `-ApiSchemaPath`. If `-ApiSchemaPath` stages schemas whose security fragments are not
+> inputs with those base claims inputs whether the schema came from package-backed core (standard mode) or
+> `-ApiSchemaPath`. If `-ApiSchemaPath` stages schemas whose security fragments are not
 > supplied by the run, bootstrap cannot infer security rules for those arbitrary resources;
 > `-ClaimsDirectoryPath` is required and remains an additive, caller-supplied input.
 
@@ -707,7 +697,7 @@ for caller-supplied fragments and does not silently substitute `sample`, `homogr
 The bootstrap logic is:
 
 1. **Core security metadata is always loaded.** The embedded `Claims.json` (Embedded mode) covers all
-   core Ed-Fi Data Standard resources. No extra configuration is needed for Mode 1 (core only).
+   core Ed-Fi Data Standard resources. No extra configuration is needed for standard mode (core only).
 
 2. **Extension security metadata is loaded based on the effective staged schema set.** If the staged
    schema set includes extension resources with matching security fragments, the bootstrap script switches CMS
@@ -737,8 +727,8 @@ The bootstrap logic is:
     claimset fragments,
     `-ClaimsDirectoryPath` points to a local directory containing one or more `*-claimset.json` files.
     Bootstrap validates that the path exists, then stages those files into the same claims workspace used for
-    extension-derived fragments. This makes `-ClaimsDirectoryPath` additive rather than mutually exclusive
-    with `-Extensions`.
+    extension-derived fragments. `-ClaimsDirectoryPath` is additive to any bootstrap-managed extension-derived
+    fragments.
 
    **Contract:** If `-ClaimsDirectoryPath` is supplied and the directory does not exist or contains no
    `*-claimset.json` files, bootstrap fails before container startup with a clear error. Bootstrap also
@@ -817,15 +807,16 @@ schema workspace as one boundary. This is the intended path for every schema-sel
 For expert `-ApiSchemaPath` flows that need additional non-core security metadata, that additive input is
 required because bootstrap does not infer security fragments for arbitrary resources.
 
-**`DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING`** is a separate, legacy flag used for dynamic management endpoints (where the Config Service API is called post-boot to push arbitrary claimset data) and for legacy dev-only workflows. It is **not** required by the proposed `-Extensions` bootstrap path and is **not** part of the standard bootstrap flow described in this design.
+**`DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING`** is a separate, legacy flag used for dynamic management endpoints (where the Config Service API is called post-boot to push arbitrary claimset data) and for legacy dev-only workflows. It is **not** required by the bootstrap path and is **not** part of the standard bootstrap flow described in this design.
 
-All three schema-selection modes are explicitly designed to operate without this flag:
+Both schema-selection modes are explicitly designed to operate without this flag:
 
-- **Mode 1 (core only)**: the bootstrap manifest claims section resolves to Embedded mode - no extra flag needed.
-- **Mode 2 (named extensions)**: the bootstrap manifest claims section resolves to Hybrid mode and points
-  at the staged claims workspace containing only the selected claimset files — activated at startup by
-  Story 04 (DMS-1154, delivered) — no extra flag needed.
-- **Mode 3 (expert `-ApiSchemaPath`)**: claims staging is automatic from the staged schema and available
+- **Standard mode (core only)**: the bootstrap manifest claims section resolves to Embedded mode - no extra flag needed.
+- **Expert mode (`-ApiSchemaPath`) with extensions**: when the staged schema set contains extension resources
+  with matching bootstrap-managed fragments, the bootstrap manifest claims section resolves to Hybrid mode and
+  points at the staged claims workspace containing those fragment files — activated at startup by Story 04
+  (DMS-1154, delivered) — no extra flag needed.
+- **Expert `-ApiSchemaPath` (general)**: claims staging is automatic from the staged schema and available
   claims inputs. When the staged schema set contains extension resources with matching fragments, the same
   bootstrap manifest mechanism stages the matching base fragments and selects Hybrid mode automatically for
   the staged runtime startup path (activated by Story 04, delivered).
@@ -1016,8 +1007,8 @@ the SeedLoader vendor application. The full seed-parameter contract is defined n
 
 | Mode | Parameter | Behavior |
 |------|-----------|----------|
-| Ed-Fi Minimal (default in standard modes only) | `load-dms-seed-data.ps1` with no seed-source flag, or wrapper `-LoadSeedData` with no seed-source flag | In Modes 1 and 2 only, resolves the repo-managed `Minimal` seed source and loads all core descriptor resources plus `schoolYearTypes`. Fast bootstrap for CI and automated testing. This default does not apply when `-ApiSchemaPath` is used. |
-| Ed-Fi Populated | `-SeedTemplate Populated` | In Modes 1 and 2 only, resolves the repo-managed `Populated` seed source and loads `Minimal` plus `localEducationAgencies`, `schools`, `courses`, `students`, and `studentSchoolAssociations`. For manual testing and demos. Not valid with `-ApiSchemaPath`. |
+| Ed-Fi Minimal (default in standard mode only) | `load-dms-seed-data.ps1` with no seed-source flag, or wrapper `-LoadSeedData` with no seed-source flag | In standard mode only, resolves the repo-managed `Minimal` seed source and loads all core descriptor resources plus `schoolYearTypes`. Fast bootstrap for CI and automated testing. This default does not apply when `-ApiSchemaPath` is used (expert mode). |
+| Ed-Fi Populated | `-SeedTemplate Populated` | In standard mode only, resolves the repo-managed `Populated` seed source and loads `Minimal` plus `localEducationAgencies`, `schools`, `courses`, `students`, and `studentSchoolAssociations`. For manual testing and demos. Not valid with `-ApiSchemaPath` (expert mode). |
 | Custom seed data | `-SeedDataPath <directory>` | Uses XML interchange files in Phase 1, and JSONL files in Phase 2, from the specified directory as the source input and copies them into the seed workspace before invocation. Bypasses bootstrap-managed artifact resolution entirely. Compatibility comes from the run's root bootstrap manifest and staged schema/security inputs: embedded claims, selected extension fragments, any additive `-ClaimsDirectoryPath` fragments, and any explicitly supplied `-AdditionalNamespacePrefix` values needed by SeedLoader vendor authorization. Bootstrap does not inspect arbitrary custom seed files to certify that every record is authorized or schema-valid ahead of time. In expert `-ApiSchemaPath` mode, this is the only supported seed-source input when seed delivery is requested. |
 
 **Parameter interaction:**
@@ -1028,23 +1019,22 @@ the SeedLoader vendor application. The full seed-parameter contract is defined n
 - `-SeedDataPath` skips bootstrap-managed artifact resolution, but bootstrap still copies the supplied seed
   files into the seed workspace so every seed flow invokes the pinned BulkLoadClient against materialized
   input directories.
-- The `-Extensions` parameter applies alongside `-SeedTemplate`. When a selected extension defines a
-  built-in seed source, that source is merged into the same bootstrap workspace. When `-SeedDataPath` is specified,
-  `-Extensions` seed-source resolution is skipped - the developer manages the contents of their own
-  directory. Schema package selection and staged security configuration from `-Extensions` still apply
-  regardless of `-SeedDataPath`, and additive `-ClaimsDirectoryPath` fragments still apply too. Custom seed
-  compatibility is therefore evaluated against the same root bootstrap manifest and staged schema/security
-  inputs as the rest of the run, even though bootstrap-managed seed-package resolution is
-  bypassed.
+- Built-in extension seed sources apply alongside `-SeedTemplate`. When an extension recorded in the staged
+  manifest defines a built-in seed source, that source is merged into the same bootstrap workspace. When
+  `-SeedDataPath` is specified, built-in seed-source resolution is skipped - the developer manages the
+  contents of their own directory. The staged schema and security configuration still apply regardless of
+  `-SeedDataPath`, and additive `-ClaimsDirectoryPath` fragments still apply too. Custom seed compatibility is
+  therefore evaluated against the same root bootstrap manifest and staged schema/security inputs as the rest
+  of the run, even though bootstrap-managed seed-package resolution is bypassed.
 - Bootstrap does not inspect arbitrary custom seed files to infer missing extensions, namespace prefixes, or
   claimsets. `-SeedDataPath` is a data-source selection mechanism, not a second schema-discovery path, not a
   dynamic claim-derivation mechanism, and not a payload-certification pass.
 - `-AdditionalNamespacePrefix` is additive only. The seed phase always includes the baseline Ed-Fi seed
-  prefixes and any selected extension prefixes, then appends de-duplicated additional values for
-  `SeedLoader` vendor creation. It does not replace baseline prefixes, infer extensions, or grant claims.
+  prefixes and any staged extension prefixes recorded in the manifest, then appends de-duplicated additional
+  values for `SeedLoader` vendor creation. It does not replace baseline prefixes, infer extensions, or grant claims.
 - `load-dms-seed-data.ps1` reads `eng/docker-compose/.bootstrap/bootstrap-manifest.json` by default. That
   root manifest is the explicit handoff from schema and claims staging to seed delivery; the seed phase does
-  not accept `-Extensions`, `-ApiSchemaPath`, or `-ClaimsDirectoryPath`.
+  not accept schema-selection or claims parameters such as `-ApiSchemaPath` or `-ClaimsDirectoryPath`.
 
 **Example commands:**
 
@@ -1113,7 +1103,7 @@ Example shape:
   "version": 1,
   "schema": {
     "selectionMode": "Standard",
-    "selectedExtensions": ["sample"],
+    "selectedExtensions": [],
     "effectiveSchemaHash": "...",
     "workspaceFingerprint": "...",
     "apiSchemaManifestPath": "ApiSchema/bootstrap-api-schema-manifest.json"
@@ -1349,11 +1339,11 @@ dependency boundary explicit:
   instance creation, broad target-selection policy, or non-selector-driven discovery.
 - **Namespace prefixes**: must cover the namespaces present in the selected seed source. For Ed-Fi-provided
   seed packages, the baseline set is `uri://ed-fi.org` and `uri://gbisd.edu`, plus the namespace prefix for
-  each loaded extension (for example, `uri://sample.ed-fi.org`). When `-Extensions` is used (see
-  [Extension Selection and Loading](#8-extension-selection-and-loading)), the extension portion of the
-  prefix list is computed dynamically from the selected extension set. Custom `-SeedDataPath` inputs may
+  each loaded extension (for example, `uri://sample.ed-fi.org`). The extension portion of the prefix list is
+  taken from the extension namespace prefixes recorded in the staged bootstrap manifest (see
+  [Extension Selection and Loading](#8-extension-selection-and-loading)). Custom `-SeedDataPath` inputs may
   add agency or custom values explicitly with `-AdditionalNamespacePrefix`; bootstrap de-duplicates those
-  values with the baseline and selected-extension prefixes before `Add-Vendor`. This is not a namespace
+  values with the baseline and staged-extension prefixes before `Add-Vendor`. This is not a namespace
   discovery mechanism, and the files must stay compatible with the schema, namespace, and security inputs
   already staged for the run.
 - **Education organization IDs**: at minimum the top-level LEA/SEA IDs already used by the standard bootstrap path. DMS-916 does not add a second parameter surface for arbitrary seed-specific education organization scoping; custom `-SeedDataPath` scenarios are supported as alternate payload sources, not as a full custom authorization-model designer.
@@ -1461,7 +1451,7 @@ already present there and must not invent a synthetic
 | `SeedLoader` claim set | Add the top-level `SeedLoader` definition and the required core permissions to the embedded claims resource at `src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json`. **This is a bootstrap blocker** for API-based seeding: if `SeedLoader` metadata is not present in CMS claims data, seed delivery must fail fast before invoking BulkLoadClient. See required permissions table below. |
 | Extension `SeedLoader` coverage | Each bootstrap-managed extension fragment must attach `SeedLoader` permissions for every resource emitted by that extension's built-in seed package, alongside the extension's normal developer-access permissions. |
 | `Add-SeedLoaderCredentials` helper | Wraps the same `Add-CmsClient` -> `Get-CmsToken` -> `Add-Vendor` -> `Add-Application` flow with Seed Loader-specific defaults; alternatively, parameterize `Get-SmokeTestCredentials` to accept a claim set name. |
-| Dynamic namespace prefix list | Computed from the standard seed baseline (`uri://ed-fi.org`, `uri://gbisd.edu`) plus the `-Extensions` parameter ([Extension Selection and Loading](#8-extension-selection-and-loading)) plus any explicit `-AdditionalNamespacePrefix` values; passed to `Add-Vendor` as a comma-separated string. |
+| Dynamic namespace prefix list | Computed from the standard seed baseline (`uri://ed-fi.org`, `uri://gbisd.edu`) plus the staged extension namespace prefixes recorded in the bootstrap manifest ([Extension Selection and Loading](#8-extension-selection-and-loading)) plus any explicit `-AdditionalNamespacePrefix` values; passed to `Add-Vendor` as a comma-separated string. |
 
 **`SeedLoader` claimset - required resource claim permissions:**
 
@@ -1543,80 +1533,53 @@ Key characteristics of the current model:
 
 ---
 
-### 8.2 Proposed `-Extensions` Parameter
+### 8.2 How Extensions Are Selected
 
-`-Extensions` is the standard developer-facing selector for adding extension artifacts to a bootstrap run.
-Extension artifacts are handled uniformly: when their schema package and companion artifacts can be resolved,
-bootstrap stages them; when an artifact cannot be resolved, the owning phase fails before Docker starts with a
-message naming the missing artifact.
-
-Omitting `-Extensions` means the default profile is the standard core Data Standard schema with no extension
-schemas, no extension claimsets, and no extension seed packages. It does not fall back to the legacy
-`eng/docker-compose` `SCHEMA_PACKAGES` baseline that included extensions by default. Any extension needed for
-the run must be selected explicitly through `-Extensions` or supplied through `-ApiSchemaPath`.
-
-Built-in seed package availability is seed-catalog-driven, not automatic per extension name. Custom seed
-payloads still flow through `-SeedDataPath`.
-
-`-Extensions` belongs to `prepare-dms-schema.ps1` (see `command-boundaries.md` §3.1). It accepts one or
-more extension identifiers typed as `String[]` through normal PowerShell array binding. The phase command
-runs before any Docker services start:
+There is **no `-Extensions` parameter**. Standard mode (omit `-ApiSchemaPath`) is package-backed
+**core-only**: it resolves and stages the core Data Standard ApiSchema package and nothing else. Extension
+schema sets are supplied through the expert `-ApiSchemaPath` filesystem path, which stages the core plus any
+extension `ApiSchema*.json` files present in the supplied directory.
 
 ```powershell
-# Examples
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -Extensions "sample"
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -Extensions "sample","extension2"
-pwsh eng/docker-compose/prepare-dms-schema.ps1   # no -Extensions: core only
+pwsh eng/docker-compose/prepare-dms-schema.ps1                                    # core-only standard mode
+pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath "C:\dev\my-schema"  # expert: core + any extensions in the directory
 ```
 
-**Default behavior**: omitting `-Extensions` loads core Ed-Fi resources only - no staged extension security
-fragments, no extension ApiSchema overlays, and no extension seed data. This is an intentional change from
-today's `eng/docker-compose` baseline, which included extensions in `SCHEMA_PACKAGES`; DMS-916 does not carry
-that default forward into the normative bootstrap contract. Select the needed extensions explicitly through
-`-Extensions` when those schemas are needed. The core-only default keeps the environment minimal and fast to
-start.
+Standard mode does not fall back to the legacy `eng/docker-compose` `SCHEMA_PACKAGES` baseline that included
+extensions by default; it loads core Ed-Fi resources only — no extension schemas, claimsets, or seed data —
+which keeps the environment minimal and fast to start. Built-in seed package availability is
+seed-catalog-driven (Story 02), and custom seed payloads flow through `-SeedDataPath`.
 
-**How it works at runtime:**
+**How it works at runtime (for extensions present in an expert `-ApiSchemaPath` schema set):**
 
-1. Bootstrap resolves extension artifacts by extension short name from the configured package and metadata
-   sources. The schema phase owns schema package resolution, the claims phase owns security fragment
-   resolution, and the seed phase owns optional built-in seed package lookup. The lookup mechanism may start
-   as script-local metadata or move to shared files as it grows, but that does not change phase ownership.
-2. `prepare-dms-schema.ps1` consumes only the schema-owned metadata. It stages the selected
-   `ApiSchema*.json` files, computes the expected `EffectiveSchemaHash`, and writes minimal schema metadata
-   for downstream phases.
-3. `prepare-dms-claims.ps1` consumes the bootstrap manifest schema section, the staged schema files, and the
-   security-owned metadata. For each selected extension with matching security fragments, it stages the
-   corresponding JSON file(s) into `eng/docker-compose/.bootstrap/claims/`; when additional fragments are
-   needed, it requires `-ClaimsDirectoryPath`. Config Service startup consumes that staged host claims
-   workspace through the claims section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json`. The
-   compatible startup wiring continues to mount the staged workspace `eng/docker-compose/.bootstrap/claims`
-   into the Config Service container for the run. Remove the redundant `/app/additional-claims` mounts from
-   `local-dms.yml` and `published-dms.yml`; DMS gets claimsets from CMS authorization metadata, not from local
-   fragment files.
-4. `load-dms-seed-data.ps1` consumes the seed catalog when seed delivery runs and built-in seed packages
-   exist for the selected extension set.
-5. If `-Extensions` is non-empty, the bootstrap manifest claims section resolves to Hybrid mode
-   automatically and the developer does not need any separate legacy claims-selection flag. Historical
-   repo behavior may still mention `-AddExtensionSecurityMetadata`, but that flag is outside the DMS-916
-   normative contract.
-6. If any specified extension artifact cannot be resolved, the owning phase exits with a clear error before
-   starting any containers.
+1. `prepare-dms-schema.ps1` stages the supplied `ApiSchema*.json` files, computes the expected
+   `EffectiveSchemaHash`, and writes the schema section of the bootstrap manifest for downstream phases.
+2. `prepare-dms-claims.ps1` consumes the bootstrap manifest schema section and the staged schema files. For
+   each project in the staged set with a matching bootstrap-managed security fragment (Sample, Homograph),
+   it stages the corresponding JSON file(s) into `eng/docker-compose/.bootstrap/claims/` and resolves the
+   claims section to Hybrid mode; for a project without a bootstrap-managed fragment (e.g. TPDM), it requires
+   caller-supplied `-ClaimsDirectoryPath` fragments. Config Service startup consumes that staged host claims
+   workspace through the claims section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json`. DMS gets
+   claimsets from CMS authorization metadata, not from local fragment files, so DMS compose files do not
+   mount the claims directory.
+3. `load-dms-seed-data.ps1` (Story 02) consumes the seed catalog when seed delivery runs and a built-in seed
+   package exists for an extension recorded in the manifest.
+4. If a required artifact cannot be resolved, the owning phase exits with a clear error before starting any
+   containers.
 
 The staged claims directory must remain in place while Docker containers are running because it is
-bind-mounted into the container at `/app/additional-claims` (activated as part of staged startup by
-Story 04, delivered). For v1,
-bootstrap uses a stable repo-local workspace under `eng/docker-compose/.bootstrap/claims` rather than per-run
+bind-mounted into the Config Service at startup (activated as part of staged startup by Story 04, delivered).
+Bootstrap uses a stable repo-local workspace under `eng/docker-compose/.bootstrap/claims` rather than per-run
 temp directories plus a state file. On same-checkout reruns, bootstrap compares the intended claims set to
-the existing workspace.
-Identical contents are reused as-is; a different intended set requires teardown because the current CMS
-startup path only initial-loads claims into empty tables and does not replace a populated claims document in
-place. Teardown removes the entire `eng/docker-compose/.bootstrap/` workspace.
+the existing workspace. Identical contents are reused as-is; a different intended set requires teardown
+because the current CMS startup path only initial-loads claims into empty tables and does not replace a
+populated claims document in place. Teardown removes the entire `eng/docker-compose/.bootstrap/` workspace.
 
-**Extension selection changes the physical schema footprint:** The database DDL is derived from the selected
-staged schema set. `-Extensions` therefore controls both which API resources are authorized and which
-extension tables are provisioned. A developer cannot safely switch between extension combinations on an
-already-provisioned database unless the live fingerprint still matches the exact selected schema set.
+**The staged schema set changes the physical schema footprint:** the database DDL is derived from the staged
+schema set, so adding or removing an extension (by changing the `-ApiSchemaPath` directory contents) changes
+both which API resources are authorized and which extension tables are provisioned. A developer cannot safely
+switch between schema sets on an already-provisioned database unless the live fingerprint still matches the
+exact staged schema set.
 
 ---
 
@@ -1659,45 +1622,45 @@ seed-catalog concern rather than a schema-selection concern.
 
 ### 8.4 Integration with ApiSchema.json Selection (Section 3)
 
-The `-Extensions` parameter is the single developer-facing control for enabling extensions. Passing it triggers three coordinated actions automatically - the developer does not need to configure each concern separately:
+The staged schema set is the single source of truth for enabling extensions. For an extension present in an
+expert `-ApiSchemaPath` schema set, three concerns are handled automatically from that staged set — the
+developer does not configure each separately:
 
-1. **ApiSchema files staged host-side (Section 3)** - The script resolves the extension's NuGet schema
-   package (e.g., `EdFi.DataStandard52.Sample.ApiSchema`) on the host, stages the resulting file in
-   `eng/docker-compose/.bootstrap/ApiSchema/`, and includes that staged file in the exact set later hashed
-   and mounted/read by DMS.
+1. **ApiSchema files staged host-side (Section 3)** - The extension's `ApiSchema*.json` file in the supplied
+   directory is normalized into `eng/docker-compose/.bootstrap/ApiSchema/` and included in the exact set
+   later hashed and mounted/read by DMS.
 
-2. **Security fragments loaded (Section 4)** - The corresponding security fragment JSON file(s) are staged
-   and bind-mounted to `/app/additional-claims`. The bootstrap manifest claims section resolves to Hybrid
-   mode automatically and points at the relative staged workspace. No separate legacy claims-selection flag is
-   part of this DMS-916 flow. For built-in extension seed packages, those fragments must attach both
-   `EdFiSandbox` and `SeedLoader` permissions to the extension resources they cover.
+2. **Security fragments loaded (Section 4)** - When the extension has a bootstrap-managed security fragment
+   (Sample, Homograph), the corresponding JSON file(s) are staged and the bootstrap manifest claims section
+   resolves to Hybrid mode automatically. An extension without a bootstrap-managed fragment (e.g. TPDM)
+   requires caller-supplied `-ClaimsDirectoryPath`. For built-in extension seed packages, those fragments
+   must attach both `EdFiSandbox` and `SeedLoader` permissions to the extension resources they cover.
 
-3. **Extension seed data handling (Section 8.3)** - When seed delivery runs, bootstrap checks
-   whether any selected extension has a built-in seed package in the seed catalog. If no selected extension
-   has one, the seed workspace remains core-only unless the developer supplies `-SeedDataPath`. If an
-   extension has a built-in seed package, its seed files are merged
-   into the same bootstrap workspace only when that package participates in the same external BulkLoadClient
-   contract used for core artifacts in the active phase.
+3. **Extension seed data handling (Section 8.3)** - When seed delivery runs, bootstrap checks whether an
+   extension recorded in the manifest has a built-in seed package in the seed catalog. If none does, the seed
+   workspace remains core-only unless the developer supplies `-SeedDataPath`. If an extension has a built-in
+   seed package, its seed files merge into the same bootstrap workspace only when that package participates in
+   the same external BulkLoadClient contract used for core artifacts in the active phase.
 
-**Example - sample-enabled bootstrap run:**
+**Example - sample-enabled bootstrap run (expert `-ApiSchemaPath`):**
 
-After schema and claims preparation have already selected the sample extension for the run, the seed-delivery
-phase behaves as follows:
+After schema and claims preparation have staged a schema set that includes the Sample extension (via
+`-ApiSchemaPath`), the seed-delivery phase behaves as follows:
 
 ```powershell
 pwsh eng/docker-compose/load-dms-seed-data.ps1
 # Result:
 #   eng/docker-compose/.bootstrap/ApiSchema/ includes the staged Sample ApiSchema.json  (Section 3)
-#   /app/additional-claims contains the sample security fragment with EdFiSandbox coverage  (Section 4)
-#   Seed workspace contains only the selected core seed source unless -SeedDataPath is supplied  (Section 8.3)
+#   the staged claims workspace contains the sample security fragment with EdFiSandbox coverage  (Section 4)
+#   Seed workspace contains only the core seed source unless -SeedDataPath is supplied  (Section 8.3)
 ```
 
-**Note - `-ApiSchemaPath` mutual exclusivity:** `-ApiSchemaPath` and `-Extensions` are mutually exclusive
-parameters. When `-ApiSchemaPath` is provided, the developer supplies a complete custom schema environment.
-Bootstrap still derives the base security set from the staged schema and available claims inputs, while any
-additional non-core security fragments come through `-ClaimsDirectoryPath`. Custom seed inputs continue to
-use `-SeedDataPath`. This preserves the schema/security single-source-of-truth principle while keeping
-arbitrary custom authorization rules explicit.
+**Note - the two modes:** standard mode (omit `-ApiSchemaPath`) stages core only; expert `-ApiSchemaPath`
+supplies a complete schema set (core plus any extensions). There is no `-Extensions` parameter. In expert
+mode, bootstrap still derives the base security set from the staged schema and available claims inputs, while
+any additional non-core security fragments come through `-ClaimsDirectoryPath` and custom seed inputs through
+`-SeedDataPath`. This preserves the schema/security single-source-of-truth principle while keeping arbitrary
+custom authorization rules explicit.
 
 ---
 
@@ -1801,7 +1764,7 @@ value to `start-local-dms.ps1`, `configure-local-data-store.ps1`, `provision-dms
 
 The Config Service is mandatory for the normative bootstrap contract. Every non-teardown
 DMS-916 bootstrap invocation starts the Config Service unconditionally, including
-the default no-argument core-only Mode 1 flow and keycloak-backed runs. `-EnableConfig` therefore remains
+the default no-argument core-only standard-mode flow and keycloak-backed runs. `-EnableConfig` therefore remains
 only as a backward-compatibility switch, not as a meaningful opt-out on the canonical bootstrap contract.
 
 **Breaking-change note:** The DMS-916 definition of `-NoDataStore` (owned by `configure-local-data-store.ps1`) deliberately narrows the current behavior. Existing scripts that used it on a fresh stack as a generic "skip creation" switch must now either drop the flag or pre-create exactly one intended target instance before rerunning. See also [Section 15](#15-breaking-changes-and-migration-notes) for the consolidated migration reference.
@@ -1812,13 +1775,12 @@ Each validation rule below is owned by the phase command responsible for the aff
 
 | Rule | Outcome |
 |------|---------|
-| `-Extensions` and `-ApiSchemaPath` both specified | "Error: -Extensions and -ApiSchemaPath are mutually exclusive. Use -Extensions for package-backed extension selection or -ApiSchemaPath for a custom schema directory." |
 | `-ApiSchemaPath` staging does not normalize to exactly one core `ApiSchema*.json` file plus zero or more extension files | "Error: -ApiSchemaPath must resolve to exactly one core ApiSchema.json and zero or more extension ApiSchema.json files after staging." |
-| `-ApiSchemaPath` stages schemas that need additional claims metadata without `-ClaimsDirectoryPath` | "Error: -ApiSchemaPath requires additional claims metadata for one or more staged schemas. Provide -ClaimsDirectoryPath with claimset fragments, or use -Extensions when package-backed artifacts are available." |
+| `-ApiSchemaPath` stages schemas that need additional claims metadata without `-ClaimsDirectoryPath` | "Error: -ApiSchemaPath requires additional claims metadata for one or more staged schemas. Provide -ClaimsDirectoryPath with claimset fragments." |
 | `-SeedTemplate` and `-SeedDataPath` both specified | "Error: -SeedTemplate and -SeedDataPath are mutually exclusive. Use -SeedTemplate for bootstrap-managed Ed-Fi templates or -SeedDataPath for a custom seed directory." |
 | Bootstrap manifest schema section was produced from `-ApiSchemaPath`, and `-SeedTemplate` is specified | "Error: -SeedTemplate is not valid with -ApiSchemaPath. Expert custom-schema mode disables bootstrap-managed seed selection; use -SeedDataPath when seed delivery is required." |
 | `load-dms-seed-data.ps1` with a bootstrap manifest schema section from `-ApiSchemaPath`, but without `-SeedDataPath` | "Error: Seed delivery with -ApiSchemaPath requires -SeedDataPath. Expert custom-schema mode does not fall back to built-in Minimal or Populated seed templates." |
-| Seed delivery with `-SeedDataPath` and `-Extensions` | `-Extensions` seed package resolution is skipped. Schema packages and staged security configuration from `-Extensions` still apply. The script emits a warning indicating that extension seed package lookup is skipped when `-SeedDataPath` is provided. |
+| Seed delivery with `-SeedDataPath` | Built-in seed package resolution is skipped. The staged schema and security configuration still apply. The script emits a warning indicating that built-in seed package lookup is skipped when `-SeedDataPath` is provided. |
 | `-AdditionalNamespacePrefix` contains a blank or malformed value | "Error: -AdditionalNamespacePrefix values must be non-empty namespace URI prefixes, for example uri://state.example.org." |
 | `load-dms-seed-data.ps1` cannot read a valid bootstrap manifest with schema, claims, and seed sections | "Error: Seed delivery requires prepared schema/security inputs. Run prepare-dms-schema.ps1 and prepare-dms-claims.ps1 first, or pass -BootstrapManifestPath to the bootstrap manifest." |
 | `-InfraOnly` without `-DmsBaseUrl` | Permitted. `start-local-dms.ps1` performs infrastructure startup and readiness checks only, then stops. This is not a checkpoint for a later bootstrap resume; instance creation, schema provisioning, and seed work remain in later explicit phase commands or wrapper orchestration. |
@@ -1836,9 +1798,9 @@ Each validation rule below is owned by the phase command responsible for the aff
 | `-ClaimsDirectoryPath` fragment references a claim set name that does not exist in the embedded `Claims.json` | "Error: Claimset fragment '<file>' references unknown claim set '<name>'. DMS-916 additive fragments may only attach to claim sets declared in the embedded Claims.json." |
 | Seed delivery runs but the pinned BulkLoadClient package cannot be resolved or does not expose the CLI surface required by the active phase | "Error: BulkLoadClient package resolution failed or the CLI surface required by the active phase (XML in Phase 1, JSONL in Phase 2) is unavailable." |
 | Seed delivery runs but the embedded claims metadata does not define the top-level `SeedLoader` claim set | "Error: Seed delivery requires the embedded CMS claims metadata to define the top-level SeedLoader claim set. Bootstrap cannot continue to BulkLoadClient until that claim set exists." |
-| Extension artifact for `-Extensions` cannot be resolved | "Error: Extension artifact resolution failed for '<name>'. Check the extension name, configured feed, package metadata, or supply a direct schema directory with -ApiSchemaPath." |
-| Seed delivery with `-Extensions` where an extension is in the seed catalog but its NuGet seed package fails to resolve | "Error: Seed package for extension '<name>' could not be resolved. Check network/feed access or supply the package manually." |
-| Seed delivery with `-Extensions` where an extension has no seed package entry in the seed catalog | Permitted with warning. Bootstrap emits an informational warning indicating no built-in seed package is available; schema and security configuration from the extension still apply. |
+| Core package cannot be resolved in standard mode | "Error: Core ApiSchema package resolution failed. Check the configured feed and package metadata, or supply a direct schema directory with -ApiSchemaPath." |
+| Seed delivery where an extension recorded in the staged manifest is in the seed catalog but its NuGet seed package fails to resolve | "Error: Seed package for extension '<name>' could not be resolved. Check network/feed access or supply the package manually." |
+| Seed delivery where an extension recorded in the staged manifest has no seed package entry in the seed catalog | Permitted with warning. Bootstrap emits an informational warning indicating no built-in seed package is available; schema and security configuration from the extension still apply. |
 | Seed delivery with a built-in extension seed source whose staged security fragments do not attach required `SeedLoader` permissions for that extension's seed resources | "Error: Extension '<name>' seed package configuration is incomplete. The staged security fragments do not provide the required SeedLoader permissions for the extension seed resources." |
 
 ---
@@ -1852,8 +1814,12 @@ wrapper (`bootstrap-local-dms.ps1`) for the happy path. Common invocations:
 # Full bootstrap via thin wrapper — core only, no seed data
 pwsh eng/docker-compose/bootstrap-local-dms.ps1
 
-# Full bootstrap with sample extension and seed data
-pwsh eng/docker-compose/bootstrap-local-dms.ps1 -Extensions sample -LoadSeedData -SeedTemplate Minimal
+# Full bootstrap with seed data (core-only standard mode)
+pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedTemplate Minimal
+
+# Extension-containing schema set: stage via expert -ApiSchemaPath first, then run the wrapper
+pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seeds/
 
 # Keycloak-backed seed loading
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -IdentityProvider keycloak -LoadSeedData -SeedTemplate Minimal
@@ -1877,7 +1843,7 @@ pwsh eng/docker-compose/start-local-dms.ps1 -d -v
 No shell/session preparation is required before invoking the wrapper. Direct phase-command invocation is
 for targeted re-runs and manual flows, and each phase requires the upstream outputs documented in
 [`command-boundaries.md`](command-boundaries.md). The story-aligned behaviors documented elsewhere -
-`-Extensions`, authoritative schema provisioning, `-InfraOnly`, `-DmsBaseUrl`, `-IdentityProvider` - apply in both
+`-ApiSchemaPath`, authoritative schema provisioning, `-InfraOnly`, `-DmsBaseUrl`, `-IdentityProvider` - apply in both
 wrapper and manual flows, but manual callers must run the dependency chain explicitly.
 
 #### 9.4.2 Wrapper Direct-Flag Interface
@@ -1916,10 +1882,9 @@ A minimal acceptable console shape is:
 Bootstrap-DMS: Starting...
 
 [prepare-dms-schema]                                       (0.4s)
-  Core:  EdFi.DataStandard52.ApiSchema        1.0.332
-  Ext:   EdFi.DataStandard52.Sample.ApiSchema 1.0.332
+  Core:  EdFi.DataStandard52.ApiSchema        1.0.329
 [prepare-dms-claims]                                       (0.2s)
-  Hybrid mode: 1 security fragment(s) staged
+  Embedded mode: core claims only
 [start-local-dms -InfraOnly]                              (13.7s)
   Infrastructure and Config Service are health-ready
 [configure-local-data-store]                             (1.4s)
@@ -1951,8 +1916,9 @@ Summary
   Total                                   216.0s
 ```
 
-> The core and extension ApiSchema packages are versioned independently and may not share a version (the
-> versions above are illustrative); bootstrap resolves each package to its own configured feed version.
+> ApiSchema package versions are illustrative; bootstrap resolves each staged package to its own configured
+> feed version. In standard mode only the core package is staged; an expert `-ApiSchemaPath` directory may
+> contain additional projects, each versioned independently.
 
 CI environments may suppress color output. The summary table is always emitted on both success and failure;
 on failure the failing phase name and error are printed before the summary.
@@ -2334,7 +2300,7 @@ table set, not just the expected hash or runtime API surface. The separation of 
 - **Schema selection also drives physical table creation** - only the tables required by the selected schema
   set are considered aligned for the run. Core-only selection yields only core tables. Core plus Sample
   yields the core tables plus the sample-extension tables required by that combined schema set.
-- **Schema selection still controls API surface and security** - the `-Extensions` value and the resulting
+- **Schema selection still controls API surface and security** - the staged schema set and the resulting
   `ApiSchema.json` determine which REST endpoints are exposed and which claimsets are loaded, and now those
   runtime inputs are expected to stay in sync with the exact physical schema provisioned for that run.
 - **`Invoke-DmsSchemaProvisioning` consumes schema context at the target level** - the bootstrap script does
@@ -2350,10 +2316,10 @@ table set, not just the expected hash or runtime API surface. The separation of 
       -TargetConnectionStrings $targetConnectionStrings
   ```
 
-- **Changing `-Extensions` is a schema-compatibility decision** - adding or removing an extension changes
-  the selected physical schema footprint for the run. The authoritative provisioning path validates or
-  provisions against the newly selected staged schema set rather than silently reusing an incompatible
-  existing database.
+- **Changing the staged schema set is a schema-compatibility decision** - adding or removing an extension
+  (by changing the `-ApiSchemaPath` directory contents) changes the physical schema footprint for the run.
+  The authoritative provisioning path validates or provisions against the newly staged schema set rather than
+  silently reusing an incompatible existing database.
 
 ### 11.6 Forward Compatibility
 
@@ -2687,7 +2653,7 @@ Companion implementation-ready story definitions live in
 | Entry point and IDE workflow | [`../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md`](../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md) | `start-local-dms.ps1` is the infrastructure-lifecycle phase command, while the normative bootstrap contract remains the composable phase-command set. `-InfraOnly` / `-DmsBaseUrl` define the two IDE-hosted workflow shapes: stop after schema provisioning, or carry the wrapper run through schema provisioning before automatically health-waiting against the external endpoint. |
 | Replace DMS ApiSchema DLL resource loading | [`../../epics/16-bootstrap/04-apischema-runtime-content-loading.md`](../../epics/16-bootstrap/04-apischema-runtime-content-loading.md) | DMS runtime reads metadata/specification JSON and XSD assets from the normalized ApiSchema workspace and ApiSchema asset manifest instead of requiring `*.ApiSchema.dll` assemblies for the bootstrap path. DMS runtime does not read NuGet packages directly. |
 | MetaEd ApiSchema asset packaging | [`../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`](../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md) | MetaEd publishes asset-only ApiSchema NuGet packages whose loose-file payload can be normalized by Story 06 without assembly-resource extraction. This is a cross-repo package-production story over the same filesystem contract, not a new DMS runtime responsibility. |
-| Package-backed standard schema selection | [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) | Story 06 delivers omitted `-Extensions` core-only mode and named `-Extensions` standard mode by resolving asset-only packages into the same normalized ApiSchema workspace, ApiSchema asset manifest, and root bootstrap manifest schema section used by Story 00. |
+| Package-backed standard schema selection | [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) | Story 06 (DMS-1156) delivers package-backed **core-only** standard mode (no `-Extensions` parameter): it resolves the asset-only core package into the same normalized ApiSchema workspace, ApiSchema asset manifest, and root bootstrap manifest schema section used by Story 00. Extension/custom schema sets use the expert `-ApiSchemaPath` path. |
 
 **Cross-story dependency notes**
 
@@ -2707,10 +2673,11 @@ Companion implementation-ready story definitions live in
   package-backed standard mode against published packages, but it is not a prerequisite for Story 00's
   direct filesystem ApiSchema loading contract. Story 00, Story 04 (delivered), and Story 05 all meet at the
   normalized filesystem workspace; Story 05 can proceed independently of Story 00 and Story 04.
-- Story 06 owns the standard developer schema-selection path: omitted `-Extensions` for core-only bootstrap
-  and named `-Extensions` for package-backed extension selection. It depends on Story 05 for asset-only package
-  inputs and on Story 00 for the shared workspace, ApiSchema asset manifest, claims-staging, and root
-  bootstrap manifest contracts. Story 02 remains the owner for seed delivery and built-in extension seed lookup.
+- Story 06 (DMS-1156) owns the standard developer schema-selection path: package-backed **core-only** standard
+  mode. There is no `-Extensions` parameter; extension/custom schema sets use the expert `-ApiSchemaPath` path
+  owned by Story 00. It depends on Story 05 for the asset-only core package input and on Story 00 for the
+  shared workspace, ApiSchema asset manifest, claims-staging, and root bootstrap manifest contracts. Story 02
+  remains the owner for seed delivery and built-in extension seed lookup.
 
 ### 13.1 Explicitly Out of Scope for DMS-916
 
@@ -2748,11 +2715,11 @@ these rows, it is outside the intended scope of this design spike.
 
 | Ticket acceptance criterion | Evidence in this document | Design completeness | Delivery readiness | Blocking dependency / gap |
 |-----------------------------|---------------------------|---------------------|--------------------|---------------------------|
-| ApiSchema.json selection - how developers choose core, extensions, or custom path | Sections 3.3, 8.2, 8.4, 9.3; [`apischema-container.md`](apischema-container.md) | Designed. The selected schema set is staged as a normalized file-based ApiSchema asset container: schema JSON drives hash/DDL/API surface, while the ApiSchema asset manifest indexes optional static content for runtime metadata/XSD endpoints. Direct filesystem ApiSchema loading is the stable core contract; package-backed selection is the Story 06 input-materialization path. | Story 00 (filesystem staging) and Story 04 (DMS-1154, runtime file-based content loading) delivered. Story 05 (MetaEd asset-only packages) and Story 06 (package-backed no-argument core-only and named `-Extensions` delivery) remain pending. | [`../../epics/16-bootstrap/00-schema-and-security-selection.md`](../../epics/16-bootstrap/00-schema-and-security-selection.md); [`../../epics/16-bootstrap/04-apischema-runtime-content-loading.md`](../../epics/16-bootstrap/04-apischema-runtime-content-loading.md); [`../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`](../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md); [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) |
+| ApiSchema.json selection - how developers choose core, extensions, or custom path | Sections 3.3, 8.2, 8.4, 9.3; [`apischema-container.md`](apischema-container.md) | Designed. The selected schema set is staged as a normalized file-based ApiSchema asset container: schema JSON drives hash/DDL/API surface, while the ApiSchema asset manifest indexes optional static content for runtime metadata/XSD endpoints. Direct filesystem ApiSchema loading is the stable core contract; package-backed selection is the Story 06 input-materialization path. | Story 00 (filesystem staging), Story 04 (DMS-1154, runtime file-based content loading), and Story 06 (DMS-1156, package-backed core-only standard mode) delivered. Story 05 (MetaEd asset-only packages) remains an external publishing prerequisite. | [`../../epics/16-bootstrap/00-schema-and-security-selection.md`](../../epics/16-bootstrap/00-schema-and-security-selection.md); [`../../epics/16-bootstrap/04-apischema-runtime-content-loading.md`](../../epics/16-bootstrap/04-apischema-runtime-content-loading.md); [`../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`](../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md); [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) |
 | Security database configuration from ApiSchema.json | Sections 4.3-4.5, 9.3 (`-ClaimsDirectoryPath`) | Designed. DMS-916 derives base claims inputs from the staged schema and available claims artifacts in every schema-selection mode. Expert `-ApiSchemaPath` mode uses `-ClaimsDirectoryPath` for additional non-core security fragments, with structural validation only. | Designed, implementation pending. Story 00 owns claims staging and direct-filesystem inputs; Story 06 feeds the same root bootstrap manifest schema contract for package-backed standard mode. | [`../../epics/16-bootstrap/00-schema-and-security-selection.md`](../../epics/16-bootstrap/00-schema-and-security-selection.md); [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md) |
 | Database schema provisioning - DDL hook separated from seed data loading, driven by selected ApiSchema.json | Sections 3.2, 11.3-11.5; [`command-boundaries.md` Section 3.5](command-boundaries.md#35-provision-dms-schemaps1--authoritative-schema-provisioning) | Designed under the strong interpretation above. Selected schema drives the DDL target/version/`EffectiveSchemaHash` validation path and the exact physical schema provisioned for that run. DMS startup provisioning is explicitly disabled, including both `AppSettings__DeployDatabaseOnStartup` and the legacy `NEED_DATABASE_SETUP` / `Backend.Installer` pre-launch path. | Designed, implementation pending. Bootstrap delegates to the SchemaTools / runtime-owned provisioning path; readiness is gated on that surface remaining stable. | [`../../epics/16-bootstrap/01-schema-deployment-safety.md`](../../epics/16-bootstrap/01-schema-deployment-safety.md); SchemaTools dependency in Section 14.3 |
 | Sample data loading - API-based seed loading replacing direct SQL, with pinned Ed-Fi XML seed templates in Phase 1 and JSONL assets in Phase 2 paired with compatible schema/security inputs | Section 6 | Designed. All DMS-side design decisions are complete: BulkLoadClient consumption contract (Section 6.1), seed-source selection (`-SeedTemplate` / `-SeedDataPath`, Section 6.2), bootstrap manifest handoff (Section 6.2.5), seed workspace with collision detection (Section 6.3.1), per-year invocation for school-year paths (Section 10), and the bootstrap manifest compatibility boundary for `-SeedDataPath`, including explicit `-AdditionalNamespacePrefix` values for SeedLoader vendor authorization. DMS-1152 Phase 1 is API-based XML loading through the repo-pinned BulkLoadClient XML surface; Phase 2 remains the JSONL target. | Phase 1 implemented by Story 02 as XML interchange. Phase 2 migration remains blocked externally by BulkLoadClient JSONL support and DMS-owned JSONL asset work. | Story 02 XML implementation; ODS-6738 and future Phase 2 JSONL asset work |
-| Extension selection - parameterized `-Extensions` flag driving schema and security automatically, and driving built-in seed data automatically only where the seed catalog defines a built-in seed package | Sections 3.3, 8.2-8.4 | Designed | Designed, implementation pending. Direct filesystem schema input belongs to Story 00; package-backed `-Extensions` materialization belongs to Story 06 after Story 05. Story 02 owns built-in extension seed lookup and loading from the bootstrap manifest. | [`../../epics/16-bootstrap/00-schema-and-security-selection.md`](../../epics/16-bootstrap/00-schema-and-security-selection.md); [`../../epics/16-bootstrap/02-api-seed-delivery.md`](../../epics/16-bootstrap/02-api-seed-delivery.md); [`../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`](../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md); [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md); see Section 14.2 |
+| Extension selection - how a developer adds extension artifacts to a bootstrap run | Sections 3.3, 8.2-8.4 | Designed | Delivered via the expert `-ApiSchemaPath` filesystem path (Story 00), which stages core plus any extension `ApiSchema*.json` files. There is no named extension-selection parameter; standard mode (Story 06) is package-backed core-only. Story 02 owns built-in extension seed lookup and loading from the bootstrap manifest. | [`../../epics/16-bootstrap/00-schema-and-security-selection.md`](../../epics/16-bootstrap/00-schema-and-security-selection.md); [`../../epics/16-bootstrap/02-api-seed-delivery.md`](../../epics/16-bootstrap/02-api-seed-delivery.md); [`../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`](../../epics/16-bootstrap/05-metaed-apischema-asset-packaging.md); [`../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md`](../../epics/16-bootstrap/06-package-backed-standard-schema-selection.md); see Section 14.2 |
 | Credential bootstrapping - enhancements for seed data loading support | Section 7 | Designed. Both credential flows are fully specified: CMS-only `EdFiSandbox` smoke-test credentials (Section 7.2.1) and the separate DMS-dependent `SeedLoader` credential flow (Section 7.2.2), including the complete `SeedLoader` permission table (resource claim URI patterns, authorization strategies, operations). Adding the `SeedLoader` top-level claim set to the embedded CMS `Claims.json` is the very first implementation task in Story 02 Task 3 — the design specifies exactly what to add. | Designed, implementation pending. Story 02 Task 3 owns adding the `SeedLoader` claim set to `src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Claims.json`; this is the first deliverable from that story and unblocks all DMS-side seed delivery. | [`../../epics/16-bootstrap/02-api-seed-delivery.md`](../../epics/16-bootstrap/02-api-seed-delivery.md) Task 3; see Section 14.2 |
 | Bootstrap entry point and safe skip behavior - composable phase commands with optional same-invocation continuation | Sections 1, 9, 9.2-9.5 | Designed. The normative contract is the composable phase commands in `command-boundaries.md`; any thin wrapper is convenience only, may expose happy-path flags, and only sequences phases and forwards values owned by those phases. "Skip/resume" means safe skip behavior across phase commands plus optional same-invocation continuation via `-InfraOnly -DmsBaseUrl` after instance configuration and schema provisioning, not a persisted resume model. | Designed, implementation pending across the phase commands and the optional thin wrapper. | [`../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md`](../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md) and the phase-command implementation tickets |
 | IDE debugging workflow - running DMS in IDE against Docker infrastructure | Section 12 | Designed | Designed, implementation pending. `-InfraOnly` and the post-provision `-DmsBaseUrl` continuation behavior are not yet implemented in `start-local-dms.ps1`. | [`../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md`](../../epics/16-bootstrap/03-entry-point-and-ide-workflow.md); see Section 14.2 |
@@ -2842,7 +2809,7 @@ or contributors.
 
 | # | Area | Old behavior | New DMS-916 behavior | Migration action |
 |---|------|--------------|----------------------|------------------|
-| 1 | Default schema profile when `-Extensions` is omitted | `SCHEMA_PACKAGES` staged Data Standard 5.2 plus extensions by default in the existing `eng/docker-compose` flow | Bootstrap resolves and stages **core only** (`EdFi.DataStandard52.ApiSchema`) when `-Extensions` is omitted | Omit `-Extensions` for core-only runs; pass the needed extension identifiers through `-Extensions` for scripts that rely on extension schemas |
+| 1 | Default standard-mode schema profile | `SCHEMA_PACKAGES` staged Data Standard 5.2 plus extensions by default in the existing `eng/docker-compose` flow | Standard mode (no `-ApiSchemaPath`) resolves and stages **core only** (`EdFi.DataStandard52.ApiSchema`) | Use standard mode for core-only runs; stage extension schemas through the expert `-ApiSchemaPath` directory for scripts that rely on extension schemas |
 | 2 | `-NoDataStore` semantics | Generic "skip instance creation" switch used on fresh stacks as a convenient no-op | **Narrow rerun escape hatch only:** valid only when exactly one existing instance is present in the current tenant scope, and invalid with `-SchoolYearRange`; zero or multiple instances fail fast requiring teardown or manual preparation | Drop the flag on fresh-stack runs, or pre-create exactly one target instance before rerunning with `-NoDataStore` |
 | 3 | Seed-loading parameter ownership | `-LoadSeedData`, `-SeedTemplate`, and `-SeedDataPath` were accepted directly by `start-local-dms.ps1` | `-LoadSeedData` is a wrapper-level opt-in only; direct `load-dms-seed-data.ps1` invocation always loads seed data and owns `-SeedTemplate`, `-SeedDataPath`, `-AdditionalNamespacePrefix`, `-BootstrapManifestPath`, the seed-phase BulkLoadClient target `-DmsBaseUrl`, and the seed-phase token endpoint selector `-IdentityProvider`; `start-local-dms.ps1` no longer accepts seed-source or seed-authorization parameters | Call `load-dms-seed-data.ps1` directly for seed loading after `prepare-dms-schema.ps1` and `prepare-dms-claims.ps1`, passing `-DmsBaseUrl` for an IDE-hosted endpoint, `-IdentityProvider` when the running environment uses a non-default provider, and `-AdditionalNamespacePrefix` when custom seed data needs additional vendor namespace authorization, or use `bootstrap-local-dms.ps1 -LoadSeedData [-SeedTemplate <name>]` which orchestrates the phase commands including seed loading |
 | 4 | Persisted data-store-ID hand-off via `.bootstrap/run-context.json` | `configure-local-data-store.ps1` wrote selected data store IDs to `.bootstrap/run-context.json`; downstream phases read that file to resolve their target set | data store IDs are emitted in a structured `configure-local-data-store.ps1` result and **forwarded in-memory** within the same wrapper invocation. Separate phase-command invocations use explicit `-DataStoreId <long[]>` or `-SchoolYear <int[]>` selectors with CMS-backed lookup; no disk artifact is written | Remove any scripts that read or depend on `.bootstrap/run-context.json`; use explicit `-DataStoreId` or `-SchoolYear` selectors when invoking `provision-dms-schema.ps1` or `load-dms-seed-data.ps1` independently |

--- a/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/command-boundaries.md
@@ -45,18 +45,18 @@ environment configuration.
 | Item | Detail |
 |---|---|
 | **Preconditions** | Story 00: filesystem ApiSchema source available directly through `-ApiSchemaPath`. Story 06: NuGet feed reachable for asset-only package materialization. No Docker services required. |
-| **Inputs** | Story 00: `-ApiSchemaPath <path>` (direct filesystem ApiSchema source). Story 06: `-Extensions <name>` (0..N, package-backed extension names), mutually exclusive with `-ApiSchemaPath`. |
+| **Inputs** | Story 00: `-ApiSchemaPath <path>` (direct filesystem ApiSchema source). Story 06: no additional input parameter; standard mode (omit `-ApiSchemaPath`) stages the package-backed core schema only. Extension/custom schema sets use Story 00 `-ApiSchemaPath`. |
 | **Outputs** | Staged workspace `eng/docker-compose/.bootstrap/ApiSchema/` containing normalized schema JSON files, optional schema-adjacent static content, and `bootstrap-api-schema-manifest.json`; the staged workspace itself is the downstream schema and runtime-asset contract consumed by later phases and by DMS runtime (staged workspace loading delivered by Story 04, DMS-1154) |
 | **Side effects** | Writes staged workspace; computes expected `EffectiveSchemaHash` via `dms-schema hash`; records manifest-relative paths for schema and optional static content in `bootstrap-api-schema-manifest.json`; writes the schema section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json` with schema-selection mode, selected extensions, the effective schema hash, an ApiSchema workspace fingerprint, and the relative ApiSchema manifest path |
-| **Failure conditions** | Story 00: missing `-ApiSchemaPath`; `-Extensions` supplied before Story 06 behavior is implemented; normalized-path collision; staged workspace exists with different content; `dms-schema hash` exits non-zero; fewer or more than 1 core schema present after staging. Story 06 adds: extension package/artifact resolution failure; `-Extensions` and `-ApiSchemaPath` both supplied; NuGet feed unreachable for package-backed materialization; selected package is missing the required asset-only ApiSchema payload; selected package contains only DLL-backed ApiSchema resources after the asset-only package switch-over. |
+| **Failure conditions** | Story 00: missing `-ApiSchemaPath`; normalized-path collision; staged workspace exists with different content; `dms-schema hash` exits non-zero; fewer or more than 1 core schema present after staging. Story 06 adds: NuGet feed unreachable for package-backed materialization; the core package is missing the required asset-only ApiSchema payload; the core package contains only DLL-backed ApiSchema resources after the asset-only package switch-over. |
 | **Must NOT do** | Start or depend on Docker services; modify `.env` or Docker Compose variables; perform DDL work; contact the Config Service; accept claims-related parameters |
 
 **Mode-to-security contract (precise):** In Story 00 direct filesystem mode (`-ApiSchemaPath`), automatic
 base security selection comes from the staged schema and available claims inputs. Any non-core schema that
 needs additional security metadata remains detectable from the staged schema files and requires
 developer-supplied claim fragments through `-ClaimsDirectoryPath`; this command does not reject that shape
-because it does not own claims inputs. Story 06 package-backed `-Extensions` mode must write the same root
-bootstrap manifest schema facts so `prepare-dms-claims.ps1` can use the same security-selection contract.
+because it does not own claims inputs. Story 06 package-backed core-only standard mode must write the same
+root bootstrap manifest schema facts so `prepare-dms-claims.ps1` can use the same security-selection contract.
 
 **Boundary note:** The stable contract is the staged filesystem ApiSchema workspace, not the package shape
 that produced it. Story 00 delivers only the direct `-ApiSchemaPath` acquisition path. Story 06
@@ -107,7 +107,7 @@ bootstrap manifest records stable prepared inputs and fingerprints only:
   "version": 1,
   "schema": {
     "selectionMode": "Standard",
-    "selectedExtensions": ["sample"],
+    "selectedExtensions": [],
     "effectiveSchemaHash": "...",
     "workspaceFingerprint": "...",
     "apiSchemaManifestPath": "ApiSchema/bootstrap-api-schema-manifest.json"
@@ -228,7 +228,7 @@ successor story.
 | **Inputs** | `-EnvironmentFile <path>` (select local settings for CMS URL, auth defaults, tenant scope, and Docker-local DMS URL); `-BootstrapManifestPath <path>` (optional override for the bootstrap manifest; defaults to `eng/docker-compose/.bootstrap/bootstrap-manifest.json`); `-DataStoreId <long[]>` (explicit numeric DMS data store ID selector; omit when exactly one instance exists); `-DmsBaseUrl <url>` (BulkLoadClient target endpoint; defaults to the Docker-local DMS URL resolved from the local settings and must be explicit for IDE-hosted seed loading); `-IdentityProvider` (auth provider used to resolve the BulkLoadClient OAuth endpoint; defaults to the provider resolved from the local settings when that parameter is omitted); `-SeedTemplate Minimal\|Populated` (mutually exclusive with `-SeedDataPath`); `-SeedDataPath <path>` (custom ODS XML interchange directory); `-AdditionalNamespacePrefix <string[]>` (optional additive namespace prefixes for custom seed authorization, especially `-SeedDataPath` payloads with agency or custom namespaces); `-SchoolYear <int[]>` (school-year filter; omit when exactly one instance exists) |
 | **Outputs** | Seeded DMS instance(s); seed workspace cleaned up on success |
 | **Side effects** | Creates `SeedLoader` application via `Add-CmsClient` / `Add-Application` using the de-duplicated baseline seed namespace prefixes, selected extension namespace prefixes, and any `-AdditionalNamespacePrefix` values; resolves BulkLoadClient package; resolves the OAuth URL from `-IdentityProvider`; materializes XML interchange files into ignored seed workspaces using BulkLoadClient-discoverable target paths such as `InterchangeName.xml`, `InterchangeName-*.xml`, and `InterchangeName/*.xml`; invokes BulkLoadClient once per selected target and seed tier with the route-qualified DMS base URL, `-d` data directory, `-w` working directory, `-k`/`-s` credentials, `-o` OAuth URL, and either `-x` staged XSD directory or `-z` XSD metadata URL; retains seed workspace on failure |
-| **Failure conditions** | Missing, malformed, unsupported-version, or incomplete bootstrap manifest; bootstrap manifest schema section says Mode 3 (`-ApiSchemaPath`) and `-SeedTemplate` is specified; zero matching instances found; multiple matching instances found without an explicit `-DataStoreId` or `-SchoolYear` selector; unsupported `-IdentityProvider`; `-SeedTemplate` and `-SeedDataPath` both supplied; blank or malformed `-AdditionalNamespacePrefix` value; BulkLoadClient exits non-zero; package-backed built-in seed source unavailable; catalog-advertised built-in seed package for an extension unavailable; DMS health endpoint unreachable; XML seed source cannot be materialized into a valid BulkLoadClient data directory; required XSD inputs are unavailable |
+| **Failure conditions** | Missing, malformed, unsupported-version, or incomplete bootstrap manifest; bootstrap manifest schema section says expert mode (`-ApiSchemaPath`) and `-SeedTemplate` is specified; zero matching instances found; multiple matching instances found without an explicit `-DataStoreId` or `-SchoolYear` selector; unsupported `-IdentityProvider`; `-SeedTemplate` and `-SeedDataPath` both supplied; blank or malformed `-AdditionalNamespacePrefix` value; BulkLoadClient exits non-zero; package-backed built-in seed source unavailable; catalog-advertised built-in seed package for an extension unavailable; DMS health endpoint unreachable; XML seed source cannot be materialized into a valid BulkLoadClient data directory; required XSD inputs are unavailable |
 | **Must NOT do** | Create `CMSReadOnlyAccess` (that belongs to `start-local-dms.ps1` through provider-specific local identity setup) or smoke-test credentials (those belong to `configure-local-data-store.ps1`); reuse `SeedLoader` credentials for smoke tests; perform DDL work; accept schema or claims parameters |
 
 **Boundary note:** This phase uses existing BulkLoadClient XML interchange loading as the API-based replacement for the deprecated direct-SQL seed path. Direct invocation of `load-dms-seed-data.ps1` always performs seed delivery; it does not accept a second `-LoadSeedData` switch. Selector resolution rule: when exactly one DMS instance exists in CMS and no selector is supplied, auto-select it; when multiple instances exist and no explicit `-DataStoreId` or `-SchoolYear` is provided, fail fast with guidance to supply an explicit selector. Endpoint resolution is phase-owned: `load-dms-seed-data.ps1` never infers the IDE URL from a prior `start-local-dms.ps1` invocation. Manual IDE-hosted seed loading passes `-DmsBaseUrl` explicitly; DMS-1152 wrappers do not expose the deferred IDE-hosted continuation flags. Identity-provider resolution is also phase-owned: direct seed invocation passes `-IdentityProvider` when the running environment uses a non-default provider; otherwise the seed phase uses the provider from the shared `-EnvironmentFile` resolver and does not rely on process environment variables left behind by an earlier `start-local-dms.ps1` call. `load-dms-seed-data.ps1` consumes schema mode, selected extensions, and extension namespace prefixes from the bootstrap manifest instead of accepting schema or claims parameters; it owns any seed-catalog lookup for built-in extension seed packages. `-AdditionalNamespacePrefix` is a declared authorization input for SeedLoader vendor creation only; it does not cause bootstrap to inspect XML files, infer missing extensions, or synthesize claim grants.
@@ -264,8 +264,15 @@ resolve the same CMS, tenant, DMS, and database defaults. It must not implement
 phase-specific behavior, retry or fallback logic, persisted resume state, schema provisioning, CMS
 configuration, or seed loading directly, and it never parses human-readable output to recover phase results.
 
-Broader wrapper consolidation flags such as `-Extensions`, `-ApiSchemaPath`, `-ClaimsDirectoryPath`, and `-Rebuild`
-remain deferred to their owning bootstrap stories. DMS-1153 delivered the local wrapper IDE workflow
+Standard-mode schema staging is package-backed **core-only**; there is no `-Extensions` parameter
+on any wrapper or phase command. When no workspace is staged, `bootstrap-local-dms.ps1` and
+`bootstrap-published-dms.ps1` stage core-only standard mode through `prepare-dms-schema.ps1` so the
+no-argument happy path needs no manual prepare step; an already-staged workspace (including a manual expert
+`-ApiSchemaPath` flow) is reused (or fails fast on mismatch) per the prepare-dms-schema.ps1 rerun contract
+rather than being rewritten. Extension/custom schema sets use the expert `-ApiSchemaPath` path. Other broader
+wrapper consolidation flags
+such as `-ApiSchemaPath`, `-ClaimsDirectoryPath`, and `-Rebuild` remain deferred to their owning bootstrap
+stories. DMS-1153 delivered the local wrapper IDE workflow
 shapes: `-InfraOnly` (pre-DMS stop; distinct from the start-script split-startup switch of the same name
 that the wrapper drives internally) and `-DmsBaseUrl` (health-wait continuation, valid only with
 `-InfraOnly`, withheld from the initial start invocation) on `bootstrap-local-dms.ps1` only.
@@ -327,7 +334,7 @@ Each phase accepts only the parameters relevant to its concern.
 
 | Phase command | Owned parameters |
 |---|---|
-| `prepare-dms-schema.ps1` | Story 00: `-ApiSchemaPath`; Story 06: `-Extensions` |
+| `prepare-dms-schema.ps1` | `-ApiSchemaPath` (Story 00 expert mode); standard mode (Story 06) takes no additional parameter and stages the core package only |
 | `prepare-dms-claims.ps1` | `-ClaimsDirectoryPath` |
 | `start-local-dms.ps1` | `-EnvironmentFile <path>`, `-Rebuild`/`-r`, `-IdentityProvider`, `-EnableConfig` (legacy compat), `-EnableKafkaUI`, `-EnableSwaggerUI`, `-d`/`-v`, `-AddExtensionSecurityMetadata` (no-manifest startup only; bootstrap mode activates staged claims from manifest), split-startup switches `-InfraOnly` and `-DmsOnly`, `-DmsBaseUrl <url>` (valid only with `-InfraOnly`) |
 | `configure-local-data-store.ps1` | `-EnvironmentFile <path>`, `-NoDataStore`, `-SchoolYearRange`, `-AddSmokeTestCredentials` |

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -5,6 +5,14 @@ jira_url: https://edfi.atlassian.net/browse/DMS-1150
 
 # Story: Bootstrap Schema and Security Selection
 
+> **Superseded note:** The `-Extensions` references below reflect this completed story's original
+> scoping, when a named / standard-mode `-Extensions` surface was still anticipated for Story 06. The story
+> instead **removed `-Extensions` entirely**: standard mode (omit `-ApiSchemaPath`) is package-backed
+> **core-only**, and extension/custom schema sets use the expert `-ApiSchemaPath` path this story owns. The
+> historical acceptance criteria and tasks below are left intact as the record of what Story 00 delivered; see
+> [`06-package-backed-standard-schema-selection.md`](06-package-backed-standard-schema-selection.md) for the
+> authoritative current contract.
+
 ## Description
 
 Implement the first schema and security input slice for developer bootstrap over the stable direct filesystem
@@ -215,7 +223,7 @@ schema contract and claims-staging contract rather than introducing a second pat
    stage/validate claim fragments in this phase.
 4. Define the bootstrap-dms compose surface and runtime env wiring (mount `.bootstrap/ApiSchema` →
    `/app/ApiSchema`, set `USE_API_SCHEMA_PATH=true`, set `API_SCHEMA_PATH=/app/ApiSchema`, clear
-   `SCHEMA_PACKAGES`) **in design only** — see the Mode 3 flow in
+   `SCHEMA_PACKAGES`) **in design only** — see the expert `-ApiSchemaPath` flow in
    [`bootstrap-design.md`](../../design-docs/bootstrap/bootstrap-design.md) for the end-state diagram
    Story 04 implements. Story 00 does not enable that runtime DMS bootstrap startup path because
    `ContentProvider` still expects `*.ApiSchema.dll` assemblies; enabling it now would cause

--- a/reference/design/backend-redesign/epics/16-bootstrap/02-api-seed-delivery.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/02-api-seed-delivery.md
@@ -81,7 +81,7 @@ direct-SQL path as an ongoing or permanent alternative.
   - repo-tag-backed Ed-Fi XML seed templates selected by `-SeedTemplate`,
   - developer-supplied XML interchange directories selected by `-SeedDataPath`.
 - When seed delivery runs without an explicit seed-source flag, bootstrap defaults to the built-in `Minimal`
-  seed template in standard Modes 1 and 2 only.
+  seed template in standard mode only.
 - In expert `-ApiSchemaPath` mode, seed delivery requires explicit `-SeedDataPath`; bootstrap must not fall
   back to built-in `Minimal` or `Populated` seed templates in that mode.
 - In expert `-ApiSchemaPath` mode, `-SeedTemplate` is invalid because bootstrap-managed seed selection is
@@ -249,7 +249,7 @@ direct-SQL path as an ongoing or permanent alternative.
 1. Implement repo-pinned BulkLoadClient resolution and pre-flight validation for the XML bootstrap path.
 2. Implement seed-source selection for `-SeedTemplate` and `-SeedDataPath` by reading the root bootstrap
    manifest first, including the default `Minimal` behavior when seed delivery runs without an explicit
-   seed-source flag in standard Modes 1 and 2, the expert-mode rule that manifest
+   seed-source flag in standard mode, the expert-mode rule that manifest
    `schema.selectionMode = ApiSchemaPath` requires explicit `-SeedDataPath` for seed delivery,
    validation that rejects `-SeedTemplate` when the bootstrap manifest came from `-ApiSchemaPath`,
    mutual-exclusion validation between `-SeedTemplate` and `-SeedDataPath`, extension-package resolution for
@@ -322,11 +322,17 @@ incomplete":
 | `-EnableKafkaUI`, `-EnableSwaggerUI`, `-EnableConfig`, `-EnvironmentFile`, `-IdentityProvider` | Delivered (forwarded to `start-(local\|published)-dms.ps1`) | — |
 | `-SchoolYearRange` | Delivered (forwarded; the year-loop iterates seed phase per year when seed loading is on) | — |
 | `-AddExtensionSecurityMetadata` | Delivered (forwarded to start phase) | — |
-| `-Extensions`, `-ApiSchemaPath` | **Not in wrapper.** Developers invoke `prepare-dms-schema.ps1` directly today. | Story 03 (schema phase consolidation into wrapper) |
+| `-ApiSchemaPath` | **Not in wrapper.** Expert filesystem schema staging; developers invoke `prepare-dms-schema.ps1` directly before the wrapper. | Schema phase consolidated into the wrapper by DMS-1156 (a clean workspace auto-stages package-backed core-only standard mode); `-ApiSchemaPath` is intentionally **not** a wrapper flag. |
 | `-ClaimsDirectoryPath` | **Not in wrapper.** Developers invoke `prepare-dms-claims.ps1` directly today. | Story 03 |
 | `-InfraOnly`, `-DmsBaseUrl` | **Not in wrapper.** | DMS-1153 (IDE-hosted workflow) |
 | `-Rebuild` / `-r` | **Not in wrapper.** Developers pass to `start-(local\|published)-dms.ps1` directly. | Future hygiene |
 | `-AddSmokeTestCredentials` | **Not in wrapper.** Owned by `configure-local-data-store.ps1` per `command-boundaries.md`. | Story 03 |
+
+> `-Extensions` previously appeared in this table as a deferred schema flag. Story 06 removed it entirely:
+> standard mode is package-backed **core-only** and the wrappers do not declare, document, or forward
+> `-Extensions`. Extension/custom schema sets use expert `-ApiSchemaPath`. See `command-boundaries.md` §3.7
+> ("there is no `-Extensions` parameter on any wrapper or phase command") and
+> `06-package-backed-standard-schema-selection.md`.
 
 ## Out of Scope
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/03-entry-point-and-ide-workflow.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/03-entry-point-and-ide-workflow.md
@@ -230,8 +230,14 @@ entry-point and IDE workflow is complete in this document even where script chan
 # Wrapper — happy path (core schema, no seed)
 pwsh eng/docker-compose/bootstrap-local-dms.ps1
 
-# Wrapper - extension + seed
-pwsh eng/docker-compose/bootstrap-local-dms.ps1 -Extensions sample -LoadSeedData -SeedTemplate Minimal
+# Wrapper - extension + seed. The wrapper does not declare or forward -Extensions/-ApiSchemaPath/
+# -ClaimsDirectoryPath; extension and custom schema sets are staged by the expert prepare phase
+# BEFORE the wrapper. Run prepare-dms-claims.ps1 -ClaimsDirectoryPath only when the staged
+# extensions' claim fragments are not auto-staged. Expert -ApiSchemaPath mode requires -SeedDataPath
+# for seed delivery (-SeedTemplate is invalid in that mode).
+pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath "./my-extension-schemas/"
+pwsh eng/docker-compose/prepare-dms-claims.ps1 -ClaimsDirectoryPath "./my-extension-claims/"
+pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath "./my-seeds/"
 
 # Wrapper - keycloak-backed happy path
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -IdentityProvider keycloak

--- a/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md
@@ -3,61 +3,69 @@ jira: DMS-1156
 jira_url: https://edfi.atlassian.net/browse/DMS-1156
 ---
 
-# Story: Package-Backed Standard Schema Selection
+# Story: Package-Backed Standard Schema Selection (core-only)
 
 ## Description
 
-Implement the package-backed standard schema-selection path for DMS developer bootstrap. This story turns
-the target day-to-day modes from the design into an owned implementation slice:
+Implement the package-backed standard schema-selection path for DMS developer bootstrap. As of the
+2026-06-16 scope decision (see Review Log), this story is **package-backed core-only standard mode**:
 
-- omitted `-Extensions` for the core-only developer default,
-- named `-Extensions` for package-backed extension selection,
+- running `prepare-dms-schema.ps1` without `-ApiSchemaPath` resolves and stages the core Data Standard
+  ApiSchema package only,
 - package-backed ApiSchema asset resolution after Story 05 publishes asset-only packages,
 - convergence on the same staged ApiSchema workspace, claims staging, and seed-input handoff contracts
   delivered by Story 00.
 
-This story exists to close the traceability gap between the DMS-916 acceptance criterion for
-parameterized extension selection and the earlier direct-filesystem-only Story 00 slice. Story 00 remains
-the expert `-ApiSchemaPath` story. Story 06 owns the standard `-Extensions` acquisition path and must feed
-the same normalized file-based ApiSchema asset container at
+Named extension package selection is **not** part of this story. There is no `-Extensions` parameter on any
+bootstrap script. Developers who need an extension-containing schema set use the expert
+`-ApiSchemaPath` filesystem path owned by Story 00, which already stages core plus any extensions present in
+the supplied directory (for example the in-repo `EdFi.DataStandard52.ApiSchema` directory, which includes
+TPDM).
+
+Story 00 remains the expert `-ApiSchemaPath` story. Story 06 owns the standard package-backed core-only
+acquisition path and must feed the same normalized file-based ApiSchema asset container at
 `eng/docker-compose/.bootstrap/ApiSchema/`.
 
 The package-backed path is only an input-materialization path. It must not introduce a second schema
 authority, claims path, seed catalog, wrapper contract, or lifecycle control plane. After this story resolves
-and stages package assets, downstream phases consume the same manifests and workspaces used for direct
-filesystem inputs.
+and stages the core package assets, downstream phases consume the same manifests and workspaces used for
+direct filesystem inputs.
 
 ## Acceptance Criteria
 
 - `prepare-dms-schema.ps1` supports standard mode without `-ApiSchemaPath` after the Story 05 package
-  prerequisite is available:
-  - omitting `-Extensions` resolves and stages the core Data Standard ApiSchema package only,
-  - supplying `-Extensions` resolves and stages the core package plus each named extension package.
-- `-Extensions` is a `String[]` parameter using normal PowerShell array binding. Multi-extension usage uses
-  syntax such as `-Extensions "sample","extension2"`; the implementation does not rely on comma-splitting a
-  single string.
-- Extension artifact availability is determined by package and companion artifact resolution; missing artifacts
-  fail fast before Docker operations start.
-- `-Extensions` and `-ApiSchemaPath` are mutually exclusive. Supplying both fails fast with guidance to use
-  standard mode for package-backed extensions or expert mode for a custom schema directory.
-- Package-backed resolution uses the configured NuGet feed and package/version defaults. Package IDs use the
+  prerequisite is available: it resolves and stages the core Data Standard ApiSchema package only.
+- `prepare-dms-schema.ps1` does not declare or accept an `-Extensions` parameter. Named extension package
+  selection through a standard-mode parameter is not supported. Invoking the script with `-Extensions` fails
+  with the native PowerShell "parameter cannot be found" error.
+- `prepare-dms-schema.ps1 -ApiSchemaPath <path>` preserves the existing expert direct-filesystem behavior
+  from Story 00, including schema sets that contain extensions. Expert mode is the supported path for
+  extension and custom schema scenarios.
+- Package-backed resolution uses the configured NuGet feed and the explicit core package/version default.
+  The default is pinned and documented in one implementation location; bootstrap must not resolve floating
+  `latest` versions or silently fall back to legacy DLL-backed packages. The core package ID uses the
   canonical Data-Standard-qualified convention defined in
   [`../../design-docs/bootstrap/apischema-container.md`](../../design-docs/bootstrap/apischema-container.md):
-  the core package is `EdFi.DataStandard52.ApiSchema`, and extension packages follow
-  `EdFi.DataStandard52.<Project>.ApiSchema`. Version defaults are documented and validated against the feed
-  during implementation.
-- Current repository package references and `SCHEMA_PACKAGES` examples may still use legacy unqualified
-  extension IDs until the Story 04/06 migration updates those consumers.
-- Package materialization rejects invalid package payloads before finalizing the staged workspace:
+  `EdFi.DataStandard52.ApiSchema`. The version default is pinned at `1.0.329`, the published asset-only
+  version verified against the feed (see
+  [`../../../../spikes/DMS-1156/asset-only-package-feed-findings.md`](../../../../spikes/DMS-1156/asset-only-package-feed-findings.md)).
+- Package-backed standard mode does not use `SCHEMA_PACKAGES` as a selector, schema authority, or runtime
+  handoff. The core package comes from the Story 06 standard-mode default; DMS runtime reads the staged
+  workspace produced by bootstrap, not the `.nupkg`, NuGet cache, or `SCHEMA_PACKAGES`.
+- Package materialization rejects invalid core package payloads before finalizing the staged workspace:
   - missing asset-only ApiSchema payload,
   - missing or malformed package manifest,
   - zero or multiple schema JSON files at the package contract path,
   - forbidden DLL-only `lib/` or `ref/` ApiSchema package shape after the asset-only package switch-over,
+  - package ID, project identity, or `isExtensionProject` values that do not match the requested core
+    package,
+  - manifest-declared static assets (`discoverySpecPath`, `xsdDirectory`) that are present but missing on
+    disk or empty; optional static content may be absent only when the manifest omits the path or records it
+    as null,
   - duplicate normalized manifest-relative paths.
 - Package-backed standard mode writes the same `bootstrap-api-schema-manifest.json` runtime asset index as
-  Story 00. That ApiSchema manifest records selected project identity, normalized schema paths, and optional
-  static content paths only. The root bootstrap manifest records standard-mode schema selection, selected
-  extension names, expected `EffectiveSchemaHash`, the ApiSchema workspace fingerprint, and the
+  Story 00. The root bootstrap manifest records standard-mode schema selection (`selectionMode = "Standard"`),
+  `selectedExtensions = @()`, expected `EffectiveSchemaHash`, the ApiSchema workspace fingerprint, and the
   relative ApiSchema manifest path.
 - The staged schema files from package-backed standard mode are the only files used for
   `EffectiveSchemaHash` calculation, Docker-hosted DMS startup, and IDE-hosted DMS startup.
@@ -65,53 +73,66 @@ filesystem inputs.
   the same mode-to-security contract used for Story 00:
   - core-only standard mode stays Embedded mode unless additive claims are supplied by another supported
     path,
-  - selected extensions automatically stage their bootstrap-managed claimset fragments when available,
+  - in expert `-ApiSchemaPath` mode, extensions present in the staged schema set automatically stage their
+    bootstrap-managed claimset fragments when available (e.g. Sample, Homograph), and extensions without a
+    bootstrap-managed fragment require caller-supplied `-ClaimsDirectoryPath` fragments,
   - no later phase re-derives extension security from command-line parameters.
-- Standard-mode selected extensions recorded in the root bootstrap manifest are the source used by
-  Story 02 seed delivery for built-in extension seed lookup. Story 06 does not load seed data directly and
-  does not define a second seed catalog.
-- The optional wrapper (`bootstrap-local-dms.ps1`) may expose `-Extensions` for the happy path, but only
-  forwards it to `prepare-dms-schema.ps1`; the wrapper does not own package resolution or schema policy.
-- Examples in the main design that use omitted `-Extensions` or named `-Extensions` are delivered by this
-  story, not by Story 00.
+- The root bootstrap manifest `selectedExtensions` value is the source used by Story 02 seed delivery for
+  built-in extension seed lookup. For core-only standard mode this is empty. Story 06 does not load seed data
+  directly and does not define a second seed catalog.
+- The optional wrappers (`bootstrap-local-dms.ps1`, `bootstrap-published-dms.ps1`) do not declare, document,
+  or forward `-Extensions`. When no bootstrap manifest exists they stage core-only standard mode before
+  continuing; when a workspace is already staged (a manual or expert prepare flow) they use it as-is.
+- Same-checkout reruns reuse an existing package-backed staged ApiSchema workspace only when the intended
+  package-backed selection produces the same `EffectiveSchemaHash` and workspace fingerprint. Different
+  package versions or staged package contents fail fast with teardown guidance rather than rewriting a
+  workspace that may still be bind-mounted into a running stack.
 
 ## Tasks
 
-1. Wire standard-mode package-backed schema resolution to the package identity convention defined above: core
-   package version defaults, namespace prefixes, and the security fragment lookup keys shared with claims
-   staging.
-2. Update `prepare-dms-schema.ps1` so standard mode is valid when `-ApiSchemaPath` is omitted:
-   core-only when `-Extensions` is omitted, and core plus selected extensions when it is supplied.
-3. Preserve `-ApiSchemaPath` as the expert direct-filesystem path from Story 00 and enforce mutual
-   exclusivity between `-ApiSchemaPath` and `-Extensions`.
-4. Implement NuGet package resolution and isolated extraction for the configured package feed, with clear
-   diagnostics for unreachable feeds, missing packages, and version-resolution failures.
-5. Validate each extracted package against the asset-only ApiSchema package contract from Story 05 before
-   copying any files into the final staged workspace.
-6. Reuse the Story 00 workspace-normalization path to stage one core schema plus zero or more extension
-   schemas, optional static content, deterministic manifest-relative paths, normalized-path collision
-   detection, and `EffectiveSchemaHash` calculation.
-7. Write package-backed standard-mode schema facts into the root bootstrap manifest schema section and ensure
-   `prepare-dms-claims.ps1` writes selected extension namespace prefixes into the root bootstrap
-   manifest seed section.
-8. Update wrapper parameter forwarding and validation so `bootstrap-local-dms.ps1 -Extensions ...` reaches
-   `prepare-dms-schema.ps1` without the wrapper owning schema resolution.
-9. Add tests for core-only standard mode, single and multiple extensions, artifact resolution failures,
-   mutual exclusivity with `-ApiSchemaPath`, invalid package payload rejection, and reuse of identical staged
-   package-backed workspaces.
-10. Update developer-facing examples and failure messages so Story 00 direct-filesystem examples and Story
-    06 package-backed standard-mode examples are clearly distinguished.
+1. Pin the standard-mode core package identity/version default in one implementation location
+   (`bootstrap-schema-catalog.psm1`): core package ID, project/endpoint tokens, feed URL, and version.
+2. Remove the `-Extensions` parameter from `prepare-dms-schema.ps1`. Standard mode (no `-ApiSchemaPath`)
+   resolves and stages the core package only.
+3. Preserve `-ApiSchemaPath` as the expert direct-filesystem path from Story 00, including extension-containing
+   filesystem schema sets.
+4. Remove the open extension-resolution behavior from the standard-mode path (`Resolve-StandardExtensionPackage`
+   and its short-name → package-ID construction). Named extension package selection is no longer supported in
+   standard mode.
+5. Implement/retain NuGet package resolution and isolated extraction for the configured feed, with clear
+   diagnostics for unreachable feeds, missing packages, missing exact default versions, and
+   version-resolution failures.
+6. Validate the extracted core package against the asset-only ApiSchema package contract from Story 05 before
+   copying any files into the final staged workspace, including package/project identity checks against the
+   requested core package.
+7. Reuse the Story 00 workspace-normalization path to stage the core schema, optional static content,
+   deterministic manifest-relative paths, normalized-path collision detection, and `EffectiveSchemaHash`
+   calculation, writing standard-mode schema facts (`selectedExtensions = @()`) into the root bootstrap
+   manifest schema section.
+8. Remove `-Extensions` from `bootstrap-local-dms.ps1`, `bootstrap-published-dms.ps1`, and
+   `Invoke-BootstrapWrapper`. Preserve clean-workspace auto-staging of core-only standard mode and the
+   `-LoadSeedData` core-only path.
+9. Update tests: keep focused coverage for core-only package-backed standard mode and core package payload
+   validation; remove tests that prove `-Extensions` comma-splitting, duplicate handling, extension package
+   resolution, open/TPDM resolution, wrapper `-Extensions` forwarding, or standard-mode extension drift;
+   preserve expert `-ApiSchemaPath` tests for extension-containing filesystem schema sets; add tests proving
+   `prepare-dms-schema.ps1`, `bootstrap-local-dms.ps1`, `bootstrap-published-dms.ps1`, and
+   `Invoke-BootstrapWrapper` no longer expose `-Extensions`.
+10. Update developer-facing examples and failure messages so Story 00 direct-filesystem examples and Story 06
+    package-backed core-only standard-mode examples are clearly distinguished, and so removed `-Extensions`
+    usage is no longer documented.
 
 ## Out of Scope
 
 - Direct filesystem `-ApiSchemaPath` staging; that belongs to Story 00.
+- Named/standard-mode extension package selection of any kind (no `-Extensions` parameter, no allowlist, no
+  open resolution). Extension and custom schema scenarios use expert `-ApiSchemaPath`.
 - DMS runtime `ContentProvider` changes; that belongs to Story 04.
 - Publishing asset-only ApiSchema packages from MetaEd; that belongs to Story 05.
 - API-based seed loading, BulkLoadClient invocation, and built-in seed package loading; those belong to
   Story 02.
 - Published agency/sysadmin seed distribution; that belongs to DMS-1119.
-- A generalized plugin system, arbitrary package IDs supplied by developers, or per-extension version
-  override features beyond the documented DMS-916 defaults.
+- Reading `SCHEMA_PACKAGES` as the Story 06 schema selector or accepting legacy unqualified package IDs.
 
 ## Design References
 
@@ -122,3 +143,61 @@ filesystem inputs.
 - [`02-api-seed-delivery.md`](02-api-seed-delivery.md)
 - [`04-apischema-runtime-content-loading.md`](04-apischema-runtime-content-loading.md)
 - [`05-metaed-apischema-asset-packaging.md`](05-metaed-apischema-asset-packaging.md)
+
+## Review Log
+
+### 2026-06-16 — scope decision: remove `-Extensions`, standard mode is core-only
+
+The team decided to refactor and simplify DMS-1156 by **removing the `-Extensions` parameter entirely**. The
+new scope is package-backed **core-only** standard schema selection. Named extension package selection is no
+longer part of this story; expert/custom extension scenarios use `-ApiSchemaPath`.
+
+This decision **supersedes the 2026-06-08 "open resolution" entry below**, which had resolved a Jira↔local
+conflict (closed mapped-extension catalog with TPDM rejection vs. open package-backed resolution) in favor of
+open resolution. Neither the closed-catalog model nor the open-resolution model applies any longer: there is
+no standard-mode extension-selection surface at all. The recurring review disagreement between the Jira
+ticket (closed catalog / TPDM rejection) and the local design (open resolution) is closed by removing the
+surface that the conflict was about.
+
+Consequences:
+
+- `prepare-dms-schema.ps1` drops `-Extensions`; standard mode stages the core package only.
+- `bootstrap-schema-catalog.psm1` drops `Resolve-StandardExtensionPackage` and the short-name project-token
+  map. The core package accessors and `Get-StandardKnownExtensionInfo` / `KnownExtensionClaimsMetadata`
+  remain: `prepare-dms-claims.ps1` still uses the latter to auto-stage Sample/Homograph claim fragments for
+  extensions present in an **expert** `-ApiSchemaPath` schema set (Story 00 behavior, unchanged).
+- The wrappers drop `-Extensions`; clean-workspace core-only auto-staging and the `-LoadSeedData` core-only
+  path are preserved.
+- The Jira DMS-1156 acceptance criteria must be updated to match this core-only scope (the closed-catalog /
+  named-`-Extensions` language is obsolete).
+
+### 2026-06-08 — package feed verification (core package pin)
+
+Verified the published core package directly on the feed
+(`reference/spikes/DMS-1156/asset-only-package-feed-findings.md`):
+
+- The core package `EdFi.DataStandard52.ApiSchema` is published as asset-only at `1.0.329` (the asset-only
+  switch-over version; `1.0.328` is still DLL-backed). It was extracted and confirmed asset-only
+  (`contentFiles/any/any/ApiSchema/…`, no `lib/`/`ref/`/`dll`).
+- Implementation consequence: `bootstrap-schema-catalog.psm1` is the single pinned location for the feed URL
+  and core version pin; the resolver can be exercised against the real `1.0.329` core package, with fixtures
+  reserved for offline failure-path tests.
+
+> Historical note: earlier revisions of this story and `apischema-container.md` documented an
+> `EdFi.DataStandard52.<Project>.ApiSchema` extension package-ID convention used by the now-removed
+> standard-mode `-Extensions` surface. Those extension package-ID references have been removed along with the
+> feature. Extension packages, where needed, are consumed through expert `-ApiSchemaPath` filesystem staging,
+> which does not construct package IDs.
+
+### 2026-06-09 — post-implementation review triage (cross-story scope)
+
+Reviewed the implemented changeset against the epic story scopes. Findings retained as in-scope for DMS-1156:
+
+- Stage-time identity lock — the project identity inside the staged core `ApiSchema.json` is asserted against
+  the validated package manifest, so a package that passes `packageId` validation cannot stage a different
+  project.
+- Optional `discoverySpecPath`/`xsdDirectory` fields may be omitted as well as null without a StrictMode
+  error; a present-but-empty/missing declared static asset fails fast.
+- `package-manifest.json` relative paths (`schemaPath`/`discoverySpecPath`/`xsdDirectory`) are rejected when
+  rooted or containing `..`, as part of validating the extracted asset-only contract before staging.
+- HTTP-feed service/version index parsing hardened against malformed/partial JSON.

--- a/reference/design/backend-redesign/epics/16-bootstrap/EPIC.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/EPIC.md
@@ -31,9 +31,10 @@ packaging, and package-backed standard schema selection.
 - Story 00 owns direct filesystem schema selection through `-ApiSchemaPath`, normalized ApiSchema
   asset-container materialization, expected `EffectiveSchemaHash` computation, staged claims preparation,
   and the root bootstrap manifest sections for schema, claims, and seed handoff. Later slices consume that
-  staged input contract rather than rebuilding it independently. Package-backed no-argument core-only mode and
-  named `-Extensions` standard modes are not part of Story 00; they belong to Story 06 after Story 05 publishes
-  asset-only ApiSchema packages.
+  staged input contract rather than rebuilding it independently. Package-backed core-only standard mode is not
+  part of Story 00; it belongs to Story 06 after Story 05 publishes asset-only ApiSchema packages. (DMS-1156
+  scope decision: standard mode is package-backed **core-only** — there is no `-Extensions` parameter;
+  extension/custom schema sets use the expert `-ApiSchemaPath` path owned by Story 00.)
 - Story 01 depends on Story 00's staged schema workspace because schema provisioning and validation run over
   that already-selected staged file set. The expected hash from Story 00 is diagnostic metadata for logging
   or comparison, not a required SchemaTools provisioning input.
@@ -67,9 +68,10 @@ packaging, and package-backed standard schema selection.
   ApiSchema loading. Story 00, Story 04, and Story 05 can proceed in parallel because all three meet at the
   normalized filesystem workspace contract.
 - Story 06 depends on Story 05 for asset-only ApiSchema packages and on Story 00 for the shared staged
-  workspace, ApiSchema asset manifest, claims-staging, and root bootstrap manifest contracts. Story 06 owns omitted
-  `-Extensions` core-only mode and named `-Extensions` standard mode. Story 02 remains the owner for actual
-  seed delivery and built-in extension seed lookup from the bootstrap manifest.
+  workspace, ApiSchema asset manifest, claims-staging, and root bootstrap manifest contracts. Story 06 owns
+  package-backed **core-only** standard mode (omit `-ApiSchemaPath`); there is no `-Extensions` parameter
+  (DMS-1156 scope decision). Story 02 remains the owner for actual seed delivery and built-in extension seed
+  lookup from the bootstrap manifest.
 
 ## Scope Guardrails
 

--- a/reference/spikes/DMS-1156/asset-only-package-feed-findings.md
+++ b/reference/spikes/DMS-1156/asset-only-package-feed-findings.md
@@ -1,0 +1,141 @@
+---
+spike: DMS-1156
+date: 2026-06-08
+---
+
+# Asset-Only Package Feed Findings
+
+**Purpose**: Verify that the core ApiSchema package is available on the Ed-Fi NuGet feed, confirm
+whether the asset-only (Story 05 / Story 06 target) core package is published, and establish the
+version pin for the package-backed core-only standard-mode work.
+
+> **Scope note (DMS-1156, 2026-06-16):** package-backed standard mode was descoped to **core-only**.
+> There is no `-Extensions` parameter and bootstrap does not resolve named extension packages.
+> Extension-package findings from the original probe have been removed; extension-containing schema
+> sets are staged through the expert `-ApiSchemaPath` filesystem path. Only the core package is
+> relevant to this story.
+
+---
+
+## 1. Feed URL
+
+```
+https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json
+```
+
+This is the `feedUrl` value in every `SCHEMA_PACKAGES` entry across all `eng/docker-compose/.env*`
+files. No `nuget.config` exists in the repository; the feed URL must be supplied explicitly in
+configuration (sourced from the standard-mode defaults in `bootstrap-schema-catalog.psm1`, not from
+`SCHEMA_PACKAGES`).
+
+---
+
+## 2. Core Package ID
+
+The standard-mode core package ID is Data-Standard-qualified: `EdFi.DataStandard52.ApiSchema`.
+
+NuGet package IDs are case-insensitive on the feed (lowercased probes resolve). The authoritative
+`projectName` / `projectEndpointName` come from the package's own `package-manifest.json`, not from
+the ID.
+
+A legacy unqualified DLL-backed core ID is still present in repo `SCHEMA_PACKAGES` config (reference
+only — not the Story 06 selector): `EdFi.DataStandard52.ApiSchema` pinned at `1.0.328` (DLL-backed).
+
+---
+
+## 3. Core Package Availability — Live Feed Probe Results (verified)
+
+The core package is published as **asset-only at `1.0.329`** (published 2026-06-05) and returns HTTP
+303 (download redirect) on the flat-container. Verified via flat2 version index,
+`dotnet package search`, and direct `.nupkg` HEAD.
+
+| Package ID                      | Version   | Shape (verified) | Status      |
+|---------------------------------|-----------|------------------|-------------|
+| `EdFi.DataStandard52.ApiSchema` | `1.0.329` | Asset-only       | Live, ready |
+
+Notes:
+- The `1.0.329` line is the asset-only transition. Core `1.0.328` (the legacy repo pin) is still
+  DLL-backed; the asset-only switch-over happened at `1.0.329`.
+
+### Verified core manifest (`EdFi.DataStandard52.ApiSchema` 1.0.329)
+
+```json
+{
+  "version": 1,
+  "packageId": "EdFi.DataStandard52.ApiSchema",
+  "projectName": "Ed-Fi",
+  "projectEndpointName": "ed-fi",
+  "isExtensionProject": false,
+  "schemaPath": "ApiSchema.json",
+  "discoverySpecPath": "discovery-spec.json",
+  "xsdDirectory": "xsd"
+}
+```
+
+---
+
+## 4. Recommended Pin
+
+Pin the core package at `1.0.329`:
+
+| Package ID                             | Pin       | Shape      |
+|----------------------------------------|-----------|------------|
+| `EdFi.DataStandard52.ApiSchema` (core) | `1.0.329` | Asset-only |
+
+This is **not** provisional — it is the published asset-only core package.
+`bootstrap-schema-catalog.psm1` is the single pinned location for the feed URL and core version pin.
+
+---
+
+## 5. Implication for the resolver
+
+- The core asset-only package exists at `1.0.329`, so the resolver + extraction path can be exercised
+  end-to-end against the **real** feed package — no fixtures required for the happy path.
+- Fixture `.nupkg` files are still valuable for **failure-path** tests (missing payload, DLL-only
+  shape, malformed/mismatched `package-manifest.json`, duplicate paths) and to keep the default test
+  suite **offline** (tests offline by default; real-feed checks opt-in/skipped).
+- The resolver resolves the core package by its pinned ID/version, feed/version driven from
+  `bootstrap-schema-catalog.psm1`.
+- The existing `ApiSchemaDownloader` CLI uses `ExtractApiSchemaJsonFromAssembly` and has no
+  `contentFiles` extraction path. Story 06 implements its own asset-only `.nupkg` extraction; it
+  cannot reuse the existing downloader.
+
+---
+
+## 6. Documented Asset-Only Payload Contract
+
+Authority: `reference/design/backend-redesign/design-docs/bootstrap/apischema-container.md`.
+
+### Required package structure
+
+```
+contentFiles/any/any/ApiSchema/
+  package-manifest.json          (required)
+  ApiSchema.json                 (required — one schema JSON at this contract path)
+  discovery-spec.json            (optional)
+  xsd/                           (optional directory)
+    *.xsd
+docs/
+  README.md
+  LICENSE
+```
+
+### Prohibited entries
+
+The package must contain **none** of: `lib/`, `ref/`, `*.dll`, `*.cs`, `bin/`, `obj/`.
+
+### `package-manifest.json` fields
+
+| Field                  | Type      | Required | Description                                              |
+|------------------------|-----------|----------|----------------------------------------------------------|
+| `version`              | integer   | yes      | Manifest schema version (currently `1`)                  |
+| `packageId`            | string    | yes      | NuGet package ID (e.g. `EdFi.DataStandard52.ApiSchema`)  |
+| `projectName`          | string    | yes      | MetaEd project name (e.g. `Ed-Fi`)                       |
+| `projectEndpointName`  | string    | yes      | API endpoint segment (e.g. `ed-fi`)                      |
+| `isExtensionProject`   | boolean   | yes      | `false` for core                                         |
+| `schemaPath`           | string    | yes      | Relative path to `ApiSchema.json` within the package     |
+| `discoverySpecPath`    | string    | nullable | Relative path to `discovery-spec.json`, or `null`        |
+| `xsdDirectory`         | string    | nullable | Relative path to XSD directory, or `null`                |
+
+All non-null manifest-declared paths must exist in the package. The schema file named in
+`schemaPath` must be parseable JSON.


### PR DESCRIPTION
## Summary
- document and verify the DS-qualified asset-only ApiSchema package contract for DMS-1156
- add package-backed standard schema selection (**core-only**); there is no `-Extensions` parameter — extension/custom schema sets use the expert `-ApiSchemaPath` filesystem path
- add package resolver/catalog helpers and claims integration, with focused Pester coverage

## Verification
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path eng/docker-compose/tests/BootstrapPackageResolver.Tests.ps1 -PassThru"
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path eng/docker-compose/tests/BootstrapStandardSchemaSelection.Tests.ps1 -PassThru"
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1 -PassThru"
- pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path eng/docker-compose/tests/BootstrapSeedDelivery.Tests.ps1 -PassThru"
- git diff --check