### PR TITLE
[DMS-1071] OWASP - Add JWT Replay Risk Coverage (DMS/CMS)

### DIFF
--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -147,9 +147,12 @@ The behaviors above are exercised by automated tests:
 **End-to-end tests**
 
 - DMS — `EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature`:
-  valid JWT replayed multiple times within its lifetime is accepted; expired and
+  valid JWT replayed multiple times within its lifetime is accepted;
   manipulated-signature tokens are rejected; authentication-failure responses do
-  not leak internal details.
+  not leak internal details. (The feature's "expired" scenario rewrites `exp`
+  without re-signing, so it is rejected on signature validation before expiry is
+  evaluated; true-expiry rejection via the lifetime check is covered by the DMS
+  unit test above.)
 - CMS — `EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature`:
   a revoked self-contained token is rejected on reuse (token issued → revoked via
   `/connect/revoke` → reused → `401`).

--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -56,8 +56,11 @@ same valid token may be presented any number of times and each request succeeds.
 **Decision:** DMS keeps standard stateless bearer semantics. A distributed
 replay-prevention cache or per-request introspection is **explicitly out of scope**
 — it would add coordination cost and latency without a corresponding threat in the
-DMS deployment model. Replay exposure is bounded by the compensating controls
-below (short token TTL, TLS, IdP-side revocation).
+DMS deployment model. Because DMS self-inspects and never calls the IdP per request,
+a token revoked at the IdP is still accepted by DMS until it expires — IdP-side
+revocation is **not** enforced for already-issued bearer tokens on this path. Replay
+exposure is therefore bounded by the *measurable* compensating controls below (short
+token TTL and signing-key rotation, plus TLS in transit), not by IdP revocation.
 
 ### CMS self-contained provider — per-request revocation-on-demand
 
@@ -79,9 +82,11 @@ provider scheme.
 
 When tokens are issued by Keycloak or another external IdP, DMS and CMS validate
 the signature and claims against the IdP's published keys but **cannot locally
-verify revocation**. Revocation, session management, and any `jti`/introspection
-semantics are owned by the IdP. This is an **IdP-dependent gap** addressed by the
-compensating controls below.
+verify revocation**, and neither app path calls the IdP per request. Revocation,
+session management, and any `jti`/introspection semantics are owned by the IdP. The
+practical constraint: an externally-issued token revoked at the IdP is still
+**accepted by these paths until it expires**. This is an **IdP-dependent gap**
+bounded (not closed) by the compensating controls below.
 
 ## `jti` handling matrix
 
@@ -118,9 +123,17 @@ externally-issued tokens), the following compensating controls bound the risk:
   capture in transit. Bearer tokens must never traverse plaintext channels.
 - **Bounded clock skew.** Lifetime validation allows only a small, fixed clock-skew
   tolerance, limiting acceptance of marginally-expired tokens.
-- **IdP-side revocation and session management.** For externally-issued tokens,
-  revocation is enforced at the IdP; operators should configure IdP revocation /
-  short-lived tokens and rotate signing keys per IdP guidance.
+- **Signing-key rotation (measurable app-side control).** Retiring a signing key
+  makes every token issued under it fail signature validation, which cuts short the
+  acceptance window for tokens already in circulation. Combined with the short TTL
+  above, this is the measurable control on the stateless paths; rotate per IdP
+  guidance.
+- **IdP-side revocation (constraint, not an app-side control).** Revoking a token at
+  the IdP does **not** retroactively reject it on the stateless app paths (DMS for
+  all tokens; CMS for externally-issued tokens) — a revoked externally-issued token
+  is accepted until it expires. IdP revocation and session management still prevent
+  *new* tokens from being issued to a compromised client, but do not invalidate
+  tokens already in circulation on these paths.
 - **Server-side revocation (CMS self-contained only).** The per-request `jti`
   status check plus `/connect/revoke` provide immediate revocation for
   self-contained tokens.

--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -140,9 +140,11 @@ The behaviors above are exercised by automated tests:
   validated repeatedly (replay is accepted)**, and **`jti` is informational
   (malformed/opaque `jti` does not affect the decision)**.
 - CMS — `EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs`:
-  `ValidateTokenAsync` accepts a token whose status is `valid` and **rejects**
-  revoked / unknown-`jti` / missing-`jti` / malformed-`jti` tokens; `RevokeTokenAsync`
-  delegates revocation for a valid `jti` and is a no-op for missing/malformed `jti`.
+  `ValidateTokenAsync` accepts a token whose status is `valid` on repeated
+  presentation (reusable while valid) and **rejects** expired (lifetime check, before
+  the status lookup), revoked, unknown-`jti`, missing-`jti`, and malformed-`jti`
+  tokens; `RevokeTokenAsync` delegates revocation for a valid `jti` and is a no-op
+  for missing/malformed `jti`.
 
 **End-to-end tests**
 

--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -1,0 +1,170 @@
+# OWASP Authentication Coverage Summary
+
+This document summarizes the authentication security posture of the **Ed-Fi Data
+Management Service (DMS)** and the **Ed-Fi DMS Configuration Service (CMS)**, with
+particular focus on **JWT replay risk** and the compensating controls that apply
+where replay prevention depends on the Identity Provider (IdP).
+
+It is the reference for OWASP-aligned authentication concerns (OWASP ASVS V3
+"Session Management" / token handling and the OWASP JWT Cheat Sheet) and maps each
+stated control to the automated tests that exercise it.
+
+## Trust paths
+
+DMS and CMS accept JSON Web Tokens (JWTs) issued under three trust paths. The
+replay posture differs by path because the responsibility for revocation differs.
+
+| Path | Token issuer | Per-request validation owner |
+|---|---|---|
+| **DMS resource API** | Configured OIDC IdP (Keycloak or the CMS self-contained provider) | DMS, by stateless self-inspection against the IdP's published signing keys |
+| **CMS self-contained provider** | CMS (OpenIddict-based, `AppSettings:IdentityProvider = self-contained`, the default) | CMS, with an additional per-request token-status check |
+| **Keycloak / external IdP** | Keycloak (`AppSettings:IdentityProvider = keycloak`) | The IdP owns revocation; DMS/CMS validate signature and claims only |
+
+## Token validation controls
+
+All paths validate the following before a request is authorized:
+
+- **Issuer** matches the configured authority.
+- **Audience** matches the configured audience.
+- **Signature** verifies against the issuer's signing key(s) (`RequireSignedTokens`).
+- **Lifetime** is enforced (`ValidateLifetime`), with **expiration required**
+  (`RequireExpirationTime`).
+- A bounded **clock skew** is allowed (DMS: configurable `ClockSkewSeconds`; CMS:
+  5 minutes).
+
+A token failing any of these checks is rejected with `401 Unauthorized`.
+
+## JWT replay posture and design decision
+
+A signed JWT access token is a **bearer credential** (RFC 6750): anyone presenting
+a valid, unexpired token is granted access. Bearer tokens are therefore inherently
+**replayable until they expire or are revoked**. The platform's stance on replay is
+deliberate and differs per trust path:
+
+### DMS resource API — stateless bearer validation, no app-side replay cache
+
+DMS performs **self-inspection** of the token rather than querying the OAuth
+provider on each request (see `TokenIntrospection.feature`). It validates the
+signature and standard claims and extracts `jti` into `ClientAuthorizations.TokenId`
+for correlation/logging only.
+
+DMS **does not** maintain a replay/nonce cache, enforce one-time use, or perform a
+per-request revocation/introspection call. Within a token's validity window, the
+same valid token may be presented any number of times and each request succeeds.
+`jti` does **not** participate in the accept/reject decision.
+
+**Decision:** DMS keeps standard stateless bearer semantics. A distributed
+replay-prevention cache or per-request introspection is **explicitly out of scope**
+— it would add coordination cost and latency without a corresponding threat in the
+DMS deployment model. Replay exposure is bounded by the compensating controls
+below (short token TTL, TLS, IdP-side revocation).
+
+### CMS self-contained provider — per-request revocation-on-demand
+
+For self-contained tokens, CMS issues a token with a GUID `jti`, persists it in the
+`dmscs.OpenIddictToken` table, and on **every** authenticated request re-checks that
+token's status by `jti` after standard validation. A request is authorized only when
+the stored status is `valid`. CMS exposes:
+
+- `POST /connect/revoke` (RFC 7009) — sets the token status to `revoked`.
+- `POST /connect/introspect` (RFC 7662) — reports active/inactive status.
+
+This is **not** one-time-use enforcement (a valid token remains reusable until it
+expires or is revoked), but it does provide **immediate, server-side revocation**:
+once a token is revoked, every subsequent use is rejected. This is the strongest
+replay control available in the platform and applies only to the self-contained
+provider scheme.
+
+### Keycloak / external IdP — delegated to the IdP
+
+When tokens are issued by Keycloak or another external IdP, DMS and CMS validate
+the signature and claims against the IdP's published keys but **cannot locally
+verify revocation**. Revocation, session management, and any `jti`/introspection
+semantics are owned by the IdP. This is an **IdP-dependent gap** addressed by the
+compensating controls below.
+
+## `jti` handling matrix
+
+How each path treats the `jti` (JWT ID) claim. "Accepted"/"Rejected" assume the
+token is otherwise validly signed and unexpired.
+
+| `jti` condition | DMS resource API | CMS self-contained |
+|---|---|---|
+| Present and status `valid` | Accepted (`jti` informational) | Accepted |
+| Missing | Accepted — `TokenId` falls back to a derived value; `jti` not required | **Rejected** (no status to confirm) |
+| Malformed (not a GUID) | Accepted — stored as an opaque string, never interpreted | **Rejected** (cannot resolve status) |
+| Unknown (not in token store) | Accepted — DMS never looks it up | **Rejected** (status absent ≠ `valid`) |
+| Revoked | Not detected app-side (IdP-dependent) | **Rejected** (status `revoked`) |
+
+## Replay / lifecycle behavior matrix
+
+| Scenario | DMS resource API | CMS self-contained |
+|---|---|---|
+| Same valid token reused before expiry | Accepted on every request | Accepted until revoked or expired |
+| Expired token | Rejected (lifetime check) | Rejected (lifetime check) |
+| Manipulated signature | Rejected | Rejected |
+| Revoked token reused | Not detected app-side (see compensating controls) | Rejected |
+| Externally-issued token, revocation unverifiable | Not detected app-side (see compensating controls) | Not detected app-side (Keycloak scheme) |
+
+## Compensating controls for IdP-dependent gaps
+
+Where app-side replay/revocation is not performed (DMS for all tokens; CMS for
+externally-issued tokens), the following compensating controls bound the risk:
+
+- **Short access-token lifetime (TTL).** A short TTL shrinks the window in which a
+  captured token can be replayed. Configure the IdP / self-contained provider for
+  the shortest TTL practical for the deployment.
+- **Transport confidentiality (TLS).** All token transport must use TLS to prevent
+  capture in transit. Bearer tokens must never traverse plaintext channels.
+- **Bounded clock skew.** Lifetime validation allows only a small, fixed clock-skew
+  tolerance, limiting acceptance of marginally-expired tokens.
+- **IdP-side revocation and session management.** For externally-issued tokens,
+  revocation is enforced at the IdP; operators should configure IdP revocation /
+  short-lived tokens and rotate signing keys per IdP guidance.
+- **Server-side revocation (CMS self-contained only).** The per-request `jti`
+  status check plus `/connect/revoke` provide immediate revocation for
+  self-contained tokens.
+- **No internal-detail leakage on failure.** Authentication failures return a
+  generic `401` (`application/problem+json` for DMS) with no failure-reason or
+  stack-trace disclosure; specifics are logged server-side only. This avoids
+  giving an attacker oracles that would aid token forgery or replay.
+
+## Test coverage map
+
+The behaviors above are exercised by automated tests:
+
+**Unit tests**
+
+- DMS — `EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs`:
+  valid token, expired token, invalid signature, missing claims, **valid token
+  validated repeatedly (replay is accepted)**, and **`jti` is informational
+  (malformed/opaque `jti` does not affect the decision)**.
+- CMS — `EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs`:
+  `ValidateTokenAsync` accepts a token whose status is `valid` and **rejects**
+  revoked / unknown-`jti` / missing-`jti` / malformed-`jti` tokens; `RevokeTokenAsync`
+  delegates revocation for a valid `jti` and is a no-op for missing/malformed `jti`.
+
+**End-to-end tests**
+
+- DMS — `EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature`:
+  valid JWT replayed multiple times within its lifetime is accepted; expired and
+  manipulated-signature tokens are rejected; authentication-failure responses do
+  not leak internal details.
+- CMS — `EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature`:
+  a revoked self-contained token is rejected on reuse (token issued → revoked via
+  `/connect/revoke` → reused → `401`).
+
+## Dynamic scanning
+
+OWASP ZAP can be run against the DMS and CMS OpenAPI specs using the convenience
+script described in [`eng/zap/README.md`](../eng/zap/README.md).
+
+## References
+
+- RFC 6749 — The OAuth 2.0 Authorization Framework
+- RFC 6750 — OAuth 2.0 Bearer Token Usage
+- RFC 7009 — OAuth 2.0 Token Revocation
+- RFC 7519 — JSON Web Token (JWT)
+- RFC 7662 — OAuth 2.0 Token Introspection
+- OWASP Application Security Verification Standard (ASVS), V3 Session Management
+- OWASP JSON Web Token (JWT) Cheat Sheet

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
@@ -159,6 +159,10 @@ public class OpenIddictTokenManagerTests
 
             var manager = CreateConfiguredTokenManager();
 
+            // NUnit reuses a single fixture instance and runs SetUp before each test, so
+            // reset before repopulating to avoid accumulation across tests.
+            _results.Clear();
+
             // Present the same token several times to prove it is reusable while valid.
             for (int i = 0; i < 3; i++)
             {
@@ -206,6 +210,51 @@ public class OpenIddictTokenManagerTests
         public void It_rejects_the_revoked_token()
         {
             _result.Should().BeFalse();
+        }
+    }
+
+    // Replayability lasts only until expiry: the lifetime check runs before the status
+    // lookup, so an expired token is rejected even when its stored status is "valid".
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithAnExpiredToken : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            // A "valid" status must not rescue an expired token.
+            var jti = Guid.NewGuid();
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(jti)).Returns("valid");
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, jti.ToString()) },
+                expired: true
+            );
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_rejects_the_expired_token()
+        {
+            _result.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_does_not_reach_the_status_check()
+        {
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(A<Guid>._)).MustNotHaveHappened();
         }
     }
 

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
@@ -3,6 +3,9 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
 using EdFi.DmsConfigurationService.Backend;
 using EdFi.DmsConfigurationService.Backend.OpenIddict.Models;
 using EdFi.DmsConfigurationService.Backend.OpenIddict.Repositories;
@@ -11,6 +14,7 @@ using FakeItEasy;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 
 namespace EdFi.DmsConfigurationService.Backend.Tests.Unit;
 
@@ -33,6 +37,56 @@ public class OpenIddictTokenManagerTests
             _secretHasher,
             _tokenRepository
         );
+    }
+
+    private const string TestIssuer = "https://cms.example.test";
+    private const string TestAudience = "ed-fi-cms-tests";
+
+    /// <summary>
+    /// Builds a token manager configured with the test issuer/audience so that
+    /// ValidateTokenAsync can verify tokens produced by the helpers below.
+    /// </summary>
+    private OpenIddictTokenManager CreateConfiguredTokenManager() =>
+        new(
+            Options.Create(new IdentityOptions { Authority = TestIssuer, Audience = TestAudience }),
+            NullLogger<OpenIddictTokenManager>.Instance,
+            _secretHasher,
+            _tokenRepository
+        );
+
+    /// <summary>
+    /// Creates an RSA signing key plus the matching public key bytes (SubjectPublicKeyInfo)
+    /// that the faked repository returns from GetActivePublicKeysAsync.
+    /// </summary>
+    private static (string KeyId, byte[] PublicKeySpki, RsaSecurityKey SigningKey) CreateSigningKey()
+    {
+        var rsa = RSA.Create(2048);
+        string keyId = Guid.NewGuid().ToString();
+        byte[] publicKeySpki = rsa.ExportSubjectPublicKeyInfo();
+        var signingKey = new RsaSecurityKey(rsa) { KeyId = keyId };
+        return (keyId, publicKeySpki, signingKey);
+    }
+
+    /// <summary>
+    /// Issues a signed JWT with the test issuer/audience and the supplied claims. The "kid"
+    /// header is emitted from the signing key so the validator can resolve the public key.
+    /// </summary>
+    private static string CreateSignedToken(
+        RsaSecurityKey signingKey,
+        IEnumerable<Claim> claims,
+        bool expired = false
+    )
+    {
+        var now = DateTime.UtcNow;
+        var jwt = new JwtSecurityToken(
+            issuer: TestIssuer,
+            audience: TestAudience,
+            claims: claims,
+            notBefore: expired ? now.AddMinutes(-15) : now.AddMinutes(-5),
+            expires: expired ? now.AddMinutes(-10) : now.AddMinutes(10),
+            signingCredentials: new SigningCredentials(signingKey, SecurityAlgorithms.RsaSha256)
+        );
+        return new JwtSecurityTokenHandler().WriteToken(jwt);
     }
 
     [TestFixture]
@@ -68,6 +122,273 @@ public class OpenIddictTokenManagerTests
             result.Should().BeOfType<TokenResult.FailureIdentityProvider>();
             var failure = (TokenResult.FailureIdentityProvider)result;
             failure.IdentityProviderError.Should().BeOfType<IdentityProviderError.InvalidClient>();
+        }
+    }
+
+    // The self-contained provider re-checks token status by jti on every request after
+    // standard validation, so a revoked token is rejected on reuse. This is the platform's
+    // strongest replay control. The fixtures below pin that behavior.
+
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithAValidStoredToken : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            var jti = Guid.NewGuid();
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(jti)).Returns("valid");
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, jti.ToString()) }
+            );
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_accepts_the_token()
+        {
+            _result.Should().BeTrue();
+        }
+    }
+
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithARevokedToken : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            var jti = Guid.NewGuid();
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(jti)).Returns("revoked");
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, jti.ToString()) }
+            );
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_rejects_the_revoked_token()
+        {
+            _result.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithAnUnknownJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            // No stored status for this jti -> repository returns null.
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(A<Guid>._)).Returns((string?)null);
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()) }
+            );
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_rejects_a_token_whose_jti_is_unknown()
+        {
+            _result.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithoutAJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            string token = CreateSignedToken(signingKey, Array.Empty<Claim>());
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_rejects_a_token_without_a_jti()
+        {
+            _result.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_does_not_query_token_status()
+        {
+            A.CallTo(() => _tokenRepository.GetTokenStatusAsync(A<Guid>._)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_ValidateTokenAsync_WithAMalformedJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (keyId, publicKeySpki, signingKey) = CreateSigningKey();
+            A.CallTo(() => _tokenRepository.GetActivePublicKeysAsync())
+                .Returns(
+                    new[]
+                    {
+                        new PublicKeyInfo { KeyId = keyId, PublicKey = publicKeySpki },
+                    }
+                );
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, "not-a-valid-guid") }
+            );
+
+            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+        }
+
+        [Test]
+        public void It_rejects_a_token_with_a_malformed_jti()
+        {
+            _result.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class Given_RevokeTokenAsync_WithAValidJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+        private Guid _jti;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (_, _, signingKey) = CreateSigningKey();
+            _jti = Guid.NewGuid();
+            A.CallTo(() => _tokenRepository.RevokeTokenAsync(_jti)).Returns(true);
+
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, _jti.ToString()) }
+            );
+
+            _result = await _tokenManager.RevokeTokenAsync(token);
+        }
+
+        [Test]
+        public void It_returns_true()
+        {
+            _result.Should().BeTrue();
+        }
+
+        [Test]
+        public void It_revokes_the_token_by_jti()
+        {
+            A.CallTo(() => _tokenRepository.RevokeTokenAsync(_jti)).MustHaveHappenedOnceExactly();
+        }
+    }
+
+    [TestFixture]
+    public class Given_RevokeTokenAsync_WithoutAJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (_, _, signingKey) = CreateSigningKey();
+            string token = CreateSignedToken(signingKey, Array.Empty<Claim>());
+
+            _result = await _tokenManager.RevokeTokenAsync(token);
+        }
+
+        [Test]
+        public void It_returns_false()
+        {
+            _result.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_does_not_call_the_repository()
+        {
+            A.CallTo(() => _tokenRepository.RevokeTokenAsync(A<Guid>._)).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    public class Given_RevokeTokenAsync_WithAMalformedJti : OpenIddictTokenManagerTests
+    {
+        private bool _result;
+
+        [SetUp]
+        public async Task Act()
+        {
+            var (_, _, signingKey) = CreateSigningKey();
+            string token = CreateSignedToken(
+                signingKey,
+                new[] { new Claim(JwtRegisteredClaimNames.Jti, "not-a-valid-guid") }
+            );
+
+            _result = await _tokenManager.RevokeTokenAsync(token);
+        }
+
+        [Test]
+        public void It_returns_false()
+        {
+            _result.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_does_not_call_the_repository()
+        {
+            A.CallTo(() => _tokenRepository.RevokeTokenAsync(A<Guid>._)).MustNotHaveHappened();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Tests.Unit/OpenIddictTokenManagerTests.cs
@@ -129,10 +129,13 @@ public class OpenIddictTokenManagerTests
     // standard validation, so a revoked token is rejected on reuse. This is the platform's
     // strongest replay control. The fixtures below pin that behavior.
 
+    // A valid self-contained token is reusable for the life of its "valid" status: the
+    // status check does not consume the token, so repeated presentations all succeed.
+    // This distinguishes the design from a one-time-use token.
     [TestFixture]
     public class Given_ValidateTokenAsync_WithAValidStoredToken : OpenIddictTokenManagerTests
     {
-        private bool _result;
+        private readonly List<bool> _results = [];
 
         [SetUp]
         public async Task Act()
@@ -154,13 +157,20 @@ public class OpenIddictTokenManagerTests
                 new[] { new Claim(JwtRegisteredClaimNames.Jti, jti.ToString()) }
             );
 
-            _result = await CreateConfiguredTokenManager().ValidateTokenAsync(token);
+            var manager = CreateConfiguredTokenManager();
+
+            // Present the same token several times to prove it is reusable while valid.
+            for (int i = 0; i < 3; i++)
+            {
+                _results.Add(await manager.ValidateTokenAsync(token));
+            }
         }
 
         [Test]
-        public void It_accepts_the_token()
+        public void It_accepts_the_token_on_every_presentation()
         {
-            _result.Should().BeTrue();
+            _results.Should().HaveCount(3);
+            _results.Should().AllBeEquivalentTo(true);
         }
     }
 

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
@@ -171,10 +171,14 @@ Feature: OWASP critical attack path protections
 
         # The self-contained provider re-checks token status by jti on every request,
         # so a revoked token is rejected on reuse even though it is still well-formed
-        # and unexpired. Revocation is delegated to the IdP under keycloak, so this
-        # scenario only runs against the self-contained provider.
+        # and unexpired. The two successful requests before revocation prove the token
+        # is reusable while valid (i.e. not one-time-use); only revocation causes the
+        # 401. Revocation is delegated to the IdP under keycloak, so this scenario only
+        # runs against the self-contained provider.
         @SelfContainedOnly
-        Scenario: 18 Revoked self-contained token is rejected on reuse
+        Scenario: 18 A valid self-contained token is reusable until it is revoked
+             When a GET request is made to "/v3/vendors"
+             Then it should respond with 200
              When a GET request is made to "/v3/vendors"
              Then it should respond with 200
              When the current token is revoked

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/OwaspCriticalPaths.feature
@@ -168,3 +168,16 @@ Feature: OWASP critical attack path protections
                   | contactEmailAddress | security@test.example |
                   | namespacePrefixes   | uri://ed-fi.org       |
              Then it should respond with 401 or 415
+
+        # The self-contained provider re-checks token status by jti on every request,
+        # so a revoked token is rejected on reuse even though it is still well-formed
+        # and unexpired. Revocation is delegated to the IdP under keycloak, so this
+        # scenario only runs against the self-contained provider.
+        @SelfContainedOnly
+        Scenario: 18 Revoked self-contained token is rejected on reuse
+             When a GET request is made to "/v3/vendors"
+             Then it should respond with 200
+             When the current token is revoked
+             Then it should respond with 200
+             When a GET request is made to "/v3/vendors"
+             Then it should respond with 401

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -294,6 +294,21 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         _apiResponse = await playwrightContext.ApiRequestContext!.PostAsync(url, options);
     }
 
+    [When("the current token is revoked")]
+    public async Task WhenTheCurrentTokenIsRevoked()
+    {
+        var content = new FormUrlEncodedContent(new Dictionary<string, string> { { "token", _token } });
+        APIRequestContextOptions options = new()
+        {
+            Headers = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/x-www-form-urlencoded" },
+            },
+            Data = await content.ReadAsStringAsync(),
+        };
+        _apiResponse = await playwrightContext.ApiRequestContext!.PostAsync("/connect/revoke", options);
+    }
+
     [When("a DELETE request is made to {string}")]
     public async Task WhenADELETERequestIsMadeTo(string url)
     {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
@@ -399,6 +399,10 @@ public class JwtValidationServiceTests
                 tokenHandler
             );
 
+            // NUnit reuses a single fixture instance across the fixture's tests and runs
+            // SetUp before each, so reset before repopulating to avoid accumulation.
+            _results.Clear();
+
             // Act - present the same token several times
             for (int i = 0; i < 3; i++)
             {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
@@ -487,4 +487,60 @@ public class JwtValidationServiceTests
             _clientAuthorizations!.TokenId.Should().Be("not-a-valid-guid-###");
         }
     }
+
+    /// <summary>
+    /// DMS does not require a jti claim. When it is absent the token is still accepted
+    /// and TokenId falls back to a derived value (a hash of the raw token) so that
+    /// log correlation still has a non-empty identifier to key on.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Valid_Token_Without_Jti : JwtValidationServiceTests
+    {
+        private ClaimsPrincipal? _principal = null;
+        private ClientAuthorizations? _clientAuthorizations = null;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (service, configurationManager, options, _, tokenHandler, signingKey) = CreateService();
+
+            var oidcConfig = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://keycloak.example.com/realms/edfi",
+            };
+            oidcConfig.SigningKeys.Add(signingKey);
+
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(Task.FromResult(oidcConfig));
+
+            var claims = new[] { new Claim("scope", "edfi-admin") };
+
+            var token = CreateTestToken(
+                claims,
+                oidcConfig.Issuer,
+                options.Value.Audience,
+                signingKey,
+                tokenHandler
+            );
+
+            // Act
+            (_principal, _clientAuthorizations) = await service.ValidateAndExtractClientAuthorizationsAsync(
+                token,
+                CancellationToken.None
+            );
+        }
+
+        [Test]
+        public void It_returns_a_valid_principal()
+        {
+            _principal.Should().NotBeNull();
+        }
+
+        [Test]
+        public void It_falls_back_to_a_derived_non_empty_token_id()
+        {
+            _clientAuthorizations!.TokenId.Should().NotBeNullOrEmpty();
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
@@ -360,4 +360,120 @@ public class JwtValidationServiceTests
             _clientAuthorizations!.DataStoreIds.Should().BeEmpty();
         }
     }
+
+    /// <summary>
+    /// DMS performs stateless self-inspection of bearer tokens and does not maintain
+    /// a replay cache or perform per-request revocation. The same valid token may be
+    /// presented repeatedly within its lifetime and is accepted every time.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Valid_Token_Validated_Repeatedly : JwtValidationServiceTests
+    {
+        private readonly List<(
+            ClaimsPrincipal? Principal,
+            ClientAuthorizations? ClientAuthorizations
+        )> _results = [];
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (service, configurationManager, options, _, tokenHandler, signingKey) = CreateService();
+
+            var oidcConfig = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://keycloak.example.com/realms/edfi",
+            };
+            oidcConfig.SigningKeys.Add(signingKey);
+
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(Task.FromResult(oidcConfig));
+
+            var claims = new[] { new Claim("jti", "replayed-token-id"), new Claim("scope", "edfi-admin") };
+
+            var token = CreateTestToken(
+                claims,
+                oidcConfig.Issuer,
+                options.Value.Audience,
+                signingKey,
+                tokenHandler
+            );
+
+            // Act - present the same token several times
+            for (int i = 0; i < 3; i++)
+            {
+                _results.Add(
+                    await service.ValidateAndExtractClientAuthorizationsAsync(token, CancellationToken.None)
+                );
+            }
+        }
+
+        [Test]
+        public void It_accepts_the_token_on_every_presentation()
+        {
+            _results.Should().OnlyContain(r => r.Principal != null && r.ClientAuthorizations != null);
+        }
+
+        [Test]
+        public void It_returns_the_same_token_id_each_time()
+        {
+            _results.Select(r => r.ClientAuthorizations!.TokenId).Should().AllBe("replayed-token-id");
+        }
+    }
+
+    /// <summary>
+    /// The jti claim is informational for DMS: it is copied to TokenId for correlation
+    /// but is never parsed or used in the accept/reject decision. A malformed (non-GUID)
+    /// jti therefore does not cause rejection.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Valid_Token_With_Malformed_Jti : JwtValidationServiceTests
+    {
+        private ClaimsPrincipal? _principal = null;
+        private ClientAuthorizations? _clientAuthorizations = null;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (service, configurationManager, options, _, tokenHandler, signingKey) = CreateService();
+
+            var oidcConfig = new OpenIdConnectConfiguration
+            {
+                Issuer = "https://keycloak.example.com/realms/edfi",
+            };
+            oidcConfig.SigningKeys.Add(signingKey);
+
+            A.CallTo(() => configurationManager.GetConfigurationAsync(A<CancellationToken>._))
+                .Returns(Task.FromResult(oidcConfig));
+
+            var claims = new[] { new Claim("jti", "not-a-valid-guid-###"), new Claim("scope", "edfi-admin") };
+
+            var token = CreateTestToken(
+                claims,
+                oidcConfig.Issuer,
+                options.Value.Audience,
+                signingKey,
+                tokenHandler
+            );
+
+            // Act
+            (_principal, _clientAuthorizations) = await service.ValidateAndExtractClientAuthorizationsAsync(
+                token,
+                CancellationToken.None
+            );
+        }
+
+        [Test]
+        public void It_returns_a_valid_principal()
+        {
+            _principal.Should().NotBeNull();
+        }
+
+        [Test]
+        public void It_stores_the_malformed_jti_verbatim_as_the_token_id()
+        {
+            _clientAuthorizations!.TokenId.Should().Be("not-a-valid-guid-###");
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Security/JwtValidationServiceTests.cs
@@ -411,7 +411,14 @@ public class JwtValidationServiceTests
         [Test]
         public void It_accepts_the_token_on_every_presentation()
         {
-            _results.Should().OnlyContain(r => r.Principal != null && r.ClientAuthorizations != null);
+            _results.Should().HaveCount(3);
+            _results
+                .Should()
+                .AllSatisfy(r =>
+                {
+                    r.Principal.Should().NotBeNull();
+                    r.ClientAuthorizations.Should().NotBeNull();
+                });
         }
 
         [Test]

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -369,4 +369,4 @@ Feature: OWASP critical attack path protections
              Then it should respond with 401
               And the response body should not contain "System."
               And the response body should not contain " at EdFi."
-              And the response body should not contain "signature"
+              And the response body should not contain "signature" ignoring case

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -344,3 +344,29 @@ Feature: OWASP critical attack path protections
                       ]
                   }
                   """
+
+        # DMS validates bearer tokens statelessly and does not maintain a replay cache,
+        # so the same valid token is accepted on every request within its lifetime.
+        @relational-backend
+        @relational-ci-shard-3
+        Scenario: 21 Valid JWT replayed multiple times within its lifetime is accepted
+            Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 200
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 200
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 200
+
+        # Authentication failures return a generic 401 without disclosing which check
+        # failed or any framework/stack-trace internals.
+        @relational-backend
+        @relational-ci-shard-3
+        Scenario: 22 Authentication failure response does not leak internal details
+            Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
+              And the token signature is manipulated
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 401
+              And the response body should not contain "System."
+              And the response body should not contain " at EdFi."
+              And the response body should not contain "signature"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -347,8 +347,7 @@ Feature: OWASP critical attack path protections
 
         # DMS validates bearer tokens statelessly and does not maintain a replay cache,
         # so the same valid token is accepted on every request within its lifetime.
-        @relational-backend
-        @relational-ci-shard-3
+        @e2e-ci-shard-3
         Scenario: 21 Valid JWT replayed multiple times within its lifetime is accepted
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
              When a GET request is made to "/ed-fi/schools"
@@ -360,8 +359,7 @@ Feature: OWASP critical attack path protections
 
         # Authentication failures return a generic 401 without disclosing which check
         # failed or any framework/stack-trace internals.
-        @relational-backend
-        @relational-ci-shard-3
+        @e2e-ci-shard-3
         Scenario: 22 Authentication failure response does not leak internal details
             Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
               And the token signature is manipulated

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -1479,6 +1479,13 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             body.Should().NotContain(text);
         }
 
+        [Then("the response body should not contain {string} ignoring case")]
+        public async Task ThenTheResponseBodyShouldNotContainIgnoringCase(string text)
+        {
+            string body = await _apiResponse.TextAsync();
+            body.Should().NotContainEquivalentOf(text);
+        }
+
         // Use Regex to find all occurrences of {id} in the body
         private static readonly Regex _findIds = IdRegex();
 


### PR DESCRIPTION
## Summary

Documents and validates the **JWT replay / revocation posture** for the DMS and CMS authentication paths, and adds focused test coverage. This is a **documentation + tests** change — no production behavior is modified.

Replay stance per trust path:

- **DMS resource API** — stateless bearer validation (signature/issuer/audience/lifetime). `jti` is informational only; no app-side replay cache or per-request revocation. Because DMS self-inspects and never introspects the IdP per request, a token revoked at the IdP is still accepted until it expires — **IdP-side revocation is a constraint, not an app-side control**. Replay is bounded by the measurable controls: short access-token TTL and signing-key rotation (plus TLS in transit).
- **CMS self-contained provider** — already enforces a per-request `jti` token-status check and supports `/connect/revoke` (RFC 7009), giving immediate server-side revocation. This PR documents and test-covers that behavior.
- **Keycloak / external IdP** — revocation delegated to the IdP; because neither app path introspects per request, an externally-issued token revoked at the IdP is likewise accepted until expiry. Compensating controls documented.

## Acceptance criteria

- [x] Replay handling design decision is documented — `docs/OWASP-AUTH-COVERAGE.md`
- [x] Tests demonstrate behavior for replayed tokens where supported — DMS & CMS unit tests; DMS & CMS E2E scenarios
- [x] IdP-dependent gaps include explicit compensating controls — `docs/OWASP-AUTH-COVERAGE.md`
- [x] OWASP auth coverage summary updated with the replay stance — `docs/OWASP-AUTH-COVERAGE.md`

## Changes (incremental commits)

1. ✅ OWASP auth coverage doc — `docs/OWASP-AUTH-COVERAGE.md`
2. ✅ DMS unit tests — replay accepted; `jti` is informational; missing-`jti` derived-TokenId fallback (`JwtValidationServiceTests.cs`)
3. ✅ CMS unit tests — `ValidateTokenAsync` status matrix; `RevokeTokenAsync` (`OpenIddictTokenManagerTests.cs`)
4. ✅ DMS + CMS E2E — replay-accepted, no-leak auth failure, revoked-token-rejected

## Verification

- `dotnet build -c Release` clean on all touched projects.
- DMS `JwtValidationServiceTests` and CMS `OpenIddictTokenManagerTests` pass locally (new fixtures included).
- E2E scenarios validated locally against a Docker stack (DMS replay-accepted + no-internal-leak; CMS reuse-then-revoke-then-reject) and run in CI: the DMS replay/no-leak scenarios in the `@e2e-ci-shard-3` lane, and the CMS revoked-token scenario under the self-contained provider via `@SelfContainedOnly`.

Kept as **Draft** so CI runs on each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
