### PR TITLE
[DMS-1066] Add baseline security response headers (DMS/CMS)

### DIFF
--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/SecurityHeadersMiddlewareTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/SecurityHeadersMiddlewareTests.cs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Middleware;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Middleware;
+
+[TestFixture]
+internal class SecurityHeadersMiddlewareTests
+{
+    // DefaultHttpContext's response feature ignores OnStarting, so a fake captures the callback
+    // and the response start is simulated by invoking it after the middleware runs.
+    private static async Task<IHeaderDictionary> RunAndStartResponseAsync(
+        Action<IHeaderDictionary>? seedUpstreamHeaders = null
+    )
+    {
+        var headers = new HeaderDictionary();
+        Func<object, Task>? onStarting = null;
+        object? onStartingState = null;
+
+        var responseFeature = A.Fake<IHttpResponseFeature>();
+        A.CallTo(() => responseFeature.Headers).Returns(headers);
+        A.CallTo(() => responseFeature.OnStarting(A<Func<object, Task>>._, A<object>._))
+            .Invokes(
+                (Func<object, Task> callback, object state) =>
+                {
+                    onStarting = callback;
+                    onStartingState = state;
+                }
+            );
+
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+        features.Set<IHttpResponseFeature>(responseFeature);
+        var context = new DefaultHttpContext(features);
+
+        seedUpstreamHeaders?.Invoke(context.Response.Headers);
+
+        var middleware = new SecurityHeadersMiddleware(_ => Task.CompletedTask);
+        await middleware.Invoke(context);
+
+        if (onStarting is not null)
+        {
+            await onStarting(onStartingState!);
+        }
+
+        return headers;
+    }
+
+    [Test]
+    public async Task It_adds_x_content_type_options_nosniff()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync();
+        headers["X-Content-Type-Options"].ToString().Should().Be("nosniff");
+    }
+
+    [Test]
+    public async Task It_adds_referrer_policy_no_referrer()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync();
+        headers["Referrer-Policy"].ToString().Should().Be("no-referrer");
+    }
+
+    [Test]
+    public async Task It_does_not_overwrite_a_value_already_present()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync(h =>
+            h["X-Content-Type-Options"] = "custom"
+        );
+        headers["X-Content-Type-Options"].ToString().Should().Be("custom");
+    }
+}

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Middleware/SecurityHeadersMiddleware.cs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Middleware;
+
+/// <summary>
+/// Adds baseline security response headers to every response. Registered on OnStarting so the
+/// headers are written just before the response is sent, which keeps them on short-circuited and
+/// error responses produced later in the pipeline. TryAdd leaves any value already set upstream intact.
+/// </summary>
+public class SecurityHeadersMiddleware(RequestDelegate next)
+{
+    private readonly RequestDelegate _next = next ?? throw new ArgumentNullException(nameof(next));
+
+    private static readonly (string Name, string Value)[] _securityHeaders =
+    [
+        ("X-Content-Type-Options", "nosniff"),
+        ("Referrer-Policy", "no-referrer"),
+    ];
+
+    public Task Invoke(HttpContext context)
+    {
+        context.Response.OnStarting(ApplyHeaders, context);
+        return _next(context);
+    }
+
+    private static Task ApplyHeaders(object state)
+    {
+        IHeaderDictionary headers = ((HttpContext)state).Response.Headers;
+        foreach ((string name, string value) in _securityHeaders)
+        {
+            headers.TryAdd(name, value);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Program.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Program.cs
@@ -62,6 +62,8 @@ if (useReverseProxyHeaders)
     app.UseForwardedHeaders();
 }
 
+app.UseMiddleware<SecurityHeadersMiddleware>();
+
 app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<TenantResolutionMiddleware>();
 

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
@@ -81,10 +81,6 @@ Feature: OWASP critical attack path protections
               And the response body should not contain "System.Exception"
               And the response body should not contain " at EdFi."
 
-        # Known gap — these headers are not set by the CMS application itself.
-        # They must be added by a reverse proxy or application middleware.
-        # Tracked for remediation: add response-header middleware to Program.cs.
-        @KnownSecurityGap @ignore
         Scenario: 11 API responses include basic security headers
              When a GET request is made to "/v3/vendors"
              Then it should respond with 200

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -367,10 +367,8 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
                 k.Equals(header.Key, StringComparison.OrdinalIgnoreCase)
             );
 
-            if (key != null)
-            {
-                _apiResponse.Headers[key].Should().Contain(expectedValue);
-            }
+            key.Should().NotBeNull($"response should include header '{header.Key}'");
+            _apiResponse.Headers[key!].Should().Contain(expectedValue);
         }
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/SecurityHeadersMiddlewareTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Infrastructure/SecurityHeadersMiddlewareTests.cs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.Infrastructure;
+
+[TestFixture]
+[Parallelizable]
+public class SecurityHeadersMiddlewareTests
+{
+    // DefaultHttpContext's response feature ignores OnStarting, so a fake captures the callback
+    // and the response start is simulated by invoking it after the middleware runs.
+    private static async Task<IHeaderDictionary> RunAndStartResponseAsync(
+        Action<IHeaderDictionary>? seedUpstreamHeaders = null
+    )
+    {
+        var headers = new HeaderDictionary();
+        Func<object, Task>? onStarting = null;
+        object? onStartingState = null;
+
+        var responseFeature = A.Fake<IHttpResponseFeature>();
+        A.CallTo(() => responseFeature.Headers).Returns(headers);
+        A.CallTo(() => responseFeature.OnStarting(A<Func<object, Task>>._, A<object>._))
+            .Invokes(
+                (Func<object, Task> callback, object state) =>
+                {
+                    onStarting = callback;
+                    onStartingState = state;
+                }
+            );
+
+        var features = new FeatureCollection();
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature());
+        features.Set<IHttpResponseFeature>(responseFeature);
+        var context = new DefaultHttpContext(features);
+
+        seedUpstreamHeaders?.Invoke(context.Response.Headers);
+
+        var middleware = new SecurityHeadersMiddleware(_ => Task.CompletedTask);
+        await middleware.Invoke(context);
+
+        if (onStarting is not null)
+        {
+            await onStarting(onStartingState!);
+        }
+
+        return headers;
+    }
+
+    [Test]
+    public async Task It_adds_x_content_type_options_nosniff()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync();
+        headers["X-Content-Type-Options"].ToString().Should().Be("nosniff");
+    }
+
+    [Test]
+    public async Task It_adds_referrer_policy_no_referrer()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync();
+        headers["Referrer-Policy"].ToString().Should().Be("no-referrer");
+    }
+
+    [Test]
+    public async Task It_does_not_overwrite_a_value_already_present()
+    {
+        IHeaderDictionary headers = await RunAndStartResponseAsync(h =>
+            h["X-Content-Type-Options"] = "custom"
+        );
+        headers["X-Content-Type-Options"].ToString().Should().Be("custom");
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/SecurityHeadersMiddleware.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/SecurityHeadersMiddleware.cs
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+
+/// <summary>
+/// Adds baseline security response headers to every response. Registered on OnStarting so the
+/// headers are written just before the response is sent, which keeps them on short-circuited and
+/// error responses produced later in the pipeline. TryAdd leaves any value already set upstream intact.
+/// </summary>
+public class SecurityHeadersMiddleware(RequestDelegate next)
+{
+    private static readonly (string Name, string Value)[] _securityHeaders =
+    [
+        ("X-Content-Type-Options", "nosniff"),
+        ("Referrer-Policy", "no-referrer"),
+    ];
+
+    public Task Invoke(HttpContext context)
+    {
+        context.Response.OnStarting(ApplyHeaders, context);
+        return next(context);
+    }
+
+    private static Task ApplyHeaders(object state)
+    {
+        IHeaderDictionary headers = ((HttpContext)state).Response.Headers;
+        foreach ((string name, string value) in _securityHeaders)
+        {
+            headers.TryAdd(name, value);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
@@ -141,6 +141,8 @@ if (useReverseProxyHeaders)
     app.UseForwardedHeaders();
 }
 
+app.UseMiddleware<SecurityHeadersMiddleware>();
+
 app.UseMiddleware<LoggingMiddleware>();
 
 var invalidConfigurationException = ReportInvalidConfiguration(app);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -192,10 +192,8 @@ Feature: OWASP critical attack path protections
               And the response body should not contain "System.Exception"
               And the response body should not contain " at EdFi."
 
-        # Known gap — these headers are not set by the DMS application itself.
-        # They must be added by a reverse proxy or application middleware.
-        # Tracked for remediation: add response-header middleware to Program.cs.
-        @KnownSecurityGap @ignore
+        @relational-backend
+        @relational-ci-shard-3
         Scenario: 11 API responses include basic security headers
              When a GET request is made to "/ed-fi/schools"
              Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -1456,10 +1456,8 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
                         k.Equals(header.Key, StringComparison.OrdinalIgnoreCase)
                     );
 
-                    if (key != null)
-                    {
-                        _apiResponse.Headers[key].Should().Contain(expectedValue);
-                    }
+                    key.Should().NotBeNull($"response should include header '{header.Key}'");
+                    _apiResponse.Headers[key!].Should().Contain(expectedValue);
                 }
             }
         }


### PR DESCRIPTION
## What

Add baseline OWASP security response headers (`X-Content-Type-Options: nosniff` and `Referrer-Policy: no-referrer`) to every DMS and CMS response, and enable the previously ignored OWASP E2E scenarios that assert them.

## Why

An OWASP review flagged that DMS and CMS responses lacked baseline security headers. Both services are APIs (not browser-rendered apps), so only the API-relevant baseline headers are in scope. Each app's OWASP E2E suite already contained a `@KnownSecurityGap @ignore` "API responses include basic security headers" scenario; this change adds the headers and un-ignores those scenarios.

Out of scope (per the ticket): `X-Frame-Options`, `Content-Security-Policy`, and `Strict-Transport-Security` are intentionally not added.

## Changes

- Add `SecurityHeadersMiddleware` to DMS (`frontend/.../Infrastructure`) and CMS (`frontend/.../Middleware`), each owning its own copy (the two frontends share no web-infra project).
  - Registers the headers via `Response.OnStarting` so they apply to short-circuited and error responses too (including those re-executed by CMS's exception handler).
  - Uses `TryAdd`, so an equivalent header value already set upstream is preserved (never overwritten).
- Register the middleware as the first content middleware in each `Program.cs`, ahead of the invalid-configuration short-circuit (and, for CMS, ahead of `UseExceptionHandler`), so headers cover success, auth/validation failures, fallback, invalid-config, health/openapi/discovery, and preflight responses.
- Un-ignore OWASP "Scenario: 11 API responses include basic security headers":
  - DMS: replace `@KnownSecurityGap @ignore` with `@relational-backend @relational-ci-shard-3` so it is selected by the relational E2E CI lane alongside the rest of that feature.
  - CMS: remove `@KnownSecurityGap @ignore` (the CMS E2E suite selects by project, not tags).
- Add focused unit tests for both apps asserting both headers are present and that an upstream-set value is not overwritten.

## Testing

- Unit tests pass: DMS 3/3, CMS 3/3.
- CSharpier-formatted; both frontend projects build clean.
- End-to-end validation of the un-ignored scenarios runs in this PR's CI (relational E2E shards + CMS E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)