### PR TITLE
[DMS-1231] Restrict generated client secrets to Basic/form-safe characters

### DIFF
--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/KeycloakClientRepositoryTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/KeycloakClientRepositoryTests.cs
@@ -76,6 +76,28 @@ public class KeycloakClientRepositoryTests
         }
 
         [Test]
+        public async Task It_should_generate_a_secret_free_of_transport_unsafe_characters()
+        {
+            var clientUuid = Guid.NewGuid().ToString();
+            var existingClient = new Client
+            {
+                ClientId = "test-client",
+                Secret = "ExistingSecret123!",
+                Name = "Test Client",
+            };
+
+            A.CallTo(() => _keycloakClientFacade.GetClientAsync("edfi", clientUuid)).Returns(existingClient);
+            A.CallTo(() => _keycloakClientFacade.UpdateClientAsync("edfi", clientUuid, existingClient))
+                .Returns(true);
+
+            var result = await _repository.ResetCredentialsAsync(clientUuid);
+
+            result.Should().BeOfType<ClientResetResult.Success>();
+            var success = (ClientResetResult.Success)result;
+            success.ClientSecret.Should().NotContainAny("+", "%", "=", "&", " ");
+        }
+
+        [Test]
         public async Task It_should_return_failure_unknown_when_the_update_does_not_succeed()
         {
             var clientUuid = Guid.NewGuid().ToString();

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/Register/ClientSecretValidationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/Register/ClientSecretValidationTests.cs
@@ -140,4 +140,46 @@ public class ClientSecretValidationTests
         result.Failed.Should().BeTrue();
         result.FailureMessage.Should().Contain("greater than or equal to 4");
     }
+
+    [Test]
+    public void It_should_exclude_transport_unsafe_characters_from_the_generated_alphabets()
+    {
+        string[] unsafeCharacters = ["+", "%", "=", "&", " "];
+
+        foreach (var character in unsafeCharacters)
+        {
+            ClientSecretValidation.GeneratedSpecialAlphabet.Should().NotContain(character);
+            ClientSecretValidation.GeneratedClientSecretAlphabet.Should().NotContain(character);
+        }
+    }
+
+    [Test]
+    public void It_should_generate_secrets_free_of_transport_unsafe_characters()
+    {
+        var options = new ClientSecretValidationOptions { MinimumLength = 32, MaximumLength = 128 };
+        string[] unsafeCharacters = ["+", "%", "=", "&", " "];
+
+        for (var iteration = 0; iteration < 500; iteration++)
+        {
+            var secret = ClientSecretValidation.GenerateSecretWithMinimumLength(options);
+
+            foreach (var character in unsafeCharacters)
+            {
+                secret.Should().NotContain(character);
+            }
+
+            Regex.IsMatch(secret, ClientSecretValidation.BuildComplexityPattern(options)).Should().BeTrue();
+        }
+    }
+
+    [TestCase("ValidSecret1+")]
+    [TestCase("ValidSecret1%")]
+    [TestCase("ValidSecret1=")]
+    [TestCase("ValidSecret1&")]
+    public void It_should_accept_transport_unsafe_special_characters_in_caller_supplied_secrets(string secret)
+    {
+        var options = new ClientSecretValidationOptions { MinimumLength = 10, MaximumLength = 16 };
+
+        Regex.IsMatch(secret, ClientSecretValidation.BuildComplexityPattern(options)).Should().BeTrue();
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/Register/ClientSecretValidationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/Model/Register/ClientSecretValidationTests.cs
@@ -182,4 +182,15 @@ public class ClientSecretValidationTests
 
         Regex.IsMatch(secret, ClientSecretValidation.BuildComplexityPattern(options)).Should().BeTrue();
     }
+
+    [Test]
+    public void It_should_accept_caller_supplied_secrets_containing_a_space_alongside_a_valid_special_character()
+    {
+        var options = new ClientSecretValidationOptions { MinimumLength = 10, MaximumLength = 16 };
+
+        Regex
+            .IsMatch("Valid Secret1!", ClientSecretValidation.BuildComplexityPattern(options))
+            .Should()
+            .BeTrue();
+    }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictClientRepositoryTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictClientRepositoryTests.cs
@@ -501,5 +501,23 @@ public class OpenIddictClientRepositoryTests
                 .BeTrue();
             A.CallTo(() => _secretHasher.HashSecretAsync(success.ClientSecret)).MustHaveHappenedOnceExactly();
         }
+
+        [Test]
+        public async Task It_should_generate_a_secret_free_of_transport_unsafe_characters()
+        {
+            // Arrange
+            A.CallTo(() =>
+                    _dataRepository.UpdateClientSecretAsync(A<Guid>._, A<string>._, A<IDbConnection>._)
+                )
+                .Returns(1);
+
+            // Act
+            var result = await _repository.ResetCredentialsAsync(Guid.NewGuid().ToString());
+
+            // Assert
+            result.Should().BeOfType<ClientResetResult.Success>();
+            var success = (ClientResetResult.Success)result;
+            success.ClientSecret.Should().NotContainAny("+", "%", "=", "&", " ");
+        }
     }
 }

--- a/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Configuration/ClientSecretValidationOptions.cs
+++ b/src/config/datamodel/EdFi.DmsConfigurationService.DataModel/Configuration/ClientSecretValidationOptions.cs
@@ -3,9 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Options;
+
+[assembly: InternalsVisibleTo("EdFi.DmsConfigurationService.Backend.Tests.Unit")]
 
 namespace EdFi.DmsConfigurationService.DataModel.Configuration;
 
@@ -59,8 +62,24 @@ public static class ClientSecretValidation
     /// </summary>
     private const string SpecialAlphabet = "!@#$%^&*()-_=+[]{}:;,.?";
     private static readonly string EscapedSpecialCharacterClass = BuildRegexCharacterClass(SpecialAlphabet);
-    private const string GeneratedClientSecretAlphabet =
-        LowercaseAlphabet + UppercaseAlphabet + DigitAlphabet + SpecialAlphabet;
+
+    /// <summary>
+    /// Characters that are unsafe for un-encoded credential transport (HTTP Basic / x-www-form-urlencoded).
+    /// Trailing space ensures the exclusion set stays complete if SpecialAlphabet ever changes.
+    /// </summary>
+    internal const string TransportUnsafeSpecialCharacters = "+%=& ";
+
+    /// <summary>
+    /// The subset of SpecialAlphabet safe for generated secrets — excludes transport-unsafe characters.
+    /// Derived from SpecialAlphabet so the generated set is always a subset of the validation set.
+    /// Value today: "!@#$^*()-_[]{}:;,.?" (19 chars).
+    /// </summary>
+    internal static readonly string GeneratedSpecialAlphabet = new(
+        SpecialAlphabet.Where(c => !TransportUnsafeSpecialCharacters.Contains(c)).ToArray()
+    );
+
+    internal static readonly string GeneratedClientSecretAlphabet =
+        LowercaseAlphabet + UppercaseAlphabet + DigitAlphabet + GeneratedSpecialAlphabet;
 
     public static string BuildComplexityPattern(ClientSecretValidationOptions options) =>
         $@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[{EscapedSpecialCharacterClass}]).{{{options.MinimumLength},{options.MaximumLength}}}$";
@@ -74,6 +93,23 @@ public static class ClientSecretValidation
     public static bool IsWithinLengthRange(string value, ClientSecretValidationOptions options) =>
         value.Length >= options.MinimumLength && value.Length <= options.MaximumLength;
 
+    /// <summary>
+    /// Generates a cryptographically random client secret of at least <paramref name="options"/>.<see cref="ClientSecretValidationOptions.MinimumLength"/> characters.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// CMS-generated secrets are Basic/form-safe: the generator draws special characters exclusively
+    /// from <see cref="GeneratedSpecialAlphabet"/>, which excludes <c>+ % = &amp;</c> and space —
+    /// the characters significant to HTTP Basic and <c>x-www-form-urlencoded</c> credential transport.
+    /// This is why <see cref="GeneratedSpecialAlphabet"/> is narrower than <see cref="SpecialAlphabet"/>.
+    /// </para>
+    /// <para>
+    /// Caller-supplied secrets are validated permissively via <see cref="SpecialAlphabet"/> /
+    /// <see cref="BuildComplexityPattern"/> and MAY contain <c>+ % = &amp;</c>.
+    /// A client using HTTP Basic that does not URL-encode its credentials (per RFC 6749 §2.3.1)
+    /// must URL-encode any self-supplied secret that contains those characters before transmitting it.
+    /// </para>
+    /// </remarks>
     public static string GenerateSecretWithMinimumLength(ClientSecretValidationOptions options)
     {
         if (options.MaximumLength < options.MinimumLength)
@@ -102,7 +138,7 @@ public static class ClientSecretValidation
             GetRandomCharacter(LowercaseAlphabet),
             GetRandomCharacter(UppercaseAlphabet),
             GetRandomCharacter(DigitAlphabet),
-            GetRandomCharacter(SpecialAlphabet),
+            GetRandomCharacter(GeneratedSpecialAlphabet),
         ];
 
         if (options.MinimumLength > secretCharacters.Length)

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Token.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Token.feature
@@ -86,3 +86,39 @@ Feature: Token validation
                       ]
                     }
                   """
+
+        Scenario: 04 CMS-minted secret authenticates via raw HTTP Basic auth
+             When a POST request is made to "/v3/vendors" with
+                  """
+                    {
+                      "company": "V-basic-{scenarioRunId}",
+                      "contactName": "Test",
+                      "contactEmailAddress": "test@gmail.com",
+                      "namespacePrefixes": "uri://basic-auth-test-{scenarioRunId}.org"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/dataStores" with
+                  """
+                    {
+                      "dataStoreType": "Test",
+                      "name": "DS-basic-{scenarioRunId}",
+                      "connectionString": "Server=test;Database=TestDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/applications" with
+                  """
+                    {
+                      "vendorId": {vendorId},
+                      "applicationName": "App-basic-{scenarioRunId}",
+                      "claimSetName": "ClaimSet04Basic",
+                      "educationOrganizationIds": [],
+                      "dataStoreIds": [{dataStoreId}]
+                    }
+                  """
+             Then it should respond with 201
+              And retrieve created key and secret
+             When a token is requested using raw HTTP Basic auth with the captured credentials
+             Then it should respond with 200
+              And the response body has a non-empty access_token

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Token.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Token.feature
@@ -87,6 +87,7 @@ Feature: Token validation
                     }
                   """
 
+        @SelfContainedOnly
         Scenario: 04 CMS-minted secret authenticates via raw HTTP Basic auth
              When a POST request is made to "/v3/vendors" with
                   """

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Hooks/SetupHooks.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Hooks/SetupHooks.cs
@@ -17,6 +17,24 @@ public static class SetupHooks
     private const ushort DbPortExternal = 5435;
     private const string DatabaseName = "edfi_configurationservice";
 
+    // HTTP Basic auth on /connect/token is only supported in self-contained
+    // (OpenIddict) mode; keycloak mode expects credentials in the form body. Scope
+    // scenarios tagged @SelfContainedOnly accordingly so they don't run under keycloak.
+    [BeforeScenario("SelfContainedOnly")]
+    public static void SkipUnlessSelfContainedIdentityProvider()
+    {
+        var identityProvider = Environment.GetEnvironmentVariable("DMS_CONFIG_IDENTITY_PROVIDER");
+        if (
+            !string.IsNullOrEmpty(identityProvider)
+            && !identityProvider.Equals("self-contained", StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            Assert.Ignore(
+                $"Requires the self-contained identity provider (HTTP Basic on /connect/token is self-contained only); current provider is '{identityProvider}'."
+            );
+        }
+    }
+
     [BeforeFeature]
     public static async Task BeforeFeature(PlaywrightContext context)
     {

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -536,6 +536,43 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         await GetClientAccessToken(_applicationKey, _applicationSecret, "edfi_admin_api/full_access");
     }
 
+    [When("a token is requested using raw HTTP Basic auth with the captured credentials")]
+    public async Task WhenATokenIsRequestedUsingRawHttpBasicAuthWithTheCapturedCredentials()
+    {
+        var credentials = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes($"{_applicationKey}:{_applicationSecret}")
+        );
+        var content = new FormUrlEncodedContent(
+            new Dictionary<string, string> { { "grant_type", "client_credentials" } }
+        );
+        APIRequestContextOptions? options = new()
+        {
+            Headers = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/x-www-form-urlencoded" },
+                { "Authorization", $"Basic {credentials}" },
+            },
+            Data = await content.ReadAsStringAsync(),
+        };
+        if (playwrightContext.ApiRequestContext != null)
+        {
+            _apiResponse = await playwrightContext.ApiRequestContext!.PostAsync("/connect/token", options);
+        }
+    }
+
+    [Then("the response body has a non-empty access_token")]
+    public async Task ThenTheResponseBodyHasANonEmptyAccessToken()
+    {
+        string responseJsonString = await _apiResponse.TextAsync();
+        JsonDocument responseJsonDoc = JsonDocument.Parse(responseJsonString);
+        JsonNode responseJson = JsonNode.Parse(responseJsonDoc.RootElement.ToString())!;
+        responseJson["access_token"].Should().NotBeNull("response should include an access_token");
+        responseJson["access_token"]!
+            .GetValue<string>()
+            .Should()
+            .NotBeNullOrWhiteSpace("access_token should be non-empty");
+    }
+
     [Then("the response body contains an object matching")]
     public async Task ThenTheResponseBodyContainsAnObjectMatching(string expectedPartial)
     {


### PR DESCRIPTION
> Supersedes #1046, which GitHub closed when its head branch was renamed to `DMS-1231` (same commits).

## Summary

CMS-generated OAuth client secrets could contain `+`, `%`, `=`, or `&` — characters that are significant to credential transport. A client using HTTP Basic (`client_secret_basic`) that does not URL-encode credentials per RFC 6749 §2.3.1 (e.g. the ODS `BulkLoadClient`) has a `+` decoded back to a space server-side, causing `401 invalid_client`; the same characters also break `x-www-form-urlencoded` form-body credentials.

This restricts the **generated**-secret alphabet to exclude `+ % = &` (and space) so a freshly minted secret authenticates reliably over both HTTP Basic and form-body transports without URL-encoding. The DMS-918 length/complexity guarantees are preserved — the generated special set still has 19 characters and minted secrets still satisfy the complexity pattern.

**User-supplied** secret validation is intentionally unchanged: callers may still supply secrets containing `+ % = &`, matching the permissive ODS reference behavior. Only what CMS mints is constrained.

## Changes

- Decouple generation from validation in `ClientSecretValidation`: a transport-unsafe exclusion set drives a derived generated alphabet; the validation regex (`BuildComplexityPattern`) is untouched.
- Both generation points — the mandatory special character and the filler alphabet — draw from the safe set.

## Testing

- **Unit**: deterministic assertion that the generated alphabets exclude `+ % = &`/space; a 500-iteration generation property test; and regressions proving caller-supplied `+ % = &` secrets are still accepted.
- **Per-backend**: OpenIddict and Keycloak `ResetCredentialsAsync` emit transport-safe secrets.
- **E2E**: a minted secret authenticates against `/connect/token` over raw (un-encoded) HTTP Basic. Scoped to the self-contained identity provider, since Basic auth on `/connect/token` is OpenIddict-only (keycloak uses form-body credentials).

