### PR TITLE
[DMS-1184] Serve `/changeQueries/v1/availableChangeVersions`

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/RelationalChangeQueryRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/RelationalChangeQueryRepositoryTests.cs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Interface;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Verifies RelationalChangeQueryRepository.GetNewestChangeVersion() reads dms.GetMaxChangeVersion()
+/// through the real SQL Server command executor and reader, tracking dms.ChangeVersionSequence.
+/// Sequence helpers are shared with GetMaxChangeVersionTestBase.
+/// </summary>
+public abstract class RelationalChangeQueryRepositoryTestBase
+{
+    protected long Result { get; set; }
+
+    protected static IChangeQueryRepository CreateRepository()
+    {
+        var commandExecutor = new MssqlRelationalCommandExecutor(
+            static async ct =>
+            {
+                var connection = new SqlConnection(Uuidv5ParityTestBase.ConnectionString);
+                await connection.OpenAsync(ct);
+                return connection;
+            },
+            NullLogger<MssqlRelationalCommandExecutor>.Instance
+        );
+
+        return new RelationalChangeQueryRepository(commandExecutor);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Fresh_ChangeVersionSequence_Read_Through_Repository
+    : RelationalChangeQueryRepositoryTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        Result = await CreateRepository().GetNewestChangeVersion();
+    }
+
+    [Test]
+    public void It_should_return_start_value_one()
+    {
+        Result.Should().Be(1L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_ChangeVersionSequence_Advanced_Three_Times_Read_Through_Repository
+    : RelationalChangeQueryRepositoryTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        await GetMaxChangeVersionTestBase.AdvanceSequence(3);
+        Result = await CreateRepository().GetNewestChangeVersion();
+    }
+
+    [Test]
+    public void It_should_return_the_last_allocated_value()
+    {
+        Result.Should().Be(3L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Repository_And_Raw_Function_Call : RelationalChangeQueryRepositoryTestBase
+{
+    private long _repositoryResult;
+    private long _rawResult;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        await GetMaxChangeVersionTestBase.AdvanceSequence(5);
+        _repositoryResult = await CreateRepository().GetNewestChangeVersion();
+        _rawResult = await GetMaxChangeVersionTestBase.CallFunction();
+    }
+
+    [Test]
+    public void It_should_match_the_direct_function_call()
+    {
+        _repositoryResult.Should().Be(_rawResult);
+        _repositoryResult.Should().Be(5L);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/EdFi.DataManagementService.Backend.Mssql.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql/EdFi.DataManagementService.Backend.Mssql.csproj
@@ -23,5 +23,6 @@
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Tests.Unit" />
+        <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Mssql.Tests.Integration" />
     </ItemGroup>
 </Project>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/RelationalChangeQueryRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/RelationalChangeQueryRepositoryTests.cs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Interface;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Verifies RelationalChangeQueryRepository.GetNewestChangeVersion() reads dms.GetMaxChangeVersion()
+/// through the real PostgreSQL command executor and reader, tracking dms.ChangeVersionSequence.
+/// Sequence helpers are shared with GetMaxChangeVersionTestBase.
+/// </summary>
+public abstract class RelationalChangeQueryRepositoryTestBase
+{
+    protected long Result { get; set; }
+
+    protected static IChangeQueryRepository CreateRepository()
+    {
+        var commandExecutor = new PostgresqlRelationalCommandExecutor(
+            static async ct => await Uuidv5ParityTestBase.DataSource.OpenConnectionAsync(ct),
+            NullLogger<PostgresqlRelationalCommandExecutor>.Instance
+        );
+
+        return new RelationalChangeQueryRepository(commandExecutor);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Fresh_ChangeVersionSequence_Read_Through_Repository
+    : RelationalChangeQueryRepositoryTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        Result = await CreateRepository().GetNewestChangeVersion();
+    }
+
+    [Test]
+    public void It_should_return_start_value_one()
+    {
+        Result.Should().Be(1L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_ChangeVersionSequence_Advanced_Three_Times_Read_Through_Repository
+    : RelationalChangeQueryRepositoryTestBase
+{
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        await GetMaxChangeVersionTestBase.AdvanceSequence(3);
+        Result = await CreateRepository().GetNewestChangeVersion();
+    }
+
+    [Test]
+    public void It_should_return_the_last_allocated_value()
+    {
+        Result.Should().Be(3L);
+    }
+}
+
+[TestFixture]
+[NonParallelizable]
+public class Given_Repository_And_Raw_Function_Call : RelationalChangeQueryRepositoryTestBase
+{
+    private long _repositoryResult;
+    private long _rawResult;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await GetMaxChangeVersionTestBase.ResetSequenceToStart();
+        await GetMaxChangeVersionTestBase.AdvanceSequence(5);
+        _repositoryResult = await CreateRepository().GetNewestChangeVersion();
+        _rawResult = await GetMaxChangeVersionTestBase.CallFunction();
+    }
+
+    [Test]
+    public void It_should_match_the_direct_function_call()
+    {
+        _repositoryResult.Should().Be(_rawResult);
+        _repositoryResult.Should().Be(5L);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/EdFi.DataManagementService.Backend.Postgresql.csproj
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql/EdFi.DataManagementService.Backend.Postgresql.csproj
@@ -18,6 +18,7 @@
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Tests.Unit" />
+        <InternalsVisibleTo Include="EdFi.DataManagementService.Backend.Postgresql.Tests.Integration" />
         <InternalsVisibleTo Include="EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit" />
     </ItemGroup>
 </Project>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@
 
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Profile;
+using EdFi.DataManagementService.Core.External.Interface;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -50,6 +51,7 @@ public static class ReferenceResolverServiceCollectionExtensions
 
         services.AddOptions();
         services.TryAdd(ServiceDescriptor.Scoped<IRelationalCommandExecutor, TRelationalCommandExecutor>());
+        services.TryAdd(ServiceDescriptor.Scoped<IChangeQueryRepository, RelationalChangeQueryRepository>());
         services.TryAdd(
             ServiceDescriptor.Scoped<
                 IRelationalParameterConfigurator,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalChangeQueryRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalChangeQueryRepository.cs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Interface;
+
+namespace EdFi.DataManagementService.Backend;
+
+/// <summary>
+/// Relational implementation of <see cref="IChangeQueryRepository"/>. Reads the newest change
+/// version from the dms.GetMaxChangeVersion() function, which is identical across PostgreSQL and
+/// SQL Server, so a single dialect-agnostic command serves both engines.
+/// </summary>
+public sealed class RelationalChangeQueryRepository(IRelationalCommandExecutor commandExecutor)
+    : IChangeQueryRepository
+{
+    private readonly IRelationalCommandExecutor _commandExecutor =
+        commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
+
+    public Task<long> GetNewestChangeVersion(CancellationToken cancellationToken = default) =>
+        _commandExecutor.ExecuteReaderAsync(
+            new RelationalCommand("SELECT dms.GetMaxChangeVersion() AS NewestChangeVersion"),
+            static async (reader, ct) =>
+            {
+                if (!await reader.ReadAsync(ct).ConfigureAwait(false))
+                {
+                    throw new InvalidOperationException("dms.GetMaxChangeVersion() returned no rows.");
+                }
+
+                return reader.GetRequiredFieldValue<long>("NewestChangeVersion");
+            },
+            cancellationToken
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalChangeQueryRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalChangeQueryRepository.cs
@@ -20,7 +20,7 @@ public sealed class RelationalChangeQueryRepository(IRelationalCommandExecutor c
 
     public Task<long> GetNewestChangeVersion(CancellationToken cancellationToken = default) =>
         _commandExecutor.ExecuteReaderAsync(
-            new RelationalCommand("SELECT dms.GetMaxChangeVersion() AS NewestChangeVersion"),
+            new RelationalCommand("SELECT dms.GetMaxChangeVersion() AS \"NewestChangeVersion\""),
             static async (reader, ct) =>
             {
                 if (!await reader.ReadAsync(ct).ConfigureAwait(false))

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
@@ -43,6 +43,11 @@ public interface IApiService
     Task<IFrontendResponse> GetTokenInfo(FrontendRequest frontendRequest);
 
     /// <summary>
+    /// DMS entry point for the Change Queries availableChangeVersions request
+    /// </summary>
+    Task<IFrontendResponse> GetAvailableChangeVersions(FrontendRequest frontendRequest);
+
+    /// <summary>
     /// DMS entry point for data model information from ApiSchema.json
     /// </summary>
     IList<IDataModelInfo> GetDataModelInfo();

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IChangeQueryRepository.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IChangeQueryRepository.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Interface;
+
+/// <summary>
+/// Backend read for the Change Queries availableChangeVersions endpoint. Relational backend only.
+/// </summary>
+public interface IChangeQueryRepository
+{
+    /// <summary>
+    /// Returns the current value of dms.ChangeVersionSequence via dms.GetMaxChangeVersion().
+    /// </summary>
+    Task<long> GetNewestChangeVersion(CancellationToken cancellationToken = default);
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/AvailableChangeVersionsHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/AvailableChangeVersionsHandlerTests.cs
@@ -78,14 +78,15 @@ public class Given_AvailableChangeVersionsHandler
     }
 
     [Test]
-    public async Task It_returns_503_when_change_query_repository_is_not_registered()
+    public async Task It_returns_404_when_change_query_repository_is_not_registered()
     {
         RequestInfo requestInfo = CreateRequestInfo(new SingleServiceProvider(repository: null));
 
         await Execute(requestInfo);
 
-        requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+        requestInfo.FrontendResponse.StatusCode.Should().Be(404);
         requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+        requestInfo.FrontendResponse.Body!.ToJsonString().Should().Contain("urn:ed-fi:api:not-found");
     }
 
     /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/AvailableChangeVersionsHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/AvailableChangeVersionsHandlerTests.cs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Handler;
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Handler;
+
+[TestFixture]
+public class Given_AvailableChangeVersionsHandler
+{
+    private static RequestInfo CreateRequestInfo(IServiceProvider scopedServiceProvider)
+    {
+        return new RequestInfo(
+            new FrontendRequest(
+                Path: "/changeQueries/v1/availableChangeVersions",
+                Body: null,
+                Form: null,
+                Headers: [],
+                QueryParameters: [],
+                TraceId: new TraceId("trace-id"),
+                RouteQualifiers: []
+            ),
+            RequestMethod.GET,
+            scopedServiceProvider
+        );
+    }
+
+    private static async Task Execute(RequestInfo requestInfo)
+    {
+        var handler = new AvailableChangeVersionsHandler(NullLogger<AvailableChangeVersionsHandler>.Instance);
+
+        await ((IPipelineStep)handler).Execute(requestInfo, () => Task.CompletedTask);
+    }
+
+    [Test]
+    public async Task It_returns_oldest_zero_and_newest_from_repository()
+    {
+        var repository = A.Fake<IChangeQueryRepository>();
+        A.CallTo(() => repository.GetNewestChangeVersion(A<CancellationToken>._)).Returns(42L);
+
+        RequestInfo requestInfo = CreateRequestInfo(new SingleServiceProvider(repository));
+
+        await Execute(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+        requestInfo
+            .FrontendResponse.Body!.ToJsonString()
+            .Should()
+            .Be("{\"oldestChangeVersion\":0,\"newestChangeVersion\":42}");
+    }
+
+    [Test]
+    public async Task It_returns_zero_newest_for_empty_database()
+    {
+        var repository = A.Fake<IChangeQueryRepository>();
+        A.CallTo(() => repository.GetNewestChangeVersion(A<CancellationToken>._)).Returns(0L);
+
+        RequestInfo requestInfo = CreateRequestInfo(new SingleServiceProvider(repository));
+
+        await Execute(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(200);
+        requestInfo
+            .FrontendResponse.Body!.ToJsonString()
+            .Should()
+            .Be("{\"oldestChangeVersion\":0,\"newestChangeVersion\":0}");
+    }
+
+    [Test]
+    public async Task It_returns_503_when_change_query_repository_is_not_registered()
+    {
+        RequestInfo requestInfo = CreateRequestInfo(new SingleServiceProvider(repository: null));
+
+        await Execute(requestInfo);
+
+        requestInfo.FrontendResponse.StatusCode.Should().Be(503);
+        requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+    }
+
+    /// <summary>
+    /// Minimal scoped service provider that resolves only IChangeQueryRepository, mirroring how the
+    /// handler resolves the repository from the request scope. A null repository models a
+    /// non-relational backend where the service is not registered.
+    /// </summary>
+    private sealed class SingleServiceProvider(IChangeQueryRepository? repository) : IServiceProvider
+    {
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(IChangeQueryRepository) ? repository : null;
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -81,6 +81,11 @@ internal class ApiService : IApiService
     private readonly Lazy<PipelineProvider> _getTokenInfoSteps;
 
     /// <summary>
+    /// The pipeline steps to satisfy a get available change versions request
+    /// </summary>
+    private readonly Lazy<PipelineProvider> _getAvailableChangeVersionsSteps;
+
+    /// <summary>
     /// The OpenAPI specification derived from core and extension ApiSchemas
     /// </summary>
     private readonly Lazy<JsonNode> _resourceOpenApiSpecification;
@@ -135,6 +140,9 @@ internal class ApiService : IApiService
         _updateSteps = new Lazy<PipelineProvider>(CreateUpdatePipeline);
         _deleteByIdSteps = new Lazy<PipelineProvider>(CreateDeleteByIdPipeline);
         _getTokenInfoSteps = new Lazy<PipelineProvider>(CreateGetTokenInfoPipeline);
+        _getAvailableChangeVersionsSteps = new Lazy<PipelineProvider>(
+            CreateGetAvailableChangeVersionsPipeline
+        );
         _resourceOpenApiSpecification = new Lazy<JsonNode>(CreateResourceOpenApiSpecification);
         _descriptorOpenApiSpecification = new Lazy<JsonNode>(CreateDescriptorOpenApiSpecification);
     }
@@ -375,6 +383,21 @@ internal class ApiService : IApiService
         return new PipelineProvider(steps);
     }
 
+    private PipelineProvider CreateGetAvailableChangeVersionsPipeline()
+    {
+        // Intentionally minimal: the common steps supply JWT auth (401) and datastore
+        // resolution, and fingerprint validation yields the existing 503 on an unprovisioned
+        // database. No ApiSchema or resource-key-seed steps, so availability does not depend on
+        // ApiSchema.json or OpenAPI path presence.
+        var steps = GetCommonInitialSteps();
+        steps.AddRange([
+            _serviceProvider.GetRequiredService<ValidateDatabaseFingerprintMiddleware>(),
+            _serviceProvider.GetRequiredService<AvailableChangeVersionsHandler>(),
+        ]);
+
+        return new PipelineProvider(steps);
+    }
+
     /// <summary>
     /// Parses the excluded domains configuration setting into an array of domain names
     /// </summary>
@@ -479,6 +502,17 @@ internal class ApiService : IApiService
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
         RequestInfo requestInfo = new(frontendRequest, RequestMethod.POST, scope.ServiceProvider);
         await _getTokenInfoSteps.Value.Run(requestInfo);
+        return requestInfo.FrontendResponse;
+    }
+
+    /// <summary>
+    /// DMS entry point for the Change Queries availableChangeVersions request
+    /// </summary>
+    public async Task<IFrontendResponse> GetAvailableChangeVersions(FrontendRequest frontendRequest)
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        RequestInfo requestInfo = new(frontendRequest, RequestMethod.GET, scope.ServiceProvider);
+        await _getAvailableChangeVersionsSteps.Value.Run(requestInfo);
         return requestInfo.FrontendResponse;
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -131,7 +131,8 @@ public static class DmsCoreServiceExtensions
             .AddTransient<ProfileWriteValidationMiddleware>()
             .AddTransient<ProfileWritePipelineMiddleware>()
             .AddSingleton<ITokenInfoRelationalMappingSetResolver, TokenInfoRelationalMappingSetResolver>()
-            .AddSingleton<GetTokenInfoHandler>();
+            .AddSingleton<GetTokenInfoHandler>()
+            .AddSingleton<AvailableChangeVersionsHandler>();
 
         return services;
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
@@ -35,7 +35,7 @@ internal sealed class AvailableChangeVersionsHandler(ILogger<AvailableChangeVers
         // than letting GetRequiredService throw an opaque missing-service exception.
         if (changeQueryRepository is null)
         {
-            logger.LogError(
+            logger.LogWarning(
                 "IChangeQueryRepository is not registered; Change Queries require the relational backend - {TraceId}",
                 requestInfo.FrontendRequest.TraceId.Value
             );

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EdFi.DataManagementService.Core.Handler;
+
+/// <summary>
+/// Handles GET /changeQueries/v1/availableChangeVersions, returning the ODS-compatible contract
+/// { "oldestChangeVersion": 0, "newestChangeVersion": &lt;dms.GetMaxChangeVersion()&gt; }.
+/// oldestChangeVersion is always 0; newestChangeVersion is read from the relational backend.
+/// </summary>
+internal sealed class AvailableChangeVersionsHandler(ILogger<AvailableChangeVersionsHandler> logger)
+    : IPipelineStep
+{
+    async Task IPipelineStep.Execute(RequestInfo requestInfo, Func<Task> next)
+    {
+        logger.LogDebug(
+            $"Entering {nameof(AvailableChangeVersionsHandler)} - {{TraceId}}",
+            requestInfo.FrontendRequest.TraceId.Value
+        );
+
+        var changeQueryRepository = requestInfo.ScopedServiceProvider.GetService<IChangeQueryRepository>();
+
+        // Change Queries are a relational-backend feature; IChangeQueryRepository is only
+        // registered on that path. Return an intentional 503 (a configuration condition) rather
+        // than letting GetRequiredService throw an opaque missing-service exception.
+        if (changeQueryRepository is null)
+        {
+            logger.LogError(
+                "IChangeQueryRepository is not registered; Change Queries require the relational backend - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+            requestInfo.FrontendResponse = new FrontendResponse(
+                StatusCode: 503,
+                Body: FailureResponse.ForServiceConfigurationError(
+                    "Change Queries require the relational backend.",
+                    requestInfo.FrontendRequest.TraceId
+                ),
+                Headers: [],
+                ContentType: "application/problem+json"
+            );
+            return;
+        }
+
+        long newestChangeVersion = await changeQueryRepository.GetNewestChangeVersion();
+
+        JsonObject body = new()
+        {
+            ["oldestChangeVersion"] = 0L,
+            ["newestChangeVersion"] = newestChangeVersion,
+        };
+
+        requestInfo.FrontendResponse = new FrontendResponse(StatusCode: 200, Body: body, Headers: []);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/AvailableChangeVersionsHandler.cs
@@ -31,8 +31,9 @@ internal sealed class AvailableChangeVersionsHandler(ILogger<AvailableChangeVers
         var changeQueryRepository = requestInfo.ScopedServiceProvider.GetService<IChangeQueryRepository>();
 
         // Change Queries are a relational-backend feature; IChangeQueryRepository is only
-        // registered on that path. Return an intentional 503 (a configuration condition) rather
-        // than letting GetRequiredService throw an opaque missing-service exception.
+        // registered on that path. When support is unavailable in the runtime the endpoint is
+        // treated as not routed and returns the standard 404 not-found response, matching the
+        // Change Queries contract (the same shape Program.cs MapFallback emits for any unrouted path).
         if (changeQueryRepository is null)
         {
             logger.LogWarning(
@@ -40,9 +41,9 @@ internal sealed class AvailableChangeVersionsHandler(ILogger<AvailableChangeVers
                 requestInfo.FrontendRequest.TraceId.Value
             );
             requestInfo.FrontendResponse = new FrontendResponse(
-                StatusCode: 503,
-                Body: FailureResponse.ForServiceConfigurationError(
-                    "Change Queries require the relational backend.",
+                StatusCode: 404,
+                Body: FailureResponse.ForNotFound(
+                    "The specified data could not be found.",
                     requestInfo.FrontendRequest.TraceId
                 ),
                 Headers: [],

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/FixedRoutePatternTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/FixedRoutePatternTests.cs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.Infrastructure;
+
+[TestFixture]
+public class FixedRoutePatternTests
+{
+    [TestFixture]
+    public class Given_No_Multitenancy
+    {
+        [TestFixture]
+        public class Given_No_Route_Qualifiers
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build([], multiTenancy: false);
+            }
+
+            [Test]
+            public void It_should_return_an_empty_prefix()
+            {
+                _result.Should().Be(string.Empty);
+            }
+        }
+
+        [TestFixture]
+        public class Given_Single_Route_Qualifier
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build(["districtId"], multiTenancy: false);
+            }
+
+            [Test]
+            public void It_should_return_the_qualifier_segment()
+            {
+                _result.Should().Be("/{districtId}");
+            }
+        }
+
+        [TestFixture]
+        public class Given_Multiple_Route_Qualifiers
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build(["districtId", "schoolYear"], multiTenancy: false);
+            }
+
+            [Test]
+            public void It_should_return_all_qualifier_segments()
+            {
+                _result.Should().Be("/{districtId}/{schoolYear}");
+            }
+        }
+    }
+
+    [TestFixture]
+    public class Given_Multitenancy_Enabled
+    {
+        [TestFixture]
+        public class Given_No_Route_Qualifiers
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build([], multiTenancy: true);
+            }
+
+            [Test]
+            public void It_should_return_the_tenant_segment()
+            {
+                _result.Should().Be("/{tenant}");
+            }
+        }
+
+        [TestFixture]
+        public class Given_Single_Route_Qualifier
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build(["districtId"], multiTenancy: true);
+            }
+
+            [Test]
+            public void It_should_return_the_tenant_before_the_qualifier()
+            {
+                _result.Should().Be("/{tenant}/{districtId}");
+            }
+        }
+
+        [TestFixture]
+        public class Given_Multiple_Route_Qualifiers
+        {
+            private string _result = string.Empty;
+
+            [SetUp]
+            public void Setup()
+            {
+                _result = FixedRoutePattern.Build(["districtId", "schoolYear"], multiTenancy: true);
+            }
+
+            [Test]
+            public void It_should_return_the_tenant_before_all_qualifiers()
+            {
+                _result.Should().Be("/{tenant}/{districtId}/{schoolYear}");
+            }
+        }
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/ChangeQueriesModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/ChangeQueriesModuleTests.cs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Interface;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.Modules;
+
+[TestFixture]
+[NonParallelizable]
+public class ChangeQueriesModuleTests
+{
+    private static IFrontendResponse FakeResponse(long newestChangeVersion)
+    {
+        JsonObject body = new()
+        {
+            ["oldestChangeVersion"] = 0L,
+            ["newestChangeVersion"] = newestChangeVersion,
+        };
+
+        var response = A.Fake<IFrontendResponse>();
+        A.CallTo(() => response.StatusCode).Returns(200);
+        A.CallTo(() => response.Body).Returns(body);
+        A.CallTo(() => response.Headers).Returns(new Dictionary<string, string>());
+        A.CallTo(() => response.ContentType).Returns("application/json");
+        return response;
+    }
+
+    [Test]
+    public async Task It_routes_available_change_versions_and_returns_the_core_response()
+    {
+        var apiService = A.Fake<IApiService>();
+        A.CallTo(() => apiService.GetAvailableChangeVersions(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeResponse(123L)));
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(collection =>
+            {
+                TestMockHelper.AddEssentialMocks(collection);
+                collection.AddTransient(x => apiService);
+            });
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/changeQueries/v1/availableChangeVersions");
+        var content = await response.Content.ReadAsStringAsync();
+        var body = JsonNode.Parse(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotBeNull();
+        body!["oldestChangeVersion"]!.GetValue<long>().Should().Be(0L);
+        body!["newestChangeVersion"]!.GetValue<long>().Should().Be(123L);
+
+        A.CallTo(() => apiService.GetAvailableChangeVersions(A<FrontendRequest>._))
+            .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_routes_under_a_tenant_prefix_when_multitenancy_is_enabled()
+    {
+        var apiService = A.Fake<IApiService>();
+        A.CallTo(() => apiService.GetAvailableChangeVersions(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeResponse(7L)));
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" }
+                    );
+                }
+            );
+            builder.ConfigureServices(collection =>
+            {
+                TestMockHelper.AddEssentialMocks(collection);
+                collection.AddTransient(x => apiService);
+            });
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/tenant1/changeQueries/v1/availableChangeVersions");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        A.CallTo(() => apiService.GetAvailableChangeVersions(A<FrontendRequest>._))
+            .MustHaveHappenedOnceExactly();
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -342,4 +342,28 @@ public static class AspNetCoreFrontend
             string.Empty
         );
     }
+
+    /// <summary>
+    /// ASP.NET Core entry point for the Change Queries availableChangeVersions request
+    /// </summary>
+    public static async Task<IResult> GetAvailableChangeVersions(
+        HttpContext httpContext,
+        IApiService apiService,
+        IOptions<AppSettings> appSettings
+    )
+    {
+        return ToResult(
+            await apiService.GetAvailableChangeVersions(
+                await FromRequest(
+                    httpContext.Request,
+                    string.Empty,
+                    appSettings,
+                    includeBody: false,
+                    includeForm: false
+                )
+            ),
+            httpContext,
+            string.Empty
+        );
+    }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/FixedRoutePattern.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/FixedRoutePattern.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+
+/// <summary>
+/// Builds the route prefix for fixed (non-resource) endpoints that sit at the server root rather
+/// than under /data, such as /oauth/token_info and /changeQueries/v1/availableChangeVersions.
+/// When multitenancy is enabled, prepends {tenant} as the first segment, followed by any
+/// configured route-qualifier segments.
+/// Examples:
+/// - No multitenancy, no qualifiers: ""
+/// - No multitenancy, with qualifiers: "/{districtId}/{schoolYear}"
+/// - Multitenancy, no qualifiers: "/{tenant}"
+/// - Multitenancy, with qualifiers: "/{tenant}/{districtId}/{schoolYear}"
+/// </summary>
+internal static class FixedRoutePattern
+{
+    public static string Build(string[] routeQualifierSegments, bool multiTenancy)
+    {
+        var segments = new List<string>();
+
+        if (multiTenancy)
+        {
+            segments.Add("{tenant}");
+        }
+
+        if (routeQualifierSegments.Length > 0)
+        {
+            segments.AddRange(routeQualifierSegments.Select(s => $"{{{s}}}"));
+        }
+
+        return segments.Count == 0 ? string.Empty : $"/{string.Join("/", segments)}";
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/ChangeQueriesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/ChangeQueriesEndpointModule.cs
@@ -11,9 +11,10 @@ using static EdFi.DataManagementService.Frontend.AspNetCore.AspNetCoreFrontend;
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Modules;
 
 /// <summary>
-/// Endpoint module for OAuth token introspection
+/// Endpoint module for the Change Queries availableChangeVersions endpoint. This is a fixed DMS
+/// route: it is not generated from ApiSchema.json and is not gated by OpenAPI path presence.
 /// </summary>
-public class TokenInfoModule(IOptions<AppSettings> appSettings) : IEndpointModule
+public class ChangeQueriesEndpointModule(IOptions<AppSettings> appSettings) : IEndpointModule
 {
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
@@ -22,6 +23,9 @@ public class TokenInfoModule(IOptions<AppSettings> appSettings) : IEndpointModul
             appSettings.Value.MultiTenancy
         );
 
-        endpoints.MapPost($"{routePattern}/oauth/token_info", GetTokenInfo);
+        endpoints.MapGet(
+            $"{routePattern}/changeQueries/v1/availableChangeVersions",
+            GetAvailableChangeVersions
+        );
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/AvailableChangeVersions.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/AvailableChangeVersions.feature
@@ -1,0 +1,46 @@
+Feature: The Change Queries availableChangeVersions endpoint reports the oldest and newest change versions available in the DMS.
+
+        @API-261 @relational-backend
+        @relational-ci-shard-4
+        Scenario: 01 GET availableChangeVersions returns the ODS-compatible contract when authenticated
+            Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a GET request is made to "/changeQueries/v1/availableChangeVersions"
+             Then it should respond with 200
+              And the response body path "oldestChangeVersion" should have value "0"
+              And the response body path "newestChangeVersion" should be a non-negative integer
+
+        @API-262 @relational-backend
+        @relational-ci-shard-4
+        Scenario: 02 newestChangeVersion increases after a resource is created
+            Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a GET request is made to "/changeQueries/v1/availableChangeVersions"
+             Then it should respond with 200
+              And the response body path "newestChangeVersion" is stored as variable "previousChangeVersion"
+             When a POST request is made to "/ed-fi/absenceEventCategoryDescriptors" with
+                  """
+                  {
+                      "codeValue": "CV-1184",
+                      "namespace": "uri://ed-fi.org/AbsenceEventCategoryDescriptor",
+                      "shortDescription": "Available Change Versions Test"
+                  }
+                  """
+             Then it should respond with 201
+             When a GET request is made to "/changeQueries/v1/availableChangeVersions"
+             Then it should respond with 200
+              And the response body path "newestChangeVersion" should be greater than variable "previousChangeVersion"
+
+        @API-263 @relational-backend
+        @relational-ci-shard-4
+        Scenario: 03 GET availableChangeVersions requires authentication
+            Given there is no Authorization header
+             When a GET request is made to "/changeQueries/v1/availableChangeVersions"
+             Then it should respond with 401
+
+        @API-264 @relational-backend
+        @relational-ci-shard-4
+        Scenario: 04 GET availableChangeVersions ignores query string parameters
+            Given the claimSet "EdFiSandbox" is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a GET request is made to "/changeQueries/v1/availableChangeVersions?minChangeVersion=1&foo=bar"
+             Then it should respond with 200
+              And the response body path "oldestChangeVersion" should have value "0"
+              And the response body path "newestChangeVersion" should be a non-negative integer

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/ProfileStepDefinitions.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -1219,6 +1220,87 @@ public class ProfileStepDefinitions(
                     $"Path '{jsonPath}' should not match the stored value in variable '{variableName}'."
                 );
         }
+    }
+
+    [Then(@"the response body path ""([^""]*)"" should be a non-negative integer")]
+    public async Task ThenTheResponseBodyPathShouldBeANonNegativeInteger(string jsonPath)
+    {
+        string responseBody = await GetCurrentApiResponse().TextAsync();
+        JsonNode responseJson = JsonNode.Parse(responseBody)!;
+
+        string[] pathParts = jsonPath.Split('.');
+        bool pathExists = TryResolvePath(
+            responseJson,
+            pathParts,
+            out JsonNode? current,
+            out string failedAtPart
+        );
+
+        pathExists
+            .Should()
+            .BeTrue(
+                $"Path '{jsonPath}' not found in response. Failed at '{failedAtPart}'. Response: {responseBody}"
+            );
+
+        current
+            .Should()
+            .NotBeNull($"Path '{jsonPath}' should resolve to a non-null value. Response: {responseBody}");
+
+        long.TryParse(current!.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long value)
+            .Should()
+            .BeTrue($"Path '{jsonPath}' should be an integer but was '{current}'.");
+
+        value.Should().BeGreaterThanOrEqualTo(0, $"Path '{jsonPath}' should be a non-negative integer.");
+    }
+
+    [Then(@"the response body path ""([^""]*)"" should be greater than variable ""([^""]*)""")]
+    public async Task ThenTheResponseBodyPathShouldBeGreaterThanVariable(string jsonPath, string variableName)
+    {
+        string responseBody = await GetCurrentApiResponse().TextAsync();
+        JsonNode responseJson = JsonNode.Parse(responseBody)!;
+
+        string[] pathParts = jsonPath.Split('.');
+        bool pathExists = TryResolvePath(
+            responseJson,
+            pathParts,
+            out JsonNode? current,
+            out string failedAtPart
+        );
+
+        pathExists
+            .Should()
+            .BeTrue(
+                $"Path '{jsonPath}' not found in response. Failed at '{failedAtPart}'. Response: {responseBody}"
+            );
+
+        current
+            .Should()
+            .NotBeNull($"Path '{jsonPath}' should resolve to a non-null value. Response: {responseBody}");
+
+        long.TryParse(
+                current!.ToString(),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out long actual
+            )
+            .Should()
+            .BeTrue($"Path '{jsonPath}' should be an integer but was '{current}'.");
+
+        long.TryParse(
+                _scenarioVariables.GetValueByName(variableName),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out long stored
+            )
+            .Should()
+            .BeTrue($"Variable '{variableName}' should hold an integer value.");
+
+        actual
+            .Should()
+            .BeGreaterThan(
+                stored,
+                $"Path '{jsonPath}' ({actual}) should be greater than variable '{variableName}' ({stored})."
+            );
     }
 
     [When(@"the response header ""([^""]*)"" is stored as variable ""([^""]*)""")]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -1707,8 +1707,11 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             // the code so it will work either way.
             input = input.StartsWith('/') ? input[1..] : input;
 
-            // metadata should not have "data" added to the URL.
-            input = input.StartsWith("metadata") || input.StartsWith("oauth") ? input : $"data/{input}";
+            // metadata, oauth, and changeQueries are server-root endpoints, not under /data.
+            input =
+                input.StartsWith("metadata") || input.StartsWith("oauth") || input.StartsWith("changeQueries")
+                    ? input
+                    : $"data/{input}";
 
             return input;
         }


### PR DESCRIPTION
## Summary

  - Adds the fixed DMS endpoint GET /changeQueries/v1/availableChangeVersions (DMS-1184), returning the ODS-compatible contract { "oldestChangeVersion": 0, "newestChangeVersion": <dms.GetMaxChangeVersion()> }. oldestChangeVersion is hardcoded to 0; newestChangeVersion comes from the relational backend.
  - Route is hardcoded, not schema-driven. New ChangeQueriesEndpointModule maps the route directly — it is not generated from ApiSchema.json and not gated by OpenAPI path presence, satisfying the "availability independent of ApiSchema" acceptance criterion.
  - Dedicated minimal pipeline in ApiService.GetAvailableChangeVersions: common initial steps supply JWT auth (401) and datastore resolution, plus ValidateDatabaseFingerprintMiddleware (503 on an unprovisioned DB) and the new AvailableChangeVersionsHandler. No ApiSchema/resource-key seeding steps are included.
  - New IChangeQueryRepository (Core.External) + RelationalChangeQueryRepository (Backend). The repository runs a single dialect-agnostic SELECT dms.GetMaxChangeVersion(), which works identically on PostgreSQL and SQL Server. It is registered scoped only on the relational path.
  - Graceful 404 on non-relational backends. When IChangeQueryRepository isn't registered, the handler returns the standard application/problem+json 404 (treated as not-routed), rather than failing.
  - Route-prefix logic extracted to FixedRoutePattern. The multitenancy/route-qualifier prefix builder previously inlined in TokenInfoModule.BuildRoutePattern is now a shared Infrastructure/FixedRoutePattern helper used by both oauth/token_info and changeQueries (DRY refactor; TokenInfoModule now delegates).
  - Casing matches ODS/API (/changeQueries/v1/availableChangeVersions, oldestChangeVersion/newestChangeVersion) — addresses Shawn Peterson's Jira comment.
  - E2E routing fix: AddDataPrefixIfNecessary now treats changeQueries as a server-root path (like metadata/oauth) instead of prefixing /data.

  Tests added
  - Unit: AvailableChangeVersionsHandlerTests (newest-from-repo, zero-for-empty-DB, 404-when-unregistered), FixedRoutePatternTests, ChangeQueriesModuleTests.
  - Integration: RelationalChangeQueryRepositoryTests in both the MSSQL and PostgreSQL integration projects — proves the endpoint against both dms.GetMaxChangeVersion() implementations.
  - E2E: ChangeQueries/AvailableChangeVersions.feature (4 scenarios) + 2 reusable step defs (should be a non-negative integer, should be greater than variable).

## Test plan

  - [ ] dotnet build --no-restore ./src/dms/EdFi.DataManagementService.sln succeeds.
  - [ ] Core unit tests pass — Given_AvailableChangeVersionsHandler (200 with oldest=0/newest=42, newest=0 for empty DB, 404 + urn:ed-fi:api:not-found when repo unregistered).
  - [ ] Frontend unit tests pass — FixedRoutePatternTests (no-tenant/no-qualifier → "", multitenancy, qualifier segments) and ChangeQueriesModuleTests (route mapping).
  - [ ] PostgreSQL integration test RelationalChangeQueryRepositoryTests passes against a provisioned DB.
  - [ ] SQL Server integration test RelationalChangeQueryRepositoryTests passes against a provisioned DB.
  - [ ] E2E scenarios pass (@relational-backend, shard 4): authenticated 200 contract; newestChangeVersion increases after a POST; 401 without Authorization; query-string params ignored (still 200).
  - [ ] Manual: GET /changeQueries/v1/availableChangeVersions with a valid token → 200 {"oldestChangeVersion":0,"newestChangeVersion":<n>}; create a resource, re-GET, confirm newestChangeVersion
  increased.
  - [ ] Manual: same request without a bearer token → 401.
  - [ ] Manual (multitenancy enabled): confirm the route resolves under the {tenant} prefix.
  - [ ] Confirm TokenInfoModule (POST /oauth/token_info) still routes correctly after the FixedRoutePattern extraction.