### PR TITLE
[DMS-1233] Normalize profile extension names to schema extension keys

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/CachedProfileServiceTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/CachedProfileServiceTests.cs
@@ -105,15 +105,34 @@ public class CachedProfileServiceTests
                 .Returns(ProfileValidationResult.Success);
         }
 
+        // The service canonicalizes extension names against the schema after validation,
+        // so the provider must expose a non-null ApiSchemaDocuments. These profiles have
+        // no extensions, so canonicalization is a no-op.
+        var schemaProvider = effectiveApiSchemaProvider ?? A.Fake<IEffectiveApiSchemaProvider>();
+        if (effectiveApiSchemaProvider is null)
+        {
+            A.CallTo(() => schemaProvider.Documents).Returns(CreateMinimalApiSchemaDocuments());
+        }
+
         return new CachedProfileService(
             cmsProvider,
             validator,
-            effectiveApiSchemaProvider ?? A.Fake<IEffectiveApiSchemaProvider>(),
+            schemaProvider,
             cache ?? CreateHybridCache(),
             new CacheSettings { ProfileCacheExpirationSeconds = 1800 },
             NullLogger<CachedProfileService>.Instance
         );
     }
+
+    private static ApiSchemaDocuments CreateMinimalApiSchemaDocuments() =>
+        new ApiSchemaBuilder()
+            .WithStartProject()
+            .WithStartResource("Student")
+            .WithEndResource()
+            .WithStartResource("School")
+            .WithEndResource()
+            .WithEndProject()
+            .ToApiSchemaDocuments();
 
     [TestFixture]
     public class Given_No_Profiles_Assigned : CachedProfileServiceTests

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -151,6 +151,74 @@ public class ProfileDataValidatorTests
             return apiSchemaDocuments;
         }
 
+        /// <summary>
+        /// Builds a schema whose insert schema exposes <c>_ext.sample</c> containing a nested
+        /// object (<c>petPreference</c>) and a nested collection (<c>pets</c>), used to exercise
+        /// unknown-extension detection inside an extension's own object/collection children.
+        /// </summary>
+        private static ApiSchemaDocuments CreateSchemaWithExtensionChildren(string resourceName)
+        {
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["_ext"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["sample"] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["petPreference"] = new JsonObject
+                                    {
+                                        ["type"] = "object",
+                                        ["properties"] = new JsonObject
+                                        {
+                                            ["minimumWeight"] = new JsonObject { ["type"] = "number" },
+                                        },
+                                    },
+                                    ["pets"] = new JsonObject
+                                    {
+                                        ["type"] = "array",
+                                        ["items"] = new JsonObject
+                                        {
+                                            ["type"] = "object",
+                                            ["properties"] = new JsonObject
+                                            {
+                                                ["petName"] = new JsonObject { ["type"] = "string" },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            var apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource(resourceName)
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            var resourceNode = apiSchemaDocuments
+                .GetCoreProjectSchema()
+                .FindResourceSchemaNodeByResourceName(new(resourceName));
+
+            if (resourceNode is JsonObject resourceObj)
+            {
+                resourceObj["jsonSchemaForInsert"] = jsonSchemaForInsert;
+            }
+
+            return apiSchemaDocuments;
+        }
+
         private static ApiSchemaDocuments CreateSchemaWithProperties(
             string resourceName,
             params string[] propertyNames
@@ -1905,6 +1973,162 @@ public class ProfileDataValidatorTests
                 .Contain(f =>
                     f.Severity == ValidationSeverity.Warning
                     && f.MemberName == "schoolReference._ext.DoesNotExist"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_report_unknown_extension_under_collection_item()
+        {
+            // Arrange — an unknown extension declared on a collection item. The collection-item
+            // _ext has no such key, so canonicalization would drop the rule; the pre-pass must
+            // report it (collections use their own traversal path).
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithCollection("Student", "studentPets", "petName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var collectionRule = new CollectionRule(
+                Name: "studentPets",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions:
+                [
+                    new ExtensionRule("DoesNotExist", MemberSelection.IncludeAll, null, null, null, null),
+                ],
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                Properties: [],
+                Objects: [],
+                Collections: [collectionRule],
+                Extensions: []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — reported with the collection-item path; severity follows the IncludeOnly
+            // collection, so it is an error.
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "studentPets[]._ext.DoesNotExist"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_report_unknown_extension_inside_resolved_extension_object()
+        {
+            // Arrange — an unknown extension nested inside an object that lives within a resolved
+            // extension (_ext.sample.petPreference._ext.DoesNotExist). Exercises the recursion
+            // from the extension into its object children.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtensionChildren("Student");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var nestedObject = new ObjectRule(
+                Name: "petPreference",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions:
+                [
+                    new ExtensionRule("DoesNotExist", MemberSelection.IncludeAll, null, null, null, null),
+                ]
+            );
+            var sampleExtension = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: [nestedObject],
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [],
+                [sampleExtension]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — reported with the full extension-child object path; severity follows the
+            // IncludeOnly object, so it is an error.
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "_ext.sample.petPreference._ext.DoesNotExist"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_report_unknown_extension_inside_resolved_extension_collection()
+        {
+            // Arrange — an unknown extension nested inside a collection within a resolved
+            // extension (_ext.sample.pets[]._ext.DoesNotExist). Exercises the recursion from the
+            // extension into its collection children.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtensionChildren("Student");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var nestedCollection = new CollectionRule(
+                Name: "pets",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions:
+                [
+                    new ExtensionRule("DoesNotExist", MemberSelection.IncludeAll, null, null, null, null),
+                ],
+                ItemFilter: null
+            );
+            var sampleExtension = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: [nestedCollection]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [],
+                [sampleExtension]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — reported with the full extension-child collection path; severity follows
+            // the IncludeOnly collection, so it is an error.
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "_ext.sample.pets[]._ext.DoesNotExist"
                     && f.Message.Contains("does not exist")
                 );
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -2250,6 +2250,105 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
+        public void Validate_should_not_escalate_extension_under_missing_object_in_exclude_only()
+        {
+            // Arrange — an ExcludeOnly profile references an object absent from the schema, and
+            // that object contains an IncludeOnly extension. The missing object is reported by
+            // member-selection validation (warning under ExcludeOnly); the extension pre-pass must
+            // not descend into the missing object and escalate its nested extension to an error,
+            // which would reject a profile that previously loaded (a loadability regression).
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var objectRule = new ObjectRule(
+                Name: "nonexistentObject",
+                MemberSelection: MemberSelection.ExcludeOnly,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions:
+                [
+                    new ExtensionRule(
+                        "X",
+                        MemberSelection.IncludeOnly,
+                        null,
+                        [new PropertyRule("a")],
+                        null,
+                        null
+                    ),
+                ]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                Properties: [],
+                Objects: [objectRule],
+                Collections: [],
+                Extensions: []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — profile still loads with feedback: the missing object is a warning and the
+            // nested extension is not escalated to an error.
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
+            result.Failures.Should().NotContain(f => f.MemberName == "nonexistentObject._ext.X");
+        }
+
+        [Test]
+        public void Validate_should_not_escalate_extension_under_missing_collection_in_exclude_only()
+        {
+            // Arrange — same as the missing-object case, for a collection absent from the schema.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithProperties("Student", "firstName");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var collectionRule = new CollectionRule(
+                Name: "nonexistentCollection",
+                MemberSelection: MemberSelection.ExcludeOnly,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions:
+                [
+                    new ExtensionRule(
+                        "X",
+                        MemberSelection.IncludeOnly,
+                        null,
+                        [new PropertyRule("a")],
+                        null,
+                        null
+                    ),
+                ],
+                ItemFilter: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                Properties: [],
+                Objects: [],
+                Collections: [collectionRule],
+                Extensions: []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — profile still loads with feedback: the missing collection is a warning and
+            // the nested extension is not escalated to an error.
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
+            result.Failures.Should().NotContain(f => f.MemberName == "nonexistentCollection[]._ext.X");
+        }
+
+        [Test]
         public void Validate_should_resolve_extension_name_to_non_lowercase_schema_key()
         {
             // Arrange — schema key is camelCase sampleStaff (not all-lowercase). The canonical

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1301,14 +1301,14 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert
+            // Assert — the unknown extension is reported once, as an error, by the
+            // mode-independent unknown-extension pre-pass.
             result.IsValid.Should().BeFalse();
             result.HasErrors.Should().BeTrue();
             result.Failures.Should().HaveCount(1);
             result.Failures[0].Severity.Should().Be(ValidationSeverity.Error);
-            result.Failures[0].MemberName.Should().Be("SampleExtension");
-            result.Failures[0].Message.Should().Contain("cannot be validated");
-            result.Failures[0].Message.Should().Contain("no _ext property");
+            result.Failures[0].MemberName.Should().Be("_ext.SampleExtension");
+            result.Failures[0].Message.Should().Contain("does not exist");
         }
 
         [Test]
@@ -1707,7 +1707,7 @@ public class ProfileDataValidatorTests
         public void Validate_should_resolve_mixed_case_extension_name_to_schema_key()
         {
             // Arrange — schema exposes the extension under the lower-case project key sample
-            // while the profile authors it as Sample, per DMS-1233.
+            // while the profile authors it as Sample.
             var validator = new ProfileDataValidator(_logger);
             _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
             A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
@@ -1773,13 +1773,13 @@ public class ProfileDataValidatorTests
                 .Failures.Should()
                 .ContainSingle(f =>
                     f.Severity == ValidationSeverity.Error
-                    && f.MemberName == "Nonexistent"
+                    && f.MemberName == "_ext.Nonexistent"
                     && f.Message.Contains("does not exist")
                 );
         }
 
         [Test]
-        public void Validate_should_warn_for_unknown_extension_under_exclude_only_parent()
+        public void Validate_should_error_for_unknown_extension_under_exclude_only_parent()
         {
             // Arrange — schema only has the sample extension, profile excludes an unknown one.
             var validator = new ProfileDataValidator(_logger);
@@ -1807,13 +1807,14 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert — unknown extension under ExcludeOnly is a warning (profile still loads).
-            result.HasErrors.Should().BeFalse();
-            result.HasWarnings.Should().BeTrue();
+            // Assert — an unknown extension reference is always an error: canonicalization drops
+            // the rule, so a tolerant warning would let it disappear silently rather than give
+            // feedback. Member-level exclusions remain tolerant; whole-extension references do not.
+            result.HasErrors.Should().BeTrue();
             result
                 .Failures.Should()
                 .ContainSingle(f =>
-                    f.Severity == ValidationSeverity.Warning && f.MemberName == "Nonexistent"
+                    f.Severity == ValidationSeverity.Error && f.MemberName == "_ext.Nonexistent"
                 );
         }
 
@@ -1853,7 +1854,54 @@ public class ProfileDataValidatorTests
                 .Failures.Should()
                 .Contain(f =>
                     f.Severity == ValidationSeverity.Error
-                    && f.MemberName == "DoesNotExist"
+                    && f.MemberName == "_ext.DoesNotExist"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_error_for_unknown_extension_nested_in_include_all_object()
+        {
+            // Arrange — an unknown extension nested inside an IncludeAll object under an
+            // IncludeAll parent. The member-selection validation short-circuits on IncludeAll,
+            // so only the mode-independent unknown-extension pre-pass can surface this; without
+            // it the rule would be dropped by canonicalization with no feedback.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithReferenceObject("Student", "schoolReference", "schoolId");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var objectRule = new ObjectRule(
+                Name: "schoolReference",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions:
+                [
+                    new ExtensionRule("DoesNotExist", MemberSelection.IncludeAll, null, null, null, null),
+                ]
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                Properties: [],
+                Objects: [objectRule],
+                Collections: [],
+                Extensions: []
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — nested unknown extension is reported with its full path.
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "schoolReference._ext.DoesNotExist"
                     && f.Message.Contains("does not exist")
                 );
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1931,6 +1931,50 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
+        public void Validate_should_error_for_unknown_include_only_extension_under_include_all_parent()
+        {
+            // Arrange — an explicit IncludeOnly extension rule selects specific members of the
+            // extension, so the extension must exist even under an IncludeAll parent. An unknown
+            // such rule is an error and must not be downgraded to a warning the parent tolerates,
+            // which would silently drop the explicit restriction.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "Smaple",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("sampleField")],
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — error (profile rejected), not a warning that loads the profile with the
+            // explicit IncludeOnly restriction silently dropped.
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "_ext.Smaple"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
         public void Validate_should_report_unknown_extension_nested_in_include_all_object()
         {
             // Arrange — an unknown extension nested inside an IncludeAll object under an

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -2158,11 +2158,51 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert — rejected with feedback rather than throwing during navigation.
+            // Assert — both resolve to schema key "sample", so the collision is rejected with an
+            // error rather than throwing during navigation.
             result.HasErrors.Should().BeTrue();
             result
                 .Failures.Should()
-                .Contain(f => f.Severity == ValidationSeverity.Error && f.Message.Contains("more than once"));
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error && f.Message.Contains("collapse to the same key")
+                );
+        }
+
+        [Test]
+        public void Validate_should_warn_not_error_for_unresolved_case_variant_extensions_under_exclude_only()
+        {
+            // Arrange — Foo and foo are both unknown (schema only has sample). Neither resolves,
+            // so canonicalization drops both; they must keep the ExcludeOnly missing-reference
+            // contract (warnings) rather than be rejected as a duplicate collision.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                [],
+                [],
+                [],
+                [
+                    new ExtensionRule("Foo", MemberSelection.IncludeAll, null, null, null, null),
+                    new ExtensionRule("foo", MemberSelection.IncludeAll, null, null, null, null),
+                ]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — two missing-reference warnings (one per unresolved name), no error, and no
+            // duplicate-collision failure.
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
+            result.Failures.Should().HaveCount(2);
+            result.Failures.Should().OnlyContain(f => f.Severity == ValidationSeverity.Warning);
+            result.Failures.Should().Contain(f => f.MemberName == "_ext.Foo");
+            result.Failures.Should().Contain(f => f.MemberName == "_ext.foo");
+            result.Failures.Should().NotContain(f => f.Message.Contains("collapse to the same key"));
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1779,7 +1779,7 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
-        public void Validate_should_error_for_unknown_extension_under_exclude_only_parent()
+        public void Validate_should_warn_for_unknown_extension_under_exclude_only_parent()
         {
             // Arrange — schema only has the sample extension, profile excludes an unknown one.
             var validator = new ProfileDataValidator(_logger);
@@ -1807,19 +1807,20 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert — an unknown extension reference is always an error: canonicalization drops
-            // the rule, so a tolerant warning would let it disappear silently rather than give
-            // feedback. Member-level exclusions remain tolerant; whole-extension references do not.
-            result.HasErrors.Should().BeTrue();
+            // Assert — ExcludeOnly tolerates a missing reference: a warning is emitted (so the
+            // profile still loads), and canonicalization drops the rule so no unresolved runtime
+            // scope is created. This preserves the existing missing-reference contract.
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
             result
                 .Failures.Should()
                 .ContainSingle(f =>
-                    f.Severity == ValidationSeverity.Error && f.MemberName == "_ext.Nonexistent"
+                    f.Severity == ValidationSeverity.Warning && f.MemberName == "_ext.Nonexistent"
                 );
         }
 
         [Test]
-        public void Validate_should_error_for_unknown_extension_under_include_all_parent()
+        public void Validate_should_warn_for_unknown_extension_under_include_all_parent()
         {
             // Arrange — an IncludeAll extension under an IncludeAll parent must still be
             // existence-checked, because canonicalization would otherwise drop it silently.
@@ -1848,19 +1849,21 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert — clear feedback (error) rather than a silent drop.
-            result.HasErrors.Should().BeTrue();
+            // Assert — IncludeAll tolerates a missing reference: a warning (clear feedback)
+            // rather than a silent drop, and the rule is dropped by canonicalization.
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
             result
                 .Failures.Should()
                 .Contain(f =>
-                    f.Severity == ValidationSeverity.Error
+                    f.Severity == ValidationSeverity.Warning
                     && f.MemberName == "_ext.DoesNotExist"
                     && f.Message.Contains("does not exist")
                 );
         }
 
         [Test]
-        public void Validate_should_error_for_unknown_extension_nested_in_include_all_object()
+        public void Validate_should_report_unknown_extension_nested_in_include_all_object()
         {
             // Arrange — an unknown extension nested inside an IncludeAll object under an
             // IncludeAll parent. The member-selection validation short-circuits on IncludeAll,
@@ -1895,12 +1898,12 @@ public class ProfileDataValidatorTests
             // Act
             var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
 
-            // Assert — nested unknown extension is reported with its full path.
-            result.HasErrors.Should().BeTrue();
+            // Assert — feedback is emitted (not silently dropped) with the nested rule's full
+            // path; severity follows the enclosing IncludeAll object, so it is a warning.
             result
                 .Failures.Should()
                 .Contain(f =>
-                    f.Severity == ValidationSeverity.Error
+                    f.Severity == ValidationSeverity.Warning
                     && f.MemberName == "schoolReference._ext.DoesNotExist"
                     && f.Message.Contains("does not exist")
                 );

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1818,6 +1818,114 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
+        public void Validate_should_error_for_unknown_extension_under_include_all_parent()
+        {
+            // Arrange — an IncludeAll extension under an IncludeAll parent must still be
+            // existence-checked, because canonicalization would otherwise drop it silently.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "DoesNotExist",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — clear feedback (error) rather than a silent drop.
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .Contain(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "DoesNotExist"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_error_for_duplicate_extension_names_differing_only_by_case()
+        {
+            // Arrange — sample and Sample both resolve to the schema key sample and would
+            // collapse to a duplicate key in ExtensionRulesByName at runtime.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                [],
+                [],
+                [],
+                [
+                    new ExtensionRule("sample", MemberSelection.IncludeAll, null, null, null, null),
+                    new ExtensionRule("Sample", MemberSelection.IncludeAll, null, null, null, null),
+                ]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — rejected with feedback rather than throwing during navigation.
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .Contain(f => f.Severity == ValidationSeverity.Error && f.Message.Contains("more than once"));
+        }
+
+        [Test]
+        public void Validate_should_resolve_extension_name_to_non_lowercase_schema_key()
+        {
+            // Arrange — schema key is camelCase sampleStaff (not all-lowercase). The canonical
+            // key must come from the schema, so a differently-cased authored name resolves.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sampleStaff", "field");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "samplestaff",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — samplestaff resolves to schema key sampleStaff; no missing-extension failure.
+            result.IsValid.Should().BeTrue();
+            result.Failures.Should().BeEmpty();
+        }
+
+        [Test]
         public void Validate_should_return_error_for_nested_object_named_link()
         {
             // Arrange — schema has schoolReference.schoolId; profile defines a nested object named "link"

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileDataValidatorTests.cs
@@ -1704,6 +1704,120 @@ public class ProfileDataValidatorTests
         }
 
         [Test]
+        public void Validate_should_resolve_mixed_case_extension_name_to_schema_key()
+        {
+            // Arrange — schema exposes the extension under the lower-case project key sample
+            // while the profile authors it as Sample, per DMS-1233.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "Sample",
+                MemberSelection: MemberSelection.IncludeOnly,
+                LogicalSchema: null,
+                Properties: [new PropertyRule("sampleField")],
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — Sample resolves to schema key sample, so there is no missing-extension failure.
+            result.IsValid.Should().BeTrue();
+            result.Failures.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Validate_should_error_for_unknown_extension_under_include_only_parent()
+        {
+            // Arrange — schema only has the sample extension, profile references an unknown one.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "Nonexistent",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.IncludeOnly,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — unknown extension under IncludeOnly is an error (profile is dropped at load).
+            result.HasErrors.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Error
+                    && f.MemberName == "Nonexistent"
+                    && f.Message.Contains("does not exist")
+                );
+        }
+
+        [Test]
+        public void Validate_should_warn_for_unknown_extension_under_exclude_only_parent()
+        {
+            // Arrange — schema only has the sample extension, profile excludes an unknown one.
+            var validator = new ProfileDataValidator(_logger);
+            _apiSchemaDocuments = CreateSchemaWithExtension("Student", "sample", "sampleField");
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents).Returns(_apiSchemaDocuments);
+
+            var extensionRule = new ExtensionRule(
+                Name: "Nonexistent",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: null
+            );
+            var contentType = new ContentTypeDefinition(
+                MemberSelection.ExcludeOnly,
+                [],
+                [],
+                [],
+                [extensionRule]
+            );
+            var resourceProfile = new ResourceProfile("Student", null, contentType, null);
+            var profileDefinition = new ProfileDefinition("TestProfile", [resourceProfile]);
+
+            // Act
+            var result = validator.Validate(profileDefinition, _effectiveApiSchemaProvider);
+
+            // Assert — unknown extension under ExcludeOnly is a warning (profile still loads).
+            result.HasErrors.Should().BeFalse();
+            result.HasWarnings.Should().BeTrue();
+            result
+                .Failures.Should()
+                .ContainSingle(f =>
+                    f.Severity == ValidationSeverity.Warning && f.MemberName == "Nonexistent"
+                );
+        }
+
+        [Test]
         public void Validate_should_return_error_for_nested_object_named_link()
         {
             // Arrange — schema has schoolReference.schoolId; profile defines a nested object named "link"

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -277,6 +277,34 @@ public class ProfileExtensionCanonicalizerTests
         }
 
         [Test]
+        public void Canonicalize_uses_schema_key_casing_not_lowercase()
+        {
+            // Arrange — schema key is camelCase sampleStaff. The canonical key must come from
+            // the schema/project endpoint name, not blind lowercasing, so an authored
+            // samplestaff must become sampleStaff (not stay lowercase).
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithRootExtension("Staff", "sampleStaff", "field"));
+
+            var writeContentType = ContentTypeWithExtension(
+                MemberSelection.ExcludeOnly,
+                Extension("samplestaff")
+            );
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert — the schema's exact casing is preserved.
+            result.Resources[0].WriteContentType!.Extensions.Single().Name.Should().Be("sampleStaff");
+        }
+
+        [Test]
         public void Canonicalize_returns_same_instance_when_already_canonical()
         {
             // Arrange — extension already uses the schema key, so nothing should be rewritten.

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -227,6 +227,31 @@ public class ProfileExtensionCanonicalizerTests
         }
 
         [Test]
+        public void Canonicalize_drops_root_extension_rule_when_extension_only_exists_nested()
+        {
+            // Arrange — the sample extension exists ONLY on staffPets[*]._ext, not at the root.
+            // A root-level extension rule must not survive, or it would emit an unresolved
+            // root $._ext.sample scope at runtime (the DMS-1233 500).
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithCollectionExtension("Staff", "staffPets", "sample"));
+
+            var writeContentType = ContentTypeWithExtension(MemberSelection.ExcludeOnly, Extension("Sample"));
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert — the root rule is dropped because the root location has no _ext.sample.
+            result.Resources[0].WriteContentType!.Extensions.Should().BeEmpty();
+        }
+
+        [Test]
         public void Canonicalize_rewrites_both_read_and_write_content_types()
         {
             // Arrange

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -231,7 +231,7 @@ public class ProfileExtensionCanonicalizerTests
         {
             // Arrange — the sample extension exists ONLY on staffPets[*]._ext, not at the root.
             // A root-level extension rule must not survive, or it would emit an unresolved
-            // root $._ext.sample scope at runtime (the DMS-1233 500).
+            // root $._ext.sample scope at runtime (the runtime 500).
             A.CallTo(() => _effectiveApiSchemaProvider.Documents)
                 .Returns(CreateSchemaWithCollectionExtension("Staff", "staffPets", "sample"));
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.ApiSchema;
+using EdFi.DataManagementService.Core.Profile;
+using FakeItEasy;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Profile;
+
+[TestFixture]
+public class ProfileExtensionCanonicalizerTests
+{
+    public class Given_ProfileExtensionCanonicalizer
+    {
+        private IEffectiveApiSchemaProvider _effectiveApiSchemaProvider = null!;
+
+        /// <summary>
+        /// Builds a schema for <paramref name="resourceName"/> whose insert schema exposes
+        /// a root-level <c>_ext.{extensionKey}</c> with the given member names.
+        /// </summary>
+        private static ApiSchemaDocuments CreateSchemaWithRootExtension(
+            string resourceName,
+            string extensionKey,
+            params string[] extensionPropertyNames
+        )
+        {
+            var extProperties = new JsonObject();
+            foreach (var name in extensionPropertyNames)
+            {
+                extProperties[name] = new JsonObject { ["type"] = "string" };
+            }
+
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["_ext"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            [extensionKey] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = extProperties,
+                            },
+                        },
+                    },
+                },
+            };
+
+            return BuildDocuments(resourceName, jsonSchemaForInsert);
+        }
+
+        /// <summary>
+        /// Builds a schema for <paramref name="resourceName"/> whose insert schema exposes
+        /// a collection whose items carry a nested <c>_ext.{extensionKey}</c>.
+        /// </summary>
+        private static ApiSchemaDocuments CreateSchemaWithCollectionExtension(
+            string resourceName,
+            string collectionName,
+            string extensionKey
+        )
+        {
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    [collectionName] = new JsonObject
+                    {
+                        ["type"] = "array",
+                        ["items"] = new JsonObject
+                        {
+                            ["type"] = "object",
+                            ["properties"] = new JsonObject
+                            {
+                                ["_ext"] = new JsonObject
+                                {
+                                    ["type"] = "object",
+                                    ["properties"] = new JsonObject
+                                    {
+                                        [extensionKey] = new JsonObject { ["type"] = "object" },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            return BuildDocuments(resourceName, jsonSchemaForInsert);
+        }
+
+        private static ApiSchemaDocuments BuildDocuments(string resourceName, JsonObject jsonSchemaForInsert)
+        {
+            var apiSchemaDocuments = new ApiSchemaBuilder()
+                .WithStartProject()
+                .WithStartResource(resourceName)
+                .WithEndResource()
+                .WithEndProject()
+                .ToApiSchemaDocuments();
+
+            var resourceNode = apiSchemaDocuments
+                .GetCoreProjectSchema()
+                .FindResourceSchemaNodeByResourceName(new(resourceName));
+
+            if (resourceNode is JsonObject resourceObj)
+            {
+                resourceObj["jsonSchemaForInsert"] = jsonSchemaForInsert;
+            }
+
+            return apiSchemaDocuments;
+        }
+
+        private static ContentTypeDefinition ContentTypeWithExtension(
+            MemberSelection parentSelection,
+            ExtensionRule extension
+        ) => new(parentSelection, [], [], [], [extension]);
+
+        private static ExtensionRule Extension(string name) =>
+            new(name, MemberSelection.IncludeAll, null, null, null, null);
+
+        [SetUp]
+        public void Setup()
+        {
+            _effectiveApiSchemaProvider = A.Fake<IEffectiveApiSchemaProvider>();
+        }
+
+        [Test]
+        public void Canonicalize_rewrites_mixed_case_extension_name_to_schema_key()
+        {
+            // Arrange — schema key is sample, profile authored it as Sample.
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithRootExtension("Staff", "sample", "firstPetOwnedDate"));
+
+            var writeContentType = ContentTypeWithExtension(MemberSelection.ExcludeOnly, Extension("Sample"));
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert
+            ExtensionRule canonical = result.Resources[0].WriteContentType!.Extensions.Single();
+            canonical.Name.Should().Be("sample");
+        }
+
+        [Test]
+        public void Canonicalize_drops_unknown_extension_rule()
+        {
+            // Arrange — schema only exposes sample, profile excludes an unknown extension.
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithRootExtension("Staff", "sample", "firstPetOwnedDate"));
+
+            var writeContentType = ContentTypeWithExtension(
+                MemberSelection.ExcludeOnly,
+                Extension("Nonexistent")
+            );
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert — the unmatched rule is removed so no unresolved runtime scope is emitted.
+            result.Resources[0].WriteContentType!.Extensions.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Canonicalize_rewrites_extension_nested_in_collection()
+        {
+            // Arrange — extension lives on collection items as staffPets[*]._ext.sample.
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithCollectionExtension("Staff", "staffPets", "sample"));
+
+            var collection = new CollectionRule(
+                Name: "staffPets",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: [Extension("Sample")],
+                ItemFilter: null
+            );
+            var writeContentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                Properties: [],
+                Objects: [],
+                Collections: [collection],
+                Extensions: []
+            );
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert
+            ExtensionRule canonical = result
+                .Resources[0]
+                .WriteContentType!.Collections.Single()
+                .Extensions!.Single();
+            canonical.Name.Should().Be("sample");
+        }
+
+        [Test]
+        public void Canonicalize_rewrites_both_read_and_write_content_types()
+        {
+            // Arrange
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithRootExtension("Staff", "sample", "firstPetOwnedDate"));
+
+            var readContentType = ContentTypeWithExtension(MemberSelection.ExcludeOnly, Extension("Sample"));
+            var writeContentType = ContentTypeWithExtension(MemberSelection.ExcludeOnly, Extension("SAMPLE"));
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, readContentType, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert
+            result.Resources[0].ReadContentType!.Extensions.Single().Name.Should().Be("sample");
+            result.Resources[0].WriteContentType!.Extensions.Single().Name.Should().Be("sample");
+        }
+
+        [Test]
+        public void Canonicalize_returns_same_instance_when_already_canonical()
+        {
+            // Arrange — extension already uses the schema key, so nothing should be rewritten.
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(CreateSchemaWithRootExtension("Staff", "sample", "firstPetOwnedDate"));
+
+            var writeContentType = ContentTypeWithExtension(MemberSelection.ExcludeOnly, Extension("sample"));
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert
+            result.Should().BeSameAs(definition);
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -372,6 +372,92 @@ public class ProfileExtensionCanonicalizerTests
         }
 
         [Test]
+        public void Canonicalize_rewrites_extension_inside_resolved_extension_collection()
+        {
+            // Arrange — _ext.sample.pets[]._ext.other: an extension nested inside a collection
+            // that lives within a resolved extension. Exercises recursion from a resolved
+            // extension into its collection children (the branch the object test does not cover).
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["_ext"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["sample"] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["pets"] = new JsonObject
+                                    {
+                                        ["type"] = "array",
+                                        ["items"] = new JsonObject
+                                        {
+                                            ["type"] = "object",
+                                            ["properties"] = new JsonObject
+                                            {
+                                                ["_ext"] = new JsonObject
+                                                {
+                                                    ["type"] = "object",
+                                                    ["properties"] = new JsonObject
+                                                    {
+                                                        ["other"] = new JsonObject { ["type"] = "object" },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(BuildDocuments("Staff", jsonSchemaForInsert));
+
+            var innerCollection = new CollectionRule(
+                Name: "pets",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                NestedCollections: null,
+                Extensions: [Extension("Other")],
+                ItemFilter: null
+            );
+            var sampleExtension = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: null,
+                Collections: [innerCollection]
+            );
+            var writeContentType = ContentTypeWithExtension(MemberSelection.IncludeAll, sampleExtension);
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert — the outer sample stays and the inner Other is rewritten to other.
+            ExtensionRule outer = result.Resources[0].WriteContentType!.Extensions.Single();
+            outer.Name.Should().Be("sample");
+            ExtensionRule inner = outer.Collections!.Single().Extensions!.Single();
+            inner.Name.Should().Be("other");
+        }
+
+        [Test]
         public void Canonicalize_drops_root_extension_rule_when_extension_only_exists_nested()
         {
             // Arrange — the sample extension exists ONLY on staffPets[*]._ext, not at the root.

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Profile/ProfileExtensionCanonicalizerTests.cs
@@ -227,6 +227,151 @@ public class ProfileExtensionCanonicalizerTests
         }
 
         [Test]
+        public void Canonicalize_rewrites_extension_nested_in_object()
+        {
+            // Arrange — extension lives on an object as addresses._ext.sample.
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["addresses"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["_ext"] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["sample"] = new JsonObject { ["type"] = "object" },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(BuildDocuments("Staff", jsonSchemaForInsert));
+
+            var objectRule = new ObjectRule(
+                Name: "addresses",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions: [Extension("Sample")]
+            );
+            var writeContentType = new ContentTypeDefinition(
+                MemberSelection.IncludeAll,
+                Properties: [],
+                Objects: [objectRule],
+                Collections: [],
+                Extensions: []
+            );
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert
+            ExtensionRule canonical = result
+                .Resources[0]
+                .WriteContentType!.Objects.Single()
+                .Extensions!.Single();
+            canonical.Name.Should().Be("sample");
+        }
+
+        [Test]
+        public void Canonicalize_rewrites_extension_inside_resolved_extension_object()
+        {
+            // Arrange — _ext.sample.obj._ext.other: an extension nested inside an object that
+            // lives within a resolved extension. Exercises recursion from a resolved extension
+            // into its object children.
+            var jsonSchemaForInsert = new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["_ext"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["sample"] = new JsonObject
+                            {
+                                ["type"] = "object",
+                                ["properties"] = new JsonObject
+                                {
+                                    ["obj"] = new JsonObject
+                                    {
+                                        ["type"] = "object",
+                                        ["properties"] = new JsonObject
+                                        {
+                                            ["_ext"] = new JsonObject
+                                            {
+                                                ["type"] = "object",
+                                                ["properties"] = new JsonObject
+                                                {
+                                                    ["other"] = new JsonObject { ["type"] = "object" },
+                                                },
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+            A.CallTo(() => _effectiveApiSchemaProvider.Documents)
+                .Returns(BuildDocuments("Staff", jsonSchemaForInsert));
+
+            var innerObject = new ObjectRule(
+                Name: "obj",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                NestedObjects: null,
+                Collections: null,
+                Extensions: [Extension("Other")]
+            );
+            var sampleExtension = new ExtensionRule(
+                Name: "sample",
+                MemberSelection: MemberSelection.IncludeAll,
+                LogicalSchema: null,
+                Properties: null,
+                Objects: [innerObject],
+                Collections: null
+            );
+            var writeContentType = ContentTypeWithExtension(MemberSelection.IncludeAll, sampleExtension);
+            var definition = new ProfileDefinition(
+                "TestProfile",
+                [new ResourceProfile("Staff", null, null, writeContentType)]
+            );
+
+            // Act
+            ProfileDefinition result = ProfileExtensionCanonicalizer.Canonicalize(
+                definition,
+                _effectiveApiSchemaProvider
+            );
+
+            // Assert — the outer sample stays and the inner Other is rewritten to other.
+            ExtensionRule outer = result.Resources[0].WriteContentType!.Extensions.Single();
+            outer.Name.Should().Be("sample");
+            ExtensionRule inner = outer.Objects!.Single().Extensions!.Single();
+            inner.Name.Should().Be("other");
+        }
+
+        [Test]
         public void Canonicalize_drops_root_extension_rule_when_extension_only_exists_nested()
         {
             // Arrange — the sample extension exists ONLY on staffPets[*]._ext, not at the root.

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
@@ -744,9 +744,11 @@ internal class CachedProfileService(
                         // Normalize extension rule names to the schema extension keys so the
                         // profile runtime (scope discovery, navigation, request/stored shaping,
                         // read projection) agrees with the schema-derived _ext member casing.
-                        // Validation has already passed at this point, so any surviving
-                        // extension rule matches a schema key; unknown extensions are rejected
-                        // during validation, and the canonicalizer drops any that remain.
+                        // Validation has produced no errors at this point: an IncludeOnly
+                        // reference to an unknown extension is an error that already dropped the
+                        // profile, while ExcludeOnly/IncludeAll references to an unknown extension
+                        // are warnings, so such rules can still be present here and the
+                        // canonicalizer drops any that do not resolve to a schema key.
                         ProfileDefinition canonicalDefinition = ProfileExtensionCanonicalizer.Canonicalize(
                             parseResult.Definition,
                             effectiveApiSchemaProvider

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
@@ -745,8 +745,8 @@ internal class CachedProfileService(
                         // profile runtime (scope discovery, navigation, request/stored shaping,
                         // read projection) agrees with the schema-derived _ext member casing.
                         // Validation has already passed at this point, so any surviving
-                        // extension rule either matches a schema key or is a warning-tolerated
-                        // unknown that the canonicalizer drops (DMS-1233).
+                        // extension rule matches a schema key; unknown extensions are rejected
+                        // during validation, and the canonicalizer drops any that remain.
                         ProfileDefinition canonicalDefinition = ProfileExtensionCanonicalizer.Canonicalize(
                             parseResult.Definition,
                             effectiveApiSchemaProvider

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/CachedProfileService.cs
@@ -741,8 +741,19 @@ internal class CachedProfileService(
                             );
                         }
 
-                        profilesByName[parseResult.Definition.ProfileName] = parseResult.Definition;
-                        nameById[profileResponse.Id] = parseResult.Definition.ProfileName;
+                        // Normalize extension rule names to the schema extension keys so the
+                        // profile runtime (scope discovery, navigation, request/stored shaping,
+                        // read projection) agrees with the schema-derived _ext member casing.
+                        // Validation has already passed at this point, so any surviving
+                        // extension rule either matches a schema key or is a warning-tolerated
+                        // unknown that the canonicalizer drops (DMS-1233).
+                        ProfileDefinition canonicalDefinition = ProfileExtensionCanonicalizer.Canonicalize(
+                            parseResult.Definition,
+                            effectiveApiSchemaProvider
+                        );
+
+                        profilesByName[canonicalDefinition.ProfileName] = canonicalDefinition;
+                        nameById[profileResponse.Id] = canonicalDefinition.ProfileName;
                     }
 
                     logger.LogDebug(

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -625,6 +625,38 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return failures;
     }
 
+    /// <summary>
+    /// Resolves an extension namespace node from the schema's <c>_ext.properties</c> by
+    /// matching <paramref name="extensionName"/> case-insensitively. Returns the matching
+    /// schema node, or null when no extension key matches. Prefers an exact (ordinal) match
+    /// to keep behavior stable when distinct keys differ only by case.
+    /// </summary>
+    private static JsonObject? ResolveExtensionSchemaNode(JsonObject? extProperties, string extensionName)
+    {
+        if (extProperties is null)
+        {
+            return null;
+        }
+
+        if (extProperties[extensionName] is JsonObject exactMatch)
+        {
+            return exactMatch;
+        }
+
+        foreach (var property in extProperties)
+        {
+            if (
+                property.Key.Equals(extensionName, StringComparison.OrdinalIgnoreCase)
+                && property.Value is JsonObject node
+            )
+            {
+                return node;
+            }
+        }
+
+        return null;
+    }
+
     private static List<ValidationFailure> ValidateExtensionRule(
         ExtensionRule extension,
         JsonObject schemaProperties,
@@ -654,7 +686,11 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         var extNode = schemaProperties["_ext"] as JsonObject;
         var extProperties = extNode?["properties"] as JsonObject;
-        var extensionSchemaNode = extProperties?[extension.Name] as JsonObject;
+        // Resolve the extension namespace case-insensitively. Profile XML preserves the
+        // authored extension name (e.g. "Sample"), but the schema exposes the extension
+        // payload under the project endpoint key (e.g. "sample"). A case-sensitive lookup
+        // would treat a validly-cased-differently extension as missing (DMS-1233).
+        var extensionSchemaNode = ResolveExtensionSchemaNode(extProperties, extension.Name);
         var extensionProperties = extensionSchemaNode?["properties"] as JsonObject;
 
         if (extensionProperties is null)

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -440,6 +440,130 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return true;
     }
 
+    /// <summary>
+    /// Recursive walk emitting a failure for any extensions container that holds two
+    /// rules whose names are equal case-insensitively. Such rules collapse to the same
+    /// schema key during canonicalization and would otherwise throw when the cached
+    /// ExtensionRulesByName dictionary is built. Reported as <see cref="ValidationSeverity.Error"/>
+    /// at every level regardless of <see cref="MemberSelection"/>.
+    /// </summary>
+    private static List<ValidationFailure> CollectDuplicateExtensionNameFailures(
+        ContentTypeDefinition contentType,
+        ValidationContext context
+    )
+    {
+        var failures = new List<ValidationFailure>();
+
+        AddDuplicateExtensionNameFailures(contentType.Extensions, context, failures);
+        foreach (var obj in contentType.Objects)
+        {
+            WalkObjectForDuplicateExtensions(obj, context, failures);
+        }
+        foreach (var collection in contentType.Collections)
+        {
+            WalkCollectionForDuplicateExtensions(collection, context, failures);
+        }
+        foreach (var extension in contentType.Extensions)
+        {
+            WalkExtensionForDuplicateExtensions(extension, context, failures);
+        }
+
+        return failures;
+    }
+
+    private static void WalkObjectForDuplicateExtensions(
+        ObjectRule objectRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
+        AddDuplicateExtensionNameFailures(objectRule.Extensions, childContext, failures);
+        foreach (var nested in objectRule.NestedObjects ?? [])
+        {
+            WalkObjectForDuplicateExtensions(nested, childContext, failures);
+        }
+        foreach (var collection in objectRule.Collections ?? [])
+        {
+            WalkCollectionForDuplicateExtensions(collection, childContext, failures);
+        }
+        foreach (var extension in objectRule.Extensions ?? [])
+        {
+            WalkExtensionForDuplicateExtensions(extension, childContext, failures);
+        }
+    }
+
+    private static void WalkCollectionForDuplicateExtensions(
+        CollectionRule collectionRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}{collectionRule.Name}[].");
+        AddDuplicateExtensionNameFailures(collectionRule.Extensions, childContext, failures);
+        foreach (var nested in collectionRule.NestedObjects ?? [])
+        {
+            WalkObjectForDuplicateExtensions(nested, childContext, failures);
+        }
+        foreach (var nestedCollection in collectionRule.NestedCollections ?? [])
+        {
+            WalkCollectionForDuplicateExtensions(nestedCollection, childContext, failures);
+        }
+        foreach (var extension in collectionRule.Extensions ?? [])
+        {
+            WalkExtensionForDuplicateExtensions(extension, childContext, failures);
+        }
+    }
+
+    private static void WalkExtensionForDuplicateExtensions(
+        ExtensionRule extensionRule,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        var childContext = context.WithPathPrefix($"{context.PathPrefix}_ext.{extensionRule.Name}.");
+        foreach (var obj in extensionRule.Objects ?? [])
+        {
+            WalkObjectForDuplicateExtensions(obj, childContext, failures);
+        }
+        foreach (var collection in extensionRule.Collections ?? [])
+        {
+            WalkCollectionForDuplicateExtensions(collection, childContext, failures);
+        }
+    }
+
+    private static void AddDuplicateExtensionNameFailures(
+        IReadOnlyList<ExtensionRule>? extensions,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (extensions is null || extensions.Count < 2)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+#pragma warning disable S3267 // Loop tracks first-seen names while emitting failures; a LINQ rewrite would obscure intent.
+        foreach (var extension in extensions)
+        {
+            if (!seen.Add(extension.Name))
+            {
+                failures.Add(
+                    new ValidationFailure(
+                        ValidationSeverity.Error,
+                        context.ProfileName,
+                        context.ResourceName,
+                        $"{context.PathPrefix}_ext.{extension.Name}",
+                        $"Extension '{extension.Name}' in {context.ContentTypeName} content type is declared more than once; "
+                            + "extension names are matched to the schema key case-insensitively, so duplicates collapse to the same key."
+                    )
+                );
+            }
+        }
+#pragma warning restore S3267
+    }
+
     private static List<ValidationFailure> ValidateContentTypeMembers(
         ContentTypeDefinition contentType,
         JsonObject schemaProperties,
@@ -463,6 +587,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // member-selection pruning. Schema validation below skips server-gen
         // names so the pre-pass is the single source of those failures.
         var failures = CollectServerGeneratedNameFailures(contentType, baseContext);
+
+        // Reject sibling extension rules that collapse to the same schema key
+        // (e.g. "sample" and "Sample"). Extension names are matched to the schema
+        // key case-insensitively, and the cached ExtensionRulesByName dictionaries
+        // are built with ToDictionary, so without this duplicates would throw at
+        // navigation time instead of surfacing as profile validation feedback.
+        failures.AddRange(CollectDuplicateExtensionNameFailures(contentType, baseContext));
 
         failures.AddRange(
             contentType.MemberSelection switch
@@ -804,11 +935,11 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 continue;
             }
 
-            if (extension.MemberSelection == MemberSelection.IncludeAll)
-            {
-                continue;
-            }
-
+            // Validate extension existence for every member selection, including
+            // IncludeAll. Unlike objects/collections (which remain in the profile as
+            // harmless no-ops when their name is unknown), an unmatched extension rule
+            // is dropped during canonicalization, so without this check an unknown
+            // IncludeAll extension would vanish with no validation feedback (DMS-1233).
             failures.AddRange(ValidateExtensionRule(extension, schemaProperties, context));
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -440,130 +440,6 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return true;
     }
 
-    /// <summary>
-    /// Recursive walk emitting a failure for any extensions container that holds two
-    /// rules whose names are equal case-insensitively. Such rules collapse to the same
-    /// schema key during canonicalization and would otherwise throw when the cached
-    /// ExtensionRulesByName dictionary is built. Reported as <see cref="ValidationSeverity.Error"/>
-    /// at every level regardless of <see cref="MemberSelection"/>.
-    /// </summary>
-    private static List<ValidationFailure> CollectDuplicateExtensionNameFailures(
-        ContentTypeDefinition contentType,
-        ValidationContext context
-    )
-    {
-        var failures = new List<ValidationFailure>();
-
-        AddDuplicateExtensionNameFailures(contentType.Extensions, context, failures);
-        foreach (var obj in contentType.Objects)
-        {
-            WalkObjectForDuplicateExtensions(obj, context, failures);
-        }
-        foreach (var collection in contentType.Collections)
-        {
-            WalkCollectionForDuplicateExtensions(collection, context, failures);
-        }
-        foreach (var extension in contentType.Extensions)
-        {
-            WalkExtensionForDuplicateExtensions(extension, context, failures);
-        }
-
-        return failures;
-    }
-
-    private static void WalkObjectForDuplicateExtensions(
-        ObjectRule objectRule,
-        ValidationContext context,
-        List<ValidationFailure> failures
-    )
-    {
-        var childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
-        AddDuplicateExtensionNameFailures(objectRule.Extensions, childContext, failures);
-        foreach (var nested in objectRule.NestedObjects ?? [])
-        {
-            WalkObjectForDuplicateExtensions(nested, childContext, failures);
-        }
-        foreach (var collection in objectRule.Collections ?? [])
-        {
-            WalkCollectionForDuplicateExtensions(collection, childContext, failures);
-        }
-        foreach (var extension in objectRule.Extensions ?? [])
-        {
-            WalkExtensionForDuplicateExtensions(extension, childContext, failures);
-        }
-    }
-
-    private static void WalkCollectionForDuplicateExtensions(
-        CollectionRule collectionRule,
-        ValidationContext context,
-        List<ValidationFailure> failures
-    )
-    {
-        var childContext = context.WithPathPrefix($"{context.PathPrefix}{collectionRule.Name}[].");
-        AddDuplicateExtensionNameFailures(collectionRule.Extensions, childContext, failures);
-        foreach (var nested in collectionRule.NestedObjects ?? [])
-        {
-            WalkObjectForDuplicateExtensions(nested, childContext, failures);
-        }
-        foreach (var nestedCollection in collectionRule.NestedCollections ?? [])
-        {
-            WalkCollectionForDuplicateExtensions(nestedCollection, childContext, failures);
-        }
-        foreach (var extension in collectionRule.Extensions ?? [])
-        {
-            WalkExtensionForDuplicateExtensions(extension, childContext, failures);
-        }
-    }
-
-    private static void WalkExtensionForDuplicateExtensions(
-        ExtensionRule extensionRule,
-        ValidationContext context,
-        List<ValidationFailure> failures
-    )
-    {
-        var childContext = context.WithPathPrefix($"{context.PathPrefix}_ext.{extensionRule.Name}.");
-        foreach (var obj in extensionRule.Objects ?? [])
-        {
-            WalkObjectForDuplicateExtensions(obj, childContext, failures);
-        }
-        foreach (var collection in extensionRule.Collections ?? [])
-        {
-            WalkCollectionForDuplicateExtensions(collection, childContext, failures);
-        }
-    }
-
-    private static void AddDuplicateExtensionNameFailures(
-        IReadOnlyList<ExtensionRule>? extensions,
-        ValidationContext context,
-        List<ValidationFailure> failures
-    )
-    {
-        if (extensions is null || extensions.Count < 2)
-        {
-            return;
-        }
-
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-#pragma warning disable S3267 // Loop tracks first-seen names while emitting failures; a LINQ rewrite would obscure intent.
-        foreach (var extension in extensions)
-        {
-            if (!seen.Add(extension.Name))
-            {
-                failures.Add(
-                    new ValidationFailure(
-                        ValidationSeverity.Error,
-                        context.ProfileName,
-                        context.ResourceName,
-                        $"{context.PathPrefix}_ext.{extension.Name}",
-                        $"Extension '{extension.Name}' in {context.ContentTypeName} content type is declared more than once; "
-                            + "extension names are matched to the schema key case-insensitively, so duplicates collapse to the same key."
-                    )
-                );
-            }
-        }
-#pragma warning restore S3267
-    }
-
     private static List<ValidationFailure> ValidateContentTypeMembers(
         ContentTypeDefinition contentType,
         JsonObject schemaProperties,
@@ -588,18 +464,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // names so the pre-pass is the single source of those failures.
         var failures = CollectServerGeneratedNameFailures(contentType, baseContext);
 
-        // Reject sibling extension rules that collapse to the same schema key
-        // (e.g. "sample" and "Sample"). Extension names are matched to the schema
-        // key case-insensitively, and the cached ExtensionRulesByName dictionaries
-        // are built with ToDictionary, so without this duplicates would throw at
-        // navigation time instead of surfacing as profile validation feedback.
-        failures.AddRange(CollectDuplicateExtensionNameFailures(contentType, baseContext));
-
-        // Reject extension rules whose name does not exist in the schema at their
-        // location, regardless of member selection. Canonicalization drops such rules
-        // wherever they appear, so this is the single source of unknown-extension
-        // feedback and prevents a nested unknown extension from disappearing silently.
-        failures.AddRange(CollectUnknownExtensionFailures(contentType, schemaProperties, baseContext));
+        // Resolve every extension rule against the schema at its own location, regardless
+        // of member selection (canonicalization walks the whole tree and drops unmatched
+        // rules, so this is the single source of extension feedback). Unknown extensions
+        // get the missing-reference severity (IncludeOnly error, otherwise warning); two
+        // rules that resolve to the same schema key would throw when ExtensionRulesByName
+        // is built, so that collision is always an error.
+        failures.AddRange(CollectExtensionResolutionFailures(contentType, schemaProperties, baseContext));
 
         failures.AddRange(
             contentType.MemberSelection switch
@@ -763,35 +634,37 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     }
 
     /// <summary>
-    /// Resolves an extension namespace node from the schema's <c>_ext.properties</c> by
-    /// matching <paramref name="extensionName"/> case-insensitively. Returns the matching
-    /// schema node, or null when no extension key matches. Prefers an exact (ordinal) match
-    /// to keep behavior stable when distinct keys differ only by case.
+    /// Resolves the canonical schema extension key for <paramref name="extensionName"/> from
+    /// the schema's <c>_ext.properties</c>, matching case-insensitively. Returns the matching
+    /// key (in the schema's casing), or null when no extension key matches. Prefers an exact
+    /// (ordinal) match to keep behavior stable when distinct keys differ only by case.
     /// </summary>
-    private static JsonObject? ResolveExtensionSchemaNode(JsonObject? extProperties, string extensionName)
+    private static string? ResolveExtensionKey(JsonObject? extProperties, string extensionName)
     {
         if (extProperties is null)
         {
             return null;
         }
 
-        if (extProperties[extensionName] is JsonObject exactMatch)
+        if (extProperties.ContainsKey(extensionName))
         {
-            return exactMatch;
+            return extensionName;
         }
 
-        foreach (var property in extProperties)
-        {
-            if (
-                property.Key.Equals(extensionName, StringComparison.OrdinalIgnoreCase)
-                && property.Value is JsonObject node
-            )
-            {
-                return node;
-            }
-        }
+        var match = extProperties.FirstOrDefault(property =>
+            property.Key.Equals(extensionName, StringComparison.OrdinalIgnoreCase)
+        );
+        return match.Key;
+    }
 
-        return null;
+    /// <summary>
+    /// Resolves the extension namespace node from the schema's <c>_ext.properties</c> for
+    /// <paramref name="extensionName"/>, matching case-insensitively, or null when no key matches.
+    /// </summary>
+    private static JsonObject? ResolveExtensionSchemaNode(JsonObject? extProperties, string extensionName)
+    {
+        string? key = ResolveExtensionKey(extProperties, extensionName);
+        return key is null ? null : extProperties?[key] as JsonObject;
     }
 
     /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
@@ -811,18 +684,24 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         as JsonObject;
 
     /// <summary>
-    /// Reports a failure for every extension rule whose name does not resolve to an extension
-    /// key in the schema's <c>_ext.properties</c> at that rule's own location — at the root and
-    /// inside objects, collections, and extensions. This runs regardless of member selection
-    /// because canonicalization drops an unmatched extension rule wherever it appears (including
-    /// under IncludeAll branches that the member-selection validation short-circuits); without
-    /// this an unknown extension would silently disappear with no validation feedback. The
-    /// traversal mirrors the canonicalizer so the two agree on exactly which rules are unknown.
-    /// Severity follows the existing missing-reference contract of the enclosing container:
-    /// IncludeOnly is an error, ExcludeOnly/IncludeAll a warning (the rule is then dropped by
-    /// canonicalization, so the profile still loads without an unresolved runtime scope).
+    /// Resolves every extension rule against the schema's <c>_ext.properties</c> at that rule's
+    /// own location — at the root and inside objects, collections, and extensions — regardless of
+    /// member selection. Canonicalization walks the whole tree and drops any unmatched extension
+    /// rule (including under IncludeAll branches that member-selection validation short-circuits),
+    /// so this is the single source of extension feedback and the traversal mirrors it. Two kinds
+    /// of failure are produced:
+    /// <list type="bullet">
+    /// <item>An extension whose name does not resolve to a schema key: severity follows the
+    /// enclosing container's missing-reference contract (IncludeOnly error, otherwise warning),
+    /// and canonicalization drops the rule so the profile loads without an unresolved scope.</item>
+    /// <item>Two sibling rules that resolve to the <em>same</em> schema key (e.g. "sample" and
+    /// "Sample"): always an error, because both survive canonicalization and the cached
+    /// ExtensionRulesByName dictionary would throw on the duplicate key.</item>
+    /// </list>
+    /// Unresolved names are never treated as duplicates: each is dropped, so case-variant unknown
+    /// names keep the missing-reference severity rather than being rejected as a collision.
     /// </summary>
-    private static List<ValidationFailure> CollectUnknownExtensionFailures(
+    private static List<ValidationFailure> CollectExtensionResolutionFailures(
         ContentTypeDefinition contentType,
         JsonObject schemaProperties,
         ValidationContext context
@@ -830,7 +709,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        CheckExtensionsExistAndRecurse(
+        CheckExtensions(
             contentType.Extensions,
             schemaProperties,
             context,
@@ -839,11 +718,11 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         );
         foreach (var obj in contentType.Objects)
         {
-            WalkObjectForUnknownExtensions(obj, schemaProperties, context, failures);
+            WalkObjectExtensions(obj, schemaProperties, context, failures);
         }
         foreach (var collection in contentType.Collections)
         {
-            WalkCollectionForUnknownExtensions(collection, schemaProperties, context, failures);
+            WalkCollectionExtensions(collection, schemaProperties, context, failures);
         }
 
         return failures;
@@ -859,15 +738,16 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             ? ValidationSeverity.Error
             : ValidationSeverity.Warning;
 
-    private static void CheckExtensionsExistAndRecurse(
+    private static void CheckExtensions(
         IReadOnlyList<ExtensionRule> extensions,
         JsonObject? schemaProperties,
         ValidationContext context,
-        ValidationSeverity severity,
+        ValidationSeverity missingSeverity,
         List<ValidationFailure> failures
     )
     {
         JsonObject? extProperties = ExtensionPropertiesAt(schemaProperties);
+        HashSet<string>? resolvedKeys = null;
 
         foreach (var extension in extensions)
         {
@@ -877,12 +757,14 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 continue;
             }
 
-            JsonObject? extensionNode = ResolveExtensionSchemaNode(extProperties, extension.Name);
-            if (extensionNode is null)
+            string? canonicalKey = ResolveExtensionKey(extProperties, extension.Name);
+            if (canonicalKey is null)
             {
+                // Unknown name: missing-reference severity. Not a duplicate — an unmatched rule
+                // is dropped by canonicalization, so case-variant unknown names cannot collide.
                 failures.Add(
                     new ValidationFailure(
-                        severity,
+                        missingSeverity,
                         context.ProfileName,
                         context.ResourceName,
                         $"{context.PathPrefix}_ext.{extension.Name}",
@@ -892,29 +774,44 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 continue;
             }
 
-            // Resolved: recurse into the extension's own objects/collections for deeper
-            // unknown extensions, at the extension's child schema location.
-            JsonObject? extensionProperties = extensionNode["properties"] as JsonObject;
+            resolvedKeys ??= new HashSet<string>(StringComparer.Ordinal);
+            if (!resolvedKeys.Add(canonicalKey))
+            {
+                // Two sibling rules resolve to the same schema key: both survive canonicalization
+                // and ExtensionRulesByName would throw on the duplicate key, so this is an error.
+                failures.Add(
+                    new ValidationFailure(
+                        ValidationSeverity.Error,
+                        context.ProfileName,
+                        context.ResourceName,
+                        $"{context.PathPrefix}_ext.{extension.Name}",
+                        $"Extension '{extension.Name}' in {context.ContentTypeName} content type resolves to schema extension key "
+                            + $"'{canonicalKey}', which is already used by another extension rule at the same level; extension names are "
+                            + "matched to the schema key case-insensitively, so these collapse to the same key."
+                    )
+                );
+                continue;
+            }
+
+            // Resolved and unique: recurse into the extension's own objects/collections at the
+            // extension's child schema location.
+            JsonObject? extensionProperties =
+                (extProperties?[canonicalKey] as JsonObject)?["properties"] as JsonObject;
             ValidationContext childContext = context.WithPathPrefix(
                 $"{context.PathPrefix}_ext.{extension.Name}."
             );
             foreach (var nestedObject in extension.Objects ?? [])
             {
-                WalkObjectForUnknownExtensions(nestedObject, extensionProperties, childContext, failures);
+                WalkObjectExtensions(nestedObject, extensionProperties, childContext, failures);
             }
             foreach (var nestedCollection in extension.Collections ?? [])
             {
-                WalkCollectionForUnknownExtensions(
-                    nestedCollection,
-                    extensionProperties,
-                    childContext,
-                    failures
-                );
+                WalkCollectionExtensions(nestedCollection, extensionProperties, childContext, failures);
             }
         }
     }
 
-    private static void WalkObjectForUnknownExtensions(
+    private static void WalkObjectExtensions(
         ObjectRule objectRule,
         JsonObject? schemaProperties,
         ValidationContext context,
@@ -931,7 +828,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         if (objectRule.Extensions is not null)
         {
-            CheckExtensionsExistAndRecurse(
+            CheckExtensions(
                 objectRule.Extensions,
                 objectProperties,
                 childContext,
@@ -941,15 +838,15 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
         foreach (var nested in objectRule.NestedObjects ?? [])
         {
-            WalkObjectForUnknownExtensions(nested, objectProperties, childContext, failures);
+            WalkObjectExtensions(nested, objectProperties, childContext, failures);
         }
         foreach (var collection in objectRule.Collections ?? [])
         {
-            WalkCollectionForUnknownExtensions(collection, objectProperties, childContext, failures);
+            WalkCollectionExtensions(collection, objectProperties, childContext, failures);
         }
     }
 
-    private static void WalkCollectionForUnknownExtensions(
+    private static void WalkCollectionExtensions(
         CollectionRule collectionRule,
         JsonObject? schemaProperties,
         ValidationContext context,
@@ -968,7 +865,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         if (collectionRule.Extensions is not null)
         {
-            CheckExtensionsExistAndRecurse(
+            CheckExtensions(
                 collectionRule.Extensions,
                 itemProperties,
                 childContext,
@@ -978,11 +875,11 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
         foreach (var nested in collectionRule.NestedObjects ?? [])
         {
-            WalkObjectForUnknownExtensions(nested, itemProperties, childContext, failures);
+            WalkObjectExtensions(nested, itemProperties, childContext, failures);
         }
         foreach (var nestedCollection in collectionRule.NestedCollections ?? [])
         {
-            WalkCollectionForUnknownExtensions(nestedCollection, itemProperties, childContext, failures);
+            WalkCollectionExtensions(nestedCollection, itemProperties, childContext, failures);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -811,13 +811,16 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         as JsonObject;
 
     /// <summary>
-    /// Reports an error for every extension rule whose name does not resolve to an extension
+    /// Reports a failure for every extension rule whose name does not resolve to an extension
     /// key in the schema's <c>_ext.properties</c> at that rule's own location — at the root and
     /// inside objects, collections, and extensions. This runs regardless of member selection
     /// because canonicalization drops an unmatched extension rule wherever it appears (including
     /// under IncludeAll branches that the member-selection validation short-circuits); without
     /// this an unknown extension would silently disappear with no validation feedback. The
     /// traversal mirrors the canonicalizer so the two agree on exactly which rules are unknown.
+    /// Severity follows the existing missing-reference contract of the enclosing container:
+    /// IncludeOnly is an error, ExcludeOnly/IncludeAll a warning (the rule is then dropped by
+    /// canonicalization, so the profile still loads without an unresolved runtime scope).
     /// </summary>
     private static List<ValidationFailure> CollectUnknownExtensionFailures(
         ContentTypeDefinition contentType,
@@ -827,7 +830,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     {
         var failures = new List<ValidationFailure>();
 
-        CheckExtensionsExistAndRecurse(contentType.Extensions, schemaProperties, context, failures);
+        CheckExtensionsExistAndRecurse(
+            contentType.Extensions,
+            schemaProperties,
+            context,
+            SeverityForMissingReference(contentType.MemberSelection),
+            failures
+        );
         foreach (var obj in contentType.Objects)
         {
             WalkObjectForUnknownExtensions(obj, schemaProperties, context, failures);
@@ -840,10 +849,21 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return failures;
     }
 
+    /// <summary>
+    /// Maps an enclosing container's member selection to the severity used when a referenced
+    /// member or extension does not exist, matching the existing validator contract: IncludeOnly
+    /// requires references to exist (error); ExcludeOnly/IncludeAll tolerate absence (warning).
+    /// </summary>
+    private static ValidationSeverity SeverityForMissingReference(MemberSelection memberSelection) =>
+        memberSelection == MemberSelection.IncludeOnly
+            ? ValidationSeverity.Error
+            : ValidationSeverity.Warning;
+
     private static void CheckExtensionsExistAndRecurse(
         IReadOnlyList<ExtensionRule> extensions,
         JsonObject? schemaProperties,
         ValidationContext context,
+        ValidationSeverity severity,
         List<ValidationFailure> failures
     )
     {
@@ -862,7 +882,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             {
                 failures.Add(
                     new ValidationFailure(
-                        ValidationSeverity.Error,
+                        severity,
                         context.ProfileName,
                         context.ResourceName,
                         $"{context.PathPrefix}_ext.{extension.Name}",
@@ -911,7 +931,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         if (objectRule.Extensions is not null)
         {
-            CheckExtensionsExistAndRecurse(objectRule.Extensions, objectProperties, childContext, failures);
+            CheckExtensionsExistAndRecurse(
+                objectRule.Extensions,
+                objectProperties,
+                childContext,
+                SeverityForMissingReference(objectRule.MemberSelection),
+                failures
+            );
         }
         foreach (var nested in objectRule.NestedObjects ?? [])
         {
@@ -942,7 +968,13 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         if (collectionRule.Extensions is not null)
         {
-            CheckExtensionsExistAndRecurse(collectionRule.Extensions, itemProperties, childContext, failures);
+            CheckExtensionsExistAndRecurse(
+                collectionRule.Extensions,
+                itemProperties,
+                childContext,
+                SeverityForMissingReference(collectionRule.MemberSelection),
+                failures
+            );
         }
         foreach (var nested in collectionRule.NestedObjects ?? [])
         {

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -782,6 +782,17 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
 
         JsonObject? objectProperties = MemberProperties(schemaProperties, objectRule.Name);
+
+        // Stop when the object itself does not resolve in the schema. The missing object is
+        // reported by the member-selection validation (which, like this, descends only into a
+        // resolved node); descending here would treat the object's child extensions as missing
+        // and could escalate a tolerated malformed profile to an error — a loadability change
+        // outside this normalization's scope.
+        if (objectProperties is null)
+        {
+            return;
+        }
+
         ValidationContext childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
 
         if (objectRule.Extensions is not null)
@@ -817,6 +828,15 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
 
         JsonObject? itemProperties = CollectionItemProperties(schemaProperties, collectionRule.Name);
+
+        // Stop when the collection itself does not resolve in the schema (see WalkObjectExtensions):
+        // the missing collection is reported by member-selection validation, and descending here
+        // would escalate its child extensions and change loadability outside this change's scope.
+        if (itemProperties is null)
+        {
+            return;
+        }
+
         ValidationContext childContext = context.WithPathPrefix(
             $"{context.PathPrefix}{collectionRule.Name}[]."
         );

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -971,7 +971,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
             // Validate the members of resolved extensions under an IncludeAll parent.
             // Existence of unknown extensions is reported separately by
-            // CollectUnknownExtensionFailures, which runs regardless of member selection.
+            // CollectExtensionResolutionFailures, which runs regardless of member selection.
             failures.AddRange(ValidateExtensionRule(extension, schemaProperties, context));
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -8,6 +8,7 @@ using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Utilities;
 using Microsoft.Extensions.Logging;
+using static EdFi.DataManagementService.Core.Profile.ProfileExtensionSchemaResolver;
 
 namespace EdFi.DataManagementService.Core.Profile;
 
@@ -634,56 +635,6 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     }
 
     /// <summary>
-    /// Resolves the canonical schema extension key for <paramref name="extensionName"/> from
-    /// the schema's <c>_ext.properties</c>, matching case-insensitively. Returns the matching
-    /// key (in the schema's casing), or null when no extension key matches. Prefers an exact
-    /// (ordinal) match to keep behavior stable when distinct keys differ only by case.
-    /// </summary>
-    private static string? ResolveExtensionKey(JsonObject? extProperties, string extensionName)
-    {
-        if (extProperties is null)
-        {
-            return null;
-        }
-
-        if (extProperties.ContainsKey(extensionName))
-        {
-            return extensionName;
-        }
-
-        var match = extProperties.FirstOrDefault(property =>
-            property.Key.Equals(extensionName, StringComparison.OrdinalIgnoreCase)
-        );
-        return match.Key;
-    }
-
-    /// <summary>
-    /// Resolves the extension namespace node from the schema's <c>_ext.properties</c> for
-    /// <paramref name="extensionName"/>, matching case-insensitively, or null when no key matches.
-    /// </summary>
-    private static JsonObject? ResolveExtensionSchemaNode(JsonObject? extProperties, string extensionName)
-    {
-        string? key = ResolveExtensionKey(extProperties, extensionName);
-        return key is null ? null : extProperties?[key] as JsonObject;
-    }
-
-    /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
-    private static JsonObject? ExtensionPropertiesAt(JsonObject? schemaProperties) =>
-        (schemaProperties?["_ext"] as JsonObject)?["properties"] as JsonObject;
-
-    /// <summary>The <c>properties</c> object of a named member's schema node, or null.</summary>
-    private static JsonObject? MemberSchemaProperties(JsonObject? schemaProperties, string memberName) =>
-        (schemaProperties?[memberName] as JsonObject)?["properties"] as JsonObject;
-
-    /// <summary>The <c>items.properties</c> object of a named collection's schema node, or null.</summary>
-    private static JsonObject? CollectionItemSchemaProperties(
-        JsonObject? schemaProperties,
-        string collectionName
-    ) =>
-        ((schemaProperties?[collectionName] as JsonObject)?["items"] as JsonObject)?["properties"]
-        as JsonObject;
-
-    /// <summary>
     /// Resolves every extension rule against the schema's <c>_ext.properties</c> at that rule's
     /// own location — at the root and inside objects, collections, and extensions — regardless of
     /// member selection. Canonicalization walks the whole tree and drops any unmatched extension
@@ -691,9 +642,10 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     /// so this is the single source of extension feedback and the traversal mirrors it. Two kinds
     /// of failure are produced:
     /// <list type="bullet">
-    /// <item>An extension whose name does not resolve to a schema key: severity follows the
-    /// enclosing container's missing-reference contract (IncludeOnly error, otherwise warning),
-    /// and canonicalization drops the rule so the profile loads without an unresolved scope.</item>
+    /// <item>An extension whose name does not resolve to a schema key: a non-IncludeAll rule
+    /// (the author explicitly selected/deselected members of the extension), or any rule under an
+    /// IncludeOnly parent, is an error; an IncludeAll rule under a tolerant parent is a warning,
+    /// and canonicalization then drops the rule so the profile loads without an unresolved scope.</item>
     /// <item>Two sibling rules that resolve to the <em>same</em> schema key (e.g. "sample" and
     /// "Sample"): always an error, because both survive canonicalization and the cached
     /// ExtensionRulesByName dictionary would throw on the duplicate key.</item>
@@ -713,7 +665,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             contentType.Extensions,
             schemaProperties,
             context,
-            SeverityForMissingReference(contentType.MemberSelection),
+            contentType.MemberSelection,
             failures
         );
         foreach (var obj in contentType.Objects)
@@ -729,20 +681,25 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
     }
 
     /// <summary>
-    /// Maps an enclosing container's member selection to the severity used when a referenced
-    /// member or extension does not exist, matching the existing validator contract: IncludeOnly
-    /// requires references to exist (error); ExcludeOnly/IncludeAll tolerate absence (warning).
+    /// Severity for an extension rule that names an extension absent from the schema. An explicit
+    /// non-IncludeAll rule selects or deselects specific members, which only makes sense if the
+    /// extension exists, so it is an error regardless of parent; a reference under an IncludeOnly
+    /// parent must also exist (error). An IncludeAll rule under a tolerant (ExcludeOnly/IncludeAll)
+    /// parent is a warning — it asserts nothing specific and canonicalization drops it safely.
     /// </summary>
-    private static ValidationSeverity SeverityForMissingReference(MemberSelection memberSelection) =>
-        memberSelection == MemberSelection.IncludeOnly
-            ? ValidationSeverity.Error
-            : ValidationSeverity.Warning;
+    private static ValidationSeverity SeverityForMissingExtension(
+        MemberSelection parentSelection,
+        MemberSelection extensionSelection
+    ) =>
+        parentSelection != MemberSelection.IncludeOnly && extensionSelection == MemberSelection.IncludeAll
+            ? ValidationSeverity.Warning
+            : ValidationSeverity.Error;
 
     private static void CheckExtensions(
         IReadOnlyList<ExtensionRule> extensions,
         JsonObject? schemaProperties,
         ValidationContext context,
-        ValidationSeverity missingSeverity,
+        MemberSelection parentSelection,
         List<ValidationFailure> failures
     )
     {
@@ -757,14 +714,14 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 continue;
             }
 
-            string? canonicalKey = ResolveExtensionKey(extProperties, extension.Name);
-            if (canonicalKey is null)
+            if (!TryResolveExtensionKey(extProperties, extension.Name, out string canonicalKey))
             {
-                // Unknown name: missing-reference severity. Not a duplicate — an unmatched rule
-                // is dropped by canonicalization, so case-variant unknown names cannot collide.
+                // Unknown name: severity per the missing-reference contract. Not a duplicate — an
+                // unmatched rule is dropped by canonicalization, so case-variant unknown names
+                // cannot collide.
                 failures.Add(
                     new ValidationFailure(
-                        missingSeverity,
+                        SeverityForMissingExtension(parentSelection, extension.MemberSelection),
                         context.ProfileName,
                         context.ResourceName,
                         $"{context.PathPrefix}_ext.{extension.Name}",
@@ -823,7 +780,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             return;
         }
 
-        JsonObject? objectProperties = MemberSchemaProperties(schemaProperties, objectRule.Name);
+        JsonObject? objectProperties = MemberProperties(schemaProperties, objectRule.Name);
         ValidationContext childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
 
         if (objectRule.Extensions is not null)
@@ -832,7 +789,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 objectRule.Extensions,
                 objectProperties,
                 childContext,
-                SeverityForMissingReference(objectRule.MemberSelection),
+                objectRule.MemberSelection,
                 failures
             );
         }
@@ -858,7 +815,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             return;
         }
 
-        JsonObject? itemProperties = CollectionItemSchemaProperties(schemaProperties, collectionRule.Name);
+        JsonObject? itemProperties = CollectionItemProperties(schemaProperties, collectionRule.Name);
         ValidationContext childContext = context.WithPathPrefix(
             $"{context.PathPrefix}{collectionRule.Name}[]."
         );
@@ -869,7 +826,7 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 collectionRule.Extensions,
                 itemProperties,
                 childContext,
-                SeverityForMissingReference(collectionRule.MemberSelection),
+                collectionRule.MemberSelection,
                 failures
             );
         }
@@ -897,13 +854,18 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         }
 
         // Existence of the extension namespace is validated independently of member
-        // selection by CollectUnknownExtensionFailures, which walks every extension rule
+        // selection by CollectExtensionResolutionFailures, which walks every extension rule
         // in the tree (the same traversal canonicalization uses to drop unmatched rules).
         // Here we only validate the members of an extension that resolves; an unresolved
         // extension has no members to check and is reported by that pre-pass.
-        var extProperties = ExtensionPropertiesAt(schemaProperties);
-        var extensionProperties =
-            ResolveExtensionSchemaNode(extProperties, extension.Name)?["properties"] as JsonObject;
+        JsonObject? extProperties = ExtensionPropertiesAt(schemaProperties);
+        JsonObject? extensionProperties = TryResolveExtensionKey(
+            extProperties,
+            extension.Name,
+            out string canonicalKey
+        )
+            ? MemberProperties(extProperties, canonicalKey)
+            : null;
 
         if (extensionProperties is null)
         {

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -595,6 +595,12 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         // navigation time instead of surfacing as profile validation feedback.
         failures.AddRange(CollectDuplicateExtensionNameFailures(contentType, baseContext));
 
+        // Reject extension rules whose name does not exist in the schema at their
+        // location, regardless of member selection. Canonicalization drops such rules
+        // wherever they appear, so this is the single source of unknown-extension
+        // feedback and prevents a nested unknown extension from disappearing silently.
+        failures.AddRange(CollectUnknownExtensionFailures(contentType, schemaProperties, baseContext));
+
         failures.AddRange(
             contentType.MemberSelection switch
             {
@@ -788,6 +794,166 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
         return null;
     }
 
+    /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
+    private static JsonObject? ExtensionPropertiesAt(JsonObject? schemaProperties) =>
+        (schemaProperties?["_ext"] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>properties</c> object of a named member's schema node, or null.</summary>
+    private static JsonObject? MemberSchemaProperties(JsonObject? schemaProperties, string memberName) =>
+        (schemaProperties?[memberName] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>items.properties</c> object of a named collection's schema node, or null.</summary>
+    private static JsonObject? CollectionItemSchemaProperties(
+        JsonObject? schemaProperties,
+        string collectionName
+    ) =>
+        ((schemaProperties?[collectionName] as JsonObject)?["items"] as JsonObject)?["properties"]
+        as JsonObject;
+
+    /// <summary>
+    /// Reports an error for every extension rule whose name does not resolve to an extension
+    /// key in the schema's <c>_ext.properties</c> at that rule's own location — at the root and
+    /// inside objects, collections, and extensions. This runs regardless of member selection
+    /// because canonicalization drops an unmatched extension rule wherever it appears (including
+    /// under IncludeAll branches that the member-selection validation short-circuits); without
+    /// this an unknown extension would silently disappear with no validation feedback. The
+    /// traversal mirrors the canonicalizer so the two agree on exactly which rules are unknown.
+    /// </summary>
+    private static List<ValidationFailure> CollectUnknownExtensionFailures(
+        ContentTypeDefinition contentType,
+        JsonObject schemaProperties,
+        ValidationContext context
+    )
+    {
+        var failures = new List<ValidationFailure>();
+
+        CheckExtensionsExistAndRecurse(contentType.Extensions, schemaProperties, context, failures);
+        foreach (var obj in contentType.Objects)
+        {
+            WalkObjectForUnknownExtensions(obj, schemaProperties, context, failures);
+        }
+        foreach (var collection in contentType.Collections)
+        {
+            WalkCollectionForUnknownExtensions(collection, schemaProperties, context, failures);
+        }
+
+        return failures;
+    }
+
+    private static void CheckExtensionsExistAndRecurse(
+        IReadOnlyList<ExtensionRule> extensions,
+        JsonObject? schemaProperties,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        JsonObject? extProperties = ExtensionPropertiesAt(schemaProperties);
+
+        foreach (var extension in extensions)
+        {
+            // Server-generated extension names are rejected by the dedicated pre-pass.
+            if (ServerGeneratedFieldNames.Contains(extension.Name))
+            {
+                continue;
+            }
+
+            JsonObject? extensionNode = ResolveExtensionSchemaNode(extProperties, extension.Name);
+            if (extensionNode is null)
+            {
+                failures.Add(
+                    new ValidationFailure(
+                        ValidationSeverity.Error,
+                        context.ProfileName,
+                        context.ResourceName,
+                        $"{context.PathPrefix}_ext.{extension.Name}",
+                        $"Extension '{extension.Name}' in {context.ContentTypeName} content type does not exist in resource '{context.ResourceName}'."
+                    )
+                );
+                continue;
+            }
+
+            // Resolved: recurse into the extension's own objects/collections for deeper
+            // unknown extensions, at the extension's child schema location.
+            JsonObject? extensionProperties = extensionNode["properties"] as JsonObject;
+            ValidationContext childContext = context.WithPathPrefix(
+                $"{context.PathPrefix}_ext.{extension.Name}."
+            );
+            foreach (var nestedObject in extension.Objects ?? [])
+            {
+                WalkObjectForUnknownExtensions(nestedObject, extensionProperties, childContext, failures);
+            }
+            foreach (var nestedCollection in extension.Collections ?? [])
+            {
+                WalkCollectionForUnknownExtensions(
+                    nestedCollection,
+                    extensionProperties,
+                    childContext,
+                    failures
+                );
+            }
+        }
+    }
+
+    private static void WalkObjectForUnknownExtensions(
+        ObjectRule objectRule,
+        JsonObject? schemaProperties,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (ServerGeneratedFieldNames.Contains(objectRule.Name))
+        {
+            return;
+        }
+
+        JsonObject? objectProperties = MemberSchemaProperties(schemaProperties, objectRule.Name);
+        ValidationContext childContext = context.WithPathPrefix($"{context.PathPrefix}{objectRule.Name}.");
+
+        if (objectRule.Extensions is not null)
+        {
+            CheckExtensionsExistAndRecurse(objectRule.Extensions, objectProperties, childContext, failures);
+        }
+        foreach (var nested in objectRule.NestedObjects ?? [])
+        {
+            WalkObjectForUnknownExtensions(nested, objectProperties, childContext, failures);
+        }
+        foreach (var collection in objectRule.Collections ?? [])
+        {
+            WalkCollectionForUnknownExtensions(collection, objectProperties, childContext, failures);
+        }
+    }
+
+    private static void WalkCollectionForUnknownExtensions(
+        CollectionRule collectionRule,
+        JsonObject? schemaProperties,
+        ValidationContext context,
+        List<ValidationFailure> failures
+    )
+    {
+        if (ServerGeneratedFieldNames.Contains(collectionRule.Name))
+        {
+            return;
+        }
+
+        JsonObject? itemProperties = CollectionItemSchemaProperties(schemaProperties, collectionRule.Name);
+        ValidationContext childContext = context.WithPathPrefix(
+            $"{context.PathPrefix}{collectionRule.Name}[]."
+        );
+
+        if (collectionRule.Extensions is not null)
+        {
+            CheckExtensionsExistAndRecurse(collectionRule.Extensions, itemProperties, childContext, failures);
+        }
+        foreach (var nested in collectionRule.NestedObjects ?? [])
+        {
+            WalkObjectForUnknownExtensions(nested, itemProperties, childContext, failures);
+        }
+        foreach (var nestedCollection in collectionRule.NestedCollections ?? [])
+        {
+            WalkCollectionForUnknownExtensions(nestedCollection, itemProperties, childContext, failures);
+        }
+    }
+
     private static List<ValidationFailure> ValidateExtensionRule(
         ExtensionRule extension,
         JsonObject schemaProperties,
@@ -801,40 +967,17 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
             return failures;
         }
 
-        if (!schemaProperties.ContainsKey("_ext"))
-        {
-            failures.Add(
-                new ValidationFailure(
-                    context.Severity,
-                    context.ProfileName,
-                    context.ResourceName,
-                    extension.Name,
-                    $"Extension '{extension.Name}' in {context.ContentTypeName} content type cannot be validated - resource has no _ext property."
-                )
-            );
-            return failures;
-        }
-
-        var extNode = schemaProperties["_ext"] as JsonObject;
-        var extProperties = extNode?["properties"] as JsonObject;
-        // Resolve the extension namespace case-insensitively. Profile XML preserves the
-        // authored extension name (e.g. "Sample"), but the schema exposes the extension
-        // payload under the project endpoint key (e.g. "sample"). A case-sensitive lookup
-        // would treat a validly-cased-differently extension as missing (DMS-1233).
-        var extensionSchemaNode = ResolveExtensionSchemaNode(extProperties, extension.Name);
-        var extensionProperties = extensionSchemaNode?["properties"] as JsonObject;
+        // Existence of the extension namespace is validated independently of member
+        // selection by CollectUnknownExtensionFailures, which walks every extension rule
+        // in the tree (the same traversal canonicalization uses to drop unmatched rules).
+        // Here we only validate the members of an extension that resolves; an unresolved
+        // extension has no members to check and is reported by that pre-pass.
+        var extProperties = ExtensionPropertiesAt(schemaProperties);
+        var extensionProperties =
+            ResolveExtensionSchemaNode(extProperties, extension.Name)?["properties"] as JsonObject;
 
         if (extensionProperties is null)
         {
-            failures.Add(
-                new ValidationFailure(
-                    context.Severity,
-                    context.ProfileName,
-                    context.ResourceName,
-                    extension.Name,
-                    $"Extension '{extension.Name}' in {context.ContentTypeName} content type does not exist in resource '{context.ResourceName}'."
-                )
-            );
             return failures;
         }
 
@@ -935,11 +1078,9 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
                 continue;
             }
 
-            // Validate extension existence for every member selection, including
-            // IncludeAll. Unlike objects/collections (which remain in the profile as
-            // harmless no-ops when their name is unknown), an unmatched extension rule
-            // is dropped during canonicalization, so without this check an unknown
-            // IncludeAll extension would vanish with no validation feedback (DMS-1233).
+            // Validate the members of resolved extensions under an IncludeAll parent.
+            // Existence of unknown extensions is reported separately by
+            // CollectUnknownExtensionFailures, which runs regardless of member selection.
             failures.AddRange(ValidateExtensionRule(extension, schemaProperties, context));
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileDataValidator.cs
@@ -467,10 +467,11 @@ internal class ProfileDataValidator(ILogger<ProfileDataValidator> logger) : IPro
 
         // Resolve every extension rule against the schema at its own location, regardless
         // of member selection (canonicalization walks the whole tree and drops unmatched
-        // rules, so this is the single source of extension feedback). Unknown extensions
-        // get the missing-reference severity (IncludeOnly error, otherwise warning); two
-        // rules that resolve to the same schema key would throw when ExtensionRulesByName
-        // is built, so that collision is always an error.
+        // rules, so this is the single source of extension feedback). An unknown extension
+        // is an error when the rule is non-IncludeAll (it explicitly selects/deselects
+        // members) or when it sits under an IncludeOnly parent; an IncludeAll rule under a
+        // tolerant parent is a warning. Two rules that resolve to the same schema key would
+        // throw when ExtensionRulesByName is built, so that collision is always an error.
         failures.AddRange(CollectExtensionResolutionFailures(contentType, schemaProperties, baseContext));
 
         failures.AddRange(

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
@@ -31,12 +31,20 @@ namespace EdFi.DataManagementService.Core.Profile;
 /// having to be schema-aware.
 /// </para>
 /// <para>
-/// An extension rule whose name matches no schema extension key is dropped from the
-/// canonicalized definition. Such a rule only survives load when its parent is
-/// <c>ExcludeOnly</c>/<c>IncludeAll</c> (a genuinely unknown extension under
+/// Resolution is <em>location-aware</em>: each extension rule is matched against the
+/// <c>_ext.properties</c> keys of the schema node at the rule's own position in the
+/// profile tree (root, or inside a specific object/collection/extension), mirroring how
+/// <see cref="ProfileDataValidator"/> navigates. A resource-wide key set would let a root
+/// rule that only resolves at a nested location survive and emit an unresolved root
+/// <c>$._ext.&lt;key&gt;</c> scope — reintroducing the same runtime 500 this change removes.
+/// </para>
+/// <para>
+/// An extension rule whose name matches no schema extension key <em>at its location</em>
+/// is dropped from the canonicalized definition. Such a rule only survives load when its
+/// parent is <c>ExcludeOnly</c>/<c>IncludeAll</c> (a genuinely unknown extension under
 /// <c>IncludeOnly</c> is a validation error that drops the whole profile). Excluding a
-/// non-existent extension is a no-op, and dropping the rule prevents an unresolved
-/// runtime scope from being emitted for it.
+/// non-existent extension is a no-op, and dropping the rule prevents an unresolved runtime
+/// scope from being emitted for it.
 /// </para>
 /// </remarks>
 internal static class ProfileExtensionCanonicalizer
@@ -63,18 +71,18 @@ internal static class ProfileExtensionCanonicalizer
         for (int i = 0; i < definition.Resources.Count; i++)
         {
             ResourceProfile resourceProfile = definition.Resources[i];
-            IReadOnlyDictionary<string, string> extensionKeys = BuildExtensionKeyMap(
+            JsonObject? rootProperties = FindResourceInsertProperties(
                 resourceProfile.ResourceName,
                 projectSchemas
             );
 
             ContentTypeDefinition? canonicalRead = CanonicalizeContentType(
                 resourceProfile.ReadContentType,
-                extensionKeys
+                rootProperties
             );
             ContentTypeDefinition? canonicalWrite = CanonicalizeContentType(
                 resourceProfile.WriteContentType,
-                extensionKeys
+                rootProperties
             );
 
             if (
@@ -100,17 +108,14 @@ internal static class ProfileExtensionCanonicalizer
     }
 
     /// <summary>
-    /// Builds a case-insensitive map of extension key (any casing) to the canonical
-    /// schema key for the named resource, gathered from every <c>_ext.properties</c>
-    /// object anywhere in the resource's <c>jsonSchemaForInsert</c>.
+    /// Resolves the <c>properties</c> object of the named resource's <c>jsonSchemaForInsert</c>,
+    /// which is the schema node the root content type members navigate against.
     /// </summary>
-    private static IReadOnlyDictionary<string, string> BuildExtensionKeyMap(
+    private static JsonObject? FindResourceInsertProperties(
         string resourceName,
         ProjectSchema[] projectSchemas
     )
     {
-        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
         foreach (ProjectSchema projectSchema in projectSchemas)
         {
             JsonNode? resourceNode = projectSchema.FindResourceSchemaNodeByResourceName(
@@ -118,49 +123,74 @@ internal static class ProfileExtensionCanonicalizer
             );
             if (resourceNode?["jsonSchemaForInsert"] is JsonObject jsonSchemaForInsert)
             {
-                CollectExtensionKeys(jsonSchemaForInsert, map);
-                break;
+                return jsonSchemaForInsert["properties"] as JsonObject;
             }
         }
 
-        return map;
+        return null;
     }
+
+    // ───────────────────────────────────────────────────────────────────────
+    //  Schema navigation helpers
+    // ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
+    private static JsonObject? ExtensionPropertiesAt(JsonObject? schemaProperties) =>
+        (schemaProperties?["_ext"] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>properties</c> object of a named member's schema node, or null.</summary>
+    private static JsonObject? MemberProperties(JsonObject? schemaProperties, string memberName) =>
+        (schemaProperties?[memberName] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>items.properties</c> object of a named collection's schema node, or null.</summary>
+    private static JsonObject? CollectionItemProperties(
+        JsonObject? schemaProperties,
+        string collectionName
+    ) =>
+        ((schemaProperties?[collectionName] as JsonObject)?["items"] as JsonObject)?["properties"]
+        as JsonObject;
 
     /// <summary>
-    /// Recursively scans a JSON schema node for <c>_ext.properties</c> objects, adding
-    /// each extension key to <paramref name="map"/> (keyed by itself for canonical lookup).
+    /// Matches <paramref name="name"/> against the extension keys at <paramref name="extProperties"/>
+    /// case-insensitively (exact ordinal match preferred). Returns false when no key matches.
     /// </summary>
-    private static void CollectExtensionKeys(JsonNode? node, Dictionary<string, string> map)
+    private static bool TryResolveExtensionKey(
+        JsonObject? extProperties,
+        string name,
+        out string canonicalKey
+    )
     {
-        if (node is JsonObject obj)
-        {
-            if (obj["_ext"] is JsonObject extNode && extNode["properties"] is JsonObject extProperties)
-            {
-#pragma warning disable S3267 // Populating a dictionary in place; a LINQ rewrite would not improve clarity.
-                foreach (var extension in extProperties)
-                {
-                    map[extension.Key] = extension.Key;
-                }
-#pragma warning restore S3267
-            }
+        canonicalKey = name;
 
-            foreach (var property in obj)
-            {
-                CollectExtensionKeys(property.Value, map);
-            }
-        }
-        else if (node is JsonArray array)
+        if (extProperties is null)
         {
-            foreach (JsonNode? item in array)
-            {
-                CollectExtensionKeys(item, map);
-            }
+            return false;
         }
+
+        if (extProperties.ContainsKey(name))
+        {
+            return true;
+        }
+
+        var match = extProperties.FirstOrDefault(property =>
+            property.Key.Equals(name, StringComparison.OrdinalIgnoreCase)
+        );
+        if (match.Key is null)
+        {
+            return false;
+        }
+
+        canonicalKey = match.Key;
+        return true;
     }
+
+    // ───────────────────────────────────────────────────────────────────────
+    //  Tree canonicalization (schema-location-aware)
+    // ───────────────────────────────────────────────────────────────────────
 
     private static ContentTypeDefinition? CanonicalizeContentType(
         ContentTypeDefinition? contentType,
-        IReadOnlyDictionary<string, string> extensionKeys
+        JsonObject? schemaProperties
     )
     {
         if (contentType is null)
@@ -168,14 +198,14 @@ internal static class ProfileExtensionCanonicalizer
             return null;
         }
 
-        IReadOnlyList<ObjectRule> objects = CanonicalizeObjects(contentType.Objects, extensionKeys);
+        IReadOnlyList<ObjectRule> objects = CanonicalizeObjects(contentType.Objects, schemaProperties);
         IReadOnlyList<CollectionRule> collections = CanonicalizeCollections(
             contentType.Collections,
-            extensionKeys
+            schemaProperties
         );
         IReadOnlyList<ExtensionRule> extensions = CanonicalizeExtensions(
             contentType.Extensions,
-            extensionKeys
+            schemaProperties
         );
 
         if (
@@ -197,7 +227,7 @@ internal static class ProfileExtensionCanonicalizer
 
     private static IReadOnlyList<ObjectRule> CanonicalizeObjects(
         IReadOnlyList<ObjectRule>? objects,
-        IReadOnlyDictionary<string, string> extensionKeys
+        JsonObject? schemaProperties
     )
     {
         if (objects is null || objects.Count == 0)
@@ -209,7 +239,10 @@ internal static class ProfileExtensionCanonicalizer
 
         for (int i = 0; i < objects.Count; i++)
         {
-            ObjectRule canonical = CanonicalizeObject(objects[i], extensionKeys);
+            ObjectRule canonical = CanonicalizeObject(
+                objects[i],
+                MemberProperties(schemaProperties, objects[i].Name)
+            );
             if (!ReferenceEquals(canonical, objects[i]))
             {
                 rewritten ??= [.. objects];
@@ -220,20 +253,17 @@ internal static class ProfileExtensionCanonicalizer
         return rewritten ?? objects;
     }
 
-    private static ObjectRule CanonicalizeObject(
-        ObjectRule rule,
-        IReadOnlyDictionary<string, string> extensionKeys
-    )
+    private static ObjectRule CanonicalizeObject(ObjectRule rule, JsonObject? schemaProperties)
     {
         IReadOnlyList<ObjectRule>? nestedObjects = rule.NestedObjects is null
             ? null
-            : CanonicalizeObjects(rule.NestedObjects, extensionKeys);
+            : CanonicalizeObjects(rule.NestedObjects, schemaProperties);
         IReadOnlyList<CollectionRule>? collections = rule.Collections is null
             ? null
-            : CanonicalizeCollections(rule.Collections, extensionKeys);
+            : CanonicalizeCollections(rule.Collections, schemaProperties);
         IReadOnlyList<ExtensionRule>? extensions = rule.Extensions is null
             ? null
-            : CanonicalizeExtensions(rule.Extensions, extensionKeys);
+            : CanonicalizeExtensions(rule.Extensions, schemaProperties);
 
         if (
             ReferenceEquals(nestedObjects, rule.NestedObjects)
@@ -254,7 +284,7 @@ internal static class ProfileExtensionCanonicalizer
 
     private static IReadOnlyList<CollectionRule> CanonicalizeCollections(
         IReadOnlyList<CollectionRule>? collections,
-        IReadOnlyDictionary<string, string> extensionKeys
+        JsonObject? schemaProperties
     )
     {
         if (collections is null || collections.Count == 0)
@@ -266,7 +296,10 @@ internal static class ProfileExtensionCanonicalizer
 
         for (int i = 0; i < collections.Count; i++)
         {
-            CollectionRule canonical = CanonicalizeCollection(collections[i], extensionKeys);
+            CollectionRule canonical = CanonicalizeCollection(
+                collections[i],
+                CollectionItemProperties(schemaProperties, collections[i].Name)
+            );
             if (!ReferenceEquals(canonical, collections[i]))
             {
                 rewritten ??= [.. collections];
@@ -277,20 +310,17 @@ internal static class ProfileExtensionCanonicalizer
         return rewritten ?? collections;
     }
 
-    private static CollectionRule CanonicalizeCollection(
-        CollectionRule rule,
-        IReadOnlyDictionary<string, string> extensionKeys
-    )
+    private static CollectionRule CanonicalizeCollection(CollectionRule rule, JsonObject? itemProperties)
     {
         IReadOnlyList<ObjectRule>? nestedObjects = rule.NestedObjects is null
             ? null
-            : CanonicalizeObjects(rule.NestedObjects, extensionKeys);
+            : CanonicalizeObjects(rule.NestedObjects, itemProperties);
         IReadOnlyList<CollectionRule>? nestedCollections = rule.NestedCollections is null
             ? null
-            : CanonicalizeCollections(rule.NestedCollections, extensionKeys);
+            : CanonicalizeCollections(rule.NestedCollections, itemProperties);
         IReadOnlyList<ExtensionRule>? extensions = rule.Extensions is null
             ? null
-            : CanonicalizeExtensions(rule.Extensions, extensionKeys);
+            : CanonicalizeExtensions(rule.Extensions, itemProperties);
 
         if (
             ReferenceEquals(nestedObjects, rule.NestedObjects)
@@ -310,12 +340,13 @@ internal static class ProfileExtensionCanonicalizer
     }
 
     /// <summary>
-    /// Rewrites each extension rule name to its canonical schema key, recurses into the
-    /// rule's own objects/collections, and drops rules whose name matches no schema key.
+    /// Rewrites each extension rule name to its canonical schema key — resolved against the
+    /// <c>_ext.properties</c> at <paramref name="schemaProperties"/> (this rule's location) —
+    /// recurses into the rule's own objects/collections, and drops rules that do not resolve here.
     /// </summary>
     private static IReadOnlyList<ExtensionRule> CanonicalizeExtensions(
         IReadOnlyList<ExtensionRule>? extensions,
-        IReadOnlyDictionary<string, string> extensionKeys
+        JsonObject? schemaProperties
     )
     {
         if (extensions is null || extensions.Count == 0)
@@ -323,25 +354,27 @@ internal static class ProfileExtensionCanonicalizer
             return extensions ?? [];
         }
 
+        JsonObject? extProperties = ExtensionPropertiesAt(schemaProperties);
         List<ExtensionRule>? rewritten = null;
 
         for (int i = 0; i < extensions.Count; i++)
         {
             ExtensionRule rule = extensions[i];
 
-            if (!extensionKeys.TryGetValue(rule.Name, out string? canonicalName))
+            if (!TryResolveExtensionKey(extProperties, rule.Name, out string canonicalName))
             {
-                // Unknown extension: drop it so no unresolved runtime scope is emitted.
+                // Unmatched at this location: drop it so no unresolved runtime scope is emitted.
                 rewritten ??= [.. extensions.Take(i)];
                 continue;
             }
 
+            JsonObject? extChildProperties = MemberProperties(extProperties, canonicalName);
             IReadOnlyList<ObjectRule>? objects = rule.Objects is null
                 ? null
-                : CanonicalizeObjects(rule.Objects, extensionKeys);
+                : CanonicalizeObjects(rule.Objects, extChildProperties);
             IReadOnlyList<CollectionRule>? collections = rule.Collections is null
                 ? null
-                : CanonicalizeCollections(rule.Collections, extensionKeys);
+                : CanonicalizeCollections(rule.Collections, extChildProperties);
 
             bool nameChanged = !string.Equals(rule.Name, canonicalName, StringComparison.Ordinal);
             bool childrenChanged =

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.ApiSchema;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Profile;
+
+/// <summary>
+/// Rewrites profile extension rule names to the API schema's extension keys so the
+/// rest of the profile runtime agrees with the schema-derived JSON shape (DMS-1233).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Profile XML preserves the authored extension name (e.g. <c>Sample</c>), but the
+/// schema, the relational write plan, and reconstituted documents all expose the
+/// extension payload under the project endpoint key (e.g. <c>sample</c>). Without
+/// normalization the write pipeline derives the compiled scope <c>$._ext.Sample</c>,
+/// which cannot be resolved case-sensitively against <c>jsonSchemaForInsert</c> and
+/// throws (a 500), and read/stored traversal misclassifies the <c>_ext</c> member.
+/// </para>
+/// <para>
+/// Canonicalizing once, at the profile-load seam, keeps every downstream consumer
+/// (<see cref="ContentTypeScopeDiscovery"/>, <see cref="ProfileTreeNavigator"/>,
+/// <see cref="WritableRequestShaper"/>, <see cref="StoredBodyShaper"/>,
+/// <see cref="StoredSideExistenceLookupBuilder"/>, <see cref="ReadableProfileProjector"/>,
+/// and <see cref="ProfileResponseFilter"/>) aligned on the canonical key without each
+/// having to be schema-aware.
+/// </para>
+/// <para>
+/// An extension rule whose name matches no schema extension key is dropped from the
+/// canonicalized definition. Such a rule only survives load when its parent is
+/// <c>ExcludeOnly</c>/<c>IncludeAll</c> (a genuinely unknown extension under
+/// <c>IncludeOnly</c> is a validation error that drops the whole profile). Excluding a
+/// non-existent extension is a no-op, and dropping the rule prevents an unresolved
+/// runtime scope from being emitted for it.
+/// </para>
+/// </remarks>
+internal static class ProfileExtensionCanonicalizer
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="definition"/> with every extension rule name
+    /// rewritten to the matching schema extension key and unmatched extension rules
+    /// removed. Returns the original instance unchanged when no rewrite is needed.
+    /// </summary>
+    public static ProfileDefinition Canonicalize(
+        ProfileDefinition definition,
+        IEffectiveApiSchemaProvider effectiveApiSchemaProvider
+    )
+    {
+        ApiSchemaDocuments apiSchemaDocuments = effectiveApiSchemaProvider.Documents;
+        ProjectSchema[] projectSchemas =
+        [
+            apiSchemaDocuments.GetCoreProjectSchema(),
+            .. apiSchemaDocuments.GetExtensionProjectSchemas(),
+        ];
+
+        List<ResourceProfile>? rewrittenResources = null;
+
+        for (int i = 0; i < definition.Resources.Count; i++)
+        {
+            ResourceProfile resourceProfile = definition.Resources[i];
+            IReadOnlyDictionary<string, string> extensionKeys = BuildExtensionKeyMap(
+                resourceProfile.ResourceName,
+                projectSchemas
+            );
+
+            ContentTypeDefinition? canonicalRead = CanonicalizeContentType(
+                resourceProfile.ReadContentType,
+                extensionKeys
+            );
+            ContentTypeDefinition? canonicalWrite = CanonicalizeContentType(
+                resourceProfile.WriteContentType,
+                extensionKeys
+            );
+
+            if (
+                ReferenceEquals(canonicalRead, resourceProfile.ReadContentType)
+                && ReferenceEquals(canonicalWrite, resourceProfile.WriteContentType)
+            )
+            {
+                rewrittenResources?.Add(resourceProfile);
+                continue;
+            }
+
+            rewrittenResources ??= [.. definition.Resources.Take(i)];
+            rewrittenResources.Add(
+                resourceProfile with
+                {
+                    ReadContentType = canonicalRead,
+                    WriteContentType = canonicalWrite,
+                }
+            );
+        }
+
+        return rewrittenResources is null ? definition : definition with { Resources = rewrittenResources };
+    }
+
+    /// <summary>
+    /// Builds a case-insensitive map of extension key (any casing) to the canonical
+    /// schema key for the named resource, gathered from every <c>_ext.properties</c>
+    /// object anywhere in the resource's <c>jsonSchemaForInsert</c>.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BuildExtensionKeyMap(
+        string resourceName,
+        ProjectSchema[] projectSchemas
+    )
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (ProjectSchema projectSchema in projectSchemas)
+        {
+            JsonNode? resourceNode = projectSchema.FindResourceSchemaNodeByResourceName(
+                new ResourceName(resourceName)
+            );
+            if (resourceNode?["jsonSchemaForInsert"] is JsonObject jsonSchemaForInsert)
+            {
+                CollectExtensionKeys(jsonSchemaForInsert, map);
+                break;
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// Recursively scans a JSON schema node for <c>_ext.properties</c> objects, adding
+    /// each extension key to <paramref name="map"/> (keyed by itself for canonical lookup).
+    /// </summary>
+    private static void CollectExtensionKeys(JsonNode? node, Dictionary<string, string> map)
+    {
+        if (node is JsonObject obj)
+        {
+            if (obj["_ext"] is JsonObject extNode && extNode["properties"] is JsonObject extProperties)
+            {
+#pragma warning disable S3267 // Populating a dictionary in place; a LINQ rewrite would not improve clarity.
+                foreach (var extension in extProperties)
+                {
+                    map[extension.Key] = extension.Key;
+                }
+#pragma warning restore S3267
+            }
+
+            foreach (var property in obj)
+            {
+                CollectExtensionKeys(property.Value, map);
+            }
+        }
+        else if (node is JsonArray array)
+        {
+            foreach (JsonNode? item in array)
+            {
+                CollectExtensionKeys(item, map);
+            }
+        }
+    }
+
+    private static ContentTypeDefinition? CanonicalizeContentType(
+        ContentTypeDefinition? contentType,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        if (contentType is null)
+        {
+            return null;
+        }
+
+        IReadOnlyList<ObjectRule> objects = CanonicalizeObjects(contentType.Objects, extensionKeys);
+        IReadOnlyList<CollectionRule> collections = CanonicalizeCollections(
+            contentType.Collections,
+            extensionKeys
+        );
+        IReadOnlyList<ExtensionRule> extensions = CanonicalizeExtensions(
+            contentType.Extensions,
+            extensionKeys
+        );
+
+        if (
+            ReferenceEquals(objects, contentType.Objects)
+            && ReferenceEquals(collections, contentType.Collections)
+            && ReferenceEquals(extensions, contentType.Extensions)
+        )
+        {
+            return contentType;
+        }
+
+        return contentType with
+        {
+            Objects = objects,
+            Collections = collections,
+            Extensions = extensions,
+        };
+    }
+
+    private static IReadOnlyList<ObjectRule> CanonicalizeObjects(
+        IReadOnlyList<ObjectRule>? objects,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        if (objects is null || objects.Count == 0)
+        {
+            return objects ?? [];
+        }
+
+        ObjectRule[]? rewritten = null;
+
+        for (int i = 0; i < objects.Count; i++)
+        {
+            ObjectRule canonical = CanonicalizeObject(objects[i], extensionKeys);
+            if (!ReferenceEquals(canonical, objects[i]))
+            {
+                rewritten ??= [.. objects];
+                rewritten[i] = canonical;
+            }
+        }
+
+        return rewritten ?? objects;
+    }
+
+    private static ObjectRule CanonicalizeObject(
+        ObjectRule rule,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        IReadOnlyList<ObjectRule>? nestedObjects = rule.NestedObjects is null
+            ? null
+            : CanonicalizeObjects(rule.NestedObjects, extensionKeys);
+        IReadOnlyList<CollectionRule>? collections = rule.Collections is null
+            ? null
+            : CanonicalizeCollections(rule.Collections, extensionKeys);
+        IReadOnlyList<ExtensionRule>? extensions = rule.Extensions is null
+            ? null
+            : CanonicalizeExtensions(rule.Extensions, extensionKeys);
+
+        if (
+            ReferenceEquals(nestedObjects, rule.NestedObjects)
+            && ReferenceEquals(collections, rule.Collections)
+            && ReferenceEquals(extensions, rule.Extensions)
+        )
+        {
+            return rule;
+        }
+
+        return rule with
+        {
+            NestedObjects = nestedObjects,
+            Collections = collections,
+            Extensions = extensions,
+        };
+    }
+
+    private static IReadOnlyList<CollectionRule> CanonicalizeCollections(
+        IReadOnlyList<CollectionRule>? collections,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        if (collections is null || collections.Count == 0)
+        {
+            return collections ?? [];
+        }
+
+        CollectionRule[]? rewritten = null;
+
+        for (int i = 0; i < collections.Count; i++)
+        {
+            CollectionRule canonical = CanonicalizeCollection(collections[i], extensionKeys);
+            if (!ReferenceEquals(canonical, collections[i]))
+            {
+                rewritten ??= [.. collections];
+                rewritten[i] = canonical;
+            }
+        }
+
+        return rewritten ?? collections;
+    }
+
+    private static CollectionRule CanonicalizeCollection(
+        CollectionRule rule,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        IReadOnlyList<ObjectRule>? nestedObjects = rule.NestedObjects is null
+            ? null
+            : CanonicalizeObjects(rule.NestedObjects, extensionKeys);
+        IReadOnlyList<CollectionRule>? nestedCollections = rule.NestedCollections is null
+            ? null
+            : CanonicalizeCollections(rule.NestedCollections, extensionKeys);
+        IReadOnlyList<ExtensionRule>? extensions = rule.Extensions is null
+            ? null
+            : CanonicalizeExtensions(rule.Extensions, extensionKeys);
+
+        if (
+            ReferenceEquals(nestedObjects, rule.NestedObjects)
+            && ReferenceEquals(nestedCollections, rule.NestedCollections)
+            && ReferenceEquals(extensions, rule.Extensions)
+        )
+        {
+            return rule;
+        }
+
+        return rule with
+        {
+            NestedObjects = nestedObjects,
+            NestedCollections = nestedCollections,
+            Extensions = extensions,
+        };
+    }
+
+    /// <summary>
+    /// Rewrites each extension rule name to its canonical schema key, recurses into the
+    /// rule's own objects/collections, and drops rules whose name matches no schema key.
+    /// </summary>
+    private static IReadOnlyList<ExtensionRule> CanonicalizeExtensions(
+        IReadOnlyList<ExtensionRule>? extensions,
+        IReadOnlyDictionary<string, string> extensionKeys
+    )
+    {
+        if (extensions is null || extensions.Count == 0)
+        {
+            return extensions ?? [];
+        }
+
+        List<ExtensionRule>? rewritten = null;
+
+        for (int i = 0; i < extensions.Count; i++)
+        {
+            ExtensionRule rule = extensions[i];
+
+            if (!extensionKeys.TryGetValue(rule.Name, out string? canonicalName))
+            {
+                // Unknown extension: drop it so no unresolved runtime scope is emitted.
+                rewritten ??= [.. extensions.Take(i)];
+                continue;
+            }
+
+            IReadOnlyList<ObjectRule>? objects = rule.Objects is null
+                ? null
+                : CanonicalizeObjects(rule.Objects, extensionKeys);
+            IReadOnlyList<CollectionRule>? collections = rule.Collections is null
+                ? null
+                : CanonicalizeCollections(rule.Collections, extensionKeys);
+
+            bool nameChanged = !string.Equals(rule.Name, canonicalName, StringComparison.Ordinal);
+            bool childrenChanged =
+                !ReferenceEquals(objects, rule.Objects) || !ReferenceEquals(collections, rule.Collections);
+
+            if (!nameChanged && !childrenChanged)
+            {
+                rewritten?.Add(rule);
+                continue;
+            }
+
+            rewritten ??= [.. extensions.Take(i)];
+            rewritten.Add(rule with { Name = canonicalName, Objects = objects, Collections = collections });
+        }
+
+        return rewritten ?? extensions;
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
@@ -6,6 +6,7 @@
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.External.Model;
+using static EdFi.DataManagementService.Core.Profile.ProfileExtensionSchemaResolver;
 
 namespace EdFi.DataManagementService.Core.Profile;
 
@@ -128,60 +129,6 @@ internal static class ProfileExtensionCanonicalizer
         }
 
         return null;
-    }
-
-    // ───────────────────────────────────────────────────────────────────────
-    //  Schema navigation helpers
-    // ───────────────────────────────────────────────────────────────────────
-
-    /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
-    private static JsonObject? ExtensionPropertiesAt(JsonObject? schemaProperties) =>
-        (schemaProperties?["_ext"] as JsonObject)?["properties"] as JsonObject;
-
-    /// <summary>The <c>properties</c> object of a named member's schema node, or null.</summary>
-    private static JsonObject? MemberProperties(JsonObject? schemaProperties, string memberName) =>
-        (schemaProperties?[memberName] as JsonObject)?["properties"] as JsonObject;
-
-    /// <summary>The <c>items.properties</c> object of a named collection's schema node, or null.</summary>
-    private static JsonObject? CollectionItemProperties(
-        JsonObject? schemaProperties,
-        string collectionName
-    ) =>
-        ((schemaProperties?[collectionName] as JsonObject)?["items"] as JsonObject)?["properties"]
-        as JsonObject;
-
-    /// <summary>
-    /// Matches <paramref name="name"/> against the extension keys at <paramref name="extProperties"/>
-    /// case-insensitively (exact ordinal match preferred). Returns false when no key matches.
-    /// </summary>
-    private static bool TryResolveExtensionKey(
-        JsonObject? extProperties,
-        string name,
-        out string canonicalKey
-    )
-    {
-        canonicalKey = name;
-
-        if (extProperties is null)
-        {
-            return false;
-        }
-
-        if (extProperties.ContainsKey(name))
-        {
-            return true;
-        }
-
-        var match = extProperties.FirstOrDefault(property =>
-            property.Key.Equals(name, StringComparison.OrdinalIgnoreCase)
-        );
-        if (match.Key is null)
-        {
-            return false;
-        }
-
-        canonicalKey = match.Key;
-        return true;
     }
 
     // ───────────────────────────────────────────────────────────────────────
@@ -356,6 +303,7 @@ internal static class ProfileExtensionCanonicalizer
 
         JsonObject? extProperties = ExtensionPropertiesAt(schemaProperties);
         List<ExtensionRule>? rewritten = null;
+        HashSet<string>? emittedKeys = null;
 
         for (int i = 0; i < extensions.Count; i++)
         {
@@ -364,6 +312,18 @@ internal static class ProfileExtensionCanonicalizer
             if (!TryResolveExtensionKey(extProperties, rule.Name, out string canonicalName))
             {
                 // Unmatched at this location: drop it so no unresolved runtime scope is emitted.
+                rewritten ??= [.. extensions.Take(i)];
+                continue;
+            }
+
+            // Defensive de-dup: sibling rules that resolve to the same schema key (e.g. "sample"
+            // and "Sample") would collapse to duplicate keys in ExtensionRulesByName and throw at
+            // navigation time. The validator rejects this, so a validated profile never reaches
+            // here, but keep the canonicalizer self-consistent for any caller by dropping the
+            // later duplicate rather than emitting a colliding key.
+            emittedKeys ??= new HashSet<string>(StringComparer.Ordinal);
+            if (!emittedKeys.Add(canonicalName))
+            {
                 rewritten ??= [.. extensions.Take(i)];
                 continue;
             }

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionCanonicalizer.cs
@@ -11,7 +11,7 @@ namespace EdFi.DataManagementService.Core.Profile;
 
 /// <summary>
 /// Rewrites profile extension rule names to the API schema's extension keys so the
-/// rest of the profile runtime agrees with the schema-derived JSON shape (DMS-1233).
+/// rest of the profile runtime agrees with the schema-derived JSON shape.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionSchemaResolver.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Profile/ProfileExtensionSchemaResolver.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+
+namespace EdFi.DataManagementService.Core.Profile;
+
+/// <summary>
+/// Shared schema navigation and extension-key resolution used by both
+/// <see cref="ProfileDataValidator"/> (which reports unknown/duplicate extensions) and
+/// <see cref="ProfileExtensionCanonicalizer"/> (which rewrites/drops them). Both must resolve
+/// the same canonical key at the same schema location for every rule, or the validator could
+/// pass a profile while the canonicalizer drops a different rule — silently re-creating the
+/// unresolved-scope failure this logic exists to prevent. Keeping the navigation in one place
+/// makes that invariant hold by construction rather than by copy-paste discipline.
+/// </summary>
+internal static class ProfileExtensionSchemaResolver
+{
+    /// <summary>The <c>_ext.properties</c> object at the current schema location, or null.</summary>
+    public static JsonObject? ExtensionPropertiesAt(JsonObject? schemaProperties) =>
+        (schemaProperties?["_ext"] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>properties</c> object of a named member's schema node, or null.</summary>
+    public static JsonObject? MemberProperties(JsonObject? schemaProperties, string memberName) =>
+        (schemaProperties?[memberName] as JsonObject)?["properties"] as JsonObject;
+
+    /// <summary>The <c>items.properties</c> object of a named collection's schema node, or null.</summary>
+    public static JsonObject? CollectionItemProperties(JsonObject? schemaProperties, string collectionName) =>
+        ((schemaProperties?[collectionName] as JsonObject)?["items"] as JsonObject)?["properties"]
+        as JsonObject;
+
+    /// <summary>
+    /// Resolves the canonical schema extension key for <paramref name="name"/> from the supplied
+    /// <c>_ext.properties</c>, matching case-insensitively and preferring an exact ordinal match.
+    /// Returns true and sets <paramref name="canonicalKey"/> to the schema's casing when matched;
+    /// returns false (leaving <paramref name="canonicalKey"/> as <paramref name="name"/>) otherwise.
+    /// </summary>
+    public static bool TryResolveExtensionKey(JsonObject? extProperties, string name, out string canonicalKey)
+    {
+        canonicalKey = name;
+
+        if (extProperties is null)
+        {
+            return false;
+        }
+
+        if (extProperties.ContainsKey(name))
+        {
+            return true;
+        }
+
+        var match = extProperties.FirstOrDefault(property =>
+            property.Key.Equals(name, StringComparison.OrdinalIgnoreCase)
+        );
+        if (match.Key is null)
+        {
+            return false;
+        }
+
+        canonicalKey = match.Key;
+        return true;
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/DiscoveryAPI.feature
@@ -308,6 +308,11 @@ Feature: The Discovery API provides information about the application version, s
                       "prefix": "Profiles"
                     },
                     {
+                      "name": "Sample-StudentAcademicRecord-Multiple-Extensions-IncludeOnly",
+                      "endpointUri": "{BASE_URL}/metadata/specifications/profiles/Sample-StudentAcademicRecord-Multiple-Extensions-IncludeOnly/resources-spec.json",
+                      "prefix": "Profiles"
+                    },
+                    {
                       "name": "Sample-StudentAcademicRecord-Multiple-Extensions-ExcludeOnly",
                       "endpointUri": "{BASE_URL}/metadata/specifications/profiles/Sample-StudentAcademicRecord-Multiple-Extensions-ExcludeOnly/resources-spec.json",
                       "prefix": "Profiles"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Profiles/ProfileExtensionFiltering.feature
@@ -260,9 +260,6 @@ Feature: Profile Extension Filtering
 
         @relational-backend
         @relational-ci-shard-2
-        # DMS-1233: Quarantined until profile extension names are normalized to the
-        # schema extension key during profile write processing.
-        @ignore
         Scenario: 09 Extension Excluded write profile applies write payload to extension members
             Given the claimSet "E2E-NoFurtherAuthRequiredClaimSet" is authorized with profile "Sample-Staff-Extension-Excluded" and namespacePrefixes "uri://ed-fi.org, uri://sample.ed-fi.org"
             When a PUT request is made to "/ed-fi/staffs/{id}" with profile "Sample-Staff-Extension-Excluded" for resource "Staff" with body


### PR DESCRIPTION
## Summary

A profile that authors an extension as `<Extension name="Sample" …>` produced a runtime **500** on relational profile writes (e.g. `PUT /ed-fi/staffs/{id}` with profile `Sample-Staff-Extension-Excluded`). The profile XML preserves the authored casing (`Sample`), but the API schema, relational write plan, and reconstituted documents expose the extension payload under the project endpoint key (`sample`). The write pipeline derived the compiled scope `$._ext.Sample`, which `EffectiveSchemaRequiredMembersBuilder` could not resolve case-sensitively against `jsonSchemaForInsert`, and threw.

This normalizes profile extension names to the schema extension key once, at the profile-load seam, so every downstream profile consumer (scope discovery, navigation, request/stored shaping, read projection, response filtering) agrees on the canonical key.

## Approach

1. **`ProfileExtensionSchemaResolver`** (new) — one shared helper for schema navigation and case-insensitive extension-key resolution (`ExtensionPropertiesAt`, `MemberProperties`, `CollectionItemProperties`, `TryResolveExtensionKey`), used by both the validator and the canonicalizer so they resolve the same key at the same location by construction.
2. **`ProfileExtensionCanonicalizer`** (new) — produces a schema-canonicalized `ProfileDefinition`: rewrites every extension rule name to the canonical schema key, resolved **location-aware** (mirroring the validator), drops rules that do not resolve so no unresolved runtime scope is emitted, and defensively de-dups any sibling rules that resolve to the same key.
3. **`ProfileDataValidator`** — recognizes case-differing extensions, and a single mode-independent pre-pass (`CollectExtensionResolutionFailures`) reports every extension rule that does not resolve at its schema location (so a rule under an `IncludeAll` branch cannot vanish silently). Severity: a non-`IncludeAll` rule (it explicitly selects/deselects members), or any rule under an `IncludeOnly` parent, is an **error**; an `IncludeAll` rule under a tolerant parent is a **warning** (then dropped by canonicalization). Two sibling rules resolving to the **same** schema key are always an error (they would throw in `ExtensionRulesByName`).
4. **`CachedProfileService`** — after validation passes, caches the canonicalized definition.

## Test / acceptance

- Un-ignored `ProfileExtensionFiltering` scenario 09 (Extension Excluded write profile → 204 with persisted `_ext.sample` members).
- Added `Sample-StudentAcademicRecord-Multiple-Extensions-IncludeOnly` to the `DiscoveryAPI` `/metadata/specifications` golden list (it now loads because the validator recognizes the `Sample`→`sample` extension).
- Core unit coverage: case-insensitive resolution (incl. a camelCase `sampleStaff` key, proving the key comes from the schema not lowercasing); location-aware canonicalization at every nesting level (root, object, collection item, and inside a resolved extension''s object/collection); unknown-extension severity by mode (incl. non-`IncludeAll` rule under `IncludeAll` parent → error); resolved same-key duplicate → error; unresolved case-variant names → warnings.

## Verification

- Full Core unit suite passes (see the **Run Unit Tests** CI job for the current result).
- Relational E2E on the current `main` base (through DMS-1229), rebuilt image: `ProfileExtensionFiltering` passes including the un-ignored scenario 09 (→ 204), and `DiscoveryAPI` matches the expected `/metadata/specifications` list. Validator/canonicalizer refinements since are invisible to the seeded profile set, which references no unknown or duplicate extensions.

## Notes

- Scenarios 08/10/11/12 remain 415 — their profiles are dropped by PascalCase **property** errors under `IncludeOnly`, which this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)