### PR TITLE
[DMS-1230] Fix 404 on multi-tenant XSD metadata file endpoint

### DIFF
--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/XsdMetaDataModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/XsdMetaDataModuleTests.cs
@@ -16,6 +16,7 @@ using FluentAssertions;
 using ImpromptuInterface;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
@@ -264,6 +265,184 @@ public class XsdMetaDataModuleTests
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task MultiTenant_XsdMetaData_Files_Returns_Xsd_File_Content()
+    {
+        // Arrange
+        Lazy<Stream> fileStream = new(() =>
+        {
+            var content = "test-content";
+            MemoryStream ms = new(Encoding.UTF8.GetBytes(content));
+            return ms;
+        });
+
+        A.CallTo(() => _contentProvider!.TryLoadXsdContent("test.xsd", "ed-fi")).Returns(fileStream);
+
+        var tenantValidator = A.Fake<ITenantValidator>();
+        A.CallTo(() => tenantValidator.ValidateTenantAsync(A<string>._)).Returns(true);
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" }
+                    );
+                }
+            );
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    TestMockHelper.AddEssentialMocks(collection);
+                    collection.AddTransient((x) => _apiService!);
+                    collection.AddTransient((x) => _contentProvider!);
+                    collection.AddTransient((x) => tenantValidator);
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/tenant1/metadata/xsd/ed-fi/test.xsd");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/xml");
+        content.Should().Contain("test-content");
+    }
+
+    [Test]
+    public async Task MultiTenant_XsdMetaData_Files_Returns_404_For_Missing_File()
+    {
+        // Arrange
+        A.CallTo(() => _contentProvider!.TryLoadXsdContent("not-exists.xsd", "ed-fi"))
+            .Returns((Lazy<Stream>?)null);
+
+        var tenantValidator = A.Fake<ITenantValidator>();
+        A.CallTo(() => tenantValidator.ValidateTenantAsync(A<string>._)).Returns(true);
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" }
+                    );
+                }
+            );
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    TestMockHelper.AddEssentialMocks(collection);
+                    collection.AddTransient((x) => _apiService!);
+                    collection.AddTransient((x) => _contentProvider!);
+                    collection.AddTransient((x) => tenantValidator);
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/tenant1/metadata/xsd/ed-fi/not-exists.xsd");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task MultiTenant_XsdMetaData_Returns_Files()
+    {
+        // Arrange
+        var tenantValidator = A.Fake<ITenantValidator>();
+        A.CallTo(() => tenantValidator.ValidateTenantAsync(A<string>._)).Returns(true);
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" }
+                    );
+                }
+            );
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    TestMockHelper.AddEssentialMocks(collection);
+                    collection.AddTransient((x) => _apiService!);
+                    collection.AddTransient((x) => _contentProvider!);
+                    collection.AddTransient((x) => tenantValidator);
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/tenant1/metadata/xsd/ed-fi/files");
+        var content = await response.Content.ReadAsStringAsync();
+
+        var files = JsonSerializer.Deserialize<List<string>>(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        files.Should().NotBeNull();
+        files?.Count().Should().Be(3);
+    }
+
+    [Test]
+    public async Task MultiTenant_XsdMetaData_FileListUrl_Is_Not_Corrupted_When_Tenant_Or_Section_Contains_Files()
+    {
+        // Arrange: section "myfiles" and tenant "tenantfiles1" both contain the word "files".
+        // The old .Replace("files","") approach would corrupt the URLs; verify it does not.
+        var files = new List<string> { "a.xsd" };
+        A.CallTo(() => _contentProvider!.IsXsdSectionKnown("myfiles")).Returns(true);
+        A.CallTo(() => _contentProvider!.ListXsdFiles("myfiles")).Returns(files);
+
+        var tenantValidator = A.Fake<ITenantValidator>();
+        A.CallTo(() => tenantValidator.ValidateTenantAsync(A<string>._)).Returns(true);
+
+        await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (context, configuration) =>
+                {
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" }
+                    );
+                }
+            );
+            builder.ConfigureServices(
+                (collection) =>
+                {
+                    TestMockHelper.AddEssentialMocks(collection);
+                    collection.AddTransient((x) => _apiService!);
+                    collection.AddTransient((x) => _contentProvider!);
+                    collection.AddTransient((x) => tenantValidator);
+                }
+            );
+        });
+        using var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/tenantfiles1/metadata/xsd/myfiles/files");
+        var content = await response.Content.ReadAsStringAsync();
+
+        var returnedFiles = JsonSerializer.Deserialize<List<string>>(content);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        returnedFiles.Should().NotBeNull();
+        returnedFiles.Should().Equal("http://localhost/tenantfiles1/metadata/xsd/myfiles/a.xsd");
     }
 }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/XsdMetadataEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/XsdMetadataEndpointModule.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
-using System.Text.RegularExpressions;
 using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
@@ -14,14 +13,8 @@ using Microsoft.Extensions.Options;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Modules;
 
-public partial class XsdMetadataEndpointModule(IOptions<AppSettings> appSettings) : IEndpointModule
+public class XsdMetadataEndpointModule(IOptions<AppSettings> appSettings) : IEndpointModule
 {
-    [GeneratedRegex(@"\/(?<section>[^/]+)\/files?")]
-    private static partial Regex PathExpressionRegex();
-
-    [GeneratedRegex(@"\/(?<section>[^/]+)\/(?<fileName>[^/]+).xsd?")]
-    private static partial Regex FilePathExpressionRegex();
-
     private readonly string ErrorResourcePath = "Invalid resource path";
 
     public void MapEndpoints(IEndpointRouteBuilder endpoints)
@@ -81,16 +74,14 @@ public partial class XsdMetadataEndpointModule(IOptions<AppSettings> appSettings
             return;
         }
 
-        var request = httpContext.Request;
-        Match match = PathExpressionRegex().Match(request.Path);
-        if (!match.Success)
+        string? section = httpContext.Request.RouteValues["section"] as string;
+        if (string.IsNullOrEmpty(section))
         {
             httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
             await httpContext.Response.WriteAsync(ErrorResourcePath);
             return;
         }
 
-        string section = match.Groups["section"].Value;
         if (!contentProvider.IsXsdSectionKnown(section))
         {
             httpContext.Response.StatusCode = (int)HttpStatusCode.NotFound;
@@ -98,7 +89,12 @@ public partial class XsdMetadataEndpointModule(IOptions<AppSettings> appSettings
             return;
         }
 
-        var baseUrl = httpContext.Request.UrlWithPathSegment().Replace("files", "");
+        const string fileListSegment = "/files";
+        var url = httpContext.Request.UrlWithPathSegment();
+        var baseUrl = url.EndsWith(fileListSegment, StringComparison.Ordinal)
+            ? $"{url[..^fileListSegment.Length]}/"
+            : url;
+
         var withFullPath = new List<string>();
         var xsdFiles = contentProvider.ListXsdFiles(section);
 
@@ -126,14 +122,13 @@ public partial class XsdMetadataEndpointModule(IOptions<AppSettings> appSettings
             return Results.Empty;
         }
 
-        var request = httpContext.Request;
-        Match match = FilePathExpressionRegex().Match(request.Path);
-        if (!match.Success)
+        string? section = httpContext.Request.RouteValues["section"] as string;
+        string? fileName = httpContext.Request.RouteValues["fileName"] as string;
+        if (string.IsNullOrEmpty(section) || string.IsNullOrEmpty(fileName))
         {
             return Results.NotFound(ErrorResourcePath);
         }
-        string section = match.Groups["section"].Value;
-        var fileName = match.Groups["fileName"].Value;
+
         var fileFullName = $"{fileName}.xsd";
         var content = contentProvider.TryLoadXsdContent(fileFullName, section);
         if (content is not null)

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/Features/InstanceManagement/TenantAwareDiscovery.feature
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/Features/InstanceManagement/TenantAwareDiscovery.feature
@@ -55,3 +55,8 @@ Feature: Tenant-Aware Discovery API
     Scenario: XSD metadata endpoint with invalid tenant returns 404
          When a GET request is made to XSD metadata endpoint with tenant "NonExistentTenant"
          Then it should respond with 404
+
+    Scenario: XSD metadata file content with valid tenant returns OK
+         When a GET request is made to XSD file "Ed-Fi-Core" in section "ed-fi" with tenant "Tenant_Discovery_255901"
+         Then it should respond with 200
+          And the response content type should be "application/xml"

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/Management/DmsApiClient.cs
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/Management/DmsApiClient.cs
@@ -170,6 +170,29 @@ public class DmsApiClient : IDisposable
     }
 
     /// <summary>
+    /// Get a specific XSD file under a tenant prefix
+    /// </summary>
+    public async Task<HttpResponseMessage> GetXsdFileWithTenantAsync(
+        string tenant,
+        string section,
+        string fileName
+    )
+    {
+        var url = $"/{tenant}/metadata/xsd/{section}/{fileName}.xsd";
+
+        // Use shared HttpClient for unauthenticated requests
+        if (string.IsNullOrEmpty(_accessToken))
+        {
+            var fullUrl = $"{_baseUrl}{url}";
+            var response = await _sharedHttpClient.GetAsync(fullUrl);
+            return response;
+        }
+
+        var authenticatedResponse = await _httpClient.GetAsync(url);
+        return authenticatedResponse;
+    }
+
+    /// <summary>
     /// GET view-claimsets management endpoint (tenant-aware)
     /// </summary>
     public async Task<HttpResponseMessage> GetViewClaimsetsAsync(string? tenant = null)

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/StepDefinitions/RouteQualifierStepDefinitions.cs
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/StepDefinitions/RouteQualifierStepDefinitions.cs
@@ -354,4 +354,35 @@ public class RouteQualifierStepDefinitions(InstanceManagementContext context)
             Console.WriteLine($"Response body: {responseBody}");
         }
     }
+
+    [When("a GET request is made to XSD file {string} in section {string} with tenant {string}")]
+    public async Task WhenAGetRequestIsMadeToXsdFileInSectionWithTenant(
+        string fileName,
+        string section,
+        string tenantName
+    )
+    {
+        // XSD file endpoints are public and don't require authentication
+        using var xsdClient = new DmsApiClient(TestConfiguration.DmsApiUrl, "");
+
+        Console.WriteLine($"GET XSD file '{fileName}' in section '{section}' with tenant: '{tenantName}'");
+
+        context.LastResponse = await xsdClient.GetXsdFileWithTenantAsync(tenantName, section, fileName);
+
+        Console.WriteLine(
+            $"Response: {(int)context.LastResponse.StatusCode} ({context.LastResponse.StatusCode})"
+        );
+        if (!context.LastResponse.IsSuccessStatusCode)
+        {
+            var responseBody = await context.LastResponse.Content.ReadAsStringAsync();
+            Console.WriteLine($"Response body: {responseBody}");
+        }
+    }
+
+    [Then("the response content type should be {string}")]
+    public void ThenTheResponseContentTypeShouldBe(string expectedMediaType)
+    {
+        context.LastResponse.Should().NotBeNull();
+        context.LastResponse!.Content.Headers.ContentType?.MediaType.Should().Be(expectedMediaType);
+    }
 }


### PR DESCRIPTION
## Summary

In multi-tenant mode the XSD metadata file-content endpoint `/{tenant}/metadata/xsd/{section}/{fileName}.xsd` returned `404` for every advertised file. `GetXsdMetadataFileContent` re-parsed the raw request path with an unanchored regex whose unescaped `.` let the `/{tenant}` prefix shift the captured segments (`section=tenant1, fileName=metadata`), so the lookup always missed. Single-tenant served correctly because there was no prefix to shift. The ODS `BulkLoadClient` self-services XSDs from this endpoint, so API-based seeding of a multi-tenant instance was blocked. Introduced by DMS-886 (multi-tenancy), which added the `/{tenant}` prefix without updating the regex.

The fix resolves both XSD handlers from the already-bound route values (`RouteValues["section"|"fileName"]`) instead of regex-parsing the path — the same idiom the module already uses for the tenant — and removes both local `[GeneratedRegex]` methods. The file-list base-URL construction is also hardened: a suffix-aware `/files` strip replaces the broad `.Replace("files", "")`, which corrupted URLs when `files` appeared in the tenant or section.

## Changes

- `XsdMetadataEndpointModule`: both handlers read route values + return `404` defensively on missing values; suffix-aware `/files` base-URL; both unused regexes removed. The unrelated Core `UtilityService.PathExpressionRegex` is untouched.

## Testing

- **Unit**: multi-tenant file-content (`200`/`404`) and file-list (`200`) cases, plus a regression proving file URLs are not corrupted when the tenant/section contains `files`. Single-tenant unit coverage unchanged (32 tests green).
- **E2E**: a focused scenario in the multi-tenant `TenantAwareDiscovery.feature` fetches a real XSD file under a provisioned tenant and asserts `200` + `application/xml` (executes in CI's multi-tenant lane).
