### PR TITLE
[DMS-1234] Map abstract identity-table unique violations to 409 identity conflicts

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit/AbstractIdentityTableDerivationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit/AbstractIdentityTableDerivationTests.cs
@@ -1656,6 +1656,38 @@ public class Given_Abstract_Identity_Column_Naming_With_Composite_Reference
             .And.NotContain("ProgramReferenceProgramTypeDescriptor");
     }
 
+    /// <summary>
+    /// Pins the table-shape contract that
+    /// <c>RelationalWriteConstraintResolver.ResolveAbstractIdentityUniqueConstraint</c> depends on, exercised
+    /// here for a reference-backed abstract resource: the primary key is exactly the surrogate
+    /// <c>DocumentId</c>, the <c>_NK</c> natural-key unique excludes <c>DocumentId</c>, and the <c>_RefKey</c>
+    /// unique is the natural key plus <c>DocumentId</c>. The resolver classifies a unique violation as a 409
+    /// identity conflict precisely when the violated constraint does not contain a primary-key column; if the
+    /// derivation ever changes this shape (PK structure, constraint membership, or an extra unique), that
+    /// heuristic would silently misclassify and this test fails first.
+    /// </summary>
+    [Test]
+    public void It_keys_the_identity_table_on_document_id_with_natural_and_reference_key_uniques()
+    {
+        var table = _abstractTable.TableModel;
+
+        table.Key.Columns.Select(column => column.ColumnName.Value).Should().Equal("DocumentId");
+
+        var uniques = table.Constraints.OfType<TableConstraint.Unique>().ToArray();
+        var naturalKey = uniques.Single(constraint =>
+            constraint.Name.EndsWith("_NK", StringComparison.Ordinal)
+        );
+        var referenceKey = uniques.Single(constraint =>
+            constraint.Name.EndsWith("_RefKey", StringComparison.Ordinal)
+        );
+
+        naturalKey.Columns.Select(column => column.Value).Should().NotContain("DocumentId");
+        referenceKey
+            .Columns.Select(column => column.Value)
+            .Should()
+            .Equal(naturalKey.Columns.Select(column => column.Value).Append("DocumentId"));
+    }
+
     private static JsonObject BuildProjectSchema() => ProgramCarrierTestSchema.BuildProjectSchema();
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
@@ -17,6 +17,8 @@ internal static class AbstractIdentitySchoolTestData
 {
     internal const string NaturalKeyConstraintName = "UX_EducationOrganizationIdentity_NK";
     internal const string ReferenceKeyConstraintName = "UX_EducationOrganizationIdentity_RefKey";
+    internal const string GeneralStudentProgramAssociationNaturalKeyConstraintName =
+        "UX_GeneralStudentProgramAssociationIdentity_NK";
 
     internal static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
     internal static readonly QualifiedResourceName LocalEducationAgencyResource = new(
@@ -26,6 +28,14 @@ internal static class AbstractIdentitySchoolTestData
     internal static readonly QualifiedResourceName EducationOrganizationResource = new(
         "Ed-Fi",
         "EducationOrganization"
+    );
+    internal static readonly QualifiedResourceName GeneralStudentProgramAssociationResource = new(
+        "Ed-Fi",
+        "GeneralStudentProgramAssociation"
+    );
+    internal static readonly QualifiedResourceName StudentProgramAssociationResource = new(
+        "Ed-Fi",
+        "StudentProgramAssociation"
     );
 
     /// <summary>
@@ -166,6 +176,115 @@ internal static class AbstractIdentitySchoolTestData
         );
 
     /// <summary>
+    /// Builds a concrete StudentProgramAssociation root table whose identity component is reference-backed
+    /// (<c>Program_EducationOrganizationId</c>, sourced from the nested <c>$.programReference</c> path).
+    /// </summary>
+    internal static DbTableModel StudentProgramAssociationRootTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "StudentProgramAssociation"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_StudentProgramAssociation",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Program_EducationOrganizationId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression(
+                        "$.programReference.educationOrganizationId",
+                        [
+                            new JsonPathSegment.Property("programReference"),
+                            new JsonPathSegment.Property("educationOrganizationId"),
+                        ]
+                    ),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+
+    /// <summary>
+    /// Models edfi."GeneralStudentProgramAssociationIdentity" the way
+    /// AbstractIdentityTableAndUnionViewDerivationPass builds a reference-backed abstract identity table:
+    /// DocumentId primary key, the _NK natural-key unique over the reference-backed identity column, the
+    /// _RefKey helper that also includes DocumentId, and the document FK.
+    /// </summary>
+    internal static DbTableModel GeneralStudentProgramAssociationIdentityTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "GeneralStudentProgramAssociationIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_GeneralStudentProgramAssociationIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Program_EducationOrganizationId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression(
+                        "$.programReference.educationOrganizationId",
+                        [
+                            new JsonPathSegment.Property("programReference"),
+                            new JsonPathSegment.Property("educationOrganizationId"),
+                        ]
+                    ),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(
+                    GeneralStudentProgramAssociationNaturalKeyConstraintName,
+                    [new DbColumnName("Program_EducationOrganizationId")]
+                ),
+                new TableConstraint.Unique(
+                    "UX_GeneralStudentProgramAssociationIdentity_RefKey",
+                    [new DbColumnName("Program_EducationOrganizationId"), new DbColumnName("DocumentId")]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_GeneralStudentProgramAssociationIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+    /// <summary>
     /// Builds the write plan and mapping set shared by the abstract-identity tests, using the single-column
     /// EducationOrganization identity table.
     /// </summary>
@@ -184,12 +303,13 @@ internal static class AbstractIdentitySchoolTestData
     internal static (ResourceWritePlan WritePlan, MappingSet MappingSet) BuildSchoolWriteModel(
         DbTableModel abstractIdentityTable
     ) =>
-        BuildEducationOrganizationSubclassWriteModel(
+        BuildSubclassWriteModel(
             SchoolResource,
             SchoolRootTable(),
             new DbColumnName("SchoolId"),
             "$.schoolId",
-            abstractIdentityTable
+            abstractIdentityTable,
+            EducationOrganizationResource
         );
 
     /// <summary>
@@ -201,27 +321,46 @@ internal static class AbstractIdentitySchoolTestData
         ResourceWritePlan WritePlan,
         MappingSet MappingSet
     ) BuildLocalEducationAgencyWriteModel() =>
-        BuildEducationOrganizationSubclassWriteModel(
+        BuildSubclassWriteModel(
             LocalEducationAgencyResource,
             LocalEducationAgencyRootTable(),
             new DbColumnName("LocalEducationAgencyId"),
             "$.localEducationAgencyId",
-            EducationOrganizationIdentityTable()
+            EducationOrganizationIdentityTable(),
+            EducationOrganizationResource
         );
 
     /// <summary>
-    /// Builds the write plan and mapping set for a concrete EducationOrganization subclass that projects into
-    /// the shared abstract identity table, parameterized by the subclass's identity column and JSONPath.
+    /// Builds a concrete StudentProgramAssociation write model that projects into the
+    /// GeneralStudentProgramAssociation abstract identity table, whose identity element is reference-backed and
+    /// therefore addressed by a multi-segment JSONPath (<c>$.programReference.educationOrganizationId</c>).
+    /// Used to prove the failure mapper resolves abstract-identity conflict values by walking a nested request
+    /// body, not just a top-level property.
     /// </summary>
-    private static (
+    internal static (
         ResourceWritePlan WritePlan,
         MappingSet MappingSet
-    ) BuildEducationOrganizationSubclassWriteModel(
+    ) BuildReferenceBackedSubclassWriteModel() =>
+        BuildSubclassWriteModel(
+            StudentProgramAssociationResource,
+            StudentProgramAssociationRootTable(),
+            new DbColumnName("Program_EducationOrganizationId"),
+            "$.programReference.educationOrganizationId",
+            GeneralStudentProgramAssociationIdentityTable(),
+            GeneralStudentProgramAssociationResource
+        );
+
+    /// <summary>
+    /// Builds the write plan and mapping set for a concrete subclass that projects into the shared abstract
+    /// identity table, parameterized by the subclass's identity column, JSONPath, and abstract superclass.
+    /// </summary>
+    private static (ResourceWritePlan WritePlan, MappingSet MappingSet) BuildSubclassWriteModel(
         QualifiedResourceName concreteResource,
         DbTableModel concreteRootTable,
         DbColumnName identityColumnName,
         string identityJsonPath,
-        DbTableModel abstractIdentityTable
+        DbTableModel abstractIdentityTable,
+        QualifiedResourceName abstractResource
     )
     {
         var resourceModel = new RelationalResourceModel(
@@ -237,10 +376,11 @@ internal static class AbstractIdentitySchoolTestData
         var writePlan = new ResourceWritePlan(resourceModel, []);
 
         var concreteKey = new ResourceKeyEntry(1, concreteResource, "1.0.0", false);
-        var educationOrganizationKey = new ResourceKeyEntry(2, EducationOrganizationResource, "1.0.0", true);
+        var abstractResourceKey = new ResourceKeyEntry(2, abstractResource, "1.0.0", true);
 
-        // EducationOrganization subclass identifiers are Int32 in these fixtures; the failure mapper reads only
-        // the identity JSONPath from this element, not its scalar type.
+        // Subclass identifiers carry an Int32 scalar type in these fixtures; the failure mapper reads only the
+        // identity JSONPath from this element (walking it against the request body), not its scalar type, so a
+        // reference-backed nested path resolves the same way.
         var referentialIdentityTrigger = new DbTriggerInfo(
             new DbTriggerName($"TR_{concreteResource.ResourceName}_ReferentialIdentity"),
             concreteRootTable.Table,
@@ -270,12 +410,12 @@ internal static class AbstractIdentitySchoolTestData
                     2,
                     [1, 2],
                     [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
-                    [concreteKey, educationOrganizationKey]
+                    [concreteKey, abstractResourceKey]
                 ),
                 SqlDialect.Pgsql,
                 [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
                 [new ConcreteResourceModel(concreteKey, ResourceStorageKind.RelationalTables, resourceModel)],
-                [new AbstractIdentityTableInfo(educationOrganizationKey, abstractIdentityTable)],
+                [new AbstractIdentityTableInfo(abstractResourceKey, abstractIdentityTable)],
                 [],
                 [],
                 [referentialIdentityTrigger]
@@ -285,12 +425,12 @@ internal static class AbstractIdentitySchoolTestData
             new Dictionary<QualifiedResourceName, short>
             {
                 [concreteResource] = concreteKey.ResourceKeyId,
-                [EducationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
+                [abstractResource] = abstractResourceKey.ResourceKeyId,
             },
             new Dictionary<short, ResourceKeyEntry>
             {
                 [concreteKey.ResourceKeyId] = concreteKey,
-                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
+                [abstractResourceKey.ResourceKeyId] = abstractResourceKey,
             },
             new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// Shared School / EducationOrganization abstract-identity model used by both the constraint-resolver and
+/// the failure-mapper abstract-identity tests, so the two suites exercise identical table shapes and cannot
+/// silently drift apart.
+/// </summary>
+internal static class AbstractIdentitySchoolTestData
+{
+    internal const string NaturalKeyConstraintName = "UX_EducationOrganizationIdentity_NK";
+    internal const string ReferenceKeyConstraintName = "UX_EducationOrganizationIdentity_RefKey";
+
+    internal static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+    internal static readonly QualifiedResourceName EducationOrganizationResource = new(
+        "Ed-Fi",
+        "EducationOrganization"
+    );
+
+    /// <summary>
+    /// Builds the concrete School root table with its <c>SchoolId</c> identity column.
+    /// </summary>
+    internal static DbTableModel SchoolRootTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("SchoolId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+
+    /// <summary>
+    /// Models edfi."EducationOrganizationIdentity" the way AbstractIdentityTableAndUnionViewDerivationPass
+    /// builds it: DocumentId primary key, the _NK natural-key unique over the projected identity column, the
+    /// _RefKey helper that also includes DocumentId, and the document FK.
+    /// </summary>
+    internal static DbTableModel EducationOrganizationIdentityTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "EducationOrganizationIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_EducationOrganizationIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("EducationOrganizationId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression(
+                        "$.educationOrganizationId",
+                        [new JsonPathSegment.Property("educationOrganizationId")]
+                    ),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_NK",
+                    [new DbColumnName("EducationOrganizationId")]
+                ),
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_RefKey",
+                    [new DbColumnName("EducationOrganizationId"), new DbColumnName("DocumentId")]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_EducationOrganizationIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+    /// <summary>
+    /// Builds the write plan and mapping set shared by the abstract-identity tests, using the single-column
+    /// EducationOrganization identity table.
+    /// </summary>
+    internal static (ResourceWritePlan WritePlan, MappingSet MappingSet) BuildSchoolWriteModel() =>
+        BuildSchoolWriteModel(EducationOrganizationIdentityTable());
+
+    /// <summary>
+    /// Builds the write plan and mapping set shared by the abstract-identity tests. The School
+    /// referential-identity trigger is always present so the failure mapper can project the concrete identity
+    /// values; the constraint resolver ignores triggers.
+    /// </summary>
+    /// <param name="abstractIdentityTable">
+    /// The abstract identity table placed in the mapping set's abstract-identity inventory. Tests pass a
+    /// composite-key variant to cover multi-column natural keys.
+    /// </param>
+    internal static (ResourceWritePlan WritePlan, MappingSet MappingSet) BuildSchoolWriteModel(
+        DbTableModel abstractIdentityTable
+    )
+    {
+        var schoolRootTable = SchoolRootTable();
+
+        var resourceModel = new RelationalResourceModel(
+            SchoolResource,
+            new DbSchemaName("edfi"),
+            ResourceStorageKind.RelationalTables,
+            schoolRootTable,
+            [schoolRootTable],
+            [],
+            []
+        );
+
+        var writePlan = new ResourceWritePlan(resourceModel, []);
+
+        var schoolKey = new ResourceKeyEntry(1, SchoolResource, "1.0.0", false);
+        var educationOrganizationKey = new ResourceKeyEntry(2, EducationOrganizationResource, "1.0.0", true);
+
+        var schoolReferentialIdentityTrigger = new DbTriggerInfo(
+            new DbTriggerName("TR_School_ReferentialIdentity"),
+            schoolRootTable.Table,
+            [new DbColumnName("DocumentId")],
+            [new DbColumnName("SchoolId")],
+            new TriggerKindParameters.ReferentialIdentityMaintenance(
+                schoolKey.ResourceKeyId,
+                SchoolResource.ProjectName,
+                SchoolResource.ResourceName,
+                [
+                    new IdentityElementMapping(
+                        new DbColumnName("SchoolId"),
+                        "$.schoolId",
+                        new RelationalScalarType(ScalarKind.Int32)
+                    ),
+                ]
+            )
+        );
+
+        var mappingSet = new MappingSet(
+            new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo(
+                    "1.0",
+                    "v1",
+                    "schema-hash",
+                    2,
+                    [1, 2],
+                    [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
+                    [schoolKey, educationOrganizationKey]
+                ),
+                SqlDialect.Pgsql,
+                [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
+                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
+                [new AbstractIdentityTableInfo(educationOrganizationKey, abstractIdentityTable)],
+                [],
+                [],
+                [schoolReferentialIdentityTrigger]
+            ),
+            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [SchoolResource] = writePlan },
+            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            new Dictionary<QualifiedResourceName, short>
+            {
+                [SchoolResource] = schoolKey.ResourceKeyId,
+                [EducationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
+            },
+            new Dictionary<short, ResourceKeyEntry>
+            {
+                [schoolKey.ResourceKeyId] = schoolKey,
+                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
+            },
+            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
+        );
+
+        return (writePlan, mappingSet);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/AbstractIdentitySchoolTestData.cs
@@ -19,6 +19,10 @@ internal static class AbstractIdentitySchoolTestData
     internal const string ReferenceKeyConstraintName = "UX_EducationOrganizationIdentity_RefKey";
 
     internal static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+    internal static readonly QualifiedResourceName LocalEducationAgencyResource = new(
+        "Ed-Fi",
+        "LocalEducationAgency"
+    );
     internal static readonly QualifiedResourceName EducationOrganizationResource = new(
         "Ed-Fi",
         "EducationOrganization"
@@ -51,6 +55,45 @@ internal static class AbstractIdentitySchoolTestData
                     new RelationalScalarType(ScalarKind.Int32),
                     false,
                     new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+
+    /// <summary>
+    /// Builds a concrete LocalEducationAgency root table with its <c>LocalEducationAgencyId</c> identity column.
+    /// Used to prove abstract-identity conflicts report the writing subclass's own identity values rather than a
+    /// hard-coded School identity.
+    /// </summary>
+    internal static DbTableModel LocalEducationAgencyRootTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "LocalEducationAgency"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_LocalEducationAgency",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("LocalEducationAgencyId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression(
+                        "$.localEducationAgencyId",
+                        [new JsonPathSegment.Property("localEducationAgencyId")]
+                    ),
                     null,
                     new ColumnStorage.Stored()
                 ),
@@ -130,7 +173,7 @@ internal static class AbstractIdentitySchoolTestData
         BuildSchoolWriteModel(EducationOrganizationIdentityTable());
 
     /// <summary>
-    /// Builds the write plan and mapping set shared by the abstract-identity tests. The School
+    /// Builds the School write plan and mapping set shared by the abstract-identity tests. The School
     /// referential-identity trigger is always present so the failure mapper can project the concrete identity
     /// values; the constraint resolver ignores triggers.
     /// </summary>
@@ -140,38 +183,77 @@ internal static class AbstractIdentitySchoolTestData
     /// </param>
     internal static (ResourceWritePlan WritePlan, MappingSet MappingSet) BuildSchoolWriteModel(
         DbTableModel abstractIdentityTable
+    ) =>
+        BuildEducationOrganizationSubclassWriteModel(
+            SchoolResource,
+            SchoolRootTable(),
+            new DbColumnName("SchoolId"),
+            "$.schoolId",
+            abstractIdentityTable
+        );
+
+    /// <summary>
+    /// Builds a LocalEducationAgency write plan and mapping set that projects into the same single-column
+    /// EducationOrganization identity table as School. Used to prove abstract-identity conflicts report the
+    /// writing subclass's own identity element (<c>localEducationAgencyId</c>) rather than School's.
+    /// </summary>
+    internal static (
+        ResourceWritePlan WritePlan,
+        MappingSet MappingSet
+    ) BuildLocalEducationAgencyWriteModel() =>
+        BuildEducationOrganizationSubclassWriteModel(
+            LocalEducationAgencyResource,
+            LocalEducationAgencyRootTable(),
+            new DbColumnName("LocalEducationAgencyId"),
+            "$.localEducationAgencyId",
+            EducationOrganizationIdentityTable()
+        );
+
+    /// <summary>
+    /// Builds the write plan and mapping set for a concrete EducationOrganization subclass that projects into
+    /// the shared abstract identity table, parameterized by the subclass's identity column and JSONPath.
+    /// </summary>
+    private static (
+        ResourceWritePlan WritePlan,
+        MappingSet MappingSet
+    ) BuildEducationOrganizationSubclassWriteModel(
+        QualifiedResourceName concreteResource,
+        DbTableModel concreteRootTable,
+        DbColumnName identityColumnName,
+        string identityJsonPath,
+        DbTableModel abstractIdentityTable
     )
     {
-        var schoolRootTable = SchoolRootTable();
-
         var resourceModel = new RelationalResourceModel(
-            SchoolResource,
+            concreteResource,
             new DbSchemaName("edfi"),
             ResourceStorageKind.RelationalTables,
-            schoolRootTable,
-            [schoolRootTable],
+            concreteRootTable,
+            [concreteRootTable],
             [],
             []
         );
 
         var writePlan = new ResourceWritePlan(resourceModel, []);
 
-        var schoolKey = new ResourceKeyEntry(1, SchoolResource, "1.0.0", false);
+        var concreteKey = new ResourceKeyEntry(1, concreteResource, "1.0.0", false);
         var educationOrganizationKey = new ResourceKeyEntry(2, EducationOrganizationResource, "1.0.0", true);
 
-        var schoolReferentialIdentityTrigger = new DbTriggerInfo(
-            new DbTriggerName("TR_School_ReferentialIdentity"),
-            schoolRootTable.Table,
+        // EducationOrganization subclass identifiers are Int32 in these fixtures; the failure mapper reads only
+        // the identity JSONPath from this element, not its scalar type.
+        var referentialIdentityTrigger = new DbTriggerInfo(
+            new DbTriggerName($"TR_{concreteResource.ResourceName}_ReferentialIdentity"),
+            concreteRootTable.Table,
             [new DbColumnName("DocumentId")],
-            [new DbColumnName("SchoolId")],
+            [identityColumnName],
             new TriggerKindParameters.ReferentialIdentityMaintenance(
-                schoolKey.ResourceKeyId,
-                SchoolResource.ProjectName,
-                SchoolResource.ResourceName,
+                concreteKey.ResourceKeyId,
+                concreteResource.ProjectName,
+                concreteResource.ResourceName,
                 [
                     new IdentityElementMapping(
-                        new DbColumnName("SchoolId"),
-                        "$.schoolId",
+                        identityColumnName,
+                        identityJsonPath,
                         new RelationalScalarType(ScalarKind.Int32)
                     ),
                 ]
@@ -188,26 +270,26 @@ internal static class AbstractIdentitySchoolTestData
                     2,
                     [1, 2],
                     [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
-                    [schoolKey, educationOrganizationKey]
+                    [concreteKey, educationOrganizationKey]
                 ),
                 SqlDialect.Pgsql,
                 [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
-                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
+                [new ConcreteResourceModel(concreteKey, ResourceStorageKind.RelationalTables, resourceModel)],
                 [new AbstractIdentityTableInfo(educationOrganizationKey, abstractIdentityTable)],
                 [],
                 [],
-                [schoolReferentialIdentityTrigger]
+                [referentialIdentityTrigger]
             ),
-            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [SchoolResource] = writePlan },
+            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [concreteResource] = writePlan },
             new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
             new Dictionary<QualifiedResourceName, short>
             {
-                [SchoolResource] = schoolKey.ResourceKeyId,
+                [concreteResource] = concreteKey.ResourceKeyId,
                 [EducationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
             },
             new Dictionary<short, ResourceKeyEntry>
             {
-                [schoolKey.ResourceKeyId] = schoolKey,
+                [concreteKey.ResourceKeyId] = concreteKey,
                 [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
             },
             new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
@@ -257,28 +257,31 @@ public class Given_Relational_Write_Constraint_Resolver
     [Test]
     public void It_resolves_abstract_identity_natural_key_when_the_violated_table_is_not_first_in_name_order()
     {
-        const string secondTableNaturalKeyName = "UX_GeneralStudentProgramAssociationIdentity_NK";
-        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel();
+        var violatedConstraintName =
+            AbstractIdentitySchoolTestData.GeneralStudentProgramAssociationNaturalKeyConstraintName;
 
-        // Production carries more than one abstract identity table (e.g. EducationOrganization and
-        // GeneralStudentProgramAssociation). Append a second so the resolver must skip the non-matching first
-        // table before matching the violated one.
+        // A StudentProgramAssociation write genuinely maintains the GeneralStudentProgramAssociation identity
+        // table. Prepend the unrelated EducationOrganization identity table, which sorts first by name, so the
+        // resolver must skip a non-matching table before matching the violated one — while still resolving a
+        // constraint the written resource actually owns.
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildReferenceBackedSubclassWriteModel();
+
         var mappingSetWithTwoAbstractTables = mappingSet with
         {
             Model = mappingSet.Model with
             {
                 AbstractIdentityTablesInNameOrder =
                 [
-                    .. mappingSet.Model.AbstractIdentityTablesInNameOrder,
                     new AbstractIdentityTableInfo(
                         new ResourceKeyEntry(
                             3,
-                            new QualifiedResourceName("Ed-Fi", "GeneralStudentProgramAssociation"),
+                            AbstractIdentitySchoolTestData.EducationOrganizationResource,
                             "1.0.0",
                             true
                         ),
-                        SecondAbstractIdentityTable(secondTableNaturalKeyName)
+                        AbstractIdentitySchoolTestData.EducationOrganizationIdentityTable()
                     ),
+                    .. mappingSet.Model.AbstractIdentityTablesInNameOrder,
                 ],
             },
         };
@@ -286,18 +289,18 @@ public class Given_Relational_Write_Constraint_Resolver
             writePlan,
             new ReferenceResolverRequest(
                 mappingSetWithTwoAbstractTables,
-                AbstractIdentitySchoolTestData.SchoolResource,
+                AbstractIdentitySchoolTestData.StudentProgramAssociationResource,
                 [],
                 []
             ),
-            new RelationalWriteExceptionClassification.UniqueConstraintViolation(secondTableNaturalKeyName)
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(violatedConstraintName)
         );
 
         var result = _sut.Resolve(request);
 
         result
             .Should()
-            .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(secondTableNaturalKeyName));
+            .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violatedConstraintName));
     }
 
     [Test]
@@ -735,63 +738,6 @@ public class Given_Relational_Write_Constraint_Resolver
                 ),
                 new TableConstraint.ForeignKey(
                     "FK_CompositeIdentity_Document",
-                    [new DbColumnName("DocumentId")],
-                    new DbTableName(new DbSchemaName("dms"), "Document"),
-                    [new DbColumnName("DocumentId")],
-                    OnDelete: ReferentialAction.Cascade
-                ),
-            ]
-        );
-
-    // Builds a second, differently named abstract identity table so the resolver's scan across
-    // AbstractIdentityTablesInNameOrder must continue past a non-matching table before matching the violated
-    // one. Shaped like the derivation output: DocumentId primary key, the natural-key unique over the projected
-    // identity column, the _RefKey helper that also appends DocumentId, and the document FK.
-    private static DbTableModel SecondAbstractIdentityTable(string naturalKeyConstraintName) =>
-        new(
-            new DbTableName(new DbSchemaName("edfi"), "GeneralStudentProgramAssociationIdentity"),
-            new JsonPathExpression("$", []),
-            new TableKey(
-                "PK_GeneralStudentProgramAssociationIdentity",
-                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
-            ),
-            [
-                new DbColumnModel(
-                    new DbColumnName("DocumentId"),
-                    ColumnKind.ParentKeyPart,
-                    new RelationalScalarType(ScalarKind.Int64),
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("ProgramName"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.String, 60),
-                    false,
-                    new JsonPathExpression("$.programName", [new JsonPathSegment.Property("programName")]),
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("Discriminator"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.String, 256),
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-            ],
-            [
-                new TableConstraint.Unique(naturalKeyConstraintName, [new DbColumnName("ProgramName")]),
-                new TableConstraint.Unique(
-                    "UX_GeneralStudentProgramAssociationIdentity_RefKey",
-                    [new DbColumnName("ProgramName"), new DbColumnName("DocumentId")]
-                ),
-                new TableConstraint.ForeignKey(
-                    "FK_GeneralStudentProgramAssociationIdentity_Document",
                     [new DbColumnName("DocumentId")],
                     new DbTableName(new DbSchemaName("dms"), "Document"),
                     [new DbColumnName("DocumentId")],

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
@@ -254,6 +254,52 @@ public class Given_Relational_Write_Constraint_Resolver
         result.Should().Be(new RelationalWriteConstraintResolution.Unresolved(referenceKeyConstraintName));
     }
 
+    [Test]
+    public void It_resolves_abstract_identity_natural_key_when_the_violated_table_is_not_first_in_name_order()
+    {
+        const string secondTableNaturalKeyName = "UX_GeneralStudentProgramAssociationIdentity_NK";
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel();
+
+        // Production carries more than one abstract identity table (e.g. EducationOrganization and
+        // GeneralStudentProgramAssociation). Append a second so the resolver must skip the non-matching first
+        // table before matching the violated one.
+        var mappingSetWithTwoAbstractTables = mappingSet with
+        {
+            Model = mappingSet.Model with
+            {
+                AbstractIdentityTablesInNameOrder =
+                [
+                    .. mappingSet.Model.AbstractIdentityTablesInNameOrder,
+                    new AbstractIdentityTableInfo(
+                        new ResourceKeyEntry(
+                            3,
+                            new QualifiedResourceName("Ed-Fi", "GeneralStudentProgramAssociation"),
+                            "1.0.0",
+                            true
+                        ),
+                        SecondAbstractIdentityTable(secondTableNaturalKeyName)
+                    ),
+                ],
+            },
+        };
+        var request = new RelationalWriteConstraintResolutionRequest(
+            writePlan,
+            new ReferenceResolverRequest(
+                mappingSetWithTwoAbstractTables,
+                AbstractIdentitySchoolTestData.SchoolResource,
+                [],
+                []
+            ),
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(secondTableNaturalKeyName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result
+            .Should()
+            .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(secondTableNaturalKeyName));
+    }
+
     private static ResolverFixture CreateFixture()
     {
         var sectionRootTable = new DbTableModel(
@@ -651,6 +697,63 @@ public class Given_Relational_Write_Constraint_Resolver
                 ),
                 new TableConstraint.ForeignKey(
                     "FK_CompositeIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+    // Builds a second, differently named abstract identity table so the resolver's scan across
+    // AbstractIdentityTablesInNameOrder must continue past a non-matching table before matching the violated
+    // one. Shaped like the derivation output: DocumentId primary key, the natural-key unique over the projected
+    // identity column, the _RefKey helper that also appends DocumentId, and the document FK.
+    private static DbTableModel SecondAbstractIdentityTable(string naturalKeyConstraintName) =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "GeneralStudentProgramAssociationIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_GeneralStudentProgramAssociationIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("ProgramName"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 60),
+                    false,
+                    new JsonPathExpression("$.programName", [new JsonPathSegment.Property("programName")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(naturalKeyConstraintName, [new DbColumnName("ProgramName")]),
+                new TableConstraint.Unique(
+                    "UX_GeneralStudentProgramAssociationIdentity_RefKey",
+                    [new DbColumnName("ProgramName"), new DbColumnName("DocumentId")]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_GeneralStudentProgramAssociationIdentity_Document",
                     [new DbColumnName("DocumentId")],
                     new DbTableName(new DbSchemaName("dms"), "Document"),
                     [new DbColumnName("DocumentId")],

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
@@ -300,6 +300,44 @@ public class Given_Relational_Write_Constraint_Resolver
             .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(secondTableNaturalKeyName));
     }
 
+    [Test]
+    public void It_resolves_abstract_identity_natural_key_with_reference_backed_identity_columns()
+    {
+        const string naturalKeyConstraintName = "UX_ReferenceBackedIdentity_NK";
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel(
+            ReferenceBackedAbstractIdentityTable()
+        );
+        var request = new RelationalWriteConstraintResolutionRequest(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, AbstractIdentitySchoolTestData.SchoolResource, [], []),
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(naturalKeyConstraintName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result
+            .Should()
+            .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(naturalKeyConstraintName));
+    }
+
+    [Test]
+    public void It_leaves_abstract_identity_reference_key_with_reference_backed_identity_columns_unresolved()
+    {
+        const string referenceKeyConstraintName = "UX_ReferenceBackedIdentity_RefKey";
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel(
+            ReferenceBackedAbstractIdentityTable()
+        );
+        var request = new RelationalWriteConstraintResolutionRequest(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, AbstractIdentitySchoolTestData.SchoolResource, [], []),
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(referenceKeyConstraintName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result.Should().Be(new RelationalWriteConstraintResolution.Unresolved(referenceKeyConstraintName));
+    }
+
     private static ResolverFixture CreateFixture()
     {
         var sectionRootTable = new DbTableModel(
@@ -754,6 +792,85 @@ public class Given_Relational_Write_Constraint_Resolver
                 ),
                 new TableConstraint.ForeignKey(
                     "FK_GeneralStudentProgramAssociationIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+    // Models an abstract identity table whose natural key includes a reference-backed identity column named
+    // with a `_DocumentId` suffix. That suffix is the convention ReferenceBindingPass uses for document FK
+    // columns, and reference-heavy natural keys really do carry such columns: the concrete Section NK is over
+    // `School_DocumentId`, and an abstract resource like GeneralStudentProgramAssociation projects reference
+    // identity components the same way. Proves the resolver compares NK columns against the *bare* `DocumentId`
+    // key column by exact equality, so a `_DocumentId`-suffixed identity column is never mistaken for the
+    // surrogate key (which would misclassify the natural-key violation as unresolved / non-409).
+    private static DbTableModel ReferenceBackedAbstractIdentityTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "ReferenceBackedIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_ReferenceBackedIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("EducationOrganization_DocumentId"),
+                    ColumnKind.DocumentFk,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    new JsonPathExpression(
+                        "$.educationOrganizationReference",
+                        [new JsonPathSegment.Property("educationOrganizationReference")]
+                    ),
+                    new QualifiedResourceName("Ed-Fi", "EducationOrganization"),
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("ProgramName"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 60),
+                    false,
+                    new JsonPathExpression("$.programName", [new JsonPathSegment.Property("programName")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(
+                    "UX_ReferenceBackedIdentity_NK",
+                    [new DbColumnName("EducationOrganization_DocumentId"), new DbColumnName("ProgramName")]
+                ),
+                new TableConstraint.Unique(
+                    "UX_ReferenceBackedIdentity_RefKey",
+                    [
+                        new DbColumnName("EducationOrganization_DocumentId"),
+                        new DbColumnName("ProgramName"),
+                        new DbColumnName("DocumentId"),
+                    ]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_ReferenceBackedIdentity_Document",
                     [new DbColumnName("DocumentId")],
                     new DbTableName(new DbSchemaName("dms"), "Document"),
                     [new DbColumnName("DocumentId")],

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
@@ -160,6 +160,62 @@ public class Given_Relational_Write_Constraint_Resolver
             );
     }
 
+    [Test]
+    public void It_resolves_abstract_identity_table_natural_key_unique_constraints_to_identity_conflicts()
+    {
+        var fixture = CreateSchoolAbstractIdentityFixture();
+        var request = new RelationalWriteConstraintResolutionRequest(
+            fixture.WritePlan,
+            fixture.ReferenceResolverRequest,
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                fixture.NaturalKeyConstraintName
+            )
+        );
+
+        var result = _sut.Resolve(request);
+
+        result
+            .Should()
+            .Be(
+                new RelationalWriteConstraintResolution.RootNaturalKeyUnique(fixture.NaturalKeyConstraintName)
+            );
+    }
+
+    [Test]
+    public void It_leaves_abstract_identity_table_reference_key_unique_constraints_unresolved()
+    {
+        var fixture = CreateSchoolAbstractIdentityFixture();
+        var request = new RelationalWriteConstraintResolutionRequest(
+            fixture.WritePlan,
+            fixture.ReferenceResolverRequest,
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                fixture.ReferenceKeyConstraintName
+            )
+        );
+
+        var result = _sut.Resolve(request);
+
+        result
+            .Should()
+            .Be(new RelationalWriteConstraintResolution.Unresolved(fixture.ReferenceKeyConstraintName));
+    }
+
+    [Test]
+    public void It_leaves_unique_constraints_absent_from_concrete_and_abstract_models_unresolved()
+    {
+        var fixture = CreateSchoolAbstractIdentityFixture();
+        const string absentConstraintName = "UX_EducationOrganizationIdentity_Absent";
+        var request = new RelationalWriteConstraintResolutionRequest(
+            fixture.WritePlan,
+            fixture.ReferenceResolverRequest,
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(absentConstraintName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result.Should().Be(new RelationalWriteConstraintResolution.Unresolved(absentConstraintName));
+    }
+
     private static ResolverFixture CreateFixture()
     {
         var sectionRootTable = new DbTableModel(
@@ -480,6 +536,155 @@ public class Given_Relational_Write_Constraint_Resolver
         );
     }
 
+    private static AbstractIdentityResolverFixture CreateSchoolAbstractIdentityFixture()
+    {
+        var schoolRootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("SchoolId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+
+        // Models edfi."EducationOrganizationIdentity" the way AbstractIdentityTableAndUnionViewDerivationPass
+        // builds it: DocumentId primary key, the _NK natural-key unique over the projected identity column,
+        // the _RefKey helper that also includes DocumentId, and the document FK.
+        var educationOrganizationIdentityTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "EducationOrganizationIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_EducationOrganizationIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("EducationOrganizationId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_NK",
+                    [new DbColumnName("EducationOrganizationId")]
+                ),
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_RefKey",
+                    [new DbColumnName("EducationOrganizationId"), new DbColumnName("DocumentId")]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_EducationOrganizationIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+        var resourceModel = new RelationalResourceModel(
+            SchoolResource,
+            new DbSchemaName("edfi"),
+            ResourceStorageKind.RelationalTables,
+            schoolRootTable,
+            [schoolRootTable],
+            [],
+            []
+        );
+
+        var writePlan = new ResourceWritePlan(resourceModel, []);
+
+        var schoolKey = new ResourceKeyEntry(1, SchoolResource, "1.0.0", false);
+        var educationOrganizationResource = new QualifiedResourceName("Ed-Fi", "EducationOrganization");
+        var educationOrganizationKey = new ResourceKeyEntry(2, educationOrganizationResource, "1.0.0", true);
+
+        var mappingSet = new MappingSet(
+            new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo(
+                    "1.0",
+                    "v1",
+                    "schema-hash",
+                    2,
+                    [1, 2],
+                    [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
+                    [schoolKey, educationOrganizationKey]
+                ),
+                SqlDialect.Pgsql,
+                [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
+                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
+                [new AbstractIdentityTableInfo(educationOrganizationKey, educationOrganizationIdentityTable)],
+                [],
+                [],
+                []
+            ),
+            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [SchoolResource] = writePlan },
+            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            new Dictionary<QualifiedResourceName, short>
+            {
+                [SchoolResource] = schoolKey.ResourceKeyId,
+                [educationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
+            },
+            new Dictionary<short, ResourceKeyEntry>
+            {
+                [schoolKey.ResourceKeyId] = schoolKey,
+                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
+            },
+            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
+        );
+
+        return new AbstractIdentityResolverFixture(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, SchoolResource, [], []),
+            NaturalKeyConstraintName: "UX_EducationOrganizationIdentity_NK",
+            ReferenceKeyConstraintName: "UX_EducationOrganizationIdentity_RefKey"
+        );
+    }
+
     private sealed record ResolverFixture(
         ResourceWritePlan WritePlan,
         ReferenceResolverRequest ReferenceResolverRequest,
@@ -488,5 +693,12 @@ public class Given_Relational_Write_Constraint_Resolver
         string DescriptorReferenceConstraintName,
         string StructuralForeignKeyConstraintName,
         string CollectionUniqueConstraintName
+    );
+
+    private sealed record AbstractIdentityResolverFixture(
+        ResourceWritePlan WritePlan,
+        ReferenceResolverRequest ReferenceResolverRequest,
+        string NaturalKeyConstraintName,
+        string ReferenceKeyConstraintName
     );
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteConstraintResolverTests.cs
@@ -216,6 +216,44 @@ public class Given_Relational_Write_Constraint_Resolver
         result.Should().Be(new RelationalWriteConstraintResolution.Unresolved(absentConstraintName));
     }
 
+    [Test]
+    public void It_resolves_composite_abstract_identity_natural_key_unique_constraints_to_identity_conflicts()
+    {
+        const string naturalKeyConstraintName = "UX_CompositeIdentity_NK";
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel(
+            CompositeAbstractIdentityTable()
+        );
+        var request = new RelationalWriteConstraintResolutionRequest(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, AbstractIdentitySchoolTestData.SchoolResource, [], []),
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(naturalKeyConstraintName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result
+            .Should()
+            .Be(new RelationalWriteConstraintResolution.RootNaturalKeyUnique(naturalKeyConstraintName));
+    }
+
+    [Test]
+    public void It_leaves_composite_abstract_identity_reference_key_unique_constraints_unresolved()
+    {
+        const string referenceKeyConstraintName = "UX_CompositeIdentity_RefKey";
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel(
+            CompositeAbstractIdentityTable()
+        );
+        var request = new RelationalWriteConstraintResolutionRequest(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, AbstractIdentitySchoolTestData.SchoolResource, [], []),
+            new RelationalWriteExceptionClassification.UniqueConstraintViolation(referenceKeyConstraintName)
+        );
+
+        var result = _sut.Resolve(request);
+
+        result.Should().Be(new RelationalWriteConstraintResolution.Unresolved(referenceKeyConstraintName));
+    }
+
     private static ResolverFixture CreateFixture()
     {
         var sectionRootTable = new DbTableModel(
@@ -538,44 +576,26 @@ public class Given_Relational_Write_Constraint_Resolver
 
     private static AbstractIdentityResolverFixture CreateSchoolAbstractIdentityFixture()
     {
-        var schoolRootTable = new DbTableModel(
-            new DbTableName(new DbSchemaName("edfi"), "School"),
-            new JsonPathExpression("$", []),
-            new TableKey(
-                "PK_School",
-                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
-            ),
-            [
-                new DbColumnModel(
-                    new DbColumnName("DocumentId"),
-                    ColumnKind.ParentKeyPart,
-                    null,
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("SchoolId"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.Int32),
-                    false,
-                    new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-            ],
-            []
-        );
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel();
 
-        // Models edfi."EducationOrganizationIdentity" the way AbstractIdentityTableAndUnionViewDerivationPass
-        // builds it: DocumentId primary key, the _NK natural-key unique over the projected identity column,
-        // the _RefKey helper that also includes DocumentId, and the document FK.
-        var educationOrganizationIdentityTable = new DbTableModel(
-            new DbTableName(new DbSchemaName("edfi"), "EducationOrganizationIdentity"),
+        return new AbstractIdentityResolverFixture(
+            writePlan,
+            new ReferenceResolverRequest(mappingSet, AbstractIdentitySchoolTestData.SchoolResource, [], []),
+            NaturalKeyConstraintName: AbstractIdentitySchoolTestData.NaturalKeyConstraintName,
+            ReferenceKeyConstraintName: AbstractIdentitySchoolTestData.ReferenceKeyConstraintName
+        );
+    }
+
+    // Models an abstract identity table for a resource whose identity spans two columns, the way
+    // AbstractIdentityTableAndUnionViewDerivationPass builds it: DocumentId primary key, the _NK natural-key
+    // unique over both projected identity columns, the _RefKey helper that also appends DocumentId, and the
+    // document FK. Proves the resolver matches multi-column natural keys, not just single-column ones.
+    private static DbTableModel CompositeAbstractIdentityTable() =>
+        new(
+            new DbTableName(new DbSchemaName("edfi"), "CompositeIdentity"),
             new JsonPathExpression("$", []),
             new TableKey(
-                "PK_EducationOrganizationIdentity",
+                "PK_CompositeIdentity",
                 [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
             ),
             [
@@ -589,11 +609,20 @@ public class Given_Relational_Write_Constraint_Resolver
                     new ColumnStorage.Stored()
                 ),
                 new DbColumnModel(
-                    new DbColumnName("EducationOrganizationId"),
+                    new DbColumnName("PartOneId"),
                     ColumnKind.Scalar,
                     new RelationalScalarType(ScalarKind.Int32),
                     false,
+                    new JsonPathExpression("$.partOneId", [new JsonPathSegment.Property("partOneId")]),
                     null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("PartTwoId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression("$.partTwoId", [new JsonPathSegment.Property("partTwoId")]),
                     null,
                     new ColumnStorage.Stored()
                 ),
@@ -609,15 +638,19 @@ public class Given_Relational_Write_Constraint_Resolver
             ],
             [
                 new TableConstraint.Unique(
-                    "UX_EducationOrganizationIdentity_NK",
-                    [new DbColumnName("EducationOrganizationId")]
+                    "UX_CompositeIdentity_NK",
+                    [new DbColumnName("PartOneId"), new DbColumnName("PartTwoId")]
                 ),
                 new TableConstraint.Unique(
-                    "UX_EducationOrganizationIdentity_RefKey",
-                    [new DbColumnName("EducationOrganizationId"), new DbColumnName("DocumentId")]
+                    "UX_CompositeIdentity_RefKey",
+                    [
+                        new DbColumnName("PartOneId"),
+                        new DbColumnName("PartTwoId"),
+                        new DbColumnName("DocumentId"),
+                    ]
                 ),
                 new TableConstraint.ForeignKey(
-                    "FK_EducationOrganizationIdentity_Document",
+                    "FK_CompositeIdentity_Document",
                     [new DbColumnName("DocumentId")],
                     new DbTableName(new DbSchemaName("dms"), "Document"),
                     [new DbColumnName("DocumentId")],
@@ -625,65 +658,6 @@ public class Given_Relational_Write_Constraint_Resolver
                 ),
             ]
         );
-
-        var resourceModel = new RelationalResourceModel(
-            SchoolResource,
-            new DbSchemaName("edfi"),
-            ResourceStorageKind.RelationalTables,
-            schoolRootTable,
-            [schoolRootTable],
-            [],
-            []
-        );
-
-        var writePlan = new ResourceWritePlan(resourceModel, []);
-
-        var schoolKey = new ResourceKeyEntry(1, SchoolResource, "1.0.0", false);
-        var educationOrganizationResource = new QualifiedResourceName("Ed-Fi", "EducationOrganization");
-        var educationOrganizationKey = new ResourceKeyEntry(2, educationOrganizationResource, "1.0.0", true);
-
-        var mappingSet = new MappingSet(
-            new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
-            new DerivedRelationalModelSet(
-                new EffectiveSchemaInfo(
-                    "1.0",
-                    "v1",
-                    "schema-hash",
-                    2,
-                    [1, 2],
-                    [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
-                    [schoolKey, educationOrganizationKey]
-                ),
-                SqlDialect.Pgsql,
-                [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
-                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
-                [new AbstractIdentityTableInfo(educationOrganizationKey, educationOrganizationIdentityTable)],
-                [],
-                [],
-                []
-            ),
-            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [SchoolResource] = writePlan },
-            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
-            new Dictionary<QualifiedResourceName, short>
-            {
-                [SchoolResource] = schoolKey.ResourceKeyId,
-                [educationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
-            },
-            new Dictionary<short, ResourceKeyEntry>
-            {
-                [schoolKey.ResourceKeyId] = schoolKey,
-                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
-            },
-            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
-        );
-
-        return new AbstractIdentityResolverFixture(
-            writePlan,
-            new ReferenceResolverRequest(mappingSet, SchoolResource, [], []),
-            NaturalKeyConstraintName: "UX_EducationOrganizationIdentity_NK",
-            ReferenceKeyConstraintName: "UX_EducationOrganizationIdentity_RefKey"
-        );
-    }
 
     private sealed record ResolverFixture(
         ResourceWritePlan WritePlan,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
@@ -221,6 +221,39 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             );
     }
 
+    [Test]
+    public void It_reports_the_writing_subclass_identity_for_abstract_education_organization_identity_conflicts()
+    {
+        // A non-School EducationOrganization subclass colliding on the shared abstract identity table must
+        // report its own identity element (localEducationAgencyId), proving the duplicate values are taken from
+        // the concrete resource's referential-identity metadata rather than a hard-coded School identity.
+        var classifier = new RecordingRelationalWriteExceptionClassifier
+        {
+            ClassificationToReturn = new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                "UX_EducationOrganizationIdentity_NK"
+            ),
+        };
+        var mapper = new RelationalWriteDatabaseFailureResultMapper(
+            classifier,
+            new RelationalWriteConstraintResolver()
+        );
+        var request = CreateLocalEducationAgencyAbstractIdentityRequest();
+
+        var isMapped = mapper.TryBuild(request, new StubDbException("unique violation"), out var result);
+
+        isMapped.Should().BeTrue();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new RelationalWriteExecutorResult.Upsert(
+                    new UpsertResult.UpsertFailureIdentityConflict(
+                        new ResourceName("LocalEducationAgency"),
+                        [new KeyValuePair<string, string>("localEducationAgencyId", "155901")]
+                    )
+                )
+            );
+    }
+
     private static RelationalWriteExecutorRequest CreateRequest(
         RelationalWriteOperationKind operationKind,
         IReadOnlyList<DocumentReference>? documentReferences = null
@@ -364,6 +397,30 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             operationKind == RelationalWriteOperationKind.Put
                 ? new RelationalWriteTargetContext.ExistingDocument(345L, updateDocumentUuid, 44L)
                 : new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
+        );
+    }
+
+    // Builds a POST request for a non-School EducationOrganization subclass (LocalEducationAgency) so the
+    // abstract-identity conflict path is exercised against a different concrete identity element.
+    private static RelationalWriteExecutorRequest CreateLocalEducationAgencyAbstractIdentityRequest()
+    {
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildLocalEducationAgencyWriteModel();
+        var createDocumentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
+
+        return new RelationalWriteExecutorRequest(
+            mappingSet,
+            RelationalWriteOperationKind.Post,
+            new RelationalWriteTargetRequest.Post(
+                new ReferentialId(Guid.Parse("99999999-8888-7777-6666-555555555555")),
+                createDocumentUuid
+            ),
+            writePlan,
+            existingDocumentReadPlan: null,
+            JsonNode.Parse("""{"localEducationAgencyId":155901,"nameOfInstitution":"Grand Bend ISD"}""")!,
+            allowIdentityUpdates: false,
+            new TraceId("abstract-identity-conflict-lea-test"),
+            new ReferenceResolverRequest(mappingSet, writePlan.Model.Resource, [], DescriptorReferences: []),
+            new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
@@ -172,7 +172,7 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             classifier,
             new RelationalWriteConstraintResolver()
         );
-        var request = CreateSchoolAbstractIdentityRequest();
+        var request = CreateSchoolAbstractIdentityRequest(RelationalWriteOperationKind.Post);
 
         var isMapped = mapper.TryBuild(request, new StubDbException("unique violation"), out var result);
 
@@ -182,6 +182,38 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             .BeEquivalentTo(
                 new RelationalWriteExecutorResult.Upsert(
                     new UpsertResult.UpsertFailureIdentityConflict(
+                        new ResourceName("School"),
+                        [new KeyValuePair<string, string>("schoolId", "155901")]
+                    )
+                )
+            );
+    }
+
+    [Test]
+    public void It_maps_abstract_education_organization_identity_unique_violations_on_put_to_identity_conflicts()
+    {
+        // The same abstract-identity natural-key violation on a PUT must surface the Update identity-conflict
+        // result, with the duplicate values still taken from the concrete School request body.
+        var classifier = new RecordingRelationalWriteExceptionClassifier
+        {
+            ClassificationToReturn = new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                "UX_EducationOrganizationIdentity_NK"
+            ),
+        };
+        var mapper = new RelationalWriteDatabaseFailureResultMapper(
+            classifier,
+            new RelationalWriteConstraintResolver()
+        );
+        var request = CreateSchoolAbstractIdentityRequest(RelationalWriteOperationKind.Put);
+
+        var isMapped = mapper.TryBuild(request, new StubDbException("unique violation"), out var result);
+
+        isMapped.Should().BeTrue();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new RelationalWriteExecutorResult.Update(
+                    new UpdateResult.UpdateFailureIdentityConflict(
                         new ResourceName("School"),
                         [new KeyValuePair<string, string>("schoolId", "155901")]
                     )
@@ -303,191 +335,35 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
         );
     }
 
-    // Dedicated, isolated builder for the abstract-identity end-to-end test. Kept separate from
-    // CreateRequest/CreateMappingSet so the recording-stub tests stay simple and unchanged.
-    private static RelationalWriteExecutorRequest CreateSchoolAbstractIdentityRequest()
+    // Dedicated, isolated builder for the abstract-identity end-to-end tests, parameterized by operation kind
+    // so both the POST and PUT identity-conflict paths are covered. Shares its table shapes with the
+    // constraint-resolver tests via AbstractIdentitySchoolTestData.
+    private static RelationalWriteExecutorRequest CreateSchoolAbstractIdentityRequest(
+        RelationalWriteOperationKind operationKind
+    )
     {
-        var schoolResource = new QualifiedResourceName("Ed-Fi", "School");
-
-        var schoolRootTable = new DbTableModel(
-            new DbTableName(new DbSchemaName("edfi"), "School"),
-            new JsonPathExpression("$", []),
-            new TableKey(
-                "PK_School",
-                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
-            ),
-            [
-                new DbColumnModel(
-                    new DbColumnName("DocumentId"),
-                    ColumnKind.ParentKeyPart,
-                    null,
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("SchoolId"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.Int32),
-                    false,
-                    new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-            ],
-            []
-        );
-
-        // Models edfi."EducationOrganizationIdentity" the way AbstractIdentityTableAndUnionViewDerivationPass
-        // builds it: DocumentId primary key, the _NK natural-key unique over the projected identity column,
-        // the _RefKey helper that also includes DocumentId, and the document FK.
-        var educationOrganizationIdentityTable = new DbTableModel(
-            new DbTableName(new DbSchemaName("edfi"), "EducationOrganizationIdentity"),
-            new JsonPathExpression("$", []),
-            new TableKey(
-                "PK_EducationOrganizationIdentity",
-                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
-            ),
-            [
-                new DbColumnModel(
-                    new DbColumnName("DocumentId"),
-                    ColumnKind.ParentKeyPart,
-                    new RelationalScalarType(ScalarKind.Int64),
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("EducationOrganizationId"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.Int32),
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-                new DbColumnModel(
-                    new DbColumnName("Discriminator"),
-                    ColumnKind.Scalar,
-                    new RelationalScalarType(ScalarKind.String, 256),
-                    false,
-                    null,
-                    null,
-                    new ColumnStorage.Stored()
-                ),
-            ],
-            [
-                new TableConstraint.Unique(
-                    "UX_EducationOrganizationIdentity_NK",
-                    [new DbColumnName("EducationOrganizationId")]
-                ),
-                new TableConstraint.Unique(
-                    "UX_EducationOrganizationIdentity_RefKey",
-                    [new DbColumnName("EducationOrganizationId"), new DbColumnName("DocumentId")]
-                ),
-                new TableConstraint.ForeignKey(
-                    "FK_EducationOrganizationIdentity_Document",
-                    [new DbColumnName("DocumentId")],
-                    new DbTableName(new DbSchemaName("dms"), "Document"),
-                    [new DbColumnName("DocumentId")],
-                    OnDelete: ReferentialAction.Cascade
-                ),
-            ]
-        );
-
-        var resourceModel = new RelationalResourceModel(
-            schoolResource,
-            new DbSchemaName("edfi"),
-            ResourceStorageKind.RelationalTables,
-            schoolRootTable,
-            [schoolRootTable],
-            [],
-            []
-        );
-
-        var resourceWritePlan = new ResourceWritePlan(resourceModel, []);
-
-        var schoolKey = new ResourceKeyEntry(1, schoolResource, "1.0.0", false);
-        var educationOrganizationResource = new QualifiedResourceName("Ed-Fi", "EducationOrganization");
-        var educationOrganizationKey = new ResourceKeyEntry(2, educationOrganizationResource, "1.0.0", true);
-
-        var schoolReferentialIdentityTrigger = new DbTriggerInfo(
-            new DbTriggerName("TR_School_ReferentialIdentity"),
-            schoolRootTable.Table,
-            [new DbColumnName("DocumentId")],
-            [new DbColumnName("SchoolId")],
-            new TriggerKindParameters.ReferentialIdentityMaintenance(
-                schoolKey.ResourceKeyId,
-                schoolResource.ProjectName,
-                schoolResource.ResourceName,
-                [
-                    new IdentityElementMapping(
-                        new DbColumnName("SchoolId"),
-                        "$.schoolId",
-                        new RelationalScalarType(ScalarKind.Int32)
-                    ),
-                ]
-            )
-        );
-
-        var mappingSet = new MappingSet(
-            new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
-            new DerivedRelationalModelSet(
-                new EffectiveSchemaInfo(
-                    "1.0",
-                    "v1",
-                    "schema-hash",
-                    2,
-                    [1, 2],
-                    [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
-                    [schoolKey, educationOrganizationKey]
-                ),
-                SqlDialect.Pgsql,
-                [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
-                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
-                [new AbstractIdentityTableInfo(educationOrganizationKey, educationOrganizationIdentityTable)],
-                [],
-                [],
-                [schoolReferentialIdentityTrigger]
-            ),
-            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [schoolResource] = resourceWritePlan },
-            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
-            new Dictionary<QualifiedResourceName, short>
-            {
-                [schoolResource] = schoolKey.ResourceKeyId,
-                [educationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
-            },
-            new Dictionary<short, ResourceKeyEntry>
-            {
-                [schoolKey.ResourceKeyId] = schoolKey,
-                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
-            },
-            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
-        );
-
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildSchoolWriteModel();
         var createDocumentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
+        var updateDocumentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
 
         return new RelationalWriteExecutorRequest(
             mappingSet,
-            RelationalWriteOperationKind.Post,
-            new RelationalWriteTargetRequest.Post(
-                new ReferentialId(Guid.Parse("99999999-8888-7777-6666-555555555555")),
-                createDocumentUuid
-            ),
-            resourceWritePlan,
+            operationKind,
+            operationKind == RelationalWriteOperationKind.Put
+                ? new RelationalWriteTargetRequest.Put(updateDocumentUuid)
+                : new RelationalWriteTargetRequest.Post(
+                    new ReferentialId(Guid.Parse("99999999-8888-7777-6666-555555555555")),
+                    createDocumentUuid
+                ),
+            writePlan,
             existingDocumentReadPlan: null,
             JsonNode.Parse("""{"schoolId":155901,"nameOfInstitution":"School Test"}""")!,
             allowIdentityUpdates: false,
             new TraceId("abstract-identity-conflict-test"),
-            new ReferenceResolverRequest(
-                mappingSet,
-                resourceWritePlan.Model.Resource,
-                [],
-                DescriptorReferences: []
-            ),
-            new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
+            new ReferenceResolverRequest(mappingSet, writePlan.Model.Resource, [], DescriptorReferences: []),
+            operationKind == RelationalWriteOperationKind.Put
+                ? new RelationalWriteTargetContext.ExistingDocument(345L, updateDocumentUuid, 44L)
+                : new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
@@ -254,6 +254,41 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             );
     }
 
+    [Test]
+    public void It_resolves_nested_reference_backed_identity_values_for_abstract_identity_conflicts()
+    {
+        // A reference-backed concrete identity element (a GeneralStudentProgramAssociation member's
+        // $.programReference.educationOrganizationId) is addressed by a multi-segment JSONPath. The mapper
+        // must read its duplicate value by walking the nested request body, and report it under the trailing
+        // path segment (educationOrganizationId), proving the abstract-identity conflict path is not limited
+        // to top-level scalar identities.
+        var classifier = new RecordingRelationalWriteExceptionClassifier
+        {
+            ClassificationToReturn = new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                AbstractIdentitySchoolTestData.GeneralStudentProgramAssociationNaturalKeyConstraintName
+            ),
+        };
+        var mapper = new RelationalWriteDatabaseFailureResultMapper(
+            classifier,
+            new RelationalWriteConstraintResolver()
+        );
+        var request = CreateReferenceBackedSubclassAbstractIdentityRequest();
+
+        var isMapped = mapper.TryBuild(request, new StubDbException("unique violation"), out var result);
+
+        isMapped.Should().BeTrue();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new RelationalWriteExecutorResult.Upsert(
+                    new UpsertResult.UpsertFailureIdentityConflict(
+                        new ResourceName("StudentProgramAssociation"),
+                        [new KeyValuePair<string, string>("educationOrganizationId", "255901001")]
+                    )
+                )
+            );
+    }
+
     private static RelationalWriteExecutorRequest CreateRequest(
         RelationalWriteOperationKind operationKind,
         IReadOnlyList<DocumentReference>? documentReferences = null
@@ -419,6 +454,33 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
             JsonNode.Parse("""{"localEducationAgencyId":155901,"nameOfInstitution":"Grand Bend ISD"}""")!,
             allowIdentityUpdates: false,
             new TraceId("abstract-identity-conflict-lea-test"),
+            new ReferenceResolverRequest(mappingSet, writePlan.Model.Resource, [], DescriptorReferences: []),
+            new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
+        );
+    }
+
+    // Builds a POST request for a concrete GeneralStudentProgramAssociation member whose identity element is
+    // reference-backed, so the mapper's nested-path identity-value resolution is exercised through the
+    // abstract-identity conflict path. The body nests the duplicate value under $.programReference.
+    private static RelationalWriteExecutorRequest CreateReferenceBackedSubclassAbstractIdentityRequest()
+    {
+        var (writePlan, mappingSet) = AbstractIdentitySchoolTestData.BuildReferenceBackedSubclassWriteModel();
+        var createDocumentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
+
+        return new RelationalWriteExecutorRequest(
+            mappingSet,
+            RelationalWriteOperationKind.Post,
+            new RelationalWriteTargetRequest.Post(
+                new ReferentialId(Guid.Parse("99999999-8888-7777-6666-555555555555")),
+                createDocumentUuid
+            ),
+            writePlan,
+            existingDocumentReadPlan: null,
+            JsonNode.Parse(
+                """{"programReference":{"educationOrganizationId":255901001},"beginDate":"2024-08-01"}"""
+            )!,
+            allowIdentityUpdates: false,
+            new TraceId("abstract-identity-conflict-reference-backed-test"),
             new ReferenceResolverRequest(mappingSet, writePlan.Model.Resource, [], DescriptorReferences: []),
             new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalWriteDatabaseFailureResultMapperTests.cs
@@ -156,6 +156,39 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
         _writeConstraintResolver.ResolveCallCount.Should().Be(0);
     }
 
+    [Test]
+    public void It_maps_abstract_education_organization_identity_unique_violations_to_identity_conflicts()
+    {
+        // Drive the real resolver through the mapper so this covers mapping
+        // UX_EducationOrganizationIdentity_NK to the literal 409 identity-conflict result, with the
+        // duplicate values taken from the concrete School request body rather than the abstract column.
+        var classifier = new RecordingRelationalWriteExceptionClassifier
+        {
+            ClassificationToReturn = new RelationalWriteExceptionClassification.UniqueConstraintViolation(
+                "UX_EducationOrganizationIdentity_NK"
+            ),
+        };
+        var mapper = new RelationalWriteDatabaseFailureResultMapper(
+            classifier,
+            new RelationalWriteConstraintResolver()
+        );
+        var request = CreateSchoolAbstractIdentityRequest();
+
+        var isMapped = mapper.TryBuild(request, new StubDbException("unique violation"), out var result);
+
+        isMapped.Should().BeTrue();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new RelationalWriteExecutorResult.Upsert(
+                    new UpsertResult.UpsertFailureIdentityConflict(
+                        new ResourceName("School"),
+                        [new KeyValuePair<string, string>("schoolId", "155901")]
+                    )
+                )
+            );
+    }
+
     private static RelationalWriteExecutorRequest CreateRequest(
         RelationalWriteOperationKind operationKind,
         IReadOnlyList<DocumentReference>? documentReferences = null
@@ -267,6 +300,194 @@ public class Given_RelationalWriteDatabaseFailureResultMapper
                 QualifiedResourceName,
                 IReadOnlyList<ResolvedSecurableElementPath>
             >()
+        );
+    }
+
+    // Dedicated, isolated builder for the abstract-identity end-to-end test. Kept separate from
+    // CreateRequest/CreateMappingSet so the recording-stub tests stay simple and unchanged.
+    private static RelationalWriteExecutorRequest CreateSchoolAbstractIdentityRequest()
+    {
+        var schoolResource = new QualifiedResourceName("Ed-Fi", "School");
+
+        var schoolRootTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "School"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_School",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    null,
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("SchoolId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    new JsonPathExpression("$.schoolId", [new JsonPathSegment.Property("schoolId")]),
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            []
+        );
+
+        // Models edfi."EducationOrganizationIdentity" the way AbstractIdentityTableAndUnionViewDerivationPass
+        // builds it: DocumentId primary key, the _NK natural-key unique over the projected identity column,
+        // the _RefKey helper that also includes DocumentId, and the document FK.
+        var educationOrganizationIdentityTable = new DbTableModel(
+            new DbTableName(new DbSchemaName("edfi"), "EducationOrganizationIdentity"),
+            new JsonPathExpression("$", []),
+            new TableKey(
+                "PK_EducationOrganizationIdentity",
+                [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            [
+                new DbColumnModel(
+                    new DbColumnName("DocumentId"),
+                    ColumnKind.ParentKeyPart,
+                    new RelationalScalarType(ScalarKind.Int64),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("EducationOrganizationId"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.Int32),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+                new DbColumnModel(
+                    new DbColumnName("Discriminator"),
+                    ColumnKind.Scalar,
+                    new RelationalScalarType(ScalarKind.String, 256),
+                    false,
+                    null,
+                    null,
+                    new ColumnStorage.Stored()
+                ),
+            ],
+            [
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_NK",
+                    [new DbColumnName("EducationOrganizationId")]
+                ),
+                new TableConstraint.Unique(
+                    "UX_EducationOrganizationIdentity_RefKey",
+                    [new DbColumnName("EducationOrganizationId"), new DbColumnName("DocumentId")]
+                ),
+                new TableConstraint.ForeignKey(
+                    "FK_EducationOrganizationIdentity_Document",
+                    [new DbColumnName("DocumentId")],
+                    new DbTableName(new DbSchemaName("dms"), "Document"),
+                    [new DbColumnName("DocumentId")],
+                    OnDelete: ReferentialAction.Cascade
+                ),
+            ]
+        );
+
+        var resourceModel = new RelationalResourceModel(
+            schoolResource,
+            new DbSchemaName("edfi"),
+            ResourceStorageKind.RelationalTables,
+            schoolRootTable,
+            [schoolRootTable],
+            [],
+            []
+        );
+
+        var resourceWritePlan = new ResourceWritePlan(resourceModel, []);
+
+        var schoolKey = new ResourceKeyEntry(1, schoolResource, "1.0.0", false);
+        var educationOrganizationResource = new QualifiedResourceName("Ed-Fi", "EducationOrganization");
+        var educationOrganizationKey = new ResourceKeyEntry(2, educationOrganizationResource, "1.0.0", true);
+
+        var schoolReferentialIdentityTrigger = new DbTriggerInfo(
+            new DbTriggerName("TR_School_ReferentialIdentity"),
+            schoolRootTable.Table,
+            [new DbColumnName("DocumentId")],
+            [new DbColumnName("SchoolId")],
+            new TriggerKindParameters.ReferentialIdentityMaintenance(
+                schoolKey.ResourceKeyId,
+                schoolResource.ProjectName,
+                schoolResource.ResourceName,
+                [
+                    new IdentityElementMapping(
+                        new DbColumnName("SchoolId"),
+                        "$.schoolId",
+                        new RelationalScalarType(ScalarKind.Int32)
+                    ),
+                ]
+            )
+        );
+
+        var mappingSet = new MappingSet(
+            new MappingSetKey("schema-hash", SqlDialect.Pgsql, "v1"),
+            new DerivedRelationalModelSet(
+                new EffectiveSchemaInfo(
+                    "1.0",
+                    "v1",
+                    "schema-hash",
+                    2,
+                    [1, 2],
+                    [new SchemaComponentInfo("ed-fi", "Ed-Fi", "1.0.0", false, "component-hash")],
+                    [schoolKey, educationOrganizationKey]
+                ),
+                SqlDialect.Pgsql,
+                [new ProjectSchemaInfo("ed-fi", "Ed-Fi", "1.0.0", false, new DbSchemaName("edfi"))],
+                [new ConcreteResourceModel(schoolKey, ResourceStorageKind.RelationalTables, resourceModel)],
+                [new AbstractIdentityTableInfo(educationOrganizationKey, educationOrganizationIdentityTable)],
+                [],
+                [],
+                [schoolReferentialIdentityTrigger]
+            ),
+            new Dictionary<QualifiedResourceName, ResourceWritePlan> { [schoolResource] = resourceWritePlan },
+            new Dictionary<QualifiedResourceName, ResourceReadPlan>(),
+            new Dictionary<QualifiedResourceName, short>
+            {
+                [schoolResource] = schoolKey.ResourceKeyId,
+                [educationOrganizationResource] = educationOrganizationKey.ResourceKeyId,
+            },
+            new Dictionary<short, ResourceKeyEntry>
+            {
+                [schoolKey.ResourceKeyId] = schoolKey,
+                [educationOrganizationKey.ResourceKeyId] = educationOrganizationKey,
+            },
+            new Dictionary<QualifiedResourceName, IReadOnlyList<ResolvedSecurableElementPath>>()
+        );
+
+        var createDocumentUuid = new DocumentUuid(Guid.Parse("cccccccc-1111-2222-3333-dddddddddddd"));
+
+        return new RelationalWriteExecutorRequest(
+            mappingSet,
+            RelationalWriteOperationKind.Post,
+            new RelationalWriteTargetRequest.Post(
+                new ReferentialId(Guid.Parse("99999999-8888-7777-6666-555555555555")),
+                createDocumentUuid
+            ),
+            resourceWritePlan,
+            existingDocumentReadPlan: null,
+            JsonNode.Parse("""{"schoolId":155901,"nameOfInstitution":"School Test"}""")!,
+            allowIdentityUpdates: false,
+            new TraceId("abstract-identity-conflict-test"),
+            new ReferenceResolverRequest(
+                mappingSet,
+                resourceWritePlan.Model.Resource,
+                [],
+                DescriptorReferences: []
+            ),
+            new RelationalWriteTargetContext.CreateNew(createDocumentUuid)
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
@@ -81,10 +81,10 @@ internal sealed class RelationalWriteConstraintResolver : IRelationalWriteConstr
 
             // An abstract identity table carries two unique constraints: the natural-key constraint over the
             // projected identity columns, and the *_RefKey helper that appends the DocumentId primary key.
-            // Only the natural-key constraint is a user-facing identity conflict; the *_RefKey helper and any
-            // other unique constraint stay unresolved. The natural key is the unique constraint that does not
-            // include the surrogate DocumentId key column; *_RefKey always appends it. Keying off the table's
-            // own primary-key columns keeps this robust to changes in the projected identity column set.
+            // A unique constraint that includes the surrogate DocumentId key column (the *_RefKey helper) is
+            // not a user-facing identity conflict and stays unresolved; a unique constraint that does not
+            // include it is the natural key and maps to an identity conflict. Keying off the table's own
+            // primary-key columns keeps this robust to changes in the projected identity column set.
             var keyColumnNames = tableModel.Key.Columns.Select(keyColumn => keyColumn.ColumnName).ToHashSet();
 
             return match.Columns.Any(keyColumnNames.Contains)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
@@ -82,16 +82,14 @@ internal sealed class RelationalWriteConstraintResolver : IRelationalWriteConstr
             // An abstract identity table carries two unique constraints: the natural-key constraint over the
             // projected identity columns, and the *_RefKey helper that appends the DocumentId primary key.
             // Only the natural-key constraint is a user-facing identity conflict; the *_RefKey helper and any
-            // other unique constraint stay unresolved. Identify the natural key by an exact column match
-            // against the projected identity columns — which carry a SourceJsonPath, while DocumentId and the
-            // Discriminator do not — mirroring the SequenceEqual check used for concrete resource roots.
-            var abstractNaturalKeyColumns = tableModel
-                .Columns.Where(column => column.SourceJsonPath is not null)
-                .Select(column => column.ColumnName);
+            // other unique constraint stay unresolved. The natural key is the unique constraint that does not
+            // include the surrogate DocumentId key column; *_RefKey always appends it. Keying off the table's
+            // own primary-key columns keeps this robust to changes in the projected identity column set.
+            var keyColumnNames = tableModel.Key.Columns.Select(keyColumn => keyColumn.ColumnName).ToHashSet();
 
-            return match.Columns.SequenceEqual(abstractNaturalKeyColumns)
-                ? new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName)
-                : new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
+            return match.Columns.Any(keyColumnNames.Contains)
+                ? new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName)
+                : new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName);
         }
 
         return new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
@@ -35,16 +35,62 @@ internal sealed class RelationalWriteConstraintResolver : IRelationalWriteConstr
     {
         var uniqueMatch = FindUniqueConstraint(request.WritePlan.Model, violation.ConstraintName);
 
-        if (uniqueMatch is null || !uniqueMatch.Table.Table.Equals(request.WritePlan.Model.Root.Table))
+        if (uniqueMatch is not null)
         {
-            return new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
+            if (!uniqueMatch.Table.Table.Equals(request.WritePlan.Model.Root.Table))
+            {
+                return new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
+            }
+
+            var rootNaturalKeyColumns = GetRootNaturalKeyColumnsOrThrow(request);
+
+            return uniqueMatch.Constraint.Columns.SequenceEqual(rootNaturalKeyColumns)
+                ? new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName)
+                : new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
         }
 
-        var rootNaturalKeyColumns = GetRootNaturalKeyColumnsOrThrow(request);
+        // The constraint is not part of the concrete resource model. A unique violation can still be a
+        // user-facing identity conflict when it originates from the abstract identity table that a concrete
+        // EducationOrganization subclass projects into (e.g. UX_EducationOrganizationIdentity_NK). Resolve
+        // those natural-key constraints to the same identity-conflict result used for concrete roots; the
+        // mapper reports the concrete request body's identity values.
+        return ResolveAbstractIdentityUniqueConstraint(request, violation);
+    }
 
-        return uniqueMatch.Constraint.Columns.SequenceEqual(rootNaturalKeyColumns)
-            ? new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName)
-            : new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
+    private static RelationalWriteConstraintResolution ResolveAbstractIdentityUniqueConstraint(
+        RelationalWriteConstraintResolutionRequest request,
+        RelationalWriteExceptionClassification.UniqueConstraintViolation violation
+    )
+    {
+        foreach (
+            var tableModel in request.ReferenceResolutionRequest.MappingSet.Model.AbstractIdentityTablesInNameOrder.Select(
+                abstractIdentityTable => abstractIdentityTable.TableModel
+            )
+        )
+        {
+            var match = tableModel
+                .Constraints.OfType<TableConstraint.Unique>()
+                .SingleOrDefault(constraint =>
+                    string.Equals(constraint.Name, violation.ConstraintName, StringComparison.Ordinal)
+                );
+
+            if (match is null)
+            {
+                continue;
+            }
+
+            // An abstract identity table carries two unique constraints: the natural-key constraint over the
+            // projected identity columns, and the *_RefKey helper that also includes the DocumentId primary
+            // key. Only the natural-key constraint is a user-facing identity conflict; the *_RefKey helper
+            // (and any other constraint) stays unresolved.
+            var documentKeyColumns = tableModel.Key.Columns.Select(column => column.ColumnName);
+
+            return match.Columns.Intersect(documentKeyColumns).Any()
+                ? new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName)
+                : new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName);
+        }
+
+        return new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
     }
 
     private static RelationalWriteConstraintResolution ResolveForeignKeyConstraint(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteConstraintResolver.cs
@@ -80,14 +80,18 @@ internal sealed class RelationalWriteConstraintResolver : IRelationalWriteConstr
             }
 
             // An abstract identity table carries two unique constraints: the natural-key constraint over the
-            // projected identity columns, and the *_RefKey helper that also includes the DocumentId primary
-            // key. Only the natural-key constraint is a user-facing identity conflict; the *_RefKey helper
-            // (and any other constraint) stays unresolved.
-            var documentKeyColumns = tableModel.Key.Columns.Select(column => column.ColumnName);
+            // projected identity columns, and the *_RefKey helper that appends the DocumentId primary key.
+            // Only the natural-key constraint is a user-facing identity conflict; the *_RefKey helper and any
+            // other unique constraint stay unresolved. Identify the natural key by an exact column match
+            // against the projected identity columns — which carry a SourceJsonPath, while DocumentId and the
+            // Discriminator do not — mirroring the SequenceEqual check used for concrete resource roots.
+            var abstractNaturalKeyColumns = tableModel
+                .Columns.Where(column => column.SourceJsonPath is not null)
+                .Select(column => column.ColumnName);
 
-            return match.Columns.Intersect(documentKeyColumns).Any()
-                ? new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName)
-                : new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName);
+            return match.Columns.SequenceEqual(abstractNaturalKeyColumns)
+                ? new RelationalWriteConstraintResolution.RootNaturalKeyUnique(violation.ConstraintName)
+                : new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);
         }
 
         return new RelationalWriteConstraintResolution.Unresolved(violation.ConstraintName);

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/IdentityConflictValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/IdentityConflictValidation.feature
@@ -18,9 +18,6 @@ Feature: Identity Conflict validation
 
         @API-183
         @e2e-ci-shard-1
-        # DMS-1234: Quarantined until abstract EducationOrganization identity-table
-        # unique violations map to 409 identity-conflict responses.
-        @ignore
         Scenario: 01 Ensure client can't create a School with the same identity as another Education Organization
              When a POST request is made to "/ed-fi/schools" with
                   """


### PR DESCRIPTION
 ## Summary

  - Fix (DMS-1234, Bug): Unique-constraint violations raised by the shared abstract EducationOrganization identity table (e.g. UX_EducationOrganizationIdentity_NK) now resolve to 409 identity-conflict responses. Previously RelationalWriteConstraintResolver only recognized constraints on a concrete resource's own root table, so creating a School whose identity collides with another EdOrg subclass fell through as unresolved instead of a 409.
  - How: When a violated constraint isn't found in the concrete resource model, the resolver now scans AbstractIdentityTablesInNameOrder for a matching unique constraint by name. It distinguishes the natural-key (_NK) constraint from the _RefKey helper via a key-column heuristic — if the constraint's columns include the table's surrogate DocumentId primary key it's the _RefKey helper and stays Unresolved; otherwise it's the natural key and maps to RootNaturalKeyUnique (→ 409). Keying off the table's own PK columns keeps this robust to changes in the
  projected identity-column set.
  - Un-quarantined E2E: Removed the @ignore + DMS-1234 quarantine comment from IdentityConflictValidation.feature Scenario 01 ("client can't create a School with the same identity as another Education Organization").
  - Unit coverage added:
    - RelationalWriteConstraintResolverTests.cs — single & composite _NK → conflict, _RefKey → unresolved, multi-abstract-table loop continuation, and reference-backed (*_DocumentId) abstract NK columns.
    - RelationalWriteDatabaseFailureResultMapperTests.cs — abstract conflict maps to Insert and Update (PUT) identity-conflict results reporting the concrete body's identity values (School,  LocalEducationAgency, and nested reference-backed $.programReference.educationOrganizationId on GSPA).
    - AbstractIdentityTableDerivationTests.cs — real-derivation invariant test pinning PK = [DocumentId], NK excludes DocumentId, RefKey = NK + DocumentId — the surrogate-key invariant the
  resolver heuristic relies on.
    - AbstractIdentitySchoolTestData.cs — shared, parameterized fixture builder extracted to de-duplicate the abstract-identity-table setup across both test files.
  - Dependency bump (looks incidental): Microsoft.OpenApi 2.0.0 → 2.7.5 in Directory.Packages.props plus two config-frontend packages.lock.json updates. This isn't part of the
  identity-conflict fix — confirm it belongs in this PR or split it out.

  Test plan

  - [ ] dotnet build --no-restore ./src/dms/EdFi.DataManagementService.sln
  - [ ] Resolver unit tests: dotnet test src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit --no-build (covers _NK→409 / _RefKey→unresolved, composite & reference-backed columns,  multi-table loop)
  - [ ] Mapper unit tests (same project) — verify abstract conflict returns identity-conflict result with the concrete body's identity values on both POST (insert) and PUT (update)
  - [ ] Derivation invariant test: dotnet test src/dms/backend/EdFi.DataManagementService.Backend.RelationalModel.Tests.Unit --no-build
  - [ ] E2E (needs live DB): the un-quarantined IdentityConflictValidation.feature Scenario 01 — POST a School with the same identity as an existing EducationOrganization → 409
  - [ ] Manual regression: concrete-root identity conflicts still return 409; non-identity unique violations are not falsely reported as 409; _RefKey violations don't produce a 409
  - [ ] dotnet csharpier format on all changed .cs files is clean