### PR TITLE
[DMS-1034] Gaps in CMS for supporting Admin App 4

### DIFF
--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetImportBehaviorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetImportBehaviorTests.cs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EdFi.DmsConfigurationService.Backend.ClaimsDataLoader;
+using EdFi.DmsConfigurationService.Backend.Postgresql.ClaimsDataLoader;
+using EdFi.DmsConfigurationService.Backend.Postgresql.Repositories;
+using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
+
+public class ClaimSetImportBehaviorTests : DatabaseTest
+{
+    private readonly IClaimSetRepository _repository = new ClaimSetRepository(
+        Configuration.DatabaseOptions,
+        Microsoft.Extensions.Logging.Abstractions.NullLogger<ClaimSetRepository>.Instance,
+        new ClaimsHierarchyRepository(
+            Configuration.DatabaseOptions,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ClaimsHierarchyRepository>.Instance,
+            new TestAuditContext()
+        ),
+        new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.ClaimsHierarchyManager(),
+        new TestAuditContext(),
+        new TenantContextProvider()
+    );
+
+    protected async Task EnsureClaimsDataLoadedInternal()
+    {
+        var claimsDataLoader = new EdFi.DmsConfigurationService.Backend.ClaimsDataLoader.ClaimsDataLoader(
+            new EdFi.DmsConfigurationService.Backend.Claims.ClaimsProvider(
+                Microsoft
+                    .Extensions
+                    .Logging
+                    .Abstractions
+                    .NullLogger<EdFi.DmsConfigurationService.Backend.Claims.ClaimsProvider>
+                    .Instance,
+                Microsoft.Extensions.Options.Options.Create(
+                    new EdFi.DmsConfigurationService.Backend.Claims.ClaimsOptions
+                    {
+                        ClaimsSource = EdFi.DmsConfigurationService.Backend.Claims.ClaimsSource.Embedded,
+                        ClaimsDirectory = "",
+                    }
+                ),
+                new EdFi.DmsConfigurationService.Backend.Claims.ClaimsValidator(
+                    Microsoft
+                        .Extensions
+                        .Logging
+                        .Abstractions
+                        .NullLogger<EdFi.DmsConfigurationService.Backend.Claims.ClaimsValidator>
+                        .Instance
+                ),
+                new EdFi.DmsConfigurationService.Backend.Claims.ClaimsFragmentComposer(
+                    Microsoft
+                        .Extensions
+                        .Logging
+                        .Abstractions
+                        .NullLogger<EdFi.DmsConfigurationService.Backend.Claims.ClaimsFragmentComposer>
+                        .Instance
+                )
+            ),
+            _repository,
+            new ClaimsHierarchyRepository(
+                Configuration.DatabaseOptions,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<ClaimsHierarchyRepository>.Instance,
+                new TestAuditContext()
+            ),
+            new ClaimsTableValidator(
+                Configuration.DatabaseOptions,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<ClaimsTableValidator>.Instance
+            ),
+            new ClaimsDocumentRepository(
+                Configuration.DatabaseOptions,
+                Microsoft.Extensions.Logging.Abstractions.NullLogger<ClaimsDocumentRepository>.Instance
+            ),
+            Microsoft
+                .Extensions
+                .Logging
+                .Abstractions
+                .NullLogger<EdFi.DmsConfigurationService.Backend.ClaimsDataLoader.ClaimsDataLoader>
+                .Instance
+        );
+
+        var result = await claimsDataLoader.LoadInitialClaimsAsync();
+        if (result is not ClaimsDataLoadResult.Success and not ClaimsDataLoadResult.AlreadyLoaded)
+        {
+            throw new System.InvalidOperationException($"Failed to load claims data: {result}");
+        }
+    }
+
+    [Test]
+    public async Task Import_should_upsert_existing_claimset()
+    {
+        await EnsureClaimsDataLoadedInternal();
+
+        var command = new ClaimSetImportCommand
+        {
+            Name = "Test-Import-Upsert",
+            ResourceClaims = new List<ResourceClaim>(),
+        };
+
+        var result1 = await _repository.Import(command);
+        result1.Should().BeOfType<ClaimSetImportResult.Success>();
+        var id1 = (result1 as ClaimSetImportResult.Success)!.Id;
+
+        var command2 = new ClaimSetImportCommand
+        {
+            Name = "Test-Import-Upsert",
+            ResourceClaims = new List<ResourceClaim>(),
+        };
+        var result2 = await _repository.Import(command2);
+        result2.Should().BeOfType<ClaimSetImportResult.Success>();
+        var id2 = (result2 as ClaimSetImportResult.Success)!.Id;
+
+        id1.Should().BeGreaterThan(0);
+        id2.Should().Be(id1);
+    }
+
+    [Test]
+    public async Task Import_should_return_warnings_for_missing_claims()
+    {
+        await EnsureClaimsDataLoadedInternal();
+
+        var rcMissing = new ResourceClaim
+        {
+            ClaimName = "http://example.org/nonexistent/Claim",
+            Actions = new List<ResourceClaimAction>
+            {
+                new ResourceClaimAction { Name = "Read", Enabled = true },
+            },
+        };
+        var command = new ClaimSetImportCommand
+        {
+            Name = "Test-Import-Warn",
+            ResourceClaims = new List<ResourceClaim> { rcMissing },
+        };
+
+        var result = await _repository.Import(command);
+        result.Should().BeOfType<ClaimSetImportResult.Success>();
+        var success = result as ClaimSetImportResult.Success;
+        var warnings = success!.Warnings ?? Enumerable.Empty<string>();
+        warnings.Should().Contain("http://example.org/nonexistent/Claim");
+    }
+
+    [Test]
+    public async Task Import_should_replace_existing_hierarchy_assignments_for_claim_set()
+    {
+        await EnsureClaimsDataLoadedInternal();
+
+        var first = await _repository.Import(
+            new ClaimSetImportCommand
+            {
+                Name = "Test-Import-Replacement",
+                ResourceClaims =
+                [
+                    new ResourceClaim
+                    {
+                        ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                        Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                    },
+                ],
+            }
+        );
+        var id = ((ClaimSetImportResult.Success)first).Id;
+
+        var second = await _repository.Import(
+            new ClaimSetImportCommand
+            {
+                Name = "Test-Import-Replacement",
+                ResourceClaims =
+                [
+                    new ResourceClaim
+                    {
+                        ClaimName = "http://ed-fi.org/identity/claims/ed-fi/student",
+                        Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                    },
+                ],
+            }
+        );
+        ((ClaimSetImportResult.Success)second).Id.Should().Be(id);
+
+        var result = (ClaimSetGetResult.Success)await _repository.GetClaimSet(id);
+        result
+            .ClaimSetResponse.ResourceClaims.Should()
+            .ContainSingle(rc => rc.ClaimName == "http://ed-fi.org/identity/claims/ed-fi/student");
+        result
+            .ClaimSetResponse.ResourceClaims.Should()
+            .NotContain(rc => rc.ClaimName == "http://ed-fi.org/identity/claims/ed-fi/school");
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetImportConcurrencyTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetImportConcurrencyTests.cs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using System.Linq;
+using System.Threading.Tasks;
+using EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
+using EdFi.DmsConfigurationService.Backend.Postgresql.Repositories;
+using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration;
+
+public class ClaimSetImportConcurrencyTests : DatabaseTest
+{
+    private class FakeClaimsHierarchyRepository : IClaimsHierarchyRepository
+    {
+        private int _saveCalls = 0;
+        private readonly TaskCompletionSource _firstGetStarted = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        private readonly TaskCompletionSource _releaseFirstGet = new(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+
+        public int SaveCalls => _saveCalls;
+
+        public Task FirstGetStarted => _firstGetStarted.Task;
+
+        public void ReleaseFirstGet() => _releaseFirstGet.TrySetResult();
+
+        public Task<ClaimsHierarchyGetResult> GetClaimsHierarchy(DbTransaction? transaction = null)
+        {
+            if (!_firstGetStarted.Task.IsCompleted)
+            {
+                _firstGetStarted.TrySetResult();
+                return WaitForReleaseThenReturnSuccess();
+            }
+
+            return Task.FromResult<ClaimsHierarchyGetResult>(CreateSuccessResult());
+        }
+
+        private async Task<ClaimsHierarchyGetResult> WaitForReleaseThenReturnSuccess()
+        {
+            await _releaseFirstGet.Task;
+            return CreateSuccessResult();
+        }
+
+        private static ClaimsHierarchyGetResult.Success CreateSuccessResult()
+        {
+            var claims = new List<Claim>
+            {
+                new Claim
+                {
+                    Name = "Root",
+                    ClaimSets = new List<ClaimSet>(),
+                    Claims = new List<Claim>(),
+                },
+            };
+
+            return new ClaimsHierarchyGetResult.Success(claims, DateTime.UtcNow, 1);
+        }
+
+        public Task<ClaimsHierarchySaveResult> SaveClaimsHierarchy(
+            List<Claim> claimsHierarchy,
+            DateTime existingLastModifiedDate,
+            DbTransaction? transaction = null
+        )
+        {
+            _saveCalls++;
+            if (_saveCalls == 1)
+            {
+                // Simulate multi-user conflict on first call
+                return Task.FromResult<ClaimsHierarchySaveResult>(
+                    new ClaimsHierarchySaveResult.FailureMultiUserConflict()
+                );
+            }
+
+            return Task.FromResult<ClaimsHierarchySaveResult>(new ClaimsHierarchySaveResult.Success());
+        }
+    }
+
+    private class RetryingWarningsClaimsHierarchyRepository : IClaimsHierarchyRepository
+    {
+        private int _getCalls;
+        private int _saveCalls;
+
+        public Task<ClaimsHierarchyGetResult> GetClaimsHierarchy(DbTransaction? transaction = null)
+        {
+            _getCalls++;
+
+            return Task.FromResult<ClaimsHierarchyGetResult>(
+                _getCalls == 1 ? CreateInitialHierarchy() : CreateRetriedHierarchy()
+            );
+        }
+
+        public Task<ClaimsHierarchySaveResult> SaveClaimsHierarchy(
+            List<Claim> claimsHierarchy,
+            DateTime existingLastModifiedDate,
+            DbTransaction? transaction = null
+        )
+        {
+            _saveCalls++;
+
+            return Task.FromResult<ClaimsHierarchySaveResult>(
+                _saveCalls == 1
+                    ? new ClaimsHierarchySaveResult.FailureMultiUserConflict()
+                    : new ClaimsHierarchySaveResult.Success()
+            );
+        }
+
+        private static ClaimsHierarchyGetResult.Success CreateInitialHierarchy()
+        {
+            return new ClaimsHierarchyGetResult.Success(
+                [
+                    new Claim
+                    {
+                        Name = "Root",
+                        ClaimSets = [],
+                        Claims = [],
+                    },
+                ],
+                DateTime.UtcNow,
+                1
+            );
+        }
+
+        private static ClaimsHierarchyGetResult.Success CreateRetriedHierarchy()
+        {
+            return new ClaimsHierarchyGetResult.Success(
+                [
+                    new Claim
+                    {
+                        Name = "Root",
+                        ClaimSets = [],
+                        Claims =
+                        [
+                            new Claim
+                            {
+                                Name = "TargetClaim",
+                                ClaimSets = [],
+                                Claims = [],
+                            },
+                        ],
+                    },
+                ],
+                DateTime.UtcNow,
+                2
+            );
+        }
+    }
+
+    [Test]
+    public async Task Import_should_retry_on_concurrency_and_succeed()
+    {
+        // Arrange
+        var fakeRepo = new FakeClaimsHierarchyRepository();
+
+        var repository = new ClaimSetRepository(
+            Configuration.DatabaseOptions,
+            NullLogger<ClaimSetRepository>.Instance,
+            fakeRepo, // IClaimsHierarchyRepository
+            new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.ClaimsHierarchyManager(),
+            new TestAuditContext(),
+            new TenantContextProvider()
+        );
+
+        var command = new ClaimSetImportCommand
+        {
+            Name = "ConcurrentImportTest",
+            ResourceClaims = new List<ResourceClaim>(),
+        };
+
+        // Act
+        var firstImport = repository.Import(command);
+        await fakeRepo.FirstGetStarted;
+        var secondImport = repository.Import(command);
+        fakeRepo.ReleaseFirstGet();
+
+        var results = await Task.WhenAll(firstImport, secondImport);
+
+        // Assert
+        results.Should().OnlyContain(result => result is ClaimSetImportResult.Success);
+        fakeRepo.SaveCalls.Should().BeGreaterThanOrEqualTo(2);
+        var resultIds = results.Select(result => ((ClaimSetImportResult.Success)result).Id).ToArray();
+        resultIds.Should().OnlyContain(id => id == resultIds[0]);
+    }
+
+    [Test]
+    public async Task Import_should_return_warnings_from_the_final_retry_only()
+    {
+        // Arrange
+        var fakeRepo = new RetryingWarningsClaimsHierarchyRepository();
+
+        var repository = new ClaimSetRepository(
+            Configuration.DatabaseOptions,
+            NullLogger<ClaimSetRepository>.Instance,
+            fakeRepo,
+            new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.ClaimsHierarchyManager(),
+            new TestAuditContext(),
+            new TenantContextProvider()
+        );
+
+        var command = new ClaimSetImportCommand
+        {
+            Name = "RetryWarningImport",
+            ResourceClaims =
+            [
+                new ResourceClaim
+                {
+                    Name = "TargetClaim",
+                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                },
+            ],
+        };
+
+        // Act
+        var result = await repository.Import(command);
+
+        // Assert
+        result.Should().BeOfType<ClaimSetImportResult.Success>();
+        ((ClaimSetImportResult.Success)result).Warnings.Should().BeNullOrEmpty();
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data.Common;
+using System.Text.Json;
 using EdFi.DmsConfigurationService.Backend.Claims;
 using EdFi.DmsConfigurationService.Backend.ClaimsDataLoader;
 using EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
@@ -98,6 +99,8 @@ public class ClaimSetTests : DatabaseTest
         [SetUp]
         public async Task Setup()
         {
+            await EnsureClaimsDataLoaded();
+
             ClaimSetInsertCommand claimSet = new() { Name = "Test-ClaimSet" };
 
             var result = await _repository.InsertClaimSet(claimSet);
@@ -109,15 +112,24 @@ public class ClaimSetTests : DatabaseTest
         [Test]
         public async Task Should_get_test_claimSet_from_get_all()
         {
-            var getResult = await _repository.QueryClaimSet(new ClaimSetQuery() { Limit = 25, Offset = 0 });
+            var getResult = await _repository.QueryClaimSet(
+                new ClaimSetQuery
+                {
+                    Limit = 25,
+                    Offset = 0,
+                    Name = "Test-ClaimSet",
+                }
+            );
             getResult.Should().BeOfType<ClaimSetQueryResult.Success>();
 
-            object claimSetFromDb = ((ClaimSetQueryResult.Success)getResult).ClaimSetResponses.First();
+            object claimSetFromDb = ((ClaimSetQueryResult.Success)getResult).ClaimSetResponses.Single();
             claimSetFromDb.Should().NotBeNull();
             claimSetFromDb.Should().BeOfType<ClaimSetResponse>();
 
             var reducedResponse = (ClaimSetResponse)claimSetFromDb;
             reducedResponse.Name.Should().Be("Test-ClaimSet");
+            reducedResponse.Applications.HasValue.Should().BeTrue();
+            reducedResponse.Applications!.Value.ValueKind.Should().Be(JsonValueKind.Array);
         }
 
         [Test]
@@ -131,6 +143,21 @@ public class ClaimSetTests : DatabaseTest
 
             var reducedResponse = (ClaimSetResponse)claimSetFromDb;
             reducedResponse.Name.Should().Be("Test-ClaimSet");
+            reducedResponse.Applications.HasValue.Should().BeTrue();
+            reducedResponse.Applications!.Value.ValueKind.Should().Be(JsonValueKind.Array);
+        }
+
+        [Test]
+        public async Task Should_return_unknown_failure_when_get_by_id_has_no_claims_hierarchy()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy(clearOnly: true);
+
+            var getByIdResult = await _repository.GetClaimSet(_id);
+
+            getByIdResult.Should().BeOfType<ClaimSetGetResult.FailureUnknown>();
+            ((ClaimSetGetResult.FailureUnknown)getByIdResult)
+                .FailureMessage.Should()
+                .Be("Claims hierarchy not found.");
         }
 
         [Test]
@@ -550,6 +577,8 @@ public class ClaimSetTests : DatabaseTest
         [SetUp]
         public async Task Setup()
         {
+            await EnsureClaimsDataLoaded();
+
             var insertResult1 = await _repository.InsertClaimSet(
                 new ClaimSetInsertCommand() { Name = "Test-One" }
             );
@@ -571,7 +600,9 @@ public class ClaimSetTests : DatabaseTest
             var result = await _repository.QueryClaimSet(new ClaimSetQuery() { Limit = 25, Offset = 0 });
             result.Should().BeOfType<ClaimSetQueryResult.Success>();
 
-            ((ClaimSetQueryResult.Success)result).ClaimSetResponses.Count().Should().Be(1);
+            ((ClaimSetQueryResult.Success)result)
+                .ClaimSetResponses.Should()
+                .ContainSingle(claimSet => claimSet.Name == "Test-Two");
         }
 
         [Test]
@@ -601,6 +632,52 @@ public class ClaimSetTests : DatabaseTest
             var deleteResult = await _repository.DeleteClaimSet(_id2);
             deleteResult.Should().BeOfType<ClaimSetDeleteResult.FailureSystemReserved>();
         }
+
+        [Test]
+        public async Task Should_remove_claim_set_from_hierarchy_when_deleted()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy();
+
+            var importResult = await _repository.Import(
+                new ClaimSetImportCommand
+                {
+                    Name = "Delete-With-Permissions",
+                    ResourceClaims =
+                    [
+                        new ResourceClaim
+                        {
+                            ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                            Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                        },
+                    ],
+                }
+            );
+            if (importResult is ClaimSetImportResult.FailureUnknown failureUnknown)
+            {
+                Assert.Fail(failureUnknown.FailureMessage);
+            }
+            importResult.Should().BeOfType<ClaimSetImportResult.Success>();
+            var id = ((ClaimSetImportResult.Success)importResult).Id;
+
+            var deleteResult = await _repository.DeleteClaimSet(id);
+            deleteResult.Should().BeOfType<ClaimSetDeleteResult.Success>();
+
+            var claimsHierarchyRepository = new ClaimsHierarchyRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<ClaimsHierarchyRepository>.Instance,
+                new TestAuditContext()
+            );
+            var hierarchy = (ClaimsHierarchyGetResult.Success)
+                await claimsHierarchyRepository.GetClaimsHierarchy();
+
+            hierarchy.Claims.Exists(c => ContainsClaimSet(c, "Delete-With-Permissions")).Should().BeFalse();
+        }
+
+        private static bool ContainsClaimSet(Claim claim, string claimSetName)
+        {
+            return claim.ClaimSets.Exists(cs => cs.Name == claimSetName)
+                || claim.Claims.Exists(c => ContainsClaimSet(c, claimSetName));
+        }
     }
 
     [TestFixture]
@@ -611,6 +688,8 @@ public class ClaimSetTests : DatabaseTest
         [SetUp]
         public async Task Setup()
         {
+            await EnsureClaimsDataLoaded();
+
             ClaimSetInsertCommand claimSet = new() { Name = "Test-Export-ClaimSet" };
 
             var result = await _repository.InsertClaimSet(claimSet);
@@ -627,6 +706,199 @@ public class ClaimSetTests : DatabaseTest
 
             var valueFromDb = ((ClaimSetExportResult.Success)result).ClaimSetExportResponse;
             valueFromDb.Name.Should().Be("Test-Export-ClaimSet");
+        }
+
+        [Test]
+        public async Task Should_return_unknown_failure_when_export_has_no_claims_hierarchy()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy(clearOnly: true);
+
+            var result = await _repository.Export(_id);
+
+            result.Should().BeOfType<ClaimSetExportResult.FailureUnknown>();
+            ((ClaimSetExportResult.FailureUnknown)result)
+                .FailureMessage.Should()
+                .Be("Claims hierarchy not found.");
+        }
+
+        [Test]
+        public async Task Should_return_configured_claims_only_with_default_and_override_strategies()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy(clearOnly: true);
+
+            var claimsHierarchyRepository = new ClaimsHierarchyRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<ClaimsHierarchyRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var claimsHierarchy = BuildHierarchy();
+            var saveResult = await claimsHierarchyRepository.SaveClaimsHierarchy(
+                claimsHierarchy,
+                DateTime.UtcNow
+            );
+            saveResult.Should().BeOfType<ClaimsHierarchySaveResult.Success>();
+
+            var insertResult = await _repository.InsertClaimSet(
+                new ClaimSetInsertCommand { Name = "Test-Export-Configured-ClaimSet" }
+            );
+            insertResult.Should().BeOfType<ClaimSetInsertResult.Success>();
+            var claimSetId = ((ClaimSetInsertResult.Success)insertResult).Id;
+
+            var getResult = await _repository.GetClaimSet(claimSetId);
+            getResult.Should().BeOfType<ClaimSetGetResult.Success>();
+
+            var exportResult = await _repository.Export(claimSetId);
+            exportResult.Should().BeOfType<ClaimSetExportResult.Success>();
+
+            var getResponse = ((ClaimSetGetResult.Success)getResult).ClaimSetResponse;
+            var exportResponse = ((ClaimSetExportResult.Success)exportResult).ClaimSetExportResponse;
+
+            AssertExportShape(getResponse);
+            AssertExportShape(exportResponse);
+        }
+
+        private static List<Claim> BuildHierarchy()
+        {
+            const string ClaimSetName = "Test-Export-Configured-ClaimSet";
+            const string RootClaimName = "http://ed-fi.org/identity/claims/domains/exportRoot";
+            const string ChildClaimName = "http://ed-fi.org/identity/claims/ed-fi/exportChild";
+            const string GrandchildClaimName = "http://ed-fi.org/identity/claims/ed-fi/exportGrandchild";
+
+            return
+            [
+                new Claim
+                {
+                    Name = RootClaimName,
+                    DefaultAuthorization = new DefaultAuthorization
+                    {
+                        Actions =
+                        [
+                            new DefaultAction
+                            {
+                                Name = "Read",
+                                AuthorizationStrategies =
+                                [
+                                    new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.AuthorizationStrategy
+                                    {
+                                        Name = "DefaultRootStrategy",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    ClaimSets =
+                    [
+                        new ClaimSet
+                        {
+                            Name = ClaimSetName,
+                            Actions = [new ClaimSetAction { Name = "Read" }],
+                        },
+                    ],
+                    Claims =
+                    [
+                        new Claim
+                        {
+                            Name = ChildClaimName,
+                            DefaultAuthorization = new DefaultAuthorization
+                            {
+                                Actions =
+                                [
+                                    new DefaultAction
+                                    {
+                                        Name = "Read",
+                                        AuthorizationStrategies =
+                                        [
+                                            new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.AuthorizationStrategy
+                                            {
+                                                Name = "DefaultChildStrategy",
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                            ClaimSets =
+                            [
+                                new ClaimSet
+                                {
+                                    Name = ClaimSetName,
+                                    Actions =
+                                    [
+                                        new ClaimSetAction
+                                        {
+                                            Name = "Read",
+                                            AuthorizationStrategyOverrides =
+                                            [
+                                                new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.AuthorizationStrategy
+                                                {
+                                                    Name = "OverrideChildStrategy",
+                                                },
+                                            ],
+                                        },
+                                        new ClaimSetAction { Name = "Update" },
+                                    ],
+                                },
+                            ],
+                            Claims =
+                            [
+                                new Claim
+                                {
+                                    Name = GrandchildClaimName,
+                                    ClaimSets = [],
+                                    Claims = [],
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ];
+        }
+
+        private static void AssertExportShape(ClaimSetResponse response)
+        {
+            const string ClaimSetName = "Test-Export-Configured-ClaimSet";
+            const string RootClaimName = "http://ed-fi.org/identity/claims/domains/exportRoot";
+            const string ChildClaimName = "http://ed-fi.org/identity/claims/ed-fi/exportChild";
+            const string GrandchildClaimName = "http://ed-fi.org/identity/claims/ed-fi/exportGrandchild";
+
+            response.Name.Should().Be(ClaimSetName);
+            response.IsSystemReserved.Should().BeFalse();
+            response.ResourceClaims.Should().HaveCount(2);
+            response.ResourceClaims.Should().NotContain(rc => rc.ClaimName == GrandchildClaimName);
+
+            var rootClaim = response.ResourceClaims!.Single(rc => rc.ClaimName == RootClaimName);
+            rootClaim.Name.Should().Be("exportRoot");
+            rootClaim.ParentClaimName.Should().BeNull();
+            rootClaim.Actions.Should().ContainSingle(action => action.Name == "Read");
+            rootClaim.Actions.Should().NotContain(action => action.Name == "Update");
+            rootClaim
+                .DefaultAuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.ActionName == "Read");
+            rootClaim
+                .DefaultAuthorizationStrategies[0]
+                .AuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.AuthorizationStrategyName == "DefaultRootStrategy");
+            rootClaim.AuthorizationStrategyOverrides.Should().BeEmpty();
+
+            var childClaim = response.ResourceClaims!.Single(rc => rc.ClaimName == ChildClaimName);
+            childClaim.Name.Should().Be("exportChild");
+            childClaim.ParentClaimName.Should().Be(RootClaimName);
+            childClaim.Actions.Should().ContainSingle(action => action.Name == "Read");
+            childClaim.Actions.Should().ContainSingle(action => action.Name == "Update");
+            childClaim
+                .DefaultAuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.ActionName == "Read");
+            childClaim
+                .DefaultAuthorizationStrategies[0]
+                .AuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.AuthorizationStrategyName == "DefaultChildStrategy");
+            childClaim
+                .AuthorizationStrategyOverrides.Should()
+                .ContainSingle(strategy => strategy.ActionName == "Read");
+            childClaim
+                .AuthorizationStrategyOverrides[0]
+                .AuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.AuthorizationStrategyName == "OverrideChildStrategy");
         }
     }
 
@@ -677,12 +949,13 @@ public class ClaimSetTests : DatabaseTest
         }
 
         [Test]
-        public async Task Should_get_duplicate_failure()
+        public async Task Should_upsert_existing_claim_set_on_import()
         {
             ClaimSetImportCommand claimSetDup = new() { Name = "Test-Import-ClaimSet", ResourceClaims = [] };
 
             var resultDup = await _repository.Import(claimSetDup);
-            resultDup.Should().BeOfType<ClaimSetImportResult.FailureDuplicateClaimSetName>();
+            resultDup.Should().BeOfType<ClaimSetImportResult.Success>();
+            ((ClaimSetImportResult.Success)resultDup).Id.Should().Be(_id);
         }
 
         [Test]
@@ -700,6 +973,160 @@ public class ClaimSetTests : DatabaseTest
                 .FailureMessage.Should()
                 .Be("Claims hierarchy not found.");
         }
+
+        [Test]
+        public async Task Should_return_system_reserved_failure_when_import_targets_existing_system_reserved_claim_set()
+        {
+            var systemReservedInsert = await _repository.InsertClaimSet(
+                new ClaimSetInsertCommand { Name = "Test-Import-System-Reserved", IsSystemReserved = true }
+            );
+            var systemReservedId = ((ClaimSetInsertResult.Success)systemReservedInsert).Id;
+
+            var result = await _repository.Import(
+                new ClaimSetImportCommand { Name = "Test-Import-System-Reserved", ResourceClaims = [] }
+            );
+
+            result.Should().BeOfType<ClaimSetImportResult.FailureSystemReserved>();
+
+            var getByIdResult = await _repository.GetClaimSet(systemReservedId);
+            getByIdResult.Should().BeOfType<ClaimSetGetResult.Success>();
+            ((ClaimSetGetResult.Success)getByIdResult).ClaimSetResponse.IsSystemReserved.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_round_trip_export_payload_back_into_import()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy(clearOnly: true);
+
+            var claimsHierarchyRepository = new ClaimsHierarchyRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<ClaimsHierarchyRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var claimsHierarchy = BuildRoundTripHierarchy();
+            var saveResult = await claimsHierarchyRepository.SaveClaimsHierarchy(
+                claimsHierarchy,
+                DateTime.UtcNow
+            );
+            saveResult.Should().BeOfType<ClaimsHierarchySaveResult.Success>();
+
+            var command = new ClaimSetImportCommand
+            {
+                Name = "Test-Import-RoundTrip",
+                ResourceClaims =
+                [
+                    new ResourceClaim
+                    {
+                        ClaimName = "http://ed-fi.org/identity/claims/domains/roundTripRoot",
+                        Actions =
+                        [
+                            new ResourceClaimAction { Name = "Read", Enabled = true },
+                            new ResourceClaimAction { Name = "Update", Enabled = false },
+                        ],
+                    },
+                    new ResourceClaim
+                    {
+                        ClaimName = "http://ed-fi.org/identity/claims/ed-fi/roundTripChild",
+                        ParentClaimName = "http://ed-fi.org/identity/claims/domains/roundTripRoot",
+                        Actions =
+                        [
+                            new ResourceClaimAction { Name = "Read", Enabled = true },
+                            new ResourceClaimAction { Name = "Delete", Enabled = true },
+                        ],
+                        AuthorizationStrategyOverrides =
+                        [
+                            new ClaimSetResourceClaimActionAuthStrategies
+                            {
+                                ActionName = "Read",
+                                AuthorizationStrategies =
+                                [
+                                    new EdFi.DmsConfigurationService.DataModel.Model.ClaimSets.AuthorizationStrategy
+                                    {
+                                        AuthorizationStrategyName = "OverrideRoundTripStrategy",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            };
+
+            var firstImport = await _repository.Import(command);
+            firstImport.Should().BeOfType<ClaimSetImportResult.Success>();
+            var claimSetId = ((ClaimSetImportResult.Success)firstImport).Id;
+
+            var exportResult = await _repository.Export(claimSetId);
+            exportResult.Should().BeOfType<ClaimSetExportResult.Success>();
+
+            var exportResponse = ((ClaimSetExportResult.Success)exportResult).ClaimSetExportResponse;
+            exportResponse.ResourceClaims.Should().HaveCount(2);
+            exportResponse
+                .ResourceClaims.Should()
+                .NotContain(rc => rc.Actions!.Any(action => action.Name == "Update"));
+
+            var roundTripJson = JsonSerializer.Serialize(
+                exportResponse,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            );
+            var roundTripCommand = JsonSerializer.Deserialize<ClaimSetImportCommand>(
+                roundTripJson,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)
+            );
+
+            roundTripCommand.Should().NotBeNull();
+            roundTripCommand!.Name.Should().Be(command.Name);
+            roundTripCommand.ResourceClaims.Should().HaveCount(2);
+
+            var roundTripRoot = roundTripCommand.ResourceClaims!.Single(rc =>
+                rc.ClaimName == "http://ed-fi.org/identity/claims/domains/roundTripRoot"
+            );
+            roundTripRoot.Actions.Should().ContainSingle(action => action.Name == "Read");
+            roundTripRoot.Actions.Should().NotContain(action => action.Name == "Update");
+
+            var roundTripChild = roundTripCommand.ResourceClaims!.Single(rc =>
+                rc.ClaimName == "http://ed-fi.org/identity/claims/ed-fi/roundTripChild"
+            );
+            roundTripChild
+                .ParentClaimName.Should()
+                .Be("http://ed-fi.org/identity/claims/domains/roundTripRoot");
+            roundTripChild
+                .AuthorizationStrategyOverrides.Should()
+                .ContainSingle(overrideStrategy => overrideStrategy.ActionName == "Read");
+            roundTripChild
+                .AuthorizationStrategyOverrides[0]
+                .AuthorizationStrategies.Should()
+                .ContainSingle(strategy => strategy.AuthorizationStrategyName == "OverrideRoundTripStrategy");
+
+            var secondImport = await _repository.Import(roundTripCommand);
+            secondImport.Should().BeOfType<ClaimSetImportResult.Success>();
+            ((ClaimSetImportResult.Success)secondImport).Id.Should().Be(claimSetId);
+
+            var finalGet = await _repository.GetClaimSet(claimSetId);
+            finalGet.Should().BeOfType<ClaimSetGetResult.Success>();
+            ((ClaimSetGetResult.Success)finalGet).ClaimSetResponse.ResourceClaims.Should().HaveCount(2);
+        }
+
+        private static List<Claim> BuildRoundTripHierarchy()
+        {
+            return
+            [
+                new Claim
+                {
+                    Name = "http://ed-fi.org/identity/claims/domains/roundTripRoot",
+                    ClaimSets = [new ClaimSet { Name = "Test-Import-RoundTrip" }],
+                    Claims =
+                    [
+                        new Claim
+                        {
+                            Name = "http://ed-fi.org/identity/claims/ed-fi/roundTripChild",
+                            ClaimSets = [new ClaimSet { Name = "Test-Import-RoundTrip" }],
+                            Claims = [],
+                        },
+                    ],
+                },
+            ];
+        }
     }
 
     [TestFixture]
@@ -711,6 +1138,8 @@ public class ClaimSetTests : DatabaseTest
         [SetUp]
         public async Task Setup()
         {
+            await EnsureClaimsDataLoaded();
+
             ClaimSetInsertCommand claimSet = new() { Name = "Original-ClaimSet" };
 
             var result = await _repository.InsertClaimSet(claimSet);
@@ -732,7 +1161,11 @@ public class ClaimSetTests : DatabaseTest
             var result = await _repository.QueryClaimSet(new ClaimSetQuery() { Limit = 25, Offset = 0 });
             result.Should().BeOfType<ClaimSetQueryResult.Success>();
 
-            ((ClaimSetQueryResult.Success)result).ClaimSetResponses.Count().Should().Be(2);
+            var claimSetNames = ((ClaimSetQueryResult.Success)result)
+                .ClaimSetResponses.Select(cs => cs.Name)
+                .ToList();
+            claimSetNames.Should().Contain("Original-ClaimSet");
+            claimSetNames.Should().Contain("Copy-Test-ClaimSet");
         }
 
         [Test]
@@ -755,6 +1188,88 @@ public class ClaimSetTests : DatabaseTest
 
             var reducedResponse2 = (ClaimSetResponse)claimSetFromDb2;
             reducedResponse2.Name.Should().Be("Copy-Test-ClaimSet");
+        }
+
+        [Test]
+        public async Task Should_clone_configured_hierarchy_assignments_when_copying_claim_set()
+        {
+            await ClaimsHierarchyTestHelper.ReinitializeClaimsHierarchy();
+
+            var importResult = await _repository.Import(
+                new ClaimSetImportCommand
+                {
+                    Name = "Original-With-Permissions",
+                    ResourceClaims =
+                    [
+                        new ResourceClaim
+                        {
+                            ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                            Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                            AuthorizationStrategyOverrides =
+                            [
+                                new ClaimSetResourceClaimActionAuthStrategies
+                                {
+                                    ActionName = "Read",
+                                    AuthorizationStrategies =
+                                    [
+                                        new EdFi.DmsConfigurationService.DataModel.Model.ClaimSets.AuthorizationStrategy
+                                        {
+                                            AuthorizationStrategyName = "NoFurtherAuthorizationRequired",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                }
+            );
+            if (importResult is ClaimSetImportResult.FailureUnknown failureUnknown)
+            {
+                Assert.Fail(failureUnknown.FailureMessage);
+            }
+            importResult.Should().BeOfType<ClaimSetImportResult.Success>();
+            var originalId = ((ClaimSetImportResult.Success)importResult).Id;
+
+            var copyResult = await _repository.Copy(
+                new ClaimSetCopyCommand { OriginalId = originalId, Name = "Copied-With-Permissions" }
+            );
+            var copiedId = ((ClaimSetCopyResult.Success)copyResult).Id;
+
+            var copied = (ClaimSetGetResult.Success)await _repository.GetClaimSet(copiedId);
+            var resourceClaim = copied
+                .ClaimSetResponse.ResourceClaims.Should()
+                .ContainSingle(rc => rc.ClaimName == "http://ed-fi.org/identity/claims/ed-fi/school")
+                .Which;
+            resourceClaim.Actions.Should().ContainSingle(a => a.Name == "Read");
+            resourceClaim.AuthorizationStrategyOverrides.Should().ContainSingle(o => o.ActionName == "Read");
+        }
+
+        [Test]
+        public async Task Should_copy_system_reserved_claim_set_as_non_system_reserved()
+        {
+            var insertReservedResult = await _repository.InsertClaimSet(
+                new ClaimSetInsertCommand { Name = "Original-System-Reserved", IsSystemReserved = true }
+            );
+            var originalReservedId = ((ClaimSetInsertResult.Success)insertReservedResult).Id;
+
+            var copyResult = await _repository.Copy(
+                new ClaimSetCopyCommand
+                {
+                    OriginalId = originalReservedId,
+                    Name = "Copied-From-System-Reserved",
+                }
+            );
+            copyResult.Should().BeOfType<ClaimSetCopyResult.Success>();
+            var copiedId = ((ClaimSetCopyResult.Success)copyResult).Id;
+
+            var copied = await _repository.GetClaimSet(copiedId);
+            copied.Should().BeOfType<ClaimSetGetResult.Success>();
+            ((ClaimSetGetResult.Success)copied).ClaimSetResponse.IsSystemReserved.Should().BeFalse();
+
+            var updateResult = await _repository.UpdateClaimSet(
+                new ClaimSetUpdateCommand { Id = copiedId, Name = "Copied-System-Reserved-Updated" }
+            );
+            updateResult.Should().BeOfType<ClaimSetUpdateResult.Success>();
         }
     }
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
@@ -4,11 +4,13 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data;
+using System.Data.Common;
 using System.Text.Json;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
 using EdFi.DmsConfigurationService.Backend.Repositories;
 using EdFi.DmsConfigurationService.Backend.Services;
+using EdFi.DmsConfigurationService.DataModel;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
@@ -146,8 +148,7 @@ public class ClaimSetRepository(
             return new ClaimSetInsertResult.Success(id);
         }
         catch (PostgresException ex)
-            when (ex.SqlState == PostgresErrorCodes.UniqueViolation && ex.Message.Contains("idx_claimsetname")
-            )
+            when (ex is { SqlState: PostgresErrorCodes.UniqueViolation, ConstraintName: "idx_claimsetname" })
         {
             logger.LogWarning(ex, "ClaimSetName must be unique");
             await transaction.RollbackAsync();
@@ -232,7 +233,7 @@ public class ClaimSetRepository(
                     Id = row.id,
                     Name = row.claimsetname,
                     IsSystemReserved = row.issystemreserved,
-                    Applications = JsonDocument.Parse(row.applications?.ToString() ?? "{}").RootElement,
+                    Applications = ParseApplications(row.applications),
                 })
                 .ToList();
 
@@ -272,15 +273,16 @@ public class ClaimSetRepository(
                 return new ClaimSetGetResult.FailureNotFound();
             }
 
-            var returnClaimSet = (
-                claimSets.Select(result => new ClaimSetResponse
-                {
-                    Id = result.id,
-                    Name = result.claimsetname,
-                    IsSystemReserved = result.issystemreserved,
-                    Applications = JsonDocument.Parse(result.applications?.ToString() ?? "{}").RootElement,
-                })
-            ).Single();
+            var hierarchyResult = await claimsHierarchyRepository.GetClaimsHierarchy();
+            if (hierarchyResult is not ClaimsHierarchyGetResult.Success hierarchy)
+            {
+                return new ClaimSetGetResult.FailureUnknown(
+                    GetClaimsHierarchyFailureMessage(hierarchyResult)
+                );
+            }
+
+            var row = claimSets.Single();
+            var returnClaimSet = CreateClaimSetResponse(row, hierarchy.Claims);
 
             return new ClaimSetGetResult.Success(returnClaimSet);
         }
@@ -509,6 +511,8 @@ public class ClaimSetRepository(
     public async Task<ClaimSetDeleteResult> DeleteClaimSet(long id)
     {
         await using var connection = new NpgsqlConnection(databaseOptions.Value.DatabaseConnection);
+        await connection.OpenAsync();
+        await using var transaction = await connection.BeginTransactionAsync();
         try
         {
             // Get the current claim set (including system-reserved for proper error messages)
@@ -521,31 +525,96 @@ public class ClaimSetRepository(
             var existingClaimSet = await connection.QuerySingleOrDefaultAsync<(
                 string claimSetName,
                 bool isSystemReserved
-            )>(getClaimSetSql, new { Id = id, TenantId });
+            )>(getClaimSetSql, new { Id = id, TenantId }, transaction);
 
             if (existingClaimSet == default)
             {
+                await transaction.RollbackAsync();
                 return new ClaimSetDeleteResult.FailureNotFound();
             }
 
             if (existingClaimSet.isSystemReserved)
             {
+                await transaction.RollbackAsync();
                 return new ClaimSetDeleteResult.FailureSystemReserved();
             }
 
             string sql = $"""
                 DELETE FROM dmscs.ClaimSet WHERE Id = @Id AND {TenantContext.TenantWhereClause()}
                 """;
-            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id, TenantId });
+            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id, TenantId }, transaction);
 
-            return affectedRows > 0
-                ? new ClaimSetDeleteResult.Success()
-                : new ClaimSetDeleteResult.FailureNotFound();
+            if (affectedRows == 0)
+            {
+                await transaction.RollbackAsync();
+                return new ClaimSetDeleteResult.FailureNotFound();
+            }
+
+            var hierarchyResult = await claimsHierarchyRepository.GetClaimsHierarchy(transaction);
+            var deleteResult = hierarchyResult switch
+            {
+                ClaimsHierarchyGetResult.Success success => await RemoveFromHierarchyAndSave(
+                    existingClaimSet.claimSetName,
+                    success.Claims,
+                    success.LastModifiedDate,
+                    transaction
+                ),
+                ClaimsHierarchyGetResult.FailureHierarchyNotFound => new ClaimSetDeleteResult.Success(),
+                ClaimsHierarchyGetResult.FailureMultipleHierarchiesFound =>
+                    new ClaimSetDeleteResult.FailureMultipleHierarchiesFound(),
+                ClaimsHierarchyGetResult.FailureUnknown failureUnknown =>
+                    new ClaimSetDeleteResult.FailureUnknown(failureUnknown.FailureMessage),
+                _ => new ClaimSetDeleteResult.FailureUnknown(
+                    $"Unhandled ClaimsHierarchyGetResult of type '{hierarchyResult.GetType().Name}'"
+                ),
+            };
+
+            if (deleteResult is ClaimSetDeleteResult.Success)
+            {
+                await transaction.CommitAsync();
+            }
+            else
+            {
+                await transaction.RollbackAsync();
+            }
+
+            return deleteResult;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Delete claim set failure");
+            await transaction.RollbackAsync();
             return new ClaimSetDeleteResult.FailureUnknown(ex.Message);
+        }
+
+        async Task<ClaimSetDeleteResult> RemoveFromHierarchyAndSave(
+            string claimSetName,
+            List<Claim> claims,
+            DateTime lastModifiedDate,
+            DbTransaction deleteTransaction
+        )
+        {
+            claimsHierarchyManager.RemoveClaimSetFromHierarchy(claimSetName, claims);
+            var saveResult = await claimsHierarchyRepository.SaveClaimsHierarchy(
+                claims,
+                lastModifiedDate,
+                deleteTransaction
+            );
+
+            return saveResult switch
+            {
+                ClaimsHierarchySaveResult.Success => new ClaimSetDeleteResult.Success(),
+                ClaimsHierarchySaveResult.FailureHierarchyNotFound => new ClaimSetDeleteResult.Success(),
+                ClaimsHierarchySaveResult.FailureMultipleHierarchiesFound =>
+                    new ClaimSetDeleteResult.FailureMultipleHierarchiesFound(),
+                ClaimsHierarchySaveResult.FailureMultiUserConflict =>
+                    new ClaimSetDeleteResult.FailureMultiUserConflict(),
+                ClaimsHierarchySaveResult.FailureUnknown failureUnknown =>
+                    new ClaimSetDeleteResult.FailureUnknown(failureUnknown.FailureMessage),
+                _ => new ClaimSetDeleteResult.FailureUnknown(
+                    $"Unhandled ClaimsHierarchySaveResult of type '{saveResult.GetType().Name}'"
+                ),
+            };
         }
     }
 
@@ -572,21 +641,45 @@ public class ClaimSetRepository(
                 return new ClaimSetExportResult.FailureNotFound();
             }
 
-            var returnClaimSet = claimSets.Select(result => new ClaimSetExportResponse
+            var hierarchyResult = await claimsHierarchyRepository.GetClaimsHierarchy();
+            if (hierarchyResult is not ClaimsHierarchyGetResult.Success hierarchy)
             {
-                Id = result.id,
-                Name = result.claimsetname,
-                IsSystemReserved = result.issystemreserved,
-                Applications = JsonDocument.Parse(result.applications?.ToString() ?? "{}").RootElement,
-            });
+                return new ClaimSetExportResult.FailureUnknown(
+                    GetClaimsHierarchyFailureMessage(hierarchyResult)
+                );
+            }
 
-            return new ClaimSetExportResult.Success(returnClaimSet.Single());
+            var row = claimSets.Single();
+            var returnClaimSet = CreateClaimSetResponse(row, hierarchy.Claims);
+
+            return new ClaimSetExportResult.Success(
+                new ClaimSetExportResponse
+                {
+                    Id = returnClaimSet.Id,
+                    Name = returnClaimSet.Name,
+                    IsSystemReserved = returnClaimSet.IsSystemReserved,
+                    Applications = returnClaimSet.Applications,
+                    ResourceClaims = returnClaimSet.ResourceClaims,
+                }
+            );
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Get claim set failure");
             return new ClaimSetExportResult.FailureUnknown(ex.Message);
         }
+    }
+
+    private static string GetClaimsHierarchyFailureMessage(ClaimsHierarchyGetResult hierarchyResult)
+    {
+        return hierarchyResult switch
+        {
+            ClaimsHierarchyGetResult.FailureHierarchyNotFound => "Claims hierarchy not found.",
+            ClaimsHierarchyGetResult.FailureMultipleHierarchiesFound =>
+                "Multiple claims hierarchies found when exactly one was expected.",
+            ClaimsHierarchyGetResult.FailureUnknown failureUnknown => failureUnknown.FailureMessage,
+            _ => $"Unhandled ClaimsHierarchyGetResult of type '{hierarchyResult.GetType().Name}'",
+        };
     }
 
     public async Task<ClaimSetImportResult> Import(ClaimSetImportCommand command)
@@ -602,28 +695,14 @@ public class ClaimSetRepository(
 
         try
         {
-            // Check if the claim set already exists (including system-reserved to prevent naming conflicts)
-            string checkSql = $"""
-                    SELECT Id FROM dmscs.ClaimSet WHERE ClaimSetName = @ClaimSetName AND {ClaimSetWhereClause()};
-                """;
-            var existingClaimSetId = await connection.QuerySingleOrDefaultAsync<long?>(
-                checkSql,
-                new { ClaimSetName = command.Name, TenantId },
-                transaction
-            );
-
-            if (existingClaimSetId != null)
-            {
-                return new ClaimSetImportResult.FailureDuplicateClaimSetName();
-            }
-
-            // Insert new claim set
             string insertSql = """
-                    INSERT INTO dmscs.ClaimSet (ClaimSetName, IsSystemReserved, CreatedBy, TenantId)
-                    VALUES(@ClaimSetName, @IsSystemReserved, @CreatedBy, @TenantId)
-                    RETURNING Id;
+                INSERT INTO dmscs.ClaimSet (ClaimSetName, IsSystemReserved, CreatedBy, TenantId)
+                VALUES (@ClaimSetName, @IsSystemReserved, @CreatedBy, @TenantId)
+                ON CONFLICT (ClaimSetName) DO NOTHING
+                RETURNING Id, IsSystemReserved, TenantId;
                 """;
-            existingClaimSetId = await connection.ExecuteScalarAsync<long>(
+
+            var claimSet = await connection.QuerySingleOrDefaultAsync<ClaimSetImportLookupResult>(
                 insertSql,
                 new
                 {
@@ -634,6 +713,40 @@ public class ClaimSetRepository(
                 },
                 transaction
             );
+
+            if (claimSet is null)
+            {
+                string existingSql = """
+                    SELECT Id, IsSystemReserved, TenantId
+                    FROM dmscs.ClaimSet
+                    WHERE ClaimSetName = @ClaimSetName;
+                    """;
+
+                claimSet = await connection.QuerySingleOrDefaultAsync<ClaimSetImportLookupResult>(
+                    existingSql,
+                    new { ClaimSetName = command.Name },
+                    transaction
+                );
+            }
+
+            if (claimSet is null)
+            {
+                throw new InvalidOperationException("Claim set upsert did not return a record.");
+            }
+
+            if (claimSet.IsSystemReserved)
+            {
+                await transaction.RollbackAsync();
+                return new ClaimSetImportResult.FailureSystemReserved();
+            }
+
+            if (claimSet.TenantId != TenantId)
+            {
+                await transaction.RollbackAsync();
+                return new ClaimSetImportResult.FailureDuplicateClaimSetName();
+            }
+
+            long claimSetId = claimSet.Id;
 
             var claimsHierarchyResult = await claimsHierarchyRepository.GetClaimsHierarchy(transaction);
 
@@ -667,7 +780,26 @@ public class ClaimSetRepository(
             claimsHierarchyManager.RemoveClaimSetFromHierarchy(command.Name, claimsHierarchy);
 
             // Apply imported claim set metadata
-            claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(command, claimsHierarchy);
+            var skippedClaims = claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(
+                command,
+                claimsHierarchy
+            );
+
+            if (skippedClaims.Count > 0)
+            {
+                string sanitizedClaimSetName = LoggingUtility.SanitizeForLog(command.Name);
+                string sanitizedSkippedClaims = string.Join(
+                    ", ",
+                    skippedClaims.Select(LoggingUtility.SanitizeForLog)
+                );
+
+                logger.LogWarning(
+                    "Skipped {SkippedCount} claims while importing claim set {ClaimSetName}: {SkippedClaims}",
+                    skippedClaims.Count,
+                    sanitizedClaimSetName,
+                    sanitizedSkippedClaims
+                );
+            }
 
             // Save the JSON hierarchy with optimistic locking
             var retryPolicy = Policy
@@ -697,7 +829,28 @@ public class ClaimSetRepository(
 
                         // Apply the changes to the refreshed claims hierarchy
                         claimsHierarchyManager.RemoveClaimSetFromHierarchy(command.Name, claimsHierarchy!);
-                        claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(command, claimsHierarchy!);
+                        var retriedSkippedClaims = claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(
+                            command,
+                            claimsHierarchy!
+                        );
+
+                        if (retriedSkippedClaims.Count > 0)
+                        {
+                            string sanitizedClaimSetName = LoggingUtility.SanitizeForLog(command.Name);
+                            string sanitizedRetriedSkippedClaims = string.Join(
+                                ", ",
+                                retriedSkippedClaims.Select(LoggingUtility.SanitizeForLog)
+                            );
+
+                            logger.LogWarning(
+                                "Skipped {SkippedCount} claims while reapplying claim set {ClaimSetName}: {SkippedClaims}",
+                                retriedSkippedClaims.Count,
+                                sanitizedClaimSetName,
+                                sanitizedRetriedSkippedClaims
+                            );
+                        }
+
+                        skippedClaims = retriedSkippedClaims;
                     }
                 );
 
@@ -723,9 +876,10 @@ public class ClaimSetRepository(
             });
 
             await transaction.CommitAsync();
-            return new ClaimSetImportResult.Success(existingClaimSetId.Value);
+            return new ClaimSetImportResult.Success(claimSetId, skippedClaims);
         }
-        catch (PostgresException ex) when (ex.SqlState == "23505" && ex.Message.Contains("idx_claimsetname"))
+        catch (PostgresException ex)
+            when (ex is { SqlState: PostgresErrorCodes.UniqueViolation, ConstraintName: "idx_claimsetname" })
         {
             logger.LogWarning(ex, "ClaimSetName must be unique");
             await transaction.RollbackAsync();
@@ -738,6 +892,8 @@ public class ClaimSetRepository(
             return new ClaimSetImportResult.FailureUnknown(ex.Message);
         }
     }
+
+    private sealed record ClaimSetImportLookupResult(long Id, bool IsSystemReserved, long? TenantId);
 
     public async Task<ClaimSetCopyResult> Copy(ClaimSetCopyCommand command)
     {
@@ -761,6 +917,7 @@ public class ClaimSetRepository(
 
             if (originalClaimSet == null)
             {
+                await transaction.RollbackAsync();
                 return new ClaimSetCopyResult.FailureNotFound();
             }
 
@@ -775,16 +932,51 @@ public class ClaimSetRepository(
                 new
                 {
                     ClaimSetName = command.Name,
-                    IsSystemReserved = (bool)originalClaimSet.issystemreserved,
+                    IsSystemReserved = false,
                     CreatedBy = auditContext.GetCurrentUser(),
                     TenantId,
                 },
                 transaction
             );
 
-            await transaction.CommitAsync();
+            var hierarchyResult = await claimsHierarchyRepository.GetClaimsHierarchy(transaction);
+            var copyResult = hierarchyResult switch
+            {
+                ClaimsHierarchyGetResult.Success success => await CloneAndSaveHierarchy(
+                    (string)originalClaimSet.claimsetname,
+                    command.Name,
+                    success.Claims,
+                    success.LastModifiedDate,
+                    transaction,
+                    newId
+                ),
+                ClaimsHierarchyGetResult.FailureHierarchyNotFound => new ClaimSetCopyResult.Success(newId),
+                ClaimsHierarchyGetResult.FailureMultipleHierarchiesFound =>
+                    new ClaimSetCopyResult.FailureMultipleHierarchiesFound(),
+                ClaimsHierarchyGetResult.FailureUnknown failureUnknown =>
+                    new ClaimSetCopyResult.FailureUnknown(failureUnknown.FailureMessage),
+                _ => new ClaimSetCopyResult.FailureUnknown(
+                    $"Unhandled ClaimsHierarchyGetResult of type '{hierarchyResult.GetType().Name}'"
+                ),
+            };
 
-            return new ClaimSetCopyResult.Success(newId);
+            if (copyResult is ClaimSetCopyResult.Success)
+            {
+                await transaction.CommitAsync();
+            }
+            else
+            {
+                await transaction.RollbackAsync();
+            }
+
+            return copyResult;
+        }
+        catch (PostgresException ex)
+            when (ex is { SqlState: PostgresErrorCodes.UniqueViolation, ConstraintName: "idx_claimsetname" })
+        {
+            logger.LogWarning(ex, "ClaimSetName must be unique");
+            await transaction.RollbackAsync();
+            return new ClaimSetCopyResult.FailureDuplicateClaimSetName();
         }
         catch (Exception ex)
         {
@@ -792,5 +984,143 @@ public class ClaimSetRepository(
             await transaction.RollbackAsync();
             return new ClaimSetCopyResult.FailureUnknown(ex.Message);
         }
+
+        async Task<ClaimSetCopyResult> CloneAndSaveHierarchy(
+            string sourceClaimSetName,
+            string targetClaimSetName,
+            List<Claim> claims,
+            DateTime lastModifiedDate,
+            DbTransaction copyTransaction,
+            long copiedId
+        )
+        {
+            claimsHierarchyManager.CloneClaimSetInHierarchy(sourceClaimSetName, targetClaimSetName, claims);
+            var saveResult = await claimsHierarchyRepository.SaveClaimsHierarchy(
+                claims,
+                lastModifiedDate,
+                copyTransaction
+            );
+
+            return saveResult switch
+            {
+                ClaimsHierarchySaveResult.Success => new ClaimSetCopyResult.Success(copiedId),
+                ClaimsHierarchySaveResult.FailureHierarchyNotFound => new ClaimSetCopyResult.Success(
+                    copiedId
+                ),
+                ClaimsHierarchySaveResult.FailureMultipleHierarchiesFound =>
+                    new ClaimSetCopyResult.FailureMultipleHierarchiesFound(),
+                ClaimsHierarchySaveResult.FailureMultiUserConflict =>
+                    new ClaimSetCopyResult.FailureMultiUserConflict(),
+                ClaimsHierarchySaveResult.FailureUnknown failureUnknown =>
+                    new ClaimSetCopyResult.FailureUnknown(failureUnknown.FailureMessage),
+                _ => new ClaimSetCopyResult.FailureUnknown(
+                    $"Unhandled ClaimsHierarchySaveResult of type '{saveResult.GetType().Name}'"
+                ),
+            };
+        }
+    }
+
+    private static ClaimSetResponse CreateClaimSetResponse(dynamic row, List<Claim> hierarchy)
+    {
+        var claimSetName = (string)row.claimsetname;
+        return new ClaimSetResponse
+        {
+            Id = row.id,
+            Name = claimSetName,
+            IsSystemReserved = row.issystemreserved,
+            Applications = ParseApplications(row.applications),
+            ResourceClaims = BuildResourceClaims(claimSetName, hierarchy),
+        };
+    }
+
+    private static JsonElement ParseApplications(object? applications)
+    {
+        using var document = JsonDocument.Parse(applications?.ToString() ?? "[]");
+        return document.RootElement.Clone();
+    }
+
+    private static List<ResourceClaim> BuildResourceClaims(string claimSetName, IEnumerable<Claim> claims)
+    {
+        var resourceClaims = new List<ResourceClaim>();
+
+        foreach (var claim in claims)
+        {
+            AddResourceClaims(claim, null);
+        }
+
+        return resourceClaims;
+
+        void AddResourceClaims(Claim claim, string? parentClaimName)
+        {
+            var matchingClaimSet = claim.ClaimSets.Find(cs =>
+                cs.Name.Equals(claimSetName, StringComparison.OrdinalIgnoreCase)
+            );
+
+            if (matchingClaimSet is not null)
+            {
+                resourceClaims.Add(
+                    new ResourceClaim
+                    {
+                        Name = GetLeafName(claim.Name),
+                        ClaimName = claim.Name,
+                        ParentClaimName = parentClaimName,
+                        Actions = matchingClaimSet
+                            .Actions.Select(action => new ResourceClaimAction
+                            {
+                                Name = action.Name,
+                                Enabled = true,
+                            })
+                            .ToList(),
+                        DefaultAuthorizationStrategies =
+                            claim
+                                .DefaultAuthorization?.Actions.Select(
+                                    defaultAction => new ClaimSetResourceClaimActionAuthStrategies
+                                    {
+                                        ActionName = defaultAction.Name,
+                                        AuthorizationStrategies = defaultAction
+                                            .AuthorizationStrategies.Select(
+                                                strategy => new AuthorizationStrategy
+                                                {
+                                                    AuthorizationStrategyName = strategy.Name,
+                                                }
+                                            )
+                                            .ToList(),
+                                    }
+                                )
+                                .ToList()
+                            ?? [],
+                        AuthorizationStrategyOverrides = matchingClaimSet
+                            .Actions.Where(action =>
+                                action.AuthorizationStrategyOverrides != null
+                                && action.AuthorizationStrategyOverrides.Any()
+                            )
+                            .Select(action => new ClaimSetResourceClaimActionAuthStrategies
+                            {
+                                ActionName = action.Name,
+                                AuthorizationStrategies = action
+                                    .AuthorizationStrategyOverrides.Select(
+                                        strategy => new AuthorizationStrategy
+                                        {
+                                            AuthorizationStrategyName = strategy.Name,
+                                        }
+                                    )
+                                    .ToList(),
+                            })
+                            .ToList(),
+                    }
+                );
+            }
+
+            foreach (var childClaim in claim.Claims)
+            {
+                AddResourceClaims(childClaim, claim.Name);
+            }
+        }
+    }
+
+    private static string GetLeafName(string claimName)
+    {
+        int lastSlashIndex = claimName.LastIndexOf('/');
+        return lastSlashIndex >= 0 ? claimName[(lastSlashIndex + 1)..] : claimName;
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
@@ -169,6 +169,7 @@ public class ClaimSetRepository(
     {
         ["id"] = "c.Id",
         ["name"] = "c.ClaimSetName",
+        ["claimSetName"] = "c.ClaimSetName",
     };
 
     private static string BuildOrderByClause(ClaimSetQuery query)

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimSetRepository.cs
@@ -916,7 +916,7 @@ public class ClaimSetRepository(
                 transaction
             );
 
-            if (originalClaimSet == null)
+            if (originalClaimSet is null)
             {
                 await transaction.RollbackAsync();
                 return new ClaimSetCopyResult.FailureNotFound();
@@ -1092,7 +1092,7 @@ public class ClaimSetRepository(
                             ?? [],
                         AuthorizationStrategyOverrides = matchingClaimSet
                             .Actions.Where(action =>
-                                action.AuthorizationStrategyOverrides != null
+                                action.AuthorizationStrategyOverrides is not null
                                 && action.AuthorizationStrategyOverrides.Any()
                             )
                             .Select(action => new ClaimSetResourceClaimActionAuthStrategies

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimsHierarchyRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ClaimsHierarchyRepository.cs
@@ -31,7 +31,10 @@ public class ClaimsHierarchyRepository(
             string sql = "SELECT Id, Hierarchy, LastModifiedDate FROM dmscs.ClaimsHierarchy";
 
             var hierarchyTuples = (
-                await connection.QueryAsync<(long id, string hierarchyJson, DateTime lastModifiedDate)>(sql)
+                await connection.QueryAsync<(long id, string hierarchyJson, DateTime lastModifiedDate)>(
+                    sql,
+                    transaction: transaction
+                )
             ).ToList();
 
             if (hierarchyTuples.Count == 0)
@@ -100,7 +103,10 @@ public class ClaimsHierarchyRepository(
             const string SelectSql = "SELECT id, lastmodifieddate FROM dmscs.ClaimsHierarchy";
 
             var existingRecords = (
-                await connection.QueryAsync<(long Id, DateTime LastModifiedDate)>(SelectSql)
+                await connection.QueryAsync<(long Id, DateTime LastModifiedDate)>(
+                    SelectSql,
+                    transaction: transaction
+                )
             ).ToList();
 
             if (existingRecords.Count > 1)
@@ -118,7 +124,8 @@ public class ClaimsHierarchyRepository(
 
                 await connection.ExecuteAsync(
                     InsertSql,
-                    new { Hierarchy = hierarchyJson, CreatedBy = auditContext.GetCurrentUser() }
+                    new { Hierarchy = hierarchyJson, CreatedBy = auditContext.GetCurrentUser() },
+                    transaction
                 );
             }
             else
@@ -149,7 +156,8 @@ public class ClaimsHierarchyRepository(
                         LastModifiedDate = existingLastModifiedDate,
                         LastModifiedAt = auditContext.GetCurrentTimestamp(),
                         ModifiedBy = auditContext.GetCurrentUser(),
-                    }
+                    },
+                    transaction
                 );
 
                 // In the remote chance a multi-user conflict happened since the last check, we need to respond with a failure.

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Infrastructure/FailureResponseTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Infrastructure/FailureResponseTests.cs
@@ -131,11 +131,32 @@ public class FailureResponseTests
             ?.GetValue<string>()
             .Should()
             .Be("Data validation failed. See 'validationErrors' for details.");
-        result["type"]?.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:data-validation-failed");
+        result["type"]?.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:data");
         result["title"]?.GetValue<string>().Should().Be("Data Validation Failed");
         result["status"]?.GetValue<int>().Should().Be(400);
         result["correlationId"]?.GetValue<string>().Should().Be(CorrelationId);
         result["validationErrors"]?.AsObject().Count.Should().Be(2);
+    }
+
+    [Test]
+    public void ForNonUniqueIdentity_ShouldReturnCorrectJsonNode()
+    {
+        // Arrange
+        string detail =
+            "The identifying value(s) of the item are the same as another item that already exists.";
+        string[] errors = ["A claim set with this name already exists."];
+
+        // Act
+        var result = FailureResponse.ForNonUniqueIdentity(detail, CorrelationId, errors);
+
+        // Assert
+        result.Should().BeOfType<JsonObject>();
+        result["detail"]?.GetValue<string>().Should().Be(detail);
+        result["type"]?.GetValue<string>().Should().Be("urn:ed-fi:api:conflict:non-unique-identity");
+        result["title"]?.GetValue<string>().Should().Be("Identifying Values Are Not Unique");
+        result["status"]?.GetValue<int>().Should().Be(409);
+        result["correlationId"]?.GetValue<string>().Should().Be(CorrelationId);
+        result["errors"]?.AsArray().Should().ContainSingle(error => error!.GetValue<string>() == errors[0]);
     }
 
     [Test]

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/ClaimSets/ClaimSetCommandTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/ClaimSets/ClaimSetCommandTests.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
+using FluentAssertions;
+
+namespace EdFi.DmsConfigurationService.Backend.Tests.Unit.Model.ClaimSets;
+
+[TestFixture]
+public class Given_ClaimSetCommands
+{
+    [Test]
+    public void It_validates_insert_command_names()
+    {
+        var validator = new ClaimSetInsertCommand.Validator();
+
+        var result = validator.Validate(
+            new ClaimSetInsertCommand { Name = "ValidClaimSet", IsSystemReserved = false }
+        );
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_validates_update_command_names()
+    {
+        var validator = new ClaimSetUpdateCommand.Validator();
+
+        var result = validator.Validate(new ClaimSetUpdateCommand { Id = 1, Name = "ValidClaimSet" });
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_validates_copy_command_names()
+    {
+        var validator = new ClaimSetCopyCommand.Validator();
+
+        var result = validator.Validate(new ClaimSetCopyCommand { OriginalId = 1, Name = "ValidClaimSet" });
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/ClaimSets/ResourceClaimValidatorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/ClaimSets/ResourceClaimValidatorTests.cs
@@ -42,7 +42,7 @@ public class ResourceClaimValidatorTests
         {
             Name = "Resource1",
             Actions = [new() { Name = "Create", Enabled = true }],
-            DefaultAuthorizationStrategiesForCRUD =
+            DefaultAuthorizationStrategies =
             [
                 new()
                 {
@@ -78,7 +78,7 @@ public class ResourceClaimValidatorTests
     }
 
     [Test]
-    public void Validate_WithResourceClaimNotInSystem_ShouldFailValidation()
+    public void Validate_WithResourceClaimNotInSystem_ShouldRecordSkippedResourceWarning()
     {
         // Arrange
         var resourceClaim = new ResourceClaim
@@ -100,7 +100,13 @@ public class ResourceClaimValidatorTests
         );
 
         // Assert
-        Failures(context).Should().Contain(e => e.ErrorMessage.Contains("not in the system"));
+        Failures(context).Should().BeEmpty();
+        context
+            .RootContextData["SkippedResourceClaims"]
+            .Should()
+            .BeOfType<List<string>>()
+            .Which.Should()
+            .ContainSingle("NonExistentResource");
     }
 
     [Test]
@@ -138,6 +144,51 @@ public class ResourceClaimValidatorTests
     }
 
     [Test]
+    public void Validate_WithCaseOnlyDuplicateResourceClaims_ShouldFailValidation()
+    {
+        // Arrange
+        var firstResourceClaim = new ResourceClaim
+        {
+            Name = "Resource1",
+            Actions = [new() { Name = "Create", Enabled = true }],
+        };
+
+        var secondResourceClaim = new ResourceClaim
+        {
+            Name = "resource1",
+            Actions = [new() { Name = "Create", Enabled = true }],
+        };
+
+        var parentClaimByResourceClaim = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Resource1", null },
+        };
+
+        var context = new ValidationContext<object>(new object());
+
+        // Act
+        _validator.Validate(
+            _actionNames,
+            _authorizationStrategyNames,
+            firstResourceClaim,
+            parentClaimByResourceClaim,
+            context,
+            "ClaimSet1"
+        );
+        _validator.Validate(
+            _actionNames,
+            _authorizationStrategyNames,
+            secondResourceClaim,
+            parentClaimByResourceClaim,
+            context,
+            "ClaimSet1"
+        );
+
+        // Assert
+        Failures(context).Should().Contain(e => e.ErrorMessage.Contains("duplicate resource"));
+    }
+
+    [Test]
     public void Validate_WithInvalidActions_ShouldFailValidation()
     {
         // Arrange
@@ -164,14 +215,14 @@ public class ResourceClaimValidatorTests
     }
 
     [Test]
-    public void Validate_WithInvalidAuthorizationStrategies_ShouldFailValidation()
+    public void Validate_WithInvalidAuthorizationStrategies_ShouldNotFailValidation()
     {
         // Arrange
         var resourceClaim = new ResourceClaim
         {
             Name = "Resource1",
             Actions = [new() { Name = "Create", Enabled = true }],
-            DefaultAuthorizationStrategiesForCRUD =
+            DefaultAuthorizationStrategies =
             [
                 new()
                 {
@@ -194,7 +245,42 @@ public class ResourceClaimValidatorTests
         );
 
         // Assert
-        Failures(context).Should().Contain(e => e.ErrorMessage.Contains("not in the system"));
+        Failures(context).Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validate_ShouldIgnoreInvalidDefaultAuthorizationStrategiesDuringImport()
+    {
+        // Arrange
+        var resourceClaim = new ResourceClaim
+        {
+            Name = "Resource1",
+            ClaimName = "Resource1",
+            Actions = [new() { Name = "Create", Enabled = true }],
+            DefaultAuthorizationStrategies =
+            [
+                new()
+                {
+                    ActionName = "Create",
+                    AuthorizationStrategies = [new() { AuthorizationStrategyName = "InvalidStrategy" }],
+                },
+            ],
+        };
+
+        var context = new ValidationContext<object>(new object());
+
+        // Act
+        _validator.Validate(
+            _actionNames,
+            _authorizationStrategyNames,
+            resourceClaim,
+            _parentClaimByResourceClaim,
+            context,
+            "ClaimSet1"
+        );
+
+        // Assert
+        Failures(context).Should().BeEmpty();
     }
 
     [Test]
@@ -205,7 +291,7 @@ public class ResourceClaimValidatorTests
         {
             Name = "Resource1",
             Actions = [new() { Name = "Create", Enabled = true }],
-            AuthorizationStrategyOverridesForCRUD =
+            AuthorizationStrategyOverrides =
             [
                 new()
                 {
@@ -256,5 +342,42 @@ public class ResourceClaimValidatorTests
 
         // Assert
         Failures(context).Should().BeEmpty();
+    }
+
+    [Test]
+    public void Validate_WithMismatchedFlatParentClaimName_ShouldRecordParentWarning()
+    {
+        // Arrange
+        var resourceClaim = new ResourceClaim
+        {
+            Name = "Resource2",
+            ClaimName = "Resource2",
+            ParentClaimName = "WrongParent",
+            Actions = [new() { Name = "Create", Enabled = true }],
+        };
+
+        var context = new ValidationContext<object>(new object());
+
+        // Act
+        _validator.Validate(
+            _actionNames,
+            _authorizationStrategyNames,
+            resourceClaim,
+            _parentClaimByResourceClaim,
+            context,
+            "ClaimSet1"
+        );
+
+        // Assert
+        Failures(context).Should().BeEmpty();
+        context.RootContextData.Should().ContainKey("ParentWarnings");
+        context
+            .RootContextData["ParentWarnings"]
+            .Should()
+            .BeOfType<List<string>>()
+            .Which.Should()
+            .ContainSingle(warning =>
+                warning.Contains("Resource2") && warning.Contains("Correct parent resource is: 'Resource1'")
+            );
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Models/ClaimsHierarchy/ClaimsHierarchyManagerTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Models/ClaimsHierarchy/ClaimsHierarchyManagerTests.cs
@@ -72,7 +72,7 @@ public class ClaimsHierarchyManagerTests
                 {
                     Name = "Claim1",
                     Actions = [new() { Name = "Read", Enabled = true }],
-                    AuthorizationStrategyOverridesForCRUD =
+                    AuthorizationStrategyOverrides =
                     [
                         new()
                         {
@@ -179,5 +179,149 @@ public class ClaimsHierarchyManagerTests
         claims[1].Claims[0].ClaimSets[0].Actions.Should().ContainSingle(a => a.Name == "Read");
         claims[1].Claims[0].ClaimSets[0].Actions.Should().ContainSingle(a => a.Name == "Update");
         claims[1].Claims[0].ClaimSets[0].Actions.Should().ContainSingle(a => a.Name == "Delete");
+    }
+
+    [Test]
+    public void ApplyImportedClaimSetToHierarchy_ShouldSkipExistingClaimSetAndReturnWarnings()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new()
+            {
+                Name = "Claim1",
+                ClaimSets = new List<ClaimSet> { new() { Name = "ExistingClaimSet" } },
+            },
+        };
+
+        var command = new ClaimSetImportCommand
+        {
+            Name = "ExistingClaimSet",
+            ResourceClaims = new List<ResourceClaim>
+            {
+                new()
+                {
+                    Name = "Claim1",
+                    Actions = new List<ResourceClaimAction>
+                    {
+                        new() { Name = "Read", Enabled = true },
+                    },
+                },
+            },
+        };
+
+        // Act
+        var warnings = _claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(command, claims);
+
+        // Assert
+        warnings.Should().ContainSingle().Which.Should().Be("Claim1");
+        claims[0].ClaimSets.Should().HaveCount(1);
+    }
+
+    [Test]
+    public void CloneClaimSetInHierarchy_ShouldCloneActionsAndOverrides()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new()
+            {
+                Name = "http://ed-fi.org/identity/claims/ed-fi/school",
+                ClaimSets =
+                [
+                    new()
+                    {
+                        Name = "Original",
+                        Actions =
+                        [
+                            new()
+                            {
+                                Name = "Read",
+                                AuthorizationStrategyOverrides =
+                                [
+                                    new EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy.AuthorizationStrategy
+                                    {
+                                        Name = "NoFurtherAuthorizationRequired",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        // Act
+        _claimsHierarchyManager.CloneClaimSetInHierarchy("Original", "Copy", claims);
+
+        // Assert
+        claims[0].ClaimSets.Should().ContainSingle(cs => cs.Name == "Original");
+        var copied = claims[0].ClaimSets.Should().ContainSingle(cs => cs.Name == "Copy").Which;
+        copied.Actions.Should().ContainSingle(a => a.Name == "Read");
+        copied
+            .Actions[0]
+            .AuthorizationStrategyOverrides.Should()
+            .ContainSingle(s => s.Name == "NoFurtherAuthorizationRequired");
+    }
+
+    [Test]
+    public void ApplyImportedClaimSetToHierarchy_ShouldUseClaimNameBeforeDisplayName()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new() { Name = "http://ed-fi.org/identity/claims/ed-fi/school", ClaimSets = [] },
+        };
+        var command = new ClaimSetImportCommand
+        {
+            Name = "Imported",
+            ResourceClaims =
+            [
+                new ResourceClaim
+                {
+                    Name = "wrong-short-name",
+                    ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                },
+            ],
+        };
+
+        // Act
+        var warnings = _claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(command, claims);
+
+        // Assert
+        warnings.Should().BeEmpty();
+        claims[0].ClaimSets.Should().ContainSingle(cs => cs.Name == "Imported");
+    }
+
+    [Test]
+    public void ApplyImportedClaimSetToHierarchy_ShouldMatchClaimUrisAndClaimSetNames_IgnoringCase()
+    {
+        // Arrange
+        var claims = new List<Claim>
+        {
+            new() { Name = "HTTP://ED-FI.ORG/IDENTITY/CLAIMS/ED-FI/SCHOOL", ClaimSets = [] },
+        };
+
+        var command = new ClaimSetImportCommand
+        {
+            Name = "mixedcase-claimset",
+            ResourceClaims =
+            [
+                new ResourceClaim
+                {
+                    ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                },
+            ],
+        };
+
+        // Act
+        var warnings = _claimsHierarchyManager.ApplyImportedClaimSetToHierarchy(command, claims);
+
+        // Assert
+        warnings.Should().BeEmpty();
+        claims[0].ClaimSets.Should().ContainSingle(cs => cs.Name == "mixedcase-claimset");
+        claims[0].ClaimSets[0].Actions.Should().ContainSingle(action => action.Name == "Read");
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
@@ -202,7 +202,7 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
     {
         return resourceClaim
             .AuthorizationStrategyOverrides.Where(overrideAction =>
-                overrideAction.ActionName != null
+                overrideAction.ActionName is not null
                 && overrideAction.ActionName.Equals(actionName, StringComparison.OrdinalIgnoreCase)
             )
             .ToList();

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Models/ClaimsHierarchy/ClaimsHierarchyManager.cs
@@ -10,7 +10,10 @@ namespace EdFi.DmsConfigurationService.Backend.Models.ClaimsHierarchy;
 public interface IClaimsHierarchyManager
 {
     void RemoveClaimSetFromHierarchy(string claimSetName, List<Claim> claims);
-    void ApplyImportedClaimSetToHierarchy(ClaimSetImportCommand command, List<Claim> claims);
+
+    void CloneClaimSetInHierarchy(string sourceClaimSetName, string targetClaimSetName, List<Claim> claims);
+
+    IReadOnlyList<string> ApplyImportedClaimSetToHierarchy(ClaimSetImportCommand command, List<Claim> claims);
 }
 
 public class ClaimsHierarchyManager : IClaimsHierarchyManager
@@ -21,7 +24,6 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
         {
             claim.ClaimSets.RemoveAll(cs => cs.Name.Equals(claimSetName, StringComparison.OrdinalIgnoreCase));
 
-            // Process down the hierarchy, recursively
             if (claim.Claims.Any())
             {
                 RemoveClaimSetFromHierarchy(claimSetName, claim.Claims);
@@ -29,99 +31,180 @@ public class ClaimsHierarchyManager : IClaimsHierarchyManager
         }
     }
 
-    public void ApplyImportedClaimSetToHierarchy(ClaimSetImportCommand command, List<Claim> claims)
+    public void CloneClaimSetInHierarchy(
+        string sourceClaimSetName,
+        string targetClaimSetName,
+        List<Claim> claims
+    )
     {
-        // Perform basic validation check (command should already be validated)
-        if (string.IsNullOrEmpty(command.Name) || command.ResourceClaims == null)
+        foreach (var claim in claims)
+        {
+            var source = claim.ClaimSets.Find(cs =>
+                cs.Name.Equals(sourceClaimSetName, StringComparison.OrdinalIgnoreCase)
+            );
+
+            if (
+                source is not null
+                && !claim.ClaimSets.Exists(cs =>
+                    cs.Name.Equals(targetClaimSetName, StringComparison.OrdinalIgnoreCase)
+                )
+            )
+            {
+                claim.ClaimSets.Add(
+                    new ClaimSet
+                    {
+                        Name = targetClaimSetName,
+                        Actions =
+                        [
+                            .. source.Actions.Select(action => new ClaimSetAction
+                            {
+                                Name = action.Name,
+                                AuthorizationStrategyOverrides =
+                                [
+                                    .. action.AuthorizationStrategyOverrides.Select(
+                                        strategy => new AuthorizationStrategy { Name = strategy.Name }
+                                    ),
+                                ],
+                            }),
+                        ],
+                    }
+                );
+            }
+
+            if (claim.Claims.Any())
+            {
+                CloneClaimSetInHierarchy(sourceClaimSetName, targetClaimSetName, claim.Claims);
+            }
+        }
+    }
+
+    public IReadOnlyList<string> ApplyImportedClaimSetToHierarchy(
+        ClaimSetImportCommand command,
+        List<Claim> claims
+    )
+    {
+        if (string.IsNullOrEmpty(command.Name) || command.ResourceClaims is null)
         {
             throw new NullReferenceException(
                 "Claim set name or resource claims are null on the import command."
             );
         }
 
-        ApplyImportedClaimSetToHierarchy(command.Name, command.ResourceClaims, claims);
-    }
+        var skippedClaimNames = new List<string>();
+        var claimsByName = BuildClaimLookup(claims);
 
-    private void ApplyImportedClaimSetToHierarchy(
-        string claimSetName,
-        List<ResourceClaim> importResourceClaims,
-        List<Claim> claims
-    )
-    {
-        // Logic to apply imported claim set metadata to the hierarchy
-        // This should ignore authorizationStrategyOverridesForCRUD with isInheritedFromParent == true
-        // Implement the logic based on the structure of ClaimSetImportCommand
-        foreach (var resourceClaim in importResourceClaims)
+        foreach (var resourceClaim in Flatten(command.ResourceClaims))
         {
-            // Find or create the claim in the hierarchy
-            var claim = claims.Find(c => c.Name == resourceClaim.Name);
+            var claimName = resourceClaim.ClaimName ?? resourceClaim.Name;
 
-            // If the claim is not found, throw an exception
-            // NOTE: The command for the import should already have been validated at this point, so this is purely a defensive check
-            if (claim == null)
+            if (string.IsNullOrWhiteSpace(claimName))
             {
-                throw new Exception(
-                    $"Claim '{resourceClaim.Name}' not found in hierarchy and cannot be imported."
-                );
+                continue;
             }
 
-            // Find or create the ClaimSet for the metadata in the claims hierarchy
-            // NOTE: It is expected that all claim set information will have been removed by a call to RemoveClaimSetFromHierarchy
-            var claimSet = claim.ClaimSets.Find(cs => cs.Name == claimSetName);
-
-            if (claimSet != null)
+            if (!claimsByName.TryGetValue(claimName, out var claim))
             {
-                throw new InvalidOperationException(
-                    "The claim set already exists in the hierarchy, but it should not have been removed first with a call to RemoveClaimSetFromHierarchy."
-                );
+                skippedClaimNames.Add(claimName);
+                continue;
             }
 
-            // Create and initialize the claim set
-            claimSet = new ClaimSet { Name = claimSetName, Actions = [] };
+            var claimSet = claim.ClaimSets.Find(cs =>
+                cs.Name.Equals(command.Name, StringComparison.OrdinalIgnoreCase)
+            );
 
+            if (claimSet is not null)
+            {
+                // Record as skipped and continue rather than throwing to allow graceful handling by callers.
+                skippedClaimNames.Add(claimName);
+                continue;
+            }
+
+            claimSet = new ClaimSet { Name = command.Name, Actions = [] };
             claim.ClaimSets.Add(claimSet);
 
-            if (resourceClaim.Actions != null)
+            if (resourceClaim.Actions is not { Count: > 0 })
             {
-                // Add actions with overrides (if present) from the ResourceClaim
-                foreach (var actionName in resourceClaim.Actions.Where(a => a.Enabled).Select(a => a.Name))
-                {
-                    // Create the action for the claim set
-                    var newAction = new ClaimSetAction
-                    {
-                        Name = actionName ?? "",
-                        AuthorizationStrategyOverrides = [],
-                    };
-
-                    // Look for overrides on import command
-                    var overrideForCrud = resourceClaim.AuthorizationStrategyOverridesForCRUD.SingleOrDefault(
-                        x => x?.ActionName == actionName
-                    );
-
-                    // If overrides for the action are present, apply them
-                    if (overrideForCrud is { AuthorizationStrategies: not null })
-                    {
-                        // Apply authorization strategy overrides
-                        newAction.AuthorizationStrategyOverrides =
-                        [
-                            .. overrideForCrud.AuthorizationStrategies.Select(
-                                strategy => new AuthorizationStrategy
-                                {
-                                    Name = strategy.AuthorizationStrategyName,
-                                }
-                            ),
-                        ];
-                    }
-
-                    claimSet.Actions.Add(newAction);
-                }
+                continue;
             }
 
-            // Recursively apply to child claims, but only if there are still resource claims to be imported
-            if (resourceClaim.Children.Count != 0 && claim.Claims.Count != 0)
+            foreach (
+                var actionName in resourceClaim
+                    .Actions.Where(action => action.Enabled)
+                    .Select(action => action.Name)
+                    .Where(name => !string.IsNullOrWhiteSpace(name))
+            )
             {
-                ApplyImportedClaimSetToHierarchy(claimSetName, resourceClaim.Children, claim.Claims);
+                var newAction = new ClaimSetAction
+                {
+                    Name = actionName!,
+                    AuthorizationStrategyOverrides = [],
+                };
+
+                var overrides = GetAuthorizationStrategyOverrides(resourceClaim, actionName!);
+
+                if (overrides.Count > 0)
+                {
+                    newAction.AuthorizationStrategyOverrides =
+                    [
+                        .. overrides
+                            .SelectMany(overrideAction => overrideAction.AuthorizationStrategies ?? [])
+                            .Select(strategy => new AuthorizationStrategy
+                            {
+                                Name = strategy.AuthorizationStrategyName,
+                            }),
+                    ];
+                }
+
+                claimSet.Actions.Add(newAction);
             }
         }
+
+        return skippedClaimNames;
+    }
+
+    private static Dictionary<string, Claim> BuildClaimLookup(IEnumerable<Claim> claims)
+    {
+        var claimLookup = new Dictionary<string, Claim>(StringComparer.OrdinalIgnoreCase);
+
+        void AddClaims(IEnumerable<Claim> currentClaims)
+        {
+            foreach (var claim in currentClaims)
+            {
+                claimLookup[claim.Name] = claim;
+                AddClaims(claim.Claims);
+            }
+        }
+
+        AddClaims(claims);
+        return claimLookup;
+    }
+
+    private static IEnumerable<ResourceClaim> Flatten(IEnumerable<ResourceClaim> resourceClaims)
+    {
+        foreach (var resourceClaim in resourceClaims)
+        {
+            yield return resourceClaim;
+
+            if (resourceClaim.Children.Count > 0)
+            {
+                foreach (var childResourceClaim in Flatten(resourceClaim.Children))
+                {
+                    yield return childResourceClaim;
+                }
+            }
+        }
+    }
+
+    private static List<ClaimSetResourceClaimActionAuthStrategies> GetAuthorizationStrategyOverrides(
+        ResourceClaim resourceClaim,
+        string actionName
+    )
+    {
+        return resourceClaim
+            .AuthorizationStrategyOverrides.Where(overrideAction =>
+                overrideAction.ActionName != null
+                && overrideAction.ActionName.Equals(actionName, StringComparison.OrdinalIgnoreCase)
+            )
+            .ToList();
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IClaimSetRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend/Repositories/IClaimSetRepository.cs
@@ -126,6 +126,16 @@ public record ClaimSetDeleteResult
     public record FailureSystemReserved() : ClaimSetDeleteResult();
 
     /// <summary>
+    /// Multiple hierarchies were found in the configuration store (not currently supported).
+    /// </summary>
+    public record FailureMultipleHierarchiesFound() : ClaimSetDeleteResult();
+
+    /// <summary>
+    /// Persistent multi-user conflicts prevent delete attempts.
+    /// </summary>
+    public record FailureMultiUserConflict() : ClaimSetDeleteResult();
+
+    /// <summary>
     /// Unexpected exception thrown and caught
     /// </summary>
     public record FailureUnknown(string FailureMessage) : ClaimSetDeleteResult();
@@ -162,6 +172,21 @@ public record ClaimSetCopyResult
     public record FailureNotFound() : ClaimSetCopyResult();
 
     /// <summary>
+    /// ClaimSetName must be unique
+    /// </summary>
+    public record FailureDuplicateClaimSetName() : ClaimSetCopyResult();
+
+    /// <summary>
+    /// Multiple hierarchies were found in the configuration store (not currently supported).
+    /// </summary>
+    public record FailureMultipleHierarchiesFound() : ClaimSetCopyResult();
+
+    /// <summary>
+    /// Persistent multi-user conflicts prevent copy attempts.
+    /// </summary>
+    public record FailureMultiUserConflict() : ClaimSetCopyResult();
+
+    /// <summary>
     /// Unexpected exception thrown and caught
     /// </summary>
     public record FailureUnknown(string FailureMessage) : ClaimSetCopyResult();
@@ -173,7 +198,7 @@ public record ClaimSetImportResult
     /// Successful insert.
     /// </summary>
     /// <param name="Id">The Id of the inserted record.</param>
-    public record Success(long Id) : ClaimSetImportResult();
+    public record Success(long Id, IEnumerable<string>? Warnings = null) : ClaimSetImportResult();
 
     /// <summary>
     /// Unexpected exception thrown and caught
@@ -184,6 +209,11 @@ public record ClaimSetImportResult
     /// ClaimSetName must be unique
     /// </summary>
     public record FailureDuplicateClaimSetName() : ClaimSetImportResult();
+
+    /// <summary>
+    /// Attempt was made to modify a system reserved claim set.
+    /// </summary>
+    public record FailureSystemReserved() : ClaimSetImportResult();
 }
 
 public record AuthorizationStrategyGetResult

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/FailureResponse.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Infrastructure/FailureResponse.cs
@@ -118,13 +118,27 @@ public static class FailureResponse
     ) =>
         CreateBaseJsonObject(
             detail: "Data validation failed. See 'validationErrors' for details.",
-            type: $"{_badRequestTypePrefix}:data-validation-failed",
+            type: $"{_badRequestTypePrefix}:data",
             title: "Data Validation Failed",
             status: 400,
             correlationId: correlationId,
             validationFailures
                 .GroupBy(x => x.PropertyName)
                 .ToDictionary(g => g.Key, g => g.Select(x => x.ErrorMessage).ToArray())
+        );
+
+    public static JsonNode ForNonUniqueIdentity(
+        string detail,
+        string correlationId,
+        string[]? errors = null
+    ) =>
+        CreateBaseJsonObject(
+            detail: detail,
+            type: $"{_conflictTypePrefix}:non-unique-identity",
+            title: "Identifying Values Are Not Unique",
+            status: 409,
+            correlationId: correlationId,
+            errors: errors
         );
 
     public static JsonNode ForBadGateway(string detail, string correlationId, string[]? errors = null) =>

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/AuthorizationStrategyListJsonConverter.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/AuthorizationStrategyListJsonConverter.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
+
+public class AuthorizationStrategyListJsonConverter : JsonConverter<List<AuthorizationStrategy>>
+{
+    public override List<AuthorizationStrategy> Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return [];
+        }
+
+        using var document = JsonDocument.ParseValue(ref reader);
+        var strategies = new List<AuthorizationStrategy>();
+
+        foreach (var element in document.RootElement.EnumerateArray())
+        {
+            string? strategyName = null;
+
+            if (element.TryGetProperty("authStrategyName", out var authStrategyNameProperty))
+            {
+                strategyName = authStrategyNameProperty.GetString();
+            }
+            else if (element.TryGetProperty("name", out var nameProperty))
+            {
+                strategyName = nameProperty.GetString();
+            }
+
+            if (string.IsNullOrWhiteSpace(strategyName))
+            {
+                continue;
+            }
+
+            strategies.Add(new AuthorizationStrategy { AuthorizationStrategyName = strategyName });
+        }
+
+        return strategies;
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        List<AuthorizationStrategy> value,
+        JsonSerializerOptions options
+    )
+    {
+        writer.WriteStartArray();
+
+        foreach (var strategy in value)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("authStrategyName", strategy.AuthorizationStrategyName);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+    }
+}

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetCopyCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetCopyCommand.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text.Json.Serialization;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
@@ -10,6 +11,8 @@ namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 public class ClaimSetCopyCommand
 {
     public long OriginalId { get; set; }
+
+    [JsonPropertyName("claimSetName")]
     public required string Name { get; set; }
 
     public class Validator : AbstractValidator<ClaimSetCopyCommand>

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetExportResponse.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetExportResponse.cs
@@ -3,19 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 
-public class ClaimSetExportResponse
-{
-    public long Id { get; set; }
-    public required string Name { get; set; }
-
-    [JsonPropertyName("_isSystemReserved")]
-    public required bool IsSystemReserved { get; set; }
-
-    [JsonPropertyName("_applications")]
-    public JsonElement? Applications { get; set; }
-}
+public class ClaimSetExportResponse : ClaimSetResponse { }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetImportCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetImportCommand.cs
@@ -3,10 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 
 public class ClaimSetImportCommand : IClaimSetCommand
 {
+    [JsonPropertyName("claimSetName")]
     public string? Name { get; set; }
 
     public List<ResourceClaim>? ResourceClaims { get; set; }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetInsertCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetInsertCommand.cs
@@ -3,10 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 
 public class ClaimSetInsertCommand : IClaimSetCommand
 {
+    [JsonPropertyName("claimSetName")]
     public required string Name { get; set; }
 
     public bool IsSystemReserved { get; set; }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetResponse.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetResponse.cs
@@ -12,6 +12,7 @@ public class ClaimSetResponse
 {
     public long Id { get; set; }
 
+    [JsonPropertyName("claimSetName")]
     public required string Name { get; set; }
 
     [JsonPropertyName("_isSystemReserved")]
@@ -19,4 +20,7 @@ public class ClaimSetResponse
 
     [JsonPropertyName("_applications")]
     public JsonElement? Applications { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<ResourceClaim>? ResourceClaims { get; set; }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetUpdateCommand.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ClaimSetUpdateCommand.cs
@@ -3,11 +3,15 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text.Json.Serialization;
+
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 
 public class ClaimSetUpdateCommand : IClaimSetCommand
 {
     public long Id { get; set; }
+
+    [JsonPropertyName("claimSetName")]
     public required string Name { get; set; }
 
     public class Validator() : ClaimSetCommandValidator<ClaimSetUpdateCommand>();

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaim.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaim.cs
@@ -9,16 +9,23 @@ namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
 
 public class ResourceClaim
 {
-    public int Id { get; set; }
     public string? Name { get; set; }
+
+    [JsonPropertyName("claimName")]
+    public string? ClaimName { get; set; }
+
+    [JsonPropertyName("parentClaimName")]
+    public string? ParentClaimName { get; set; }
+
     public List<ResourceClaimAction>? Actions { get; set; }
 
-    [JsonPropertyName("_defaultAuthorizationStrategiesForCrud")]
-    public List<ClaimSetResourceClaimActionAuthStrategies?> DefaultAuthorizationStrategiesForCRUD { get; set; } =
-    [];
-    public List<ClaimSetResourceClaimActionAuthStrategies?> AuthorizationStrategyOverridesForCRUD { get; set; } =
-    [];
+    [JsonPropertyName("_defaultAuthorizationStrategies")]
+    public List<ClaimSetResourceClaimActionAuthStrategies> DefaultAuthorizationStrategies { get; set; } = [];
 
+    [JsonPropertyName("authorizationStrategyOverrides")]
+    public List<ClaimSetResourceClaimActionAuthStrategies> AuthorizationStrategyOverrides { get; set; } = [];
+
+    [JsonIgnore]
     public List<ResourceClaim> Children { get; set; } = [];
 }
 
@@ -31,6 +38,9 @@ public class ResourceClaimAction
 public class ClaimSetResourceClaimActionAuthStrategies
 {
     public int? ActionId { get; set; }
+
     public string? ActionName { get; set; }
-    public IEnumerable<AuthorizationStrategy>? AuthorizationStrategies { get; set; }
+
+    [JsonConverter(typeof(AuthorizationStrategyListJsonConverter))]
+    public List<AuthorizationStrategy>? AuthorizationStrategies { get; set; }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using FluentValidation;
 
 namespace EdFi.DmsConfigurationService.DataModel.Model.ClaimSets;
@@ -19,16 +20,17 @@ public class ResourceClaimValidator
     )
     {
         const string PropertyName = "ResourceClaims";
+        string? resourceClaimName = resourceClaim.ClaimName ?? resourceClaim.Name;
 
         context.MessageFormatter.AppendArgument("Name", claimSetName);
-        context.MessageFormatter.AppendArgument("ResourceClaimName", resourceClaim.Name);
+        context.MessageFormatter.AppendArgument("ResourceClaimName", resourceClaimName);
 
-        ValidateResourceClaimExists(context, resourceClaim, parentClaimByResourceClaim, PropertyName);
+        ValidateResourceClaimExists(context, resourceClaimName, parentClaimByResourceClaim, PropertyName);
 
-        ValidateNoDuplicateResourceClaims(resourceClaim, context, PropertyName);
+        ValidateNoDuplicateResourceClaims(resourceClaimName, context, PropertyName);
         ValidateActions(resourceClaim.Actions, actionNames, context, PropertyName);
-        ValidateAuthStrategies(authorizationStrategyNames, resourceClaim, context, PropertyName);
         ValidateAuthStrategiesOverride(authorizationStrategyNames, resourceClaim, context, PropertyName);
+        ValidateParentClaimName(resourceClaim, parentClaimByResourceClaim, context);
 
         ValidateChildren(
             actionNames,
@@ -43,22 +45,85 @@ public class ResourceClaimValidator
 
     private static void ValidateResourceClaimExists<T>(
         ValidationContext<T> context,
-        ResourceClaim resourceClaim,
+        string? resourceClaimName,
         IDictionary<string, string?> parentClaimByResourceClaim,
         string propertyName
     )
     {
-        if (!parentClaimByResourceClaim.ContainsKey(resourceClaim.Name!))
+        // Use propertyName to satisfy analyzer when the method intentionally records warnings instead of failures
+        _ = propertyName;
+
+        if (
+            string.IsNullOrWhiteSpace(resourceClaimName)
+            || !parentClaimByResourceClaim.ContainsKey(resourceClaimName)
+        )
         {
-            context.AddFailure(
-                propertyName,
-                "This Claim Set contains a resource which is not in the system. ClaimSet Name: '{Name}' Resource name: '{ResourceClaimName}'"
-            );
+            // Record skipped resource claim as a warning for later processing (do not fail validation)
+            if (
+                !context.RootContextData.TryGetValue("SkippedResourceClaims", out var skippedObj)
+                || skippedObj is not List<string> skippedList
+            )
+            {
+                skippedList = new List<string>();
+                context.RootContextData["SkippedResourceClaims"] = skippedList;
+            }
+
+            skippedList.Add(resourceClaimName ?? string.Empty);
+            return;
         }
     }
 
-    private static void ValidateNoDuplicateResourceClaims<T>(
+    private static void ValidateParentClaimName<T>(
         ResourceClaim resourceClaim,
+        IReadOnlyDictionary<string, string?> parentClaimByResourceClaim,
+        ValidationContext<T> context
+    )
+    {
+        string? resourceClaimName = resourceClaim.ClaimName ?? resourceClaim.Name;
+
+        if (
+            string.IsNullOrWhiteSpace(resourceClaimName)
+            || !parentClaimByResourceClaim.TryGetValue(resourceClaimName, out var expectedParentClaimName)
+        )
+        {
+            return;
+        }
+
+        if (
+            string.Equals(
+                resourceClaim.ParentClaimName,
+                expectedParentClaimName,
+                StringComparison.OrdinalIgnoreCase
+            )
+        )
+        {
+            return;
+        }
+
+        if (
+            string.IsNullOrWhiteSpace(resourceClaim.ParentClaimName)
+            && string.IsNullOrWhiteSpace(expectedParentClaimName)
+        )
+        {
+            return;
+        }
+
+        if (
+            !context.RootContextData.TryGetValue("ParentWarnings", out var parentWarningsObject)
+            || parentWarningsObject is not List<string> parentWarnings
+        )
+        {
+            parentWarnings = [];
+            context.RootContextData["ParentWarnings"] = parentWarnings;
+        }
+
+        parentWarnings.Add(
+            $"Child resource '{resourceClaimName}' added to the wrong parent resource. Correct parent resource is: '{expectedParentClaimName}'."
+        );
+    }
+
+    private static void ValidateNoDuplicateResourceClaims<T>(
+        string? resourceClaimName,
         ValidationContext<T> context,
         string propertyName
     )
@@ -71,7 +136,7 @@ public class ResourceClaimValidator
             || seenObject is not HashSet<string> seenResources
         )
         {
-            seenResources = [];
+            seenResources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             rootData["SeenResourceClaims"] = seenResources;
         }
 
@@ -80,11 +145,11 @@ public class ResourceClaimValidator
             || duplicatesObject is not HashSet<string> duplicateResources
         )
         {
-            duplicateResources = [];
+            duplicateResources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             rootData["DuplicateResources"] = duplicateResources;
         }
 
-        string? resourceKey = resourceClaim.Name;
+        string? resourceKey = resourceClaimName;
 
         if (
             !string.IsNullOrWhiteSpace(resourceKey)
@@ -109,6 +174,9 @@ public class ResourceClaimValidator
         string propertyName
     )
     {
+        // Use propertyName to satisfy analyzer when warnings are recorded instead of validation failures
+        _ = propertyName;
+
         if (resourceClaim.Children.Count != 0)
         {
             foreach (var childResourceClaim in resourceClaim.Children)
@@ -125,9 +193,18 @@ public class ResourceClaimValidator
 
                     if (expectedParentResourceName == null)
                     {
-                        context.AddFailure(
-                            propertyName,
-                            "'{ChildResource}' can not be added as a child resource."
+                        // Record a warning for a child that cannot be added as a child resource
+                        if (
+                            !context.RootContextData.TryGetValue("ParentWarnings", out var pwObj)
+                            || pwObj is not List<string> parentWarnings
+                        )
+                        {
+                            parentWarnings = new List<string>();
+                            context.RootContextData["ParentWarnings"] = parentWarnings;
+                        }
+
+                        parentWarnings.Add(
+                            $"Child resource '{childResourceClaim.Name}' cannot be added as a child resource to '{resourceClaim.Name}'."
                         );
                     }
                     else if (
@@ -138,13 +215,18 @@ public class ResourceClaimValidator
                         )
                     )
                     {
-                        context.MessageFormatter.AppendArgument(
-                            "CorrectParentResource",
-                            expectedParentResourceName
-                        );
-                        context.AddFailure(
-                            propertyName,
-                            "Child resource: '{ChildResource}' added to the wrong parent resource. Correct parent resource is: '{CorrectParentResource}'."
+                        // Record a warning for parent mismatch instead of failing validation
+                        if (
+                            !context.RootContextData.TryGetValue("ParentWarnings", out var pmObj)
+                            || pmObj is not List<string> parentWarnings
+                        )
+                        {
+                            parentWarnings = new List<string>();
+                            context.RootContextData["ParentWarnings"] = parentWarnings;
+                        }
+
+                        parentWarnings.Add(
+                            $"Child resource '{childResourceClaim.Name}' added to the wrong parent resource. Correct parent resource is: '{expectedParentResourceName}'."
                         );
                     }
                 }
@@ -168,11 +250,9 @@ public class ResourceClaimValidator
         string propertyName
     )
     {
-        if (resourceClaim.AuthorizationStrategyOverridesForCRUD.Count != 0)
+        if (resourceClaim.AuthorizationStrategyOverrides.Count != 0)
         {
-            foreach (
-                var authStrategyOverrideWithAction in resourceClaim.AuthorizationStrategyOverridesForCRUD
-            )
+            foreach (var authStrategyOverrideWithAction in resourceClaim.AuthorizationStrategyOverrides)
             {
                 if (authStrategyOverrideWithAction?.AuthorizationStrategies != null)
                 {
@@ -194,44 +274,6 @@ public class ResourceClaimValidator
                                 "This resource claim contains an authorization strategy which is not in the system. ClaimSet Name: '{Name}' Resource name: '{ResourceClaimName}' Authorization strategy: '{AuthorizationStrategyName}'."
                             );
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    private static void ValidateAuthStrategies<T>(
-        List<string> dbAuthStrategies,
-        ResourceClaim resourceClaim,
-        ValidationContext<T> context,
-        string propertyName
-    )
-    {
-        if (resourceClaim.DefaultAuthorizationStrategiesForCRUD.Count != 0)
-        {
-            foreach (var defaultASWithAction in resourceClaim.DefaultAuthorizationStrategiesForCRUD)
-            {
-                if (defaultASWithAction?.AuthorizationStrategies == null)
-                {
-                    continue;
-                }
-
-                foreach (
-                    var authStrategyName in defaultASWithAction.AuthorizationStrategies.Select(defaultAs =>
-                        defaultAs.AuthorizationStrategyName
-                    )
-                )
-                {
-                    if (authStrategyName != null && !dbAuthStrategies.Contains(authStrategyName))
-                    {
-                        context.MessageFormatter.AppendArgument(
-                            "AuthorizationStrategyName",
-                            authStrategyName
-                        );
-                        context.AddFailure(
-                            propertyName,
-                            "This resource claim contains an authorization strategy which is not in the system. ClaimSet Name: '{Name}' Resource name: '{ResourceClaimName}' Authorization strategy: '{AuthorizationStrategyName}'."
-                        );
                     }
                 }
             }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Model/ClaimSets/ResourceClaimValidator.cs
@@ -191,7 +191,7 @@ public class ResourceClaimValidator
                 {
                     context.MessageFormatter.AppendArgument("ChildResource", childResourceClaim.Name);
 
-                    if (expectedParentResourceName == null)
+                    if (expectedParentResourceName is null)
                     {
                         // Record a warning for a child that cannot be added as a child resource
                         if (

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/DataModel/ResourceClaimValidatorTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/DataModel/ResourceClaimValidatorTests.cs
@@ -74,7 +74,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -94,7 +94,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim2",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -150,7 +150,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -170,7 +170,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "NonExistingClaim",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -196,22 +196,24 @@ public class ResourceClaimValidatorTests
                 CreateResourceClaimsMap(("resourceClaim1", null))
             );
 
-            // Act
-            var validationResult = await validator.ValidateAsync(request);
+            // Act - run validation with an explicit ValidationContext so the validator's RootContextData is accessible
+            var validationContext = new ValidationContext<FakeRequest>(request);
+            var validationResult = await validator.ValidateAsync(validationContext);
 
-            // Assert
-            validationResult.IsValid.Should().BeFalse();
-            validationResult.Errors.Count.Should().Be(1);
-            validationResult
-                .Errors[0]
-                .ErrorMessage.Should()
-                .Contain(
-                    "This Claim Set contains a resource which is not in the system. ClaimSet Name: 'TestClaimset' Resource name: 'NonExistingClaim'"
-                );
+            // Assert - validator now records missing resources as warnings (not failures)
+            validationResult.IsValid.Should().BeTrue();
+
+            validationContext
+                .RootContextData.TryGetValue("SkippedResourceClaims", out var skippedObj)
+                .Should()
+                .BeTrue();
+            skippedObj.Should().BeOfType<List<string>>();
+            var skipped = (List<string>)skippedObj!;
+            skipped.Should().Contain("NonExistingClaim");
         }
 
         [Test]
-        public async Task Given_a_root_resource_claim_added_as_a_child_should_return_validation_error()
+        public async Task Given_a_root_resource_claim_added_as_a_child_should_not_fail_validation()
         {
             // Arrange
             var resourceClaims = new List<ResourceClaim>
@@ -220,7 +222,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -241,7 +243,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "resourceClaim2",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -273,12 +275,8 @@ public class ResourceClaimValidatorTests
             var validationResult = await validator.ValidateAsync(request);
 
             // Assert
-            validationResult.IsValid.Should().BeFalse();
-            validationResult.Errors.Count.Should().Be(1);
-            validationResult
-                .Errors[0]
-                .ErrorMessage.Should()
-                .Contain("'resourceClaim2' can not be added as a child resource.");
+            validationResult.IsValid.Should().BeTrue();
+            validationResult.Errors.Should().BeEmpty();
         }
 
         [Test]
@@ -291,7 +289,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "ActionNotExists" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -344,7 +342,7 @@ public class ResourceClaimValidatorTests
                         new ResourceClaimAction { Enabled = true, Name = "Read" },
                         new ResourceClaimAction { Enabled = true, Name = "Create" },
                     ],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -396,7 +394,7 @@ public class ResourceClaimValidatorTests
                         new ResourceClaimAction { Enabled = false, Name = "Create" },
                         new ResourceClaimAction { Enabled = false, Name = "Read" },
                     ],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -446,7 +444,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -485,7 +483,7 @@ public class ResourceClaimValidatorTests
         }
 
         [Test]
-        public async Task Given_a_non_existing_authorization_strategy_should_return_validation_error()
+        public async Task Given_a_non_existing_default_authorization_strategy_should_not_fail_validation()
         {
             // Arrange
             var resourceClaims = new List<ResourceClaim>
@@ -494,7 +492,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -515,7 +513,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1a",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -547,14 +545,8 @@ public class ResourceClaimValidatorTests
             var validationResult = await validator.ValidateAsync(request);
 
             // Assert
-            validationResult.IsValid.Should().BeFalse();
-            validationResult.Errors.Count.Should().Be(1);
-            validationResult
-                .Errors[0]
-                .ErrorMessage.Should()
-                .Contain(
-                    "This resource claim contains an authorization strategy which is not in the system. ClaimSet Name: 'TestClaimset' Resource name: 'childResourceClaim1a' Authorization strategy: 'InvalidAuthStrategy'."
-                );
+            validationResult.IsValid.Should().BeTrue();
+            validationResult.Errors.Should().BeEmpty();
         }
 
         [Test]
@@ -567,7 +559,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -588,7 +580,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1a",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            AuthorizationStrategyOverridesForCRUD =
+                            AuthorizationStrategyOverrides =
                             [
                                 new()
                                 {
@@ -603,7 +595,7 @@ public class ResourceClaimValidatorTests
                                     ],
                                 },
                             ],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -655,7 +647,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -675,7 +667,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -724,7 +716,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -745,7 +737,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1a",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -765,7 +757,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1b",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -787,7 +779,7 @@ public class ResourceClaimValidatorTests
                                     // This is a duplicate resource claim
                                     Name = "childResourceClaim1a",
                                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                                    DefaultAuthorizationStrategiesForCRUD =
+                                    DefaultAuthorizationStrategies =
                                     [
                                         new()
                                         {
@@ -847,7 +839,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -868,7 +860,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1a",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -888,7 +880,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1a",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -932,7 +924,7 @@ public class ResourceClaimValidatorTests
         }
 
         [Test]
-        public async Task Given_an_invalid_auth_strategy_on_child_resource_claim()
+        public async Task Given_an_invalid_default_auth_strategy_on_child_resource_claim_should_not_fail_validation()
         {
             // Arrange
             var existingResourceClaims = new List<ResourceClaim>
@@ -941,7 +933,7 @@ public class ResourceClaimValidatorTests
                 {
                     Name = "resourceClaim1",
                     Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                    DefaultAuthorizationStrategiesForCRUD =
+                    DefaultAuthorizationStrategies =
                     [
                         new()
                         {
@@ -962,7 +954,7 @@ public class ResourceClaimValidatorTests
                         {
                             Name = "childResourceClaim1",
                             Actions = [new ResourceClaimAction { Enabled = true, Name = "Create" }],
-                            DefaultAuthorizationStrategiesForCRUD =
+                            DefaultAuthorizationStrategies =
                             [
                                 new()
                                 {
@@ -993,14 +985,8 @@ public class ResourceClaimValidatorTests
             var validationResult = await validator.ValidateAsync(request);
 
             // Assert
-            validationResult.IsValid.Should().BeFalse();
-            validationResult.Errors.Count.Should().Be(1);
-            validationResult
-                .Errors[0]
-                .ErrorMessage.Should()
-                .Contain(
-                    "This resource claim contains an authorization strategy which is not in the system. ClaimSet Name: 'TestClaimset' Resource name: 'childResourceClaim1' Authorization strategy: 'InvalidAuthStrategy'."
-                );
+            validationResult.IsValid.Should().BeTrue();
+            validationResult.Errors.Should().BeEmpty();
         }
     }
 };

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Infrastructure/PagingQueryValidatorTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Infrastructure/PagingQueryValidatorTests.cs
@@ -92,4 +92,16 @@ public class Given_PagingQueryValidators
         var result = scenario.Validate();
         result.IsValid.Should().BeTrue();
     }
+
+    [Test]
+    public void Claim_set_orderBy_accepts_claim_set_name_alias()
+    {
+        var scenario = new ValidationScenario<FrontendClaimSetQuery>(
+            new ClaimSetPagingQueryValidator(),
+            new FrontendClaimSetQuery { OrderBy = "claimSetName" },
+            true
+        );
+        var result = scenario.Validate();
+        result.IsValid.Should().BeTrue();
+    }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApiClientModuleTests.cs
@@ -952,7 +952,7 @@ public class ApiClientModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1000,7 +1000,7 @@ public class ApiClientModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1102,7 +1102,7 @@ public class ApiClientModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1150,7 +1150,7 @@ public class ApiClientModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -351,7 +351,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -382,7 +382,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -435,7 +435,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -831,7 +831,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -880,7 +880,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -998,7 +998,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1047,7 +1047,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1188,7 +1188,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1237,7 +1237,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1356,7 +1356,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -1406,7 +1406,7 @@ public class ApplicationModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimSetModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimSetModuleTests.cs
@@ -1505,11 +1505,59 @@ public class ClaimSetModuleTests
         }
 
         [Test]
+        public async Task Should_return_200_with_claim_set_name_orderBy_alias()
+        {
+            ClaimSetQuery? capturedQuery = null;
+            A.CallTo(() => _claimSetRepository.QueryClaimSet(A<ClaimSetQuery>.Ignored))
+                .Invokes(call => capturedQuery = call.GetArgument<ClaimSetQuery>(0))
+                .Returns(new ClaimSetQueryResult.Success([]));
+
+            using var client = SetUpClient();
+            var response = await client.GetAsync("/v3/claimSets?orderBy=claimSetName&direction=DESC");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            capturedQuery.Should().NotBeNull();
+            capturedQuery!.OrderBy.Should().Be("claimSetName");
+        }
+
+        [Test]
         public async Task Should_return_200_when_filter_name_is_provided()
         {
             using var client = SetUpClient();
             var response = await client.GetAsync("/v3/claimSets?name=MyClaimSet");
             response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        [Test]
+        public async Task Should_bind_claim_set_name_filter_alias_to_repository_query()
+        {
+            ClaimSetQuery? capturedQuery = null;
+            A.CallTo(() => _claimSetRepository.QueryClaimSet(A<ClaimSetQuery>.Ignored))
+                .Invokes(call => capturedQuery = call.GetArgument<ClaimSetQuery>(0))
+                .Returns(new ClaimSetQueryResult.Success([]));
+
+            using var client = SetUpClient();
+            var response = await client.GetAsync("/v3/claimSets?claimSetName=MyClaimSet");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            capturedQuery.Should().NotBeNull();
+            capturedQuery!.Name.Should().Be("MyClaimSet");
+        }
+
+        [Test]
+        public async Task Should_prefer_claim_set_name_filter_when_both_aliases_are_provided()
+        {
+            ClaimSetQuery? capturedQuery = null;
+            A.CallTo(() => _claimSetRepository.QueryClaimSet(A<ClaimSetQuery>.Ignored))
+                .Invokes(call => capturedQuery = call.GetArgument<ClaimSetQuery>(0))
+                .Returns(new ClaimSetQueryResult.Success([]));
+
+            using var client = SetUpClient();
+            var response = await client.GetAsync("/v3/claimSets?name=OldName&claimSetName=PreferredName");
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            capturedQuery.Should().NotBeNull();
+            capturedQuery!.Name.Should().Be("PreferredName");
         }
 
         [Test]

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimSetModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimSetModuleTests.cs
@@ -97,6 +97,16 @@ public class ClaimSetModuleTests
                             Id = 1,
                             Name = "ClaimSet with ResourceClaims",
                             IsSystemReserved = true,
+                            ResourceClaims =
+                            [
+                                new ResourceClaim
+                                {
+                                    Name = "systemDescriptors",
+                                    ClaimName = "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                                    ParentClaimName = null,
+                                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                                },
+                            ],
                         }
                     )
                 );
@@ -118,14 +128,31 @@ public class ClaimSetModuleTests
                             Id = 1,
                             Name = "ClaimSet with ResourceClaims",
                             IsSystemReserved = true,
+                            ResourceClaims =
+                            [
+                                new ResourceClaim
+                                {
+                                    Name = "systemDescriptors",
+                                    ClaimName = "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                                    ParentClaimName = null,
+                                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                                },
+                            ],
                         }
                     )
                 );
 
             A.CallTo(() => _claimSetRepository.Import(A<ClaimSetImportCommand>.Ignored))
-                .Returns(new ClaimSetImportResult.Success(2));
+                .Returns(
+                    new ClaimSetImportResult.Success(
+                        2,
+                        new[] { "Skipped: http://example.org/nonexistent/Claim" }
+                    )
+                );
 
             A.CallTo(() => _dataProvider.GetActions()).Returns(["Create", "Read", "Update", "Delete"]);
+            A.CallTo(() => _dataProvider.GetAuthorizationStrategies())
+                .Returns(["NoFurtherAuthorizationRequired"]);
 
             A.CallTo(() => _claimsHierarchyRepository.GetClaimsHierarchy(A<DbTransaction>.Ignored))
                 .Returns(
@@ -150,7 +177,7 @@ public class ClaimSetModuleTests
                 new StringContent(
                     """
                     {
-                        "name":"Testing-POST-for-ClaimSet"
+                        "claimSetName":"Testing-POST-for-ClaimSet"
                     }
                     """,
                     Encoding.UTF8,
@@ -166,7 +193,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "id": 1,
-                        "name": "Test-11"
+                        "claimSetName": "Test-11"
                     }
                     """,
                     Encoding.UTF8,
@@ -180,7 +207,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "originalId" : 1,
-                        "name": "Test-Copy"
+                        "claimSetName": "Test-Copy"
                     }
                     """,
                     Encoding.UTF8,
@@ -193,7 +220,7 @@ public class ClaimSetModuleTests
                 new StringContent(
                     """
                     {
-                        "name" : "Testing-Import-for-ClaimSet"
+                        "claimSetName" : "Testing-Import-for-ClaimSet"
                     }
                     """,
                     Encoding.UTF8,
@@ -209,8 +236,270 @@ public class ClaimSetModuleTests
             updateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
             deleteResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
             copyResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+            copyResponse.Headers.Location!.ToString().Should().EndWith("/v3/claimSets/1");
             exportResponse.StatusCode.Should().Be(HttpStatusCode.OK);
             importResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+            // Verify import response body contains our combined warnings array (repository-provided plus any validator warnings)
+            var importJson = JsonNode.Parse(await importResponse.Content.ReadAsStringAsync());
+            importJson!["id"]!.GetValue<int>().Should().Be(2);
+            importJson["warnings"]!
+                .AsArray()
+                .Select(n => n!.GetValue<string>())
+                .Should()
+                .Contain("Skipped: http://example.org/nonexistent/Claim");
+
+            var getByIdJson = JsonNode.Parse(await getByIdResponse.Content.ReadAsStringAsync());
+            getByIdJson!["claimSetName"]!.GetValue<string>().Should().Be("ClaimSet with ResourceClaims");
+            getByIdJson["resourceClaims"]!.AsArray().Should().HaveCount(1);
+
+            var exportJson = JsonNode.Parse(await exportResponse.Content.ReadAsStringAsync());
+            exportJson!["claimSetName"]!.GetValue<string>().Should().Be("ClaimSet with ResourceClaims");
+            exportJson["resourceClaims"]!.AsArray().Should().HaveCount(1);
+        }
+
+        [Test]
+        public async Task GetById_should_emit_v3_authorization_strategy_field_names()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.GetClaimSet(1))
+                .Returns(
+                    new ClaimSetGetResult.Success(
+                        new ClaimSetResponse
+                        {
+                            Id = 1,
+                            Name = "ClaimSetV3",
+                            IsSystemReserved = false,
+                            ResourceClaims =
+                            [
+                                new ResourceClaim
+                                {
+                                    Name = "school",
+                                    ClaimName = "http://ed-fi.org/identity/claims/ed-fi/school",
+                                    ParentClaimName =
+                                        "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+                                    Actions = [new ResourceClaimAction { Name = "Read", Enabled = true }],
+                                    DefaultAuthorizationStrategies =
+                                    [
+                                        new ClaimSetResourceClaimActionAuthStrategies
+                                        {
+                                            ActionName = "Read",
+                                            AuthorizationStrategies =
+                                            [
+                                                new AuthorizationStrategy
+                                                {
+                                                    AuthorizationStrategyName =
+                                                        "NoFurtherAuthorizationRequired",
+                                                },
+                                            ],
+                                        },
+                                    ],
+                                    AuthorizationStrategyOverrides = [],
+                                },
+                            ],
+                        }
+                    )
+                );
+
+            using var client = SetUpClient();
+
+            // Act
+            var response = await client.GetAsync("/v3/claimSets/1");
+            var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+            var resourceClaim = json["resourceClaims"]!.AsArray()[0]!;
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            resourceClaim["_defaultAuthorizationStrategies"].Should().NotBeNull();
+            resourceClaim["authorizationStrategyOverrides"].Should().NotBeNull();
+            resourceClaim["_defaultAuthorizationStrategiesForCrud"].Should().BeNull();
+            resourceClaim["authorizationStrategyOverridesForCRUD"].Should().BeNull();
+            resourceClaim["_defaultAuthorizationStrategies"]![0]!["authorizationStrategies"]![0]![
+                "authStrategyName"
+            ]!
+                .GetValue<string>()
+                .Should()
+                .Be("NoFurtherAuthorizationRequired");
+            resourceClaim["_defaultAuthorizationStrategies"]![0]!["authorizationStrategies"]![0]!
+                ["name"]
+                .Should()
+                .BeNull();
+        }
+
+        [Test]
+        public async Task Import_should_bind_v3_auth_strategy_name_and_include_parent_mismatch_warning()
+        {
+            // Arrange
+            A.CallTo(() => _claimsHierarchyRepository.GetClaimsHierarchy(A<DbTransaction>.Ignored))
+                .Returns(
+                    new ClaimsHierarchyGetResult.Success(
+                        [
+                            new()
+                            {
+                                Name = "http://ed-fi.org/identity/claims/domains/educationOrganizations",
+                                Claims = [new() { Name = "http://ed-fi.org/identity/claims/ed-fi/school" }],
+                            },
+                        ],
+                        DateTime.Now,
+                        1
+                    )
+                );
+
+            ClaimSetImportCommand? capturedCommand = null;
+
+            A.CallTo(() => _claimSetRepository.Import(A<ClaimSetImportCommand>.Ignored))
+                .Invokes(call => capturedCommand = call.GetArgument<ClaimSetImportCommand>(0))
+                .Returns(new ClaimSetImportResult.Success(9));
+
+            using var client = SetUpClient();
+
+            // Act
+            var response = await client.PostAsync(
+                "/v3/claimSets/import",
+                new StringContent(
+                    """
+                    {
+                        "claimSetName": "Imported-ClaimSet",
+                        "resourceClaims": [
+                            {
+                                "name": "school",
+                                "claimName": "http://ed-fi.org/identity/claims/ed-fi/school",
+                                "parentClaimName": "http://ed-fi.org/identity/claims/domains/wrongParent",
+                                "actions": [
+                                    {
+                                        "name": "Read",
+                                        "enabled": true
+                                    }
+                                ],
+                                "authorizationStrategyOverrides": [
+                                    {
+                                        "actionName": "Read",
+                                        "authorizationStrategies": [
+                                            {
+                                                "authStrategyName": "NoFurtherAuthorizationRequired"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "_defaultAuthorizationStrategies": [
+                                    {
+                                        "actionName": "Read",
+                                        "authorizationStrategies": [
+                                            {
+                                                "authStrategyName": "UnknownDefaultShouldBeIgnored"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+            var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            capturedCommand.Should().NotBeNull();
+            capturedCommand!.ResourceClaims.Should().ContainSingle();
+            capturedCommand
+                .ResourceClaims![0]
+                .AuthorizationStrategyOverrides.Should()
+                .ContainSingle(o => o.ActionName == "Read");
+            capturedCommand
+                .ResourceClaims![0]
+                .AuthorizationStrategyOverrides[0]
+                .AuthorizationStrategies.Should()
+                .ContainSingle(s => s.AuthorizationStrategyName == "NoFurtherAuthorizationRequired");
+            json["warnings"]!
+                .AsArray()
+                .Select(n => n!.GetValue<string>())
+                .Should()
+                .Contain(warning => warning.Contains("Correct parent resource is"));
+        }
+
+        [Test]
+        public async Task Import_should_deduplicate_repeated_warning_text()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.Import(A<ClaimSetImportCommand>.Ignored))
+                .Returns(new ClaimSetImportResult.Success(9, ["http://example.org/nonexistent/Claim"]));
+
+            using var client = SetUpClient();
+
+            // Act
+            var response = await client.PostAsync(
+                "/v3/claimSets/import",
+                new StringContent(
+                    """
+                    {
+                        "claimSetName": "Imported-ClaimSet",
+                        "resourceClaims": [
+                            {
+                                "claimName": "http://example.org/nonexistent/Claim",
+                                "actions": [
+                                    {
+                                        "name": "Read",
+                                        "enabled": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+            var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            json["warnings"]!.AsArray().Should().HaveCount(1);
+            json["warnings"]![0]!.GetValue<string>().Should().Be("http://example.org/nonexistent/Claim");
+        }
+
+        [Test]
+        public async Task Import_should_deduplicate_repeated_warning_text_ignoring_case()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.Import(A<ClaimSetImportCommand>.Ignored))
+                .Returns(new ClaimSetImportResult.Success(9, ["HTTP://EXAMPLE.ORG/NONEXISTENT/CLAIM"]));
+
+            using var client = SetUpClient();
+
+            // Act
+            var response = await client.PostAsync(
+                "/v3/claimSets/import",
+                new StringContent(
+                    """
+                    {
+                        "claimSetName": "Imported-ClaimSet",
+                        "resourceClaims": [
+                            {
+                                "claimName": "http://example.org/nonexistent/claim",
+                                "actions": [
+                                    {
+                                        "name": "Read",
+                                        "enabled": true
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+            var json = JsonNode.Parse(await response.Content.ReadAsStringAsync())!;
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
+            json["warnings"]!.AsArray().Should().HaveCount(1);
         }
     }
 
@@ -240,43 +529,32 @@ public class ClaimSetModuleTests
 
             string invalidInsertBody = """
                 {
-                   "name" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+                   "claimSetName" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
                 }
                 """;
             string claimSetNameWithWhiteSpace = """
                 {
-                   "name" : "ClaimSet name with white space"
+                   "claimSetName" : "ClaimSet name with white space"
                 }
                 """;
 
             string invalidPutBody = """
                 {
                     "id": 1,
-                    "name" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+                    "claimSetName" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
                 }
                 """;
 
             string invalidImportBody = """
                 {
-                    "name" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
-                    "resourceClaims" : [
-                    {
-                        "name": "Test ResourceClaim",
-                        "actions": [
-                          {
-                            "name": "Create",
-                            "enabled": true
-                          }
-                        ]
-                    }
-                ]
+                    "claimSetName" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
                 }
                 """;
 
             string invalidCopyBody = """
                 {
                     "originalId" : 1,
-                    "name" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+                    "claimSetName" : "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
                 }
                 """;
 
@@ -311,7 +589,7 @@ public class ClaimSetModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -332,7 +610,7 @@ public class ClaimSetModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -354,7 +632,7 @@ public class ClaimSetModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -373,7 +651,7 @@ public class ClaimSetModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -392,7 +670,7 @@ public class ClaimSetModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -440,7 +718,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "id": 2,
-                        "name": "Test-11",
+                        "claimSetName": "Test-11",
                         "resourceClaims": [
                             {
                                 "name": "Test ResourceClaim",
@@ -504,7 +782,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "id": 1,
-                        "name": "Test-11",
+                        "claimSetName": "Test-11",
                         "resourceClaims": [
                              {
                                 "name": "Test ResourceClaim",
@@ -529,7 +807,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "originalId" : 1,
-                        "name": "Test-Copy"
+                        "claimSetName": "Test-Copy"
                     }
                     """,
                     Encoding.UTF8,
@@ -605,7 +883,7 @@ public class ClaimSetModuleTests
                 new StringContent(
                     """
                     {
-                        "name":"Testing-POST-for-ClaimSet"
+                        "claimSetName":"Testing-POST-for-ClaimSet"
                     }
                     """,
                     Encoding.UTF8,
@@ -621,7 +899,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "id": 1,
-                        "name": "Test-11",
+                        "claimSetName": "Test-11",
                         "resourceClaims": [
                          {
                             "name": "Test ResourceClaim",
@@ -646,7 +924,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "originalId" : 1,
-                        "name": "Test-Copy"
+                        "claimSetName": "Test-Copy"
                     }
                     """,
                     Encoding.UTF8,
@@ -659,7 +937,7 @@ public class ClaimSetModuleTests
                 new StringContent(
                     """
                     {
-                        "name" : "Testing-Import-for-ClaimSet",
+                        "claimSetName" : "Testing-Import-for-ClaimSet",
                         "resourceClaims" : [
                             {
                                 "name": "Test ResourceClaim",
@@ -728,7 +1006,7 @@ public class ClaimSetModuleTests
                 new StringContent(
                     """
                     {
-                        "name":"Testing-POST-for-ClaimSet"
+                        "claimSetName":"Testing-POST-for-ClaimSet"
                     }
                     """,
                     Encoding.UTF8,
@@ -740,23 +1018,21 @@ public class ClaimSetModuleTests
             var expectedPostResponse = JsonNode.Parse(
                 """
                 {
-                  "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
-                  "title": "Data Validation Failed",
-                  "status": 400,
+                  "detail": "The identifying value(s) of the item are the same as another item that already exists.",
+                  "type": "urn:ed-fi:api:conflict:non-unique-identity",
+                  "title": "Identifying Values Are Not Unique",
+                  "status": 409,
                   "correlationId": "{correlationId}",
-                  "validationErrors": {
-                    "Name": [
-                      "A claim set with this name already exists in the database. Please enter a unique name."
-                    ]
-                  },
-                  "errors": []
+                  "validationErrors": {},
+                  "errors": [
+                    "A claim set with this name already exists."
+                  ]
                 }
                 """.Replace("{correlationId}", actualPostResponse!["correlationId"]!.GetValue<string>())
             );
 
             //Assert
-            addResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            addResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
             JsonNode.DeepEquals(actualPostResponse, expectedPostResponse).Should().BeTrue();
         }
 
@@ -774,7 +1050,7 @@ public class ClaimSetModuleTests
                     """
                     {
                         "id": 333,
-                        "name":"Testing-PUT-for-ClaimSet"
+                        "claimSetName":"Testing-PUT-for-ClaimSet"
                     }
                     """,
                     Encoding.UTF8,
@@ -786,23 +1062,21 @@ public class ClaimSetModuleTests
             var expectedPostResponse = JsonNode.Parse(
                 """
                 {
-                  "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
-                  "title": "Data Validation Failed",
-                  "status": 400,
+                  "detail": "The identifying value(s) of the item are the same as another item that already exists.",
+                  "type": "urn:ed-fi:api:conflict:non-unique-identity",
+                  "title": "Identifying Values Are Not Unique",
+                  "status": 409,
                   "correlationId": "{correlationId}",
-                  "validationErrors": {
-                    "Name": [
-                      "A claim set with this name already exists in the database. Please enter a unique name."
-                    ]
-                  },
-                  "errors": []
+                  "validationErrors": {},
+                  "errors": [
+                    "A claim set with this name already exists."
+                  ]
                 }
                 """.Replace("{correlationId}", actualPostResponse!["correlationId"]!.GetValue<string>())
             );
 
             //Assert
-            addResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            addResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
             JsonNode.DeepEquals(actualPostResponse, expectedPostResponse).Should().BeTrue();
         }
 
@@ -815,7 +1089,7 @@ public class ClaimSetModuleTests
 
             string importBody = """
                 {
-                    "name" : "Test-Duplicate"
+                    "claimSetName" : "Test-Duplicate"
                 }
                 """;
 
@@ -829,23 +1103,63 @@ public class ClaimSetModuleTests
             var expectedImportResponse = JsonNode.Parse(
                 """
                 {
-                  "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
-                  "title": "Data Validation Failed",
-                  "status": 400,
+                  "detail": "The identifying value(s) of the item are the same as another item that already exists.",
+                  "type": "urn:ed-fi:api:conflict:non-unique-identity",
+                  "title": "Identifying Values Are Not Unique",
+                  "status": 409,
                   "correlationId": "{correlationId}",
-                  "validationErrors": {
-                    "Name": [
-                      "A claim set with this name already exists in the database. Please enter a unique name."
-                    ]
-                  },
-                  "errors": []
+                  "validationErrors": {},
+                  "errors": [
+                    "A claim set with this name already exists."
+                  ]
                 }
                 """.Replace("{correlationId}", actualImportResponse!["correlationId"]!.GetValue<string>())
             );
 
-            importResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            importResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
             JsonNode.DeepEquals(actualImportResponse, expectedImportResponse).Should().Be(true);
+        }
+
+        [Test]
+        public async Task Should_return_duplicate_claimSetName_error_message_on_copy()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.Copy(A<ClaimSetCopyCommand>.Ignored))
+                .Returns(new ClaimSetCopyResult.FailureDuplicateClaimSetName());
+
+            string copyBody = """
+                {
+                    "originalId" : 1,
+                    "claimSetName" : "Test-Duplicate"
+                }
+                """;
+
+            // Act
+            var copyResponse = await _client.PostAsync(
+                "/v3/claimSets/copy",
+                new StringContent(copyBody, Encoding.UTF8, "application/json")
+            );
+
+            var actualCopyResponse = JsonNode.Parse(await copyResponse.Content.ReadAsStringAsync());
+            var expectedCopyResponse = JsonNode.Parse(
+                """
+                {
+                  "detail": "The identifying value(s) of the item are the same as another item that already exists.",
+                  "type": "urn:ed-fi:api:conflict:non-unique-identity",
+                  "title": "Identifying Values Are Not Unique",
+                  "status": 409,
+                  "correlationId": "{correlationId}",
+                  "validationErrors": {},
+                  "errors": [
+                    "A claim set with this name already exists."
+                  ]
+                }
+                """.Replace("{correlationId}", actualCopyResponse!["correlationId"]!.GetValue<string>())
+            );
+
+            // Assert
+            copyResponse.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            JsonNode.DeepEquals(actualCopyResponse, expectedCopyResponse).Should().BeTrue();
         }
     }
 
@@ -877,7 +1191,7 @@ public class ClaimSetModuleTests
             var updateBody = """
                 {
                     "id": 1,
-                    "name": "Updated-ClaimSet"
+                    "claimSetName": "Updated-ClaimSet"
                 }
                 """;
 
@@ -936,7 +1250,7 @@ public class ClaimSetModuleTests
             var updateBody = """
                 {
                     "id": 1,
-                    "name": "Updated-ClaimSet"
+                    "claimSetName": "Updated-ClaimSet"
                 }
                 """;
 
@@ -951,6 +1265,76 @@ public class ClaimSetModuleTests
                 """
                 {
                     "detail": "Unable to update claim set due to multi-user conflicts. Retry the request.",
+                    "type": "urn:ed-fi:api:conflict",
+                    "title": "Conflict",
+                    "status": 409,
+                    "correlationId": "{correlationId}",
+                    "validationErrors": {},
+                    "errors": []
+                }
+                """.Replace("{correlationId}", actualResponseJson!["correlationId"]!.GetValue<string>())
+            );
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            JsonNode.DeepEquals(actualResponseJson, expectedResponseJson).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_return_conflict_when_multi_user_conflict_occurs_on_claim_set_copy()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.Copy(A<ClaimSetCopyCommand>.Ignored))
+                .Returns(new ClaimSetCopyResult.FailureMultiUserConflict());
+
+            var copyBody = """
+                {
+                    "originalId": 1,
+                    "claimSetName": "Copy-Target"
+                }
+                """;
+
+            // Act
+            var response = await _client.PostAsync(
+                "/v3/claimSets/copy",
+                new StringContent(copyBody, Encoding.UTF8, "application/json")
+            );
+
+            var actualResponseJson = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+            var expectedResponseJson = JsonNode.Parse(
+                """
+                {
+                    "detail": "Unable to copy claim set due to multi-user conflicts. Retry the request.",
+                    "type": "urn:ed-fi:api:conflict",
+                    "title": "Conflict",
+                    "status": 409,
+                    "correlationId": "{correlationId}",
+                    "validationErrors": {},
+                    "errors": []
+                }
+                """.Replace("{correlationId}", actualResponseJson!["correlationId"]!.GetValue<string>())
+            );
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+            JsonNode.DeepEquals(actualResponseJson, expectedResponseJson).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_return_conflict_when_multi_user_conflict_occurs_on_claim_set_delete()
+        {
+            // Arrange
+            A.CallTo(() => _claimSetRepository.DeleteClaimSet(A<long>.Ignored))
+                .Returns(new ClaimSetDeleteResult.FailureMultiUserConflict());
+
+            // Act
+            var response = await _client.DeleteAsync("/v3/claimSets/1");
+
+            var actualResponseJson = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+            var expectedResponseJson = JsonNode.Parse(
+                """
+                {
+                    "detail": "Unable to delete claim set due to multi-user conflicts. Retry the request.",
                     "type": "urn:ed-fi:api:conflict",
                     "title": "Conflict",
                     "status": 409,
@@ -995,7 +1379,7 @@ public class ClaimSetModuleTests
             var updateBody = """
                 {
                     "id": 1,
-                    "name": "Updated-System-Reserved-ClaimSet"
+                    "claimSetName": "Updated-System-Reserved-ClaimSet"
                 }
                 """;
 
@@ -1010,6 +1394,50 @@ public class ClaimSetModuleTests
                 """
                 {
                     "detail": "The specified claim set is system-reserved and cannot be updated.",
+                    "type": "urn:ed-fi:api:bad-request",
+                    "title": "Bad Request",
+                    "status": 400,
+                    "correlationId": "{correlationId}",
+                    "validationErrors": {},
+                    "errors": []
+                }
+                """.Replace("{correlationId}", actualResponseJson!["correlationId"]!.GetValue<string>())
+            );
+
+            // Assert
+            response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            JsonNode.DeepEquals(actualResponseJson, expectedResponseJson).Should().BeTrue();
+        }
+
+        [Test]
+        public async Task Should_return_bad_request_when_attempt_made_to_import_a_system_reserved_claim_set()
+        {
+            // Arrange
+            A.CallTo(() => _dataProvider.GetActions()).Returns(["Create", "Read", "Update", "Delete"]);
+            A.CallTo(() => _dataProvider.GetAuthorizationStrategies())
+                .Returns(["NoFurtherAuthorizationRequired"]);
+            A.CallTo(() => _claimsHierarchyRepository.GetClaimsHierarchy(A<DbTransaction>.Ignored))
+                .Returns(new ClaimsHierarchyGetResult.Success([], DateTime.Now, 1));
+            A.CallTo(() => _claimSetRepository.Import(A<ClaimSetImportCommand>.Ignored))
+                .Returns(new ClaimSetImportResult.FailureSystemReserved());
+
+            var importBody = """
+                {
+                    "claimSetName": "System-Reserved"
+                }
+                """;
+
+            // Act
+            var response = await _client.PostAsync(
+                "/v3/claimSets/import",
+                new StringContent(importBody, Encoding.UTF8, "application/json")
+            );
+
+            var actualResponseJson = JsonNode.Parse(await response.Content.ReadAsStringAsync());
+            var expectedResponseJson = JsonNode.Parse(
+                """
+                {
+                    "detail": "The specified claim set is system-reserved and cannot be imported.",
                     "type": "urn:ed-fi:api:bad-request",
                     "title": "Bad Request",
                     "status": 400,

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/TenantModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/TenantModuleTests.cs
@@ -199,10 +199,7 @@ public class TenantModuleTests
                     .GetValue<string>()
                     .Should()
                     .Be("Data validation failed. See 'validationErrors' for details.");
-                actualPostResponse["type"]!
-                    .GetValue<string>()
-                    .Should()
-                    .Be("urn:ed-fi:api:bad-request:data-validation-failed");
+                actualPostResponse["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:data");
                 actualPostResponse["title"]!.GetValue<string>().Should().Be("Data Validation Failed");
                 actualPostResponse["status"]!.GetValue<int>().Should().Be(400);
                 actualPostResponse["correlationId"]!.GetValue<string>().Should().NotBeNullOrEmpty();

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/VendorModuleTests.cs
@@ -294,7 +294,7 @@ public class VendorModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",
@@ -322,7 +322,7 @@ public class VendorModuleTests
                 """
                 {
                   "detail": "Data validation failed. See 'validationErrors' for details.",
-                  "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                  "type": "urn:ed-fi:api:bad-request:data",
                   "title": "Data Validation Failed",
                   "status": 400,
                   "correlationId": "{correlationId}",

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/PagingQueryValidators.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Infrastructure/PagingQueryValidators.cs
@@ -134,6 +134,7 @@ public class ClaimSetPagingQueryValidator : PagingQueryValidator<FrontendClaimSe
     {
         "id",
         "name",
+        "claimSetName",
     };
 
     public ClaimSetPagingQueryValidator()

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Models/FrontendQueryModels.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Models/FrontendQueryModels.cs
@@ -155,7 +155,11 @@ public class FrontendClaimSetQuery : FrontendPagingQuery
     [FromQuery(Name = "name")]
     public string? Name { get; set; }
 
-    public ClaimSetQuery ToQuery() => ApplyPagingTo(new ClaimSetQuery { Id = Id, Name = Name });
+    [FromQuery(Name = "claimSetName")]
+    public string? ClaimSetName { get; set; }
+
+    public ClaimSetQuery ToQuery() =>
+        ApplyPagingTo(new ClaimSetQuery { Id = Id, Name = ClaimSetName ?? Name });
 }
 
 public class FrontendProfileQuery : FrontendPagingQuery

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimSetModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimSetModule.cs
@@ -18,6 +18,18 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
 
 public class ClaimSetModule : IEndpointModule
 {
+    private static IResult DuplicateClaimSetName(HttpContext httpContext)
+    {
+        return Results.Json(
+            FailureResponse.ForNonUniqueIdentity(
+                "The identifying value(s) of the item are the same as another item that already exists.",
+                httpContext.TraceIdentifier,
+                ["A claim set with this name already exists."]
+            ),
+            statusCode: (int)HttpStatusCode.Conflict
+        );
+    }
+
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapSecuredPost("/v3/claimSets/", InsertClaimSet);
@@ -48,19 +60,7 @@ public class ClaimSetModule : IEndpointModule
                 $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path.Value?.TrimEnd('/')}/{success.Id}",
                 null
             ),
-            ClaimSetInsertResult.FailureDuplicateClaimSetName => Results.Json(
-                FailureResponse.ForDataValidation(
-                    new[]
-                    {
-                        new ValidationFailure(
-                            "Name",
-                            "A claim set with this name already exists in the database. Please enter a unique name."
-                        ),
-                    },
-                    httpContext.TraceIdentifier
-                ),
-                statusCode: (int)HttpStatusCode.BadRequest
-            ),
+            ClaimSetInsertResult.FailureDuplicateClaimSetName => DuplicateClaimSetName(httpContext),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
     }
@@ -94,7 +94,7 @@ public class ClaimSetModule : IEndpointModule
 
         return result switch
         {
-            ClaimSetGetResult.Success success => Results.Ok(success.ClaimSetResponse),
+            ClaimSetGetResult.Success success => Results.Json(success.ClaimSetResponse),
             ClaimSetGetResult.FailureNotFound => Results.Json(
                 FailureResponse.ForNotFound(
                     $"ClaimSet {id} not found. It may have been recently deleted.",
@@ -128,18 +128,7 @@ public class ClaimSetModule : IEndpointModule
         return result switch
         {
             ClaimSetUpdateResult.Success => Results.NoContent(),
-            ClaimSetUpdateResult.FailureDuplicateClaimSetName => Results.Json(
-                FailureResponse.ForDataValidation(
-                    [
-                        new ValidationFailure(
-                            "Name",
-                            "A claim set with this name already exists in the database. Please enter a unique name."
-                        ),
-                    ],
-                    httpContext.TraceIdentifier
-                ),
-                statusCode: (int)HttpStatusCode.BadRequest
-            ),
+            ClaimSetUpdateResult.FailureDuplicateClaimSetName => DuplicateClaimSetName(httpContext),
             ClaimSetUpdateResult.FailureMultiUserConflict => Results.Json(
                 FailureResponse.ForConflict(
                     $"Unable to update claim set due to multi-user conflicts. Retry the request.",
@@ -200,6 +189,17 @@ public class ClaimSetModule : IEndpointModule
                 ),
                 statusCode: (int)HttpStatusCode.NotFound
             ),
+            ClaimSetDeleteResult.FailureMultiUserConflict => Results.Json(
+                FailureResponse.ForConflict(
+                    "Unable to delete claim set due to multi-user conflicts. Retry the request.",
+                    httpContext.TraceIdentifier
+                ),
+                statusCode: (int)HttpStatusCode.Conflict
+            ),
+            ClaimSetDeleteResult.FailureMultipleHierarchiesFound => Results.Json(
+                FailureResponse.ForUnknown(httpContext.TraceIdentifier),
+                statusCode: (int)HttpStatusCode.InternalServerError
+            ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
     }
@@ -216,7 +216,7 @@ public class ClaimSetModule : IEndpointModule
 
         return result switch
         {
-            ClaimSetExportResult.Success success => Results.Ok(success.ClaimSetExportResponse),
+            ClaimSetExportResult.Success success => Results.Json(success.ClaimSetExportResponse),
             ClaimSetExportResult.FailureNotFound => Results.Json(
                 FailureResponse.ForNotFound(
                     $"ClaimSet {id} not found. It may have been recently deleted.",
@@ -244,7 +244,7 @@ public class ClaimSetModule : IEndpointModule
         return result switch
         {
             ClaimSetCopyResult.Success success => Results.Created(
-                $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path.Value?.TrimEnd('/')}/{success.Id}",
+                $"{request.Scheme}://{request.Host}{request.PathBase}{GetClaimSetsPath(request)}/{success.Id}",
                 null
             ),
             ClaimSetCopyResult.FailureNotFound => Results.Json(
@@ -253,6 +253,18 @@ public class ClaimSetModule : IEndpointModule
                     httpContext.TraceIdentifier
                 ),
                 statusCode: (int)HttpStatusCode.NotFound
+            ),
+            ClaimSetCopyResult.FailureDuplicateClaimSetName => DuplicateClaimSetName(httpContext),
+            ClaimSetCopyResult.FailureMultiUserConflict => Results.Json(
+                FailureResponse.ForConflict(
+                    "Unable to copy claim set due to multi-user conflicts. Retry the request.",
+                    httpContext.TraceIdentifier
+                ),
+                statusCode: (int)HttpStatusCode.Conflict
+            ),
+            ClaimSetCopyResult.FailureMultipleHierarchiesFound => Results.Json(
+                FailureResponse.ForUnknown(httpContext.TraceIdentifier),
+                statusCode: (int)HttpStatusCode.InternalServerError
             ),
             _ => FailureResults.Unknown(httpContext.TraceIdentifier),
         };
@@ -335,27 +347,53 @@ public class ClaimSetModule : IEndpointModule
 
         var request = httpContext.Request;
 
-        return importResult switch
+        switch (importResult)
         {
-            ClaimSetImportResult.Success success => Results.Created(
-                $"{request.Scheme}://{request.Host}{request.PathBase}{GetClaimSetsPath()}/{success.Id}",
-                null
-            ),
-            ClaimSetImportResult.FailureDuplicateClaimSetName => Results.Json(
-                FailureResponse.ForDataValidation(
-                    new[]
-                    {
-                        new ValidationFailure(
-                            "Name",
-                            "A claim set with this name already exists in the database. Please enter a unique name."
-                        ),
-                    },
-                    httpContext.TraceIdentifier
-                ),
-                statusCode: (int)HttpStatusCode.BadRequest
-            ),
-            _ => FailureResults.Unknown(httpContext.TraceIdentifier),
-        };
+            case ClaimSetImportResult.Success success:
+                // Combine repository warnings with validator-detected warnings (skipped resources and parent mismatches)
+                var validatorWarnings = new List<string>();
+
+                if (
+                    validationContext.RootContextData.TryGetValue("SkippedResourceClaims", out var skippedObj)
+                    && skippedObj is List<string> skipped
+                )
+                {
+                    validatorWarnings.AddRange(skipped);
+                }
+
+                if (
+                    validationContext.RootContextData.TryGetValue("ParentWarnings", out var parentObj)
+                    && parentObj is List<string> parentWarnings
+                )
+                {
+                    validatorWarnings.AddRange(parentWarnings);
+                }
+
+                var combined = (success.Warnings ?? Enumerable.Empty<string>())
+                    .Concat(validatorWarnings)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToArray();
+
+                return Results.Created(
+                    $"{request.Scheme}://{request.Host}{request.PathBase}{GetClaimSetsPath(request)}/{success.Id}",
+                    new { Id = success.Id, Warnings = combined }
+                );
+
+            case ClaimSetImportResult.FailureDuplicateClaimSetName:
+                return DuplicateClaimSetName(httpContext);
+
+            case ClaimSetImportResult.FailureSystemReserved:
+                return Results.Json(
+                    FailureResponse.ForBadRequest(
+                        "The specified claim set is system-reserved and cannot be imported.",
+                        httpContext.TraceIdentifier
+                    ),
+                    statusCode: (int)HttpStatusCode.BadRequest
+                );
+
+            default:
+                return FailureResults.Unknown(httpContext.TraceIdentifier);
+        }
 
         static IEnumerable<KeyValuePair<string, string?>> ExtractClaimHierarchyTuples(List<Claim> rootClaims)
         {
@@ -371,27 +409,24 @@ public class ClaimSetModule : IEndpointModule
                 }
             }
         }
+    }
 
-        string? GetClaimSetsPath()
+    private static string GetClaimSetsPath(HttpRequest request)
+    {
+        const string ClaimSetsSegment = "/claimSets/";
+
+        if (!request.Path.HasValue)
         {
-            const string ClaimSetsSegment = "/claimSets/";
-
-            if (!request.Path.HasValue)
-            {
-                return null;
-            }
-
-            int claimSetsPos = request.Path.Value.IndexOf(
-                ClaimSetsSegment,
-                StringComparison.OrdinalIgnoreCase
-            );
-
-            if (claimSetsPos < 0)
-            {
-                return request.Path.Value.TrimEnd('/');
-            }
-
-            return request.Path.Value.Substring(0, claimSetsPos + ClaimSetsSegment.Length - 1);
+            return string.Empty;
         }
+
+        int claimSetsPos = request.Path.Value.IndexOf(ClaimSetsSegment, StringComparison.OrdinalIgnoreCase);
+
+        if (claimSetsPos < 0)
+        {
+            return request.Path.Value.TrimEnd('/');
+        }
+
+        return request.Path.Value.Substring(0, claimSetsPos + ClaimSetsSegment.Length - 1);
     }
 }

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ApiClients.feature
@@ -137,7 +137,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -173,7 +173,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -209,7 +209,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -368,7 +368,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -414,7 +414,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -460,7 +460,7 @@ Feature: ApiClients endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Applications.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Applications.feature
@@ -348,7 +348,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HN8RI9E3O45G:00000004",
@@ -377,7 +377,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HN8RI9E3O45G:00000004",
@@ -406,7 +406,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HN8RI9E3O45G:00000004",
@@ -435,7 +435,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HN8RI9E3O45G:00000004",
@@ -464,7 +464,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -612,7 +612,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HNEJBSQ1BUK4:00000004",
@@ -714,7 +714,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "correlationId": "0HN8RI9E3O45G:00000004",
@@ -744,7 +744,7 @@ Feature: Applications endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimSets.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimSets.feature
@@ -12,21 +12,21 @@ Feature: ClaimSets endpoints
                   [
                       {
                           "id": {claimSetId:E2E-NameSpaceBasedClaimSet},
-                          "name": "E2E-NameSpaceBasedClaimSet",
+                          "claimSetName": "E2E-NameSpaceBasedClaimSet",
                           "_isSystemReserved": true,
-                          "_applications": {}
+                          "_applications": []
                       },
                       {
                           "id": {claimSetId:E2E-NoFurtherAuthRequiredClaimSet},
-                          "name": "E2E-NoFurtherAuthRequiredClaimSet",
+                          "claimSetName": "E2E-NoFurtherAuthRequiredClaimSet",
                           "_isSystemReserved": true,
-                          "_applications": {}
+                          "_applications": []
                       },
                       {
                           "id": {claimSetId:E2E-RelationshipsWithEdOrgsOnlyClaimSet},
-                          "name": "E2E-RelationshipsWithEdOrgsOnlyClaimSet",
+                          "claimSetName": "E2E-RelationshipsWithEdOrgsOnlyClaimSet",
                           "_isSystemReserved": true,
-                          "_applications": {}
+                          "_applications": []
                       }
                   ]
                   """
@@ -39,9 +39,9 @@ Feature: ClaimSets endpoints
                   [
                       {
                           "id": {claimSetId:E2E-NoFurtherAuthRequiredClaimSet},
-                          "name": "E2E-NoFurtherAuthRequiredClaimSet",
+                          "claimSetName": "E2E-NoFurtherAuthRequiredClaimSet",
                           "_isSystemReserved": true,
-                          "_applications": {}
+                          "_applications": []
                       }
                   ]
                   """
@@ -53,9 +53,10 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "id": {claimSetId:E2E-NoFurtherAuthRequiredClaimSet},
-                      "name": "E2E-NoFurtherAuthRequiredClaimSet",
+                      "claimSetName": "E2E-NoFurtherAuthRequiredClaimSet",
                       "_isSystemReserved": true,
-                      "_applications": {}
+                      "_applications": [],
+                      "resourceClaims": "{*}"
                   }
                   """
 
@@ -63,7 +64,7 @@ Feature: ClaimSets endpoints
              When a POST request is made to "/v3/claimSets" with
                   """
                   {
-                      "name": "NewClaimSet"
+                      "claimSetName": "NewClaimSet"
                   }
                   """
              Then it should respond with 201
@@ -77,7 +78,7 @@ Feature: ClaimSets endpoints
                   """
                     {
                         "id": {claimSetId},
-                        "name": "UpdatedClaimSet"
+                        "claimSetName": "UpdatedClaimSet"
                     }
                   """
              Then it should respond with 204
@@ -87,9 +88,10 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "id": {claimSetId},
-                      "name": "UpdatedClaimSet",
+                      "claimSetName": "UpdatedClaimSet",
                       "_isSystemReserved": false,
-                      "_applications": {}
+                      "_applications": [],
+                      "resourceClaims": "{*}"
                   }
                   """
              When a DELETE request is made to "/v3/claimSets/{claimSetId}"
@@ -112,28 +114,26 @@ Feature: ClaimSets endpoints
 
         Scenario: 06 Verify error handling when trying to POST a duplicate claim set name
             Given the system has these "claimSets"
-                  | name                  | isSystemReserved |
+                  | claimSetName          | isSystemReserved |
                   | DuplicateTestClaimSet | false            |
              When a POST request is made to "/v3/claimSets" with
                   """
                   {
-                      "name": "DuplicateTestClaimSet"
+                      "claimSetName": "DuplicateTestClaimSet"
                   }
                   """
-             Then it should respond with 400
+             Then it should respond with 409
               And the response body is
                   """
                   {
-                      "detail": "Data validation failed. See 'validationErrors' for details.",
-                      "type": "urn:ed-fi:api:bad-request:data-validation-failed",
-                      "title": "Data Validation Failed",
-                      "status": 400,
-                      "validationErrors": {
-                          "Name": [
-                              "A claim set with this name already exists in the database. Please enter a unique name."
-                          ]
-                      },
-                      "errors": []
+                      "detail": "The identifying value(s) of the item are the same as another item that already exists.",
+                      "type": "urn:ed-fi:api:conflict:non-unique-identity",
+                      "title": "Identifying Values Are Not Unique",
+                      "status": 409,
+                      "validationErrors": {},
+                      "errors": [
+                          "A claim set with this name already exists."
+                      ]
                   }
                   """
 
@@ -142,7 +142,7 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "id": 8,
-                      "name": "UpdatedSystemReservedClaimSet"
+                      "claimSetName": "UpdatedSystemReservedClaimSet"
                   }
                   """
              Then it should respond with 400
@@ -177,7 +177,7 @@ Feature: ClaimSets endpoints
              When a POST request is made to "/v3/claimSets" with
                   """
                   {
-                      "name": "TestClaimSetMismatchedIds"
+                      "claimSetName": "TestClaimSetMismatchedIds"
                   }
                   """
              Then it should respond with 201
@@ -191,7 +191,7 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "id": 999,
-                      "name": "TestClaimSetMismatchedIdsUpdated"
+                      "claimSetName": "TestClaimSetMismatchedIdsUpdated"
                   }
                   """
              Then it should respond with 400
@@ -199,7 +199,7 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "detail": "Data validation failed. See 'validationErrors' for details.",
-                      "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                      "type": "urn:ed-fi:api:bad-request:data",
                       "title": "Data Validation Failed",
                       "status": 400,
                       "validationErrors": {
@@ -214,24 +214,24 @@ Feature: ClaimSets endpoints
              When a POST request is made to "/v3/claimSets/import" with
                   """
                   {
-                      "name": "AcademicHonorClaimSet",
+                      "claimSetName": "AcademicHonorClaimSet",
                       "resourceClaims": [
                           {
-                              "name": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                              "name": "systemDescriptors",
+                              "claimName": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
                               "actions": [
                                  { "name": "Create", "enabled": true }
-                              ],
-                              "children": [
-                                  {
-                                      "name": "http://ed-fi.org/identity/claims/ed-fi/academicHonorCategoryDescriptor",
-                                      "actions": [
-                                          { "name": "Create", "enabled": true },
-                                          { "name": "Read", "enabled": true },
-                                          { "name": "Update", "enabled": true },
-                                          { "name": "Delete", "enabled": true }
-                                      ],
-                                      "children": []
-                                  }
+                              ]
+                          },
+                          {
+                              "name": "academicHonorCategoryDescriptor",
+                              "claimName": "http://ed-fi.org/identity/claims/ed-fi/academicHonorCategoryDescriptor",
+                              "parentClaimName": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                              "actions": [
+                                  { "name": "Create", "enabled": true },
+                                  { "name": "Read", "enabled": true },
+                                  { "name": "Update", "enabled": true },
+                                  { "name": "Delete", "enabled": true }
                               ]
                           }
                       ]
@@ -249,20 +249,20 @@ Feature: ClaimSets endpoints
              When a POST request is made to "/v3/claimSets/import" with
                   """
                   {
-                      "name": "InvalidClaimSet",
+                      "claimSetName": "InvalidClaimSet",
                       "resourceClaims": [
                           {
-                              "name": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                              "name": "systemDescriptors",
+                              "claimName": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
                               "actions": [
                                  { "name": "Create", "enabled": true}
-                              ],
-                              "children": [
-                                  {
-                                      "name": "http://ed-fi.org/identity/claims/ed-fi/academicHonorCategoryDescriptor",
-                                      "actions": [],
-                                      "children": []
-                                  }
                               ]
+                          },
+                          {
+                              "name": "academicHonorCategoryDescriptor",
+                              "claimName": "http://ed-fi.org/identity/claims/ed-fi/academicHonorCategoryDescriptor",
+                              "parentClaimName": "http://ed-fi.org/identity/claims/domains/systemDescriptors",
+                              "actions": []
                           }
                       ]
                   }
@@ -272,7 +272,7 @@ Feature: ClaimSets endpoints
                   """
                   {
                       "detail": "Data validation failed. See 'validationErrors' for details.",
-                      "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                      "type": "urn:ed-fi:api:bad-request:data",
                       "title": "Data Validation Failed",
                       "status": 400,
                       "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Connect.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Connect.feature
@@ -39,7 +39,7 @@ Feature: Connect endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -62,7 +62,7 @@ Feature: Connect endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -85,7 +85,7 @@ Feature: Connect endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -108,7 +108,7 @@ Feature: Connect endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -143,7 +143,7 @@ Feature: Connect endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreContexts.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreContexts.feature
@@ -194,7 +194,7 @@ Feature: Data Store Context
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreDerivatives.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStoreDerivatives.feature
@@ -232,7 +232,7 @@ Feature: DataStoreDerivatives endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -258,7 +258,7 @@ Feature: DataStoreDerivatives endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -285,7 +285,7 @@ Feature: DataStoreDerivatives endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -311,7 +311,7 @@ Feature: DataStoreDerivatives endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -347,7 +347,7 @@ Feature: DataStoreDerivatives endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStores.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/DataStores.feature
@@ -216,7 +216,7 @@ Feature: DataStores endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -242,7 +242,7 @@ Feature: DataStores endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -268,7 +268,7 @@ Feature: DataStores endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {
@@ -304,7 +304,7 @@ Feature: DataStores endpoints
                   """
                     {
                         "detail": "Data validation failed. See 'validationErrors' for details.",
-                        "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                        "type": "urn:ed-fi:api:bad-request:data",
                         "title": "Data Validation Failed",
                         "status": 400,
                         "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Vendors.feature
@@ -221,7 +221,7 @@ Feature: Vendors endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -247,7 +247,7 @@ Feature: Vendors endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -273,7 +273,7 @@ Feature: Vendors endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {
@@ -299,7 +299,7 @@ Feature: Vendors endpoints
                   """
                   {
                     "detail": "Data validation failed. See 'validationErrors' for details.",
-                    "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                    "type": "urn:ed-fi:api:bad-request:data",
                     "title": "Data Validation Failed",
                     "status": 400,
                     "validationErrors": {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -453,6 +453,16 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         }
     }
 
+    [Then(@"the response body is an object where")]
+    public async Task ThenTheResponseBodyIsAnObjectWhere(Table table)
+    {
+        string content = await _apiResponse.TextAsync();
+        var jsonObject = JsonNode.Parse(content)?.AsObject();
+
+        jsonObject.Should().NotBeNull();
+        ValidateResponseBodyObject(table, jsonObject);
+    }
+
     private static void ValidateResponseBodyObject(Table table, JsonNode? obj)
     {
         foreach (var row in table.Rows)
@@ -776,9 +786,16 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         // Find the claim set with the matching name
         foreach (var claimSet in claimSets.RootElement.EnumerateArray())
         {
+            var matchesByClaimSetName =
+                claimSet.TryGetProperty("claimSetName", out var claimSetNameProperty)
+                && claimSetNameProperty.GetString() == claimSetName;
+
+            var matchesByLegacyName =
+                claimSet.TryGetProperty("name", out var legacyNameProperty)
+                && legacyNameProperty.GetString() == claimSetName;
+
             if (
-                claimSet.TryGetProperty("name", out var nameProperty)
-                && nameProperty.GetString() == claimSetName
+                (matchesByClaimSetName || matchesByLegacyName)
                 && claimSet.TryGetProperty("id", out var idProperty)
             )
             {

--- a/src/dms/tests/RestClient/test.claimSets.http
+++ b/src/dms/tests/RestClient/test.claimSets.http
@@ -1,0 +1,350 @@
+# Claim Sets CMS/DMS smoke tests
+#
+# This file exercises the claim set endpoints added or updated on this branch:
+# - CMS claim set CRUD, copy, export, and import endpoints
+# - CMS claims management upload/reload endpoints
+# - DMS claimset reload/view endpoints
+# - Full v3 claim set payloads described in reference/design/claimset-export-import
+#
+# Prerequisites:
+# - Start the local DMS/CMS stack as described in `eng/docker-compose`
+# - Ensure the Configuration Service is available on port 8081 and DMS on port 8080
+# - Run the requests top-to-bottom with the VS Code REST Client extension
+
+@configPort=8081
+@dmsPort=8080
+@claimSetRunId={{$datetime 'yyyyMMddHHmmss'}}-{{$randomInt 0 999999}}
+@claimSetName=RestClient-ClaimSet-{{claimSetRunId}}
+@updatedClaimSetName=RestClient-ClaimSet-Updated-{{claimSetRunId}}
+@copiedClaimSetName=RestClient-ClaimSet-Copy-{{claimSetRunId}}
+@importedClaimSetName=DistrictHostedSISVendor-{{claimSetRunId}}
+@importedUpsertClaimSetName=DistrictHostedSISVendor-{{claimSetRunId}}
+@importedWarningClaimSetName=DistrictHostedSISVendor-Warnings-{{claimSetRunId}}
+@uploadClaimSetName=RestClientUploadClaimSet-{{claimSetRunId}}
+
+@educationOrganizationsClaim=http://ed-fi.org/identity/claims/domains/educationOrganizations
+@schoolClaim=http://ed-fi.org/identity/claims/ed-fi/school
+@academicHonorCategoryClaim=http://ed-fi.org/identity/claims/ed-fi/academicHonorCategoryDescriptor
+@missingClaim=http://ed-fi.org/identity/claims/ed-fi/claim-that-does-not-exist
+@namespaceBasedStrategy=NamespaceBased
+@noFurtherAuthRequiredStrategy=NoFurtherAuthorizationRequired
+
+@sysAdminId=DmsConfigurationService
+@sysAdminSecret=ValidClientSecret1234567890!Abcd
+
+# -----------------------------------------------------------------------------
+# 1. Bootstrap CMS authentication
+# -----------------------------------------------------------------------------
+
+### 1.1 Get a Configuration Service token
+# @name configTokenRequest
+POST http://localhost:{{configPort}}/connect/token
+Content-Type: application/x-www-form-urlencoded
+
+client_id={{sysAdminId}}
+&client_secret={{sysAdminSecret}}
+&grant_type=client_credentials
+&scope=edfi_admin_api/full_access
+
+###
+# @ref configTokenRequest
+@configToken={{configTokenRequest.response.body.access_token}}
+
+# -----------------------------------------------------------------------------
+# 2. CMS claim set CRUD
+# -----------------------------------------------------------------------------
+
+### 2.1 Create a claim set
+# @name createClaimSet
+POST http://localhost:{{configPort}}/v3/claimSets/
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "claimSetName": "{{claimSetName}}"
+}
+
+###
+# @ref createClaimSet
+@claimSetLocation={{createClaimSet.response.headers.location}}
+
+### 2.2 Create a duplicate claim set with the same name
+# Expected: 409 Identifying Values Are Not Unique
+POST http://localhost:{{configPort}}/v3/claimSets/
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "claimSetName": "{{claimSetName}}"
+}
+
+### 2.3 Read the created claim set
+# @name getClaimSet
+GET {{claimSetLocation}}
+Authorization: bearer {{configToken}}
+
+###
+# @ref getClaimSet
+@claimSetId={{getClaimSet.response.body.id}}
+
+### 2.4 Update the claim set
+PUT http://localhost:{{configPort}}/v3/claimSets/{{claimSetId}}
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "id": {{claimSetId}},
+  "claimSetName": "{{updatedClaimSetName}}"
+}
+
+### 2.5 List claim sets with paging and sorting
+GET http://localhost:{{configPort}}/v3/claimSets?offset=0&limit=5&orderBy=name&direction=ASC
+Authorization: bearer {{configToken}}
+
+### 2.6 Export the claim set
+# Expected: 200 OK with the same v3 payload shape as GET /v3/claimSets/{id}
+GET http://localhost:{{configPort}}/v3/claimSets/{{claimSetId}}/export
+Authorization: bearer {{configToken}}
+
+### 2.7 Copy the claim set
+# @name copyClaimSet
+POST http://localhost:{{configPort}}/v3/claimSets/copy
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "originalId": {{claimSetId}},
+  "claimSetName": "{{copiedClaimSetName}}"
+}
+
+###
+# @ref copyClaimSet
+@copyClaimSetLocation={{copyClaimSet.response.headers.location}}
+
+### 2.8 Read the copied claim set
+# @name getCopiedClaimSet
+GET {{copyClaimSetLocation}}
+Authorization: bearer {{configToken}}
+
+###
+# @ref getCopiedClaimSet
+@copiedClaimSetId={{getCopiedClaimSet.response.body.id}}
+
+### 2.9 Delete the copied claim set
+DELETE http://localhost:{{configPort}}/v3/claimSets/{{copiedClaimSetId}}
+Authorization: bearer {{configToken}}
+
+### 2.10 Import a new claim set with the complete v3 payload from the design
+# @name importClaimSet
+POST http://localhost:{{configPort}}/v3/claimSets/import
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "claimSetName": "{{importedClaimSetName}}",
+  "resourceClaims": [
+    {
+      "name": "educationOrganizations",
+      "claimName": "{{educationOrganizationsClaim}}",
+      "parentClaimName": null,
+      "actions": [
+        { "name": "Read", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        {
+          "actionName": "Read",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Create",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Update",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Delete",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        }
+      ],
+      "authorizationStrategyOverrides": []
+    },
+    {
+      "name": "school",
+      "claimName": "{{schoolClaim}}",
+      "parentClaimName": "{{educationOrganizationsClaim}}",
+      "actions": [
+        { "name": "Create", "enabled": true },
+        { "name": "Read", "enabled": true },
+        { "name": "Update", "enabled": true },
+        { "name": "Delete", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        {
+          "actionName": "Create",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Read",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Update",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Delete",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        }
+      ],
+      "authorizationStrategyOverrides": [
+        {
+          "actionName": "Create",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{namespaceBasedStrategy}}" }
+          ]
+        }
+      ]
+    }
+  ]
+}
+
+###
+# @ref importClaimSet
+@importedClaimSetLocation={{importClaimSet.response.headers.location}}
+
+### 2.11 Read back the imported claim set
+# @name getImportedClaimSet
+GET {{importedClaimSetLocation}}
+Authorization: bearer {{configToken}}
+
+###
+# @ref getImportedClaimSet
+@importedClaimSetId={{getImportedClaimSet.response.body.id}}
+
+### 2.12 Export the imported claim set
+# Expected: the same JSON payload shape as GET and the nested strategy names use authStrategyName
+GET http://localhost:{{configPort}}/v3/claimSets/{{importedClaimSetId}}/export
+Authorization: bearer {{configToken}}
+
+### 2.13 Re-import the same claim set name with a reduced payload to validate upsert/replacement
+# @name importClaimSetUpsert
+POST http://localhost:{{configPort}}/v3/claimSets/import
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "claimSetName": "{{importedUpsertClaimSetName}}",
+  "resourceClaims": [
+    {
+      "name": "educationOrganizations",
+      "claimName": "{{educationOrganizationsClaim}}",
+      "parentClaimName": null,
+      "actions": [
+        { "name": "Read", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        {
+          "actionName": "Read",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        }
+      ],
+      "authorizationStrategyOverrides": []
+    }
+  ]
+}
+
+###
+# @ref importClaimSetUpsert
+@importedUpsertClaimSetLocation={{importClaimSetUpsert.response.headers.location}}
+
+### 2.14 Read back the upserted claim set
+# @name getUpsertedClaimSet
+GET {{importedUpsertClaimSetLocation}}
+Authorization: bearer {{configToken}}
+
+###
+# @ref getUpsertedClaimSet
+@importedUpsertClaimSetId={{getUpsertedClaimSet.response.body.id}}
+
+### 2.15 Import a claim set with a missing node and a bad parent to validate warning handling
+# @name importClaimSetWithWarnings
+POST http://localhost:{{configPort}}/v3/claimSets/import
+Content-Type: application/json
+Authorization: bearer {{configToken}}
+
+{
+  "claimSetName": "{{importedWarningClaimSetName}}",
+  "resourceClaims": [
+    {
+      "name": "missingClaim",
+      "claimName": "{{missingClaim}}",
+      "parentClaimName": "{{educationOrganizationsClaim}}",
+      "actions": [
+        { "name": "Read", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [],
+      "authorizationStrategyOverrides": []
+    },
+    {
+      "name": "academicHonorCategoryDescriptor",
+      "claimName": "{{academicHonorCategoryClaim}}",
+      "parentClaimName": "{{educationOrganizationsClaim}}",
+      "actions": [
+        { "name": "Read", "enabled": true },
+        { "name": "Update", "enabled": true }
+      ],
+      "_defaultAuthorizationStrategies": [
+        {
+          "actionName": "Read",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        },
+        {
+          "actionName": "Update",
+          "authorizationStrategies": [
+            { "authStrategyName": "{{noFurtherAuthRequiredStrategy}}" }
+          ]
+        }
+      ],
+      "authorizationStrategyOverrides": []
+    }
+  ]
+}
+
+###
+# @ref importClaimSetWithWarnings
+@importedWarningClaimSetLocation={{importClaimSetWithWarnings.response.headers.location}}
+
+### 2.16 Read back the warning import
+# @name getWarningClaimSet
+GET {{importedWarningClaimSetLocation}}
+Authorization: bearer {{configToken}}
+
+###
+# @ref getWarningClaimSet
+@importedWarningClaimSetId={{getWarningClaimSet.response.body.id}}
+
+### 2.17 Clean up imported claim sets
+DELETE http://localhost:{{configPort}}/v3/claimSets/{{importedWarningClaimSetId}}
+Authorization: bearer {{configToken}}


### PR DESCRIPTION
## Summary

Updates CMS support for Admin App 4 claim set workflows by aligning claim set retrieval, export, and import with the revised v3 contract. The implementation preserves configured hierarchy structure, keeps default authorization separate from claim-specific overrides, and supports a cleaner round-trip path between Admin API exports and CMS imports.

Import behavior is also improved for migration scenarios by continuing past missing hierarchy entries with warnings instead of failing the entire operation. Error responses follow the shared Problem Details-style format used across the service.

## References

- [Claim Set Export / Import API Design](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/tree/main/reference/design/claimset-export-import/claim-set-export-import-api-design.md)
- [Claims Migration](https://github.com/Ed-Fi-Alliance-OSS/Data-Management-Service/tree/main/reference/design/claimset-export-import/claims-migration.md)
- [Error Response Knowledge Base](https://edfi.atlassian.net/wiki/spaces/rc/pages/58589185/Error+Response+Knowledge+Base)
