### PR TITLE
[DMS-1217] Add claim set export/import design docs

### DIFF
--- a/reference/design/claimset-export-import/README.md
+++ b/reference/design/claimset-export-import/README.md
@@ -1,0 +1,18 @@
+# Documents
+
+- [Claim Set Export / Import API Design](claim-set-export-import-api-design.md)
+    Defines the revised payload format for CMS claim set retrieval, export,
+    and import in Ed-Fi API v8 so that mappings to the CMS data store
+    remain clear and unambiguous. The format changes are intentionally
+    limited; see the Payload Differences (v2 vs v3) section for a detailed
+    comparison.
+
+- [Claims Migration: Options, Recommendations, and Two-Phase Approach for Ed-Fi API Transition](claims-migration.md)
+    Describes the recommended approach for migrating security configuration
+    from ODS/API to Ed-Fi API v8 by using a separate utility that is already
+    partially implemented. Because the Admin API currently supports export
+    only on a claim set by claim set basis, and because the CMS data store
+    must first be seeded with the core authorization hierarchy,
+    organizations should complete the one-time baseline activity described
+    in Option 1: Bulk XML Migration before relying on incremental claim set
+    export and import operations.

--- a/reference/design/claimset-export-import/claim-set-export-import-api-design.md
+++ b/reference/design/claimset-export-import/claim-set-export-import-api-design.md
@@ -1,0 +1,349 @@
+# Claim Set Export / Import API Design
+
+- [Executive Summary](#executive-summary)
+- [Background](#background)
+- [Key Concepts](#key-concepts)
+  - [Configured vs expanded hierarchy](#configured-vs-expanded-hierarchy)
+  - [Authorization strategy: default vs override](#authorization-strategy-default-vs-override)
+  - [Parent-child configurations](#parent-child-configurations)
+- [Design Decision 1: Response Structure](#design-decision-1-response-structure)
+- [Design Decision 2: Authorization Strategy Representation](#design-decision-2-authorization-strategy-representation)
+- [Complete Recommended Format](#complete-recommended-format)
+  - [GET /v3/claimSets/{id} and GET /v3/claimSets/{id}/export](#get-v3claimsetsid-and-get-v3claimsetsidexport)
+  - [POST /v3/claimSets/import](#post-v3claimsetsimport)
+- [Payload Differences (v2 vs v3)](#payload-differences-v2-vs-v3)
+  - [Side-by-side example: DistrictHostedSISVendor](#side-by-side-example-districthostedsisvendor)
+    - [Admin API v2](#admin-api-v2)
+    - [CMS v3](#cms-v3)
+- [Admin App Impact](#admin-app-impact)
+  - [Rendering sketch for v3](#rendering-sketch-for-v3)
+
+## Executive Summary
+
+This document defines the revised payload and behavior for `GET /v3/claimSets/{id}`, `GET /v3/claimSets/{id}/export`, and `POST /v3/claimSets/import` in Configuration Management Service (CMS, Ed-Fi API v8). CMS already exposes these routes; this design replaces the existing claim set retrieval, export, and import contracts with the v3 payload described here.
+
+| Decision                     | Recommendation                             | Rationale                                                                                          |
+|------------------------------|--------------------------------------------|----------------------------------------------------------------------------------------------------|
+| What to expose               | Configured hierarchy nodes only            | 11 nodes for SISVendor, not 200+ expanded leaf nodes — preserves intent, enables round-trip import |
+| Response structure           | Flat list with `parentClaimName`           | Linear import, clean OpenAPI schema; UI reconstructs tree with one `groupBy`                       |
+| Auth strategy representation | Default + override separately (`_` prefix) | Preserves override intent; import writes only what's explicitly set                                |
+| Format adapter               | In `CmsHierarchy` utility, not the CMS API | CMS accepts one clean format; Admin API translation stays in migration tooling                     |
+
+See [Claims Migration](claims-migration.md) for the migration pipeline design.
+
+## Background
+
+- **Admin API** (`AdminAPI-2.x`) — supports Management API v1/v2 (v3 planned). Stores authorization hierarchy in relational tables. Implements `GET /v2/claimSets/{id}`, `GET /v2/claimSets/{id}/export`, and `POST /v2/claimSets/import`.
+
+- **CMS** (`Data-Management-Service/src/config`) — implements Management API v3 only. Stores authorization hierarchy at runtime in `dmscs.ClaimsHierarchy`; `AuthorizationHierarchy.json` is the seed/import artifact used to populate that table. The current claim set retrieval, export, and import endpoints must be updated to use the revised v3 contract in this document.
+
+- **Admin App** — must support all three API versions simultaneously. The v2 claim set UI is read-only; v1 has write capability.
+
+---
+## Key Concepts
+
+### Configured vs expanded hierarchy
+
+The CMS runtime hierarchy stored in `dmscs.ClaimsHierarchy` keeps authorization at the **node where it is configured**. `AuthorizationHierarchy.json` uses the same hierarchy shape as a seed/import artifact. A domain-level entry covers all children by inheritance:
+
+```text
+systemDescriptors (domain)   → SISVendor: [Read]   ← 1 configured entry
+  └─ absenceEventCategoryDescriptor                 ← inherits Read (not stored)
+  └─ academicSubjectDescriptor                      ← inherits Read (not stored)
+  ... (209 child descriptors)
+```
+
+CMS `GET /v3/authorizationMetadata`, consumed by DMS at runtime, walks to leaf nodes to resolve effective permissions — correct for the authorization middleware and effective authorization review, wrong for authorization configuration and management.
+
+Exporting at the configured level preserves intent, keeps payload size manageable, and supports correct round-trip import. Exporting leaf nodes loses configuration intent, produces redundant entries, and breaks round-trip behavior.
+
+### Authorization strategy: default vs override
+
+Authorization strategies come from two sources:
+
+| Source                           | Stored on               | Applies to                  |
+|----------------------------------|-------------------------|-----------------------------|
+| `defaultAuthorization`           | Resource hierarchy node | All claim sets on this node |
+| `authorizationStrategyOverrides` | Claim set entry         | This claim set only         |
+
+Example: `BootstrapDescriptorsandEdOrgs` on `systemDescriptors` — the node default for `Create` is `NamespaceBased`, but this claim set overrides it to `NoFurtherAuthorizationRequired`. `SISVendor` on the same node has no override and inherits the default.
+
+Separating these fields preserves intent, simplifies import logic, and enables clear UI representation.
+
+### Parent-child configurations
+
+A claim set can appear at both a domain node and a specific child node with different settings — the child entry is a deliberate exception:
+
+| Claim Set                 | Domain                   | Domain Actions | Child                       | Child Actions             |
+|---------------------------|--------------------------|----------------|-----------------------------|---------------------------|
+| `DistrictHostedSISVendor` | `educationOrganizations` | Read           | `school`                    | CRUD                      |
+| `DistrictHostedSISVendor` | `educationOrganizations` | Read           | `localEducationAgency`      | Read, Update              |
+| `AssessmentVendor`        | `systemDescriptors`      | Read           | `academicSubjectDescriptor` | CRUD                      |
+| `EdFiAPIPublisherWriter`  | `relationshipBasedData`  | CRUD           | `communityProviderLicense`  | CRUD + strategy overrides |
+
+---
+## Design Decision 1: Response Structure
+
+**Decision: Flat list with** `parentClaimName`
+
+All configured nodes at the same array level; parent relationship expressed via `parentClaimName`.
+
+```json
+{
+  "claimSetName": "DistrictHostedSISVendor",
+  "resourceClaims": [
+    {
+      "name": "educationOrganizations",
+      "claimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "parentClaimName": null,
+      "actions": [{ "name": "Read", "enabled": true }],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Read", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    },
+    {
+      "name": "school",
+      "claimName": "http://ed-fi.org/identity/claims/ed-fi/school",
+      "parentClaimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "actions": [
+        { "name": "Create", "enabled": true }, { "name": "Read", "enabled": true },
+        { "name": "Update", "enabled": true }, { "name": "Delete", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Update", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Delete", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    }
+  ]
+}
+```
+
+`school` is a sibling of `educationOrganizations`, not nested inside it. The Admin App can reconstruct the tree with one `groupBy(parentClaimName)` pass.
+
+**Not chosen: nested** `children` **array** (Admin API v2 shape) — requires recursive import traversal and produces awkward OpenAPI `$ref` cycles.
+
+---
+## Design Decision 2: Authorization Strategy Representation
+
+**Decision: Separate default and override fields**
+
+```json
+"_defaultAuthorizationStrategies": [
+  { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NamespaceBased" }] },
+  { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+],
+"authorizationStrategyOverrides": [
+  { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+]
+```
+
+- `_defaultAuthorizationStrategies` — read-only context (`_` prefix signals not writable on import); sourced from `node.defaultAuthorization`
+
+- `authorizationStrategyOverrides` — writable; empty means "using defaults", non-empty means "deliberately different"
+
+**Not chosen: single effective strategy field** — cannot distinguish override from default; import would need to infer override intent by comparing against the hierarchy.
+
+---
+## Complete Recommended Format
+
+### `GET /v3/claimSets/{id}` and `GET /v3/claimSets/{id}/export`
+
+Both endpoints return the same response. `/export` is retained as an alias to avoid breaking changes for clients already calling it.
+
+```json
+{
+  "id": 42,
+  "claimSetName": "DistrictHostedSISVendor",
+  "_isSystemReserved": false,
+  "_applications": [
+    { "applicationName": "My SIS Application" }
+  ],
+  "resourceClaims": [
+    {
+      "name": "educationOrganizations",
+      "claimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "parentClaimName": null,
+      "actions": [{ "name": "Read", "enabled": true }],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Update", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Delete", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    },
+    {
+      "name": "school",
+      "claimName": "http://ed-fi.org/identity/claims/ed-fi/school",
+      "parentClaimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "actions": [
+        { "name": "Create", "enabled": true }, { "name": "Read", "enabled": true },
+        { "name": "Update", "enabled": true }, { "name": "Delete", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Update", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Delete", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    }
+  ]
+}
+```
+
+### `POST /v3/claimSets/import`
+
+Accepts the same `resourceClaims` array. Per entry:
+
+| Field                                                                           | On import                                         |
+|---------------------------------------------------------------------------------|---------------------------------------------------|
+| `claimName`                                                                     | Locates the node in the stored CMS hierarchy      |
+| `actions[].name` + `enabled`                                                    | Written to `claimSets[].actions` on the node      |
+| `authorizationStrategyOverrides`                                                | Written to matching actions if non-empty          |
+| `parentClaimName`, `_defaultAuthorizationStrategies`, `id`, `_isSystemReserved` | Ignored                                           |
+
+- Node found, claim set exists → upsert
+
+- Node found, claim set absent → insert
+
+- Node not found → warning in response, processing continues (non-fatal)
+
+- Additive/surgical — other claim sets on the same node are unaffected
+
+⚠️ Import does not create new hierarchy nodes. See [Claims Migration](claims-migration.md) for handling custom resources.
+
+These are intentional behavior changes for the existing CMS import route: duplicate claim set names are merged by upsert, missing resource claim nodes are reported as warnings rather than stopping the whole import, and the accepted payload is the flat URI-based v3 shape rather than the nested Admin API v2 shape.
+
+---
+## Payload Differences (v2 vs v3)
+
+| Aspect                      | Admin API v2                               | CMS v3                                                            |
+|-----------------------------|--------------------------------------------|-------------------------------------------------------------------|
+| Resource identifier         | Short name: `"school"`                     | Full claim URI: `"http://ed-fi.org/identity/claims/ed-fi/school"` |
+| Parent-child relationship   | Nested `children` array                    | Flat list with `parentClaimName`                                  |
+| Default auth strategy field | `_defaultAuthorizationStrategiesForCrud`   | `_defaultAuthorizationStrategies`                                 |
+| Override field              | `authorizationStrategyOverridesForCRUD`    | `authorizationStrategyOverrides`                                  |
+| IDs                         | `actionId`, `authStrategyId` (DB integers) | Not present — identified by name                                  |
+| `isInheritedFromParent`     | Present                                    | Not present — derivable from `parentClaimName`                    |
+| `IsParent` flag             | Present                                    | Not present — implied by `parentClaimName: null`                  |
+| Export level                | May include all leaf resources             | Configured hierarchy nodes only                                   |
+| `ForCrud` / `ForCRUD` suffix | Present                                    | Removed — v3 also covers `ReadChanges`                            |
+
+### Side-by-side example: `DistrictHostedSISVendor`
+
+#### Admin API v2
+
+```json
+{
+  "id": 7,
+  "name": "DistrictHostedSISVendor",
+  "_isSystemReserved": false,
+  "_applications": [],
+  "resourceClaims": [
+    {
+      "id": 24,
+      "name": "educationOrganizations",
+      "actions": [{ "name": "Read", "enabled": true }],
+      "_defaultAuthorizationStrategiesForCrud": [
+        { "actionId": 2, "actionName": "Read", "authorizationStrategies": [
+            { "authStrategyId": 1, "authStrategyName": "NoFurtherAuthorizationRequired", "isInheritedFromParent": false }
+        ]}
+      ],
+      "authorizationStrategyOverridesForCRUD": [],
+      "children": [
+        {
+          "id": 31,
+          "name": "school",
+          "actions": [
+            { "name": "Create", "enabled": true }, { "name": "Read", "enabled": true },
+            { "name": "Update", "enabled": true }, { "name": "Delete", "enabled": true }
+          ],
+          "_defaultAuthorizationStrategiesForCrud": [
+            { "actionId": 1, "actionName": "Create", "authorizationStrategies": [{ "authStrategyId": 1, "authStrategyName": "NoFurtherAuthorizationRequired", "isInheritedFromParent": true }] },
+            { "actionId": 2, "actionName": "Read",   "authorizationStrategies": [{ "authStrategyId": 1, "authStrategyName": "NoFurtherAuthorizationRequired", "isInheritedFromParent": true }] },
+            { "actionId": 3, "actionName": "Update", "authorizationStrategies": [{ "authStrategyId": 1, "authStrategyName": "NoFurtherAuthorizationRequired", "isInheritedFromParent": true }] },
+            { "actionId": 4, "actionName": "Delete", "authorizationStrategies": [{ "authStrategyId": 1, "authStrategyName": "NoFurtherAuthorizationRequired", "isInheritedFromParent": true }] }
+          ],
+          "authorizationStrategyOverridesForCRUD": [],
+          "children": []
+        }
+      ]
+    }
+  ]
+}
+```
+
+#### CMS v3
+
+```json
+{
+  "id": 7,
+  "claimSetName": "DistrictHostedSISVendor",
+  "_isSystemReserved": false,
+  "resourceClaims": [
+    {
+      "name": "educationOrganizations",
+      "claimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "parentClaimName": null,
+      "actions": [{ "name": "Read", "enabled": true }],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Update", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Delete", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    },
+    {
+      "name": "school",
+      "claimName": "http://ed-fi.org/identity/claims/ed-fi/school",
+      "parentClaimName": "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+      "actions": [
+        { "name": "Create", "enabled": true }, { "name": "Read", "enabled": true },
+        { "name": "Update", "enabled": true }, { "name": "Delete", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        { "actionName": "Create", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Read",   "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Update", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] },
+        { "actionName": "Delete", "authorizationStrategies": [{ "authStrategyName": "NoFurtherAuthorizationRequired" }] }
+      ],
+      "authorizationStrategyOverrides": []
+    }
+  ]
+}
+```
+
+`school` moves from `educationOrganizations.children[]` to a sibling entry with `parentClaimName`. All relational IDs and `isInheritedFromParent` are dropped — v3 is self-contained with URIs and string names.
+
+See [Claims Migration](claims-migration.md) for the translation steps.
+
+---
+## Admin App Impact
+
+A new `ResourceClaimsTableV3.tsx` is required regardless of format choice.
+
+| Area                  | Impact                                                                                                                     |
+|-----------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Tree rendering        | One `groupBy(parentClaimName)` before render                                                                               |
+| Auth strategy display | Merge `_defaultAuthorizationStrategies` + `authorizationStrategyOverrides` per cell — same logic as v2 `AuthStrategyBadge` |
+| Import UI (future)    | Construct flat array for POST body                                                                                         |
+| V1/V2 components      | No change                                                                                                                  |
+
+### Rendering sketch for v3
+
+```text
+resourceClaims
+  → groupBy(parentClaimName)          // Map<uri|null, entry[]>
+  → render roots (parentClaimName null) as top-level rows
+  → render grouped children indented under their parent
+  → per action cell:
+      override present  → blue badge
+      no override       → gray italic badge (default strategy)
+      action disabled   → red "Denied" badge
+```

--- a/reference/design/claimset-export-import/claims-migration.md
+++ b/reference/design/claimset-export-import/claims-migration.md
@@ -1,0 +1,198 @@
+# Claims Migration: Options, Recommendations, and Two-Phase Approach for Ed-Fi API Transition
+
+- [Executive Summary](#executive-summary)
+- [Existing Utility: CmsHierarchy](#existing-utility-cmshierarchy)
+- [Option 1: Bulk XML Migration](#option-1-bulk-xml-migration)
+- [Option 2: Per-Claim-Set API Migration](#option-2-per-claim-set-api-migration)
+- [Recommendation: Two-Phase Approach](#recommendation-two-phase-approach)
+- [Work Required](#work-required)
+- [Decision Table](#decision-table)
+
+## Executive Summary
+
+Organizations moving from ODS API v7 / Admin API v2 to Ed-Fi API v8 / CMS need to migrate their security configuration — both the **resource hierarchy** (domains, leaf resources, default authorization strategies) and **claim set assignments** (which claim sets access which resources, with what actions and overrides).
+
+Two complementary options exist, serving different phases:
+
+| Scope                          | Option 1 — Bulk XML    | Option 2 — Per-claim-set API                 |
+|--------------------------------|------------------------|----------------------------------------------|
+| Migrates hierarchy             | ✅ Yes                 | ❌ No — must already exist                   |
+| Migrates custom resources      | ✅ Yes                 | ❌ No — skipped with warning if absent       |
+| Migrates claim set assignments | ✅ All at once         | ✅ One at a time                             |
+| When to use                    | Initial CMS deployment | Incremental migration and ongoing operations |
+
+⚠️ **Critical risk:** if a resource does not exist in the CMS hierarchy, Option 2 reports a warning and skips that resource assignment. Organizations with custom or extension resources must run Option 1 first.
+
+**Recommendation:** Run Option 1 once to establish the full hierarchy baseline. Use Option 2 for all subsequent claim set operations.
+
+See [Claim Set Export / Import API Design](claim-set-export-import-api-design.md) for the CMS API format design.
+
+## Existing Utility: `CmsHierarchy`
+
+`eng/CmsHierarchy/CmsHierarchy.csproj` already covers the core of both migration paths:
+
+`ParseXml` — converts security XML export into `AuthorizationHierarchy.json` (full hierarchy, all claim sets, custom resources).
+
+`Transform` — merges per-claim-set JSON files into an existing hierarchy. Handles plural-to-singular name normalization to match Admin API short names to CMS URI segments.
+
+⚠️ **Current behaviour in** `Transform`**:** if `ClaimSetToAuthHierarchy.TransformClaims` cannot find a resource name in the existing hierarchy, the entry is silently skipped because the method has no missing-resource branch. A claim set export does not carry the parent relationship, claim URI, or `defaultAuthorization` needed to create a missing node. The new Option 2 flow must surface these cases as warnings instead of silent skips.
+
+Both options extend this utility with two new commands: `SeedDatabase` and `ConvertClaimSet`.
+
+## Option 1: Bulk XML Migration
+
+### Pipeline
+
+```text
+ODS/API Security Database
+    │  (declarative security policies export)
+    ▼
+security.xml
+    │  dotnet CmsHierarchy --command ParseXml
+    ▼
+AuthorizationHierarchy.json
+    │  NEW: dotnet CmsHierarchy --command SeedDatabase
+    ▼
+CMS PostgreSQL (dmscs.ClaimsHierarchy table)
+```
+
+### Pros
+
+- Complete and lossless — entire security setup including custom/extension resources
+- `ParseXml` already exists — no new parsing logic needed
+- No CMS API dependency — works before any CMS endpoints are built
+
+### Cons
+
+- All-or-nothing — overwrites entire hierarchy; CMS-specific changes are lost if re-run
+- Not API-driven — writes directly to the database, bypasses CMS validation
+- Requires ODS DB access — not available via Admin API
+
+### Missing piece: `--command SeedDatabase`
+
+```shell
+dotnet CmsHierarchy --command SeedDatabase \
+    --input AuthorizationHierarchy.json \
+    --connectionString "Host=localhost;Database=edfi_cms;..."
+```
+
+Upserts the JSON into `dmscs.ClaimsHierarchy`. Run once at initial CMS deployment; not repeated.
+
+## Option 2: Per-Claim-Set API Migration
+
+### Pipeline
+
+```text
+Admin API GET /v2/claimSets/{id}/export
+    │  NEW: dotnet CmsHierarchy --command ConvertClaimSet
+    ▼
+CMS POST /v3/claimSets/import
+    │
+    ▼
+CMS PostgreSQL (claim set entries merged into existing hierarchy)
+```
+
+### Pros
+
+- Selective and non-destructive — only touches named claim sets
+- API-driven — goes through CMS validation
+- Incremental — validate one claim set before importing the next
+- Ongoing use — same API serves post-migration operations
+
+### Cons
+
+- Requires CMS hierarchy baseline — cannot create missing nodes
+- Custom resources are skipped with warnings when a resource is absent
+- Requires the revised `POST /v3/claimSets/import` contract described in the API design
+- Format adapter needed — Admin API v2 format → CMS v3 format
+- Claim set name constraints differ — CMS claim set names do not allow
+    spaces, while legacy ODS/Admin API claim sets may include spaces
+
+### Format Adapter: `--command ConvertClaimSet`
+
+New command in `CmsHierarchy` that translates an Admin API v2 export into a CMS v3 import payload. Reuses existing `SearchRecursive` + `PluralToSingular` from `ClaimSetToAuthHierarchy.cs`.
+
+```shell
+dotnet CmsHierarchy --command ConvertClaimSet \
+    --input sis-vendor-claimset.json \
+    --output cms-sis-vendor.json \
+    --outputFormat ToFile
+```
+
+Translation steps:
+
+1. **Flatten** `children` — emit each nested entry as a sibling, setting `parentClaimName` to the parent's resolved claim URI
+2. **Resolve names to URIs** — `"school"` → `"http://ed-fi.org/identity/claims/ed-fi/school"` via `SearchRecursive` + `PluralToSingular`
+3. **Drop relational IDs** — remove `id`, `actionId`, `authStrategyId`, `isInheritedFromParent`
+4. **Rename fields** — `_defaultAuthorizationStrategiesForCrud` → `_defaultAuthorizationStrategies`, `authorizationStrategyOverridesForCRUD` → `authorizationStrategyOverrides`
+5. **Normalize claim set names for CMS** — when a source claim set name
+    includes spaces, convert it to the CMS-compliant form before import
+    (for example, by removing spaces) so migration payloads are accepted
+
+See the [v2 vs v3 payload differences](claim-set-export-import-api-design.md) for a full before/after example.
+
+## Recommendation: Two-Phase Approach
+
+### Phase 1 - Initial deployment (run once)
+
+```shell
+# 1. Export security configuration from ODS (per declarative security policies doc)
+#    Produces: security.xml
+
+# 2. Convert to CMS hierarchy format
+dotnet CmsHierarchy --command ParseXml \
+    --input security.xml \
+    --output AuthorizationHierarchy.json \
+    --outputFormat ToFile
+
+# 3. Seed CMS database
+dotnet CmsHierarchy --command SeedDatabase \
+    --input AuthorizationHierarchy.json \
+    --connectionString "Host=...;Database=edfi_cms;..."
+```
+
+### Phase 2 - Ongoing operations
+
+Note: CMS claim set names do not allow spaces. If a legacy claim set name
+contains spaces, normalize it to a CMS-compliant value during
+`ConvertClaimSet` processing before calling `POST /v3/claimSets/import`.
+
+```text
+# Export from Admin API
+GET /v2/claimSets/{id}/export  ->  sisvendor.json
+
+# Convert format
+dotnet CmsHierarchy --command ConvertClaimSet \
+    --input sisvendor.json \
+    --output cms-sisvendor.json
+
+# Import into CMS
+POST /v3/claimSets/import  (body: cms-sisvendor.json)
+```
+
+## Work Required
+
+### Utility additions (`CmsHierarchy`)
+
+| Command                       | Description                                                       | Effort       |
+|-------------------------------|-------------------------------------------------------------------|--------------|
+| `--command SeedDatabase`      | Upsert `AuthorizationHierarchy.json` into `dmscs.ClaimsHierarchy` | Small        |
+| `--command ConvertClaimSet`   | Translate Admin API v2 export → CMS v3 import format              | Small-Medium |
+| Warning output in `Transform` | Log resource names not found instead of silent skip               | Small        |
+
+### CMS API additions
+
+| Endpoint                    | Description                                                           | Effort                                                       |
+|-----------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------|
+| `GET /v3/claimSets/{id}/export` | Return configured-hierarchy-level claim set with defaults + overrides | Medium — reuses `AuthorizationMetadataResponseFactory` logic |
+| `POST /v3/claimSets/import` | Accept flat `resourceClaims` array; merge into hierarchy              | Medium — reuses `TransformClaims` logic                      |
+
+## Decision Table
+
+| Scenario                                          | Recommended approach                                             |
+|---------------------------------------------------|------------------------------------------------------------------|
+| Initial migration, standard Ed-Fi resources only  | Option 1 or Option 2 (if CMS ships with full standard hierarchy) |
+| Initial migration, any custom/extension resources | Option 1 required first                                          |
+| Running Admin API and CMS in parallel             | Option 2 for ongoing sync                                        |
+| Net-new claim set created in CMS                  | Option 2 import API or CMS UI                                    |
+| Disaster recovery / full re-seed                  | Option 1                                                         |

--- a/reference/design/claimset-export-import/claims-migration.md
+++ b/reference/design/claimset-export-import/claims-migration.md
@@ -184,8 +184,34 @@ POST /v3/claimSets/import  (body: cms-sisvendor.json)
 
 | Endpoint                    | Description                                                           | Effort                                                       |
 |-----------------------------|-----------------------------------------------------------------------|--------------------------------------------------------------|
-| `GET /v3/claimSets/{id}/export` | Return configured-hierarchy-level claim set with defaults + overrides | Medium — reuses `AuthorizationMetadataResponseFactory` logic |
-| `POST /v3/claimSets/import` | Accept flat `resourceClaims` array; merge into hierarchy              | Medium — reuses `TransformClaims` logic                      |
+| `GET /v3/claimSets/{id}` | Return configured-hierarchy-level claim set with defaults + overrides | Medium — share configured-node traversal with `/export`      |
+| `GET /v3/claimSets/{id}/export` | Return configured-hierarchy-level claim set with defaults + overrides | Medium — implement configured-node hierarchy traversal       |
+| `POST /v3/claimSets/import` | Accept flat `resourceClaims` array; upsert claim set and replace its hierarchy assignments with warning support | Medium — adapt CMS runtime hierarchy-merge path |
+
+Export must not reuse `AuthorizationMetadataResponseFactory` as its traversal
+algorithm. That factory supports `GET /v3/authorizationMetadata`, which expands
+effective permissions to leaf resources for DMS runtime authorization. Claim set
+retrieval/export must instead walk the stored hierarchy, collect nodes whose
+`claimSets` contains the requested claim set, and emit:
+
+- `parentClaimName` from the configured node's parent
+- `_defaultAuthorizationStrategies` from the node's `defaultAuthorization`
+- `authorizationStrategyOverrides` from the matching claim set entry
+- `actions` from the matching claim set entry
+
+`GET /v3/claimSets/{id}` and `GET /v3/claimSets/{id}/export` must use the same
+configured-node response builder so the two routes return the same payload.
+
+Import should reuse or adapt the CMS runtime hierarchy merge flow used by
+`ClaimSetRepository.Import` and `ClaimsHierarchyManager.ApplyImportedClaimSetToHierarchy`.
+The import API treats `claimSetName` as the natural key: create the claim set row
+when it is absent, update the existing row when present, remove that claim set's
+current hierarchy assignments, and apply the valid submitted configured nodes.
+Missing hierarchy nodes and `parentClaimName` mismatches produce warnings in the
+response and do not prevent valid nodes from committing.
+`ClaimSetToAuthHierarchy.TransformClaims` remains useful as an offline utility
+analog for migration concepts such as existing-hierarchy lookup and name
+normalization, but it should not be treated as the CMS API implementation target.
 
 ## Decision Table
 


### PR DESCRIPTION
Add design and migration documentation for claim set export/import. Introduces API design for CMS v3 (GET /v3/claimSets/{id}, GET /v3/claimSets/{id}/export, POST /v3/claimSets/import) with a flat resourceClaims format, separate default vs override authorization strategy fields, and payload differences vs Admin API v2. Adds migration guidance recommending a two-phase approach (one-time bulk XML SeedDatabase plus ongoing per-claim-set ConvertClaimSet imports), and describes required CmsHierarchy utility commands and Admin App impacts. Files added: reference/design/claimset-export-import/README.md, claim-set-export-import-api-design.md, claims-migration.md.