### PR TITLE
[DMS-912] Update OpenAPI Generator to 7.19.0 for .NET 10 SDK

### DIFF
--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -203,7 +203,7 @@ jobs:
       - name: Verify SDK Generation
         run: |
           Write-Host "Checking SDK generation results..."
-          $sdkPath = "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll"
+          $sdkPath = "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll"
           Write-Host "Expected SDK path: $sdkPath"
 
           if (Test-Path $sdkPath) {
@@ -236,12 +236,12 @@ jobs:
 
       - name: Run NonDestructive DMS SDK Tests
         run: |
-          ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll" -OAuthUrl "http://localhost:8080/oauth/token"
+          ./Invoke-NonDestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll" -OAuthUrl "http://localhost:8080/oauth/token"
         working-directory: eng/smoke_test/
 
       - name: Run Destructive DMS SDK Tests
         run: |
-          ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net8.0/EdFi.DmsApi.TestSdk.dll" -OAuthUrl "http://localhost:8080/oauth/token"
+          ./Invoke-DestructiveSdkTests.ps1 -BaseUrl "http://localhost:8080" -Key "$env:SMOKE_TEST_KEY" -Secret "$env:SMOKE_TEST_SECRET" -SdkPath "${{ github.workspace }}/eng/sdkGen/csharp/src/EdFi.DmsApi.TestSdk/bin/Release/net10.0/EdFi.DmsApi.TestSdk.dll" -OAuthUrl "http://localhost:8080/oauth/token"
         working-directory: eng/smoke_test/
 
       - name: Run NonDestructive ODS SDK Tests

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -13,6 +13,12 @@ on:
     paths: # Only run on PRs that change relevant files
       - 'src/Directory.Packages.props'
       - '**/OpenApiDocument.cs'
+      # SDK generation + smoke tooling this workflow exercises, so changes to them
+      # are covered by PR validation instead of only the cron run (DMS-912).
+      - '.github/workflows/scheduled-smoke-test.yml'
+      - 'build-sdk.ps1'
+      - 'eng/smoke_test/**'
+      - 'eng/sdkGen/**'
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -451,7 +451,7 @@ CLAUDE.local.md
 
 # SDK generation artifacts
 /eng/sdkGen/csharp/*
-openApi-codegen-cli.jar
+openApi-codegen-cli*.jar
 /.github/copilot-instructions.md
 
 # Claude temporary files leaking into the project root in 2.1.5

--- a/build-sdk.ps1
+++ b/build-sdk.ps1
@@ -81,9 +81,15 @@ $solutionRoot = "$PSScriptRoot/$OutputFolder"
 $projectPath = "$solutionRoot/src/$PackageName/$PackageName.csproj"
 $nuspecPath = "$PSScriptRoot/eng/sdkGen/$PackageName.nuspec"
 
+# OpenAPI Generator CLI version used to generate the SDK. The jar is cached
+# locally under a version-specific filename so that bumping this value forces a
+# fresh download instead of silently reusing a previously downloaded generator.
+$OpenApiGeneratorVersion = "7.19.0"
+$codeGenJar = "openApi-codegen-cli-$OpenApiGeneratorVersion.jar"
+
 function DownloadCodeGen {
-    if (-not (Test-Path -Path openApi-codegen-cli.jar)) {
-        Invoke-WebRequest -OutFile openApi-codegen-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.19.0/openapi-generator-cli-7.19.0.jar
+    if (-not (Test-Path -Path $codeGenJar)) {
+        Invoke-WebRequest -OutFile $codeGenJar "https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$OpenApiGeneratorVersion/openapi-generator-cli-$OpenApiGeneratorVersion.jar"
     }
 }
 
@@ -126,7 +132,7 @@ function GenerateSdk {
     $mappings = ($operationIds | Sort-Object -Unique | ForEach-Object { "$(Normalize-OperationId $_)=$(Capitalize-FirstChar $_)" }) -join ","
     # Example --operation-id-name-mappings deleteHomographContactsById=Delete_HomographContactsById
 
-    & java -Xmx5g -jar openApi-codegen-cli.jar generate `
+    & java -Xmx5g -jar $codeGenJar generate `
     -g csharp `
     -i $Endpoint `
     --api-package $ApiPackage `

--- a/build-sdk.ps1
+++ b/build-sdk.ps1
@@ -83,7 +83,7 @@ $nuspecPath = "$PSScriptRoot/eng/sdkGen/$PackageName.nuspec"
 
 function DownloadCodeGen {
     if (-not (Test-Path -Path openApi-codegen-cli.jar)) {
-        Invoke-WebRequest -OutFile openApi-codegen-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.9.0/openapi-generator-cli-7.9.0.jar
+        Invoke-WebRequest -OutFile openApi-codegen-cli.jar https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.19.0/openapi-generator-cli-7.19.0.jar
     }
 }
 
@@ -133,7 +133,7 @@ function GenerateSdk {
     --model-package $ModelPackage `
     -o $OutputFolder `
     --operation-id-name-mappings $mappings `
-    --additional-properties "packageName=$PackageName,targetFramework=net8.0,netCoreProjectFile=true" `
+    --additional-properties "packageName=$PackageName,targetFramework=net10.0,netCoreProjectFile=true,library=restsharp" `
     --global-property modelTests=false `
     --global-property apiTests=false `
     --global-property apiDocs=false `

--- a/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.Sdk.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright @ $year$ Ed-Fi Alliance, LLC and Contributors</copyright>
     <tags>Ed-Fi API SDK</tags>
     <dependencies>
-      <group targetFramework="net8.0">
+      <group targetFramework="net10.0">
         <dependency id="NewtonSoft.Json" version="13.0.3" />
         <dependency id="JsonSubTypes" version="2.0.1" />
         <dependency id="RestSharp" version="112.0.0" />
@@ -23,6 +23,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.DmsApi.Sdk\bin\Release\net8.0\EdFi.DmsApi.Sdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.Sdk\bin\Release\net10.0\EdFi.DmsApi.Sdk.dll" target="lib\net10.0" />
   </files>
 </package>

--- a/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
+++ b/eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright @ $year$ Ed-Fi Alliance, LLC and Contributors</copyright>
     <tags>Ed-Fi API TestSdk</tags>
     <dependencies>
-      <group targetFramework="net8.0">
+      <group targetFramework="net10.0">
         <dependency id="NewtonSoft.Json" version="13.0.3" />
         <dependency id="JsonSubTypes" version="2.0.1" />
         <dependency id="RestSharp" version="112.0.0" />
@@ -23,6 +23,6 @@
   </metadata>
   <files>
     <file src="readme.txt" target="" />
-    <file src="csharp\src\EdFi.DmsApi.TestSdk\bin\Release\net8.0\EdFi.DmsApi.TestSdk.dll" target="lib\net8.0" />
+    <file src="csharp\src\EdFi.DmsApi.TestSdk\bin\Release\net10.0\EdFi.DmsApi.TestSdk.dll" target="lib\net10.0" />
   </files>
 </package>


### PR DESCRIPTION
## Summary

Resolves [DMS-912](https://edfi.atlassian.net/browse/DMS-912) — update the OpenAPI Generator so the generated C# SDKs support .NET 10.

- Bump OpenAPI Generator CLI **7.9.0 → 7.19.0** (latest stable; `net10.0` is supported and the default `targetFramework` from 7.18+).
- Retarget the generated SDKs to **net10.0**.
- **Pin `library=restsharp`** in the generator invocation. The csharp generator's *default library* changed from `restsharp` (7.9.0) to `generichost` (7.19.0). The script previously relied on the default, so a bare version bump would silently swap the SDK's HTTP stack (RestSharp → HttpClient), serializer (Newtonsoft.Json → System.Text.Json), and public API surface — and break the `.nuspec` dependency declarations. Pinning the library keeps the generated SDK equivalent to today's, only retargeted to net10.0.

## Files changed

- `build-sdk.ps1` — generator jar URL `7.9.0 → 7.19.0`; `targetFramework=net8.0 → net10.0`; added `library=restsharp`.
- `eng/sdkGen/EdFi.DmsApi.Sdk.nuspec` / `eng/sdkGen/EdFi.DmsApi.TestSdk.nuspec` — dependency-group `targetFramework` and packaged DLL `src`/`lib` paths `net8.0 → net10.0`.

## Validation (local, against OpenAPI Generator 7.19.0)

Ran the generator with the exact `build-sdk.ps1` flags for both packages:

| Package | Generate | TargetFramework | Dependencies | `dotnet build -c Release` |
| --- | --- | --- | --- | --- |
| `EdFi.DmsApi.Sdk` | exit 0 | `net10.0` | RestSharp 112.0.0 / Newtonsoft.Json 13.0.3 / JsonSubTypes 2.0.1 / Polly 8.1.0 (matches nuspec) | 0 warnings / 0 errors |
| `EdFi.DmsApi.TestSdk` | exit 0 | `net10.0` | same set | 0 warnings / 0 errors |

The 7.9.0-vs-7.19.0 generated file manifest is identical (29 files, none added/removed) once `library=restsharp` is pinned, and the underscore `operationId` mapping still works.

## Follow-up before merge

Per the ticket's "Before merging manually run" note, the full regeneration against a live DMS should still be run via the **Pkg EdFi.DmsApi.Sdk** and **Pkg EdFi.DmsApi.TestSdk** workflows (needs a running DMS serving the spec at `localhost:8080`); my local validation used a representative spec since Docker wasn't available in the dev environment.

A modernization option (move the SDK to `generichost`/System.Text.Json) and its impact is documented as a comment on DMS-912 for separate consideration — it is intentionally **not** part of this minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DMS-912]: https://edfi.atlassian.net/browse/DMS-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ