### PR TITLE
[DMS-1247] Add TPDM security metadata support for DMS bootstrap

### DIFF
--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -202,12 +202,17 @@ elsewhere).
 Expert mode stages ApiSchema files directly from a local directory. Use this path for custom
 or in-repo schema directories that are not published as NuGet packages.
 
+`../../src/dms/EdFi.DataStandard52.ApiSchema` below is the conventional local materialization
+directory (reserved in `.gitignore`); it is absent on a fresh checkout, so populate it with the DS 5.2
+core plus any extension `ApiSchema*.json` files first — or point `-ApiSchemaPath` at any local directory
+that already contains them.
+
 ```pwsh
 # Stage schema and claims, then start DMS.
 # -ClaimsDirectoryPath is only needed for a non-bootstrap-mapped (custom) extension. Core plus the
 # built-in extensions (Sample, Homograph, TPDM) need no fragment argument: Sample and Homograph
 # stage claim fragments, while TPDM's claims ship in the embedded DS 5.2 set (no fragment staged).
-./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
+./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
 ./prepare-dms-claims.ps1 [-ClaimsDirectoryPath <directory-with-custom-extension-claimset-fragment>]
 ./bootstrap-local-dms.ps1
 ```
@@ -368,7 +373,7 @@ the health wait, then start DMS in the IDE between phases:
 
 ```pwsh
 cd eng/docker-compose
-./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath ...
+./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath ...
 ./prepare-dms-claims.ps1
 ./start-local-dms.ps1 -InfraOnly -IdentityProvider self-contained
 ./configure-local-data-store.ps1 -AddSmokeTestCredentials

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -204,9 +204,10 @@ or in-repo schema directories that are not published as NuGet packages.
 
 ```pwsh
 # Stage schema and claims, then start DMS.
-# -ClaimsDirectoryPath is only needed for a non-bootstrap-mapped (custom) extension; core plus the
-# built-in extensions (Sample, Homograph, TPDM) stage claims without it.
-./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+# -ClaimsDirectoryPath is only needed for a non-bootstrap-mapped (custom) extension. Core plus the
+# built-in extensions (Sample, Homograph, TPDM) need no fragment argument: Sample and Homograph
+# stage claim fragments, while TPDM's claims ship in the embedded DS 5.2 set (no fragment staged).
+./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
 ./prepare-dms-claims.ps1 [-ClaimsDirectoryPath <directory-with-custom-extension-claimset-fragment>]
 ./bootstrap-local-dms.ps1
 ```
@@ -233,14 +234,11 @@ the DMS container via `bootstrap-dms.yml`; staged claims are activated per
 `claims.mode` in the manifest. The staged workspace is runtime-authoritative in
 bootstrap mode.
 
-The full in-repo `EdFi.DataStandard52.ApiSchema` directory includes TPDM.
-Bootstrap maps the built-in Sample, Homograph, and TPDM extensions: Sample and
-Homograph stage claim fragments, while TPDM's security metadata is already
-carried by the embedded DS 5.2 claims, so no TPDM fragment is staged. The full
-in-repo DS 5.2 schema (core plus Sample, Homograph, and TPDM) therefore
-bootstraps without `-ClaimsDirectoryPath`; that argument is only needed for a
-custom extension outside the bootstrap map. Note this applies to Data Standard
-5.2, where TPDM is a separate extension; Data Standard 6.1 folds TPDM into core.
+The full DS 5.2 ApiSchema set - core plus the Sample, Homograph, and TPDM
+extensions - is bootstrap-mapped end to end (see Expert mode above for how each
+is handled), so staging it needs no `-ClaimsDirectoryPath`. This applies to Data
+Standard 5.2, where TPDM is a separate extension; Data Standard 6.1 folds TPDM
+into core.
 
 Bootstrap mode provisions the relational DMS schema only. Relational DMS
 CDC/Kafka support is pending a separate implementation, so bootstrap startup
@@ -370,7 +368,7 @@ the health wait, then start DMS in the IDE between phases:
 
 ```pwsh
 cd eng/docker-compose
-./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath ...
+./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath ...
 ./prepare-dms-claims.ps1
 ./start-local-dms.ps1 -InfraOnly -IdentityProvider self-contained
 ./configure-local-data-store.ps1 -AddSmokeTestCredentials

--- a/eng/docker-compose/README.md
+++ b/eng/docker-compose/README.md
@@ -173,10 +173,13 @@ infrastructure → configure → provision → DMS over the staged workspace), n
 the stack unconfigured.
 
 To bootstrap an **extension-containing** schema set, use Expert mode (`-ApiSchemaPath`) below; it
-stages core plus any extensions present in the supplied directory. `prepare-dms-claims.ps1`
-auto-stages bootstrap-managed claim fragments (Sample, Homograph) for extensions present in that
-schema set; extensions that require caller-supplied claim fragments (e.g. TPDM) need an additional
-`-ClaimsDirectoryPath` argument to `prepare-dms-claims.ps1`.
+stages core plus any extensions present in the supplied directory. Extension security metadata is
+bootstrap-managed for the built-in extensions: `prepare-dms-claims.ps1` auto-stages the Sample and
+Homograph claim fragments, and recognizes TPDM as already covered by the embedded DS 5.2 claims
+(no fragment is staged for TPDM). Only extensions that are **not** bootstrap-mapped (a custom
+extension you supply) require an additional `-ClaimsDirectoryPath` argument to
+`prepare-dms-claims.ps1`. TPDM is a Data Standard 5.2 extension, so it is bootstrapped through
+Expert `-ApiSchemaPath`, not package-backed standard mode (which is core-only).
 
 **Wrapper shorthand:** `bootstrap-local-dms.ps1` stages core-only standard mode in-line (when no
 workspace is staged) and then starts the stack. It auto-discovers the `dms-schema` executable
@@ -200,9 +203,11 @@ Expert mode stages ApiSchema files directly from a local directory. Use this pat
 or in-repo schema directories that are not published as NuGet packages.
 
 ```pwsh
-# Stage schema and claims, then start DMS
+# Stage schema and claims, then start DMS.
+# -ClaimsDirectoryPath is only needed for a non-bootstrap-mapped (custom) extension; core plus the
+# built-in extensions (Sample, Homograph, TPDM) stage claims without it.
 ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
-./prepare-dms-claims.ps1 -ClaimsDirectoryPath <directory-with-tpdm-claimset-fragment>
+./prepare-dms-claims.ps1 [-ClaimsDirectoryPath <directory-with-custom-extension-claimset-fragment>]
 ./bootstrap-local-dms.ps1
 ```
 
@@ -228,11 +233,14 @@ the DMS container via `bootstrap-dms.yml`; staged claims are activated per
 `claims.mode` in the manifest. The staged workspace is runtime-authoritative in
 bootstrap mode.
 
-The full in-repo `EdFi.DataStandard52.ApiSchema` directory includes TPDM. Story
-00 automatically maps only Sample and Homograph extension claim fragments, so
-the full in-repo schema requires `-ClaimsDirectoryPath` with a TPDM
-`*-claimset.json` fragment. For a schema set containing only core, Sample, and
-Homograph, the claims command can be run without `-ClaimsDirectoryPath`.
+The full in-repo `EdFi.DataStandard52.ApiSchema` directory includes TPDM.
+Bootstrap maps the built-in Sample, Homograph, and TPDM extensions: Sample and
+Homograph stage claim fragments, while TPDM's security metadata is already
+carried by the embedded DS 5.2 claims, so no TPDM fragment is staged. The full
+in-repo DS 5.2 schema (core plus Sample, Homograph, and TPDM) therefore
+bootstraps without `-ClaimsDirectoryPath`; that argument is only needed for a
+custom extension outside the bootstrap map. Note this applies to Data Standard
+5.2, where TPDM is a separate extension; Data Standard 6.1 folds TPDM into core.
 
 Bootstrap mode provisions the relational DMS schema only. Relational DMS
 CDC/Kafka support is pending a separate implementation, so bootstrap startup

--- a/eng/docker-compose/bootstrap-claims-gate.psm1
+++ b/eng/docker-compose/bootstrap-claims-gate.psm1
@@ -372,18 +372,12 @@ function Assert-SingleVerificationCheck {
     #>
     param(
         [Parameter(Mandatory)]
-        [string]
-        $CmsBaseUrl,
-
-        [Parameter(Mandatory)]
-        [string]
-        $AccessToken,
-
-        [Parameter(Mandatory)]
         $Check,
 
-        [string]
-        $Tenant = ""
+        # The /authorizationMetadata response for $Check.claimSetName, already fetched by the caller.
+        # Test-CmsClaimsReady memoizes this per claim set so repeated claim sets are fetched once.
+        # $null means the claim set was not found (404).
+        $Metadata
     )
 
     $claimSetName = [string]$Check.claimSetName
@@ -402,20 +396,13 @@ function Assert-SingleVerificationCheck {
         throw "Claims-ready gate: a verification check has an empty action. Manifest may be malformed."
     }
 
-    # Query CMS for the authorization metadata filtered to the expected claim set.
-    $metadata = Get-AuthorizationMetadataResponse `
-        -CmsBaseUrl $CmsBaseUrl `
-        -AccessToken $AccessToken `
-        -ClaimSetName $claimSetName `
-        -Tenant $Tenant
-
-    if ($null -eq $metadata) {
+    if ($null -eq $Metadata) {
         throw "Claims-ready gate FAILED: claim set '$(Format-ClaimsGateLogSafeText $claimSetName)' was not found in CMS /authorizationMetadata. CMS may not yet have applied the expected claims. /health green and /v2/claimSets name presence alone do not satisfy this gate."
     }
 
     # /authorizationMetadata returns an array of claim-set objects when no filter is applied;
     # with ?claimSetName= it returns the filtered subset. Normalize to array either way.
-    $claimSetArray = @($metadata)
+    $claimSetArray = @($Metadata)
 
     # Locate the matching claim set entry.
     $matchingClaimSet = $claimSetArray | Where-Object {
@@ -647,6 +634,9 @@ function Test-CmsClaimsReady {
     $checkIndex = 0
     $verifiedCount = 0
     $deferredCount = 0
+    # Memoize the /authorizationMetadata response per claim set: multiple checks commonly target the
+    # same claim set (e.g. EdFiSandbox), and the response is identical for each, so fetch it once.
+    $metadataByClaimSet = @{}
     foreach ($check in $checks) {
         $checkIndex++
 
@@ -675,11 +665,17 @@ function Test-CmsClaimsReady {
 
         Write-Information "Claims gate: verifying check $checkIndex/$($checks.Count) - claimSet=$(Format-ClaimsGateLogSafeText $logClaimSet) resourceClaim=$(Format-ClaimsGateLogSafeText $logResourceClaim) action=$(Format-ClaimsGateLogSafeText $logAction)." -InformationAction Continue
 
-        Assert-SingleVerificationCheck `
-            -CmsBaseUrl $resolvedCmsBaseUrl `
-            -AccessToken $resolvedToken `
-            -Check $check `
-            -Tenant $resolvedTenant
+        # Fetch /authorizationMetadata once per claim set and reuse it for every check on that set.
+        $checkClaimSetName = [string]$logClaimSet
+        if (-not $metadataByClaimSet.ContainsKey($checkClaimSetName)) {
+            $metadataByClaimSet[$checkClaimSetName] = Get-AuthorizationMetadataResponse `
+                -CmsBaseUrl $resolvedCmsBaseUrl `
+                -AccessToken $resolvedToken `
+                -ClaimSetName $checkClaimSetName `
+                -Tenant $resolvedTenant
+        }
+
+        Assert-SingleVerificationCheck -Check $check -Metadata $metadataByClaimSet[$checkClaimSetName]
 
         $verifiedCount++
     }

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -121,23 +121,23 @@
     or validate the staged workspace before starting infrastructure.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1
-    Expert mode (filesystem). Stage the in-repo ApiSchema directory (which includes TPDM
-    and other extensions) and claims workspaces manually, then start the local stack. The
-    in-repo directory requires -ClaimsDirectoryPath with a TPDM claim fragment unless
-    only core, Sample, and Homograph extensions are staged.
+    Expert mode (filesystem). Stage a local ApiSchema directory (which may include TPDM
+    and other extensions) and claims workspaces manually, then start the local stack.
+    -ClaimsDirectoryPath is needed only for a custom extension outside the bootstrap map;
+    core, Sample, Homograph, and TPDM are all handled without it.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Expert mode with seed loading. Prepare the bootstrap manifest, then start the stack and
     load developer-supplied XML interchange files.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly
     IDE pre-DMS stop: start infrastructure, configure the data store, provision the schema,
@@ -145,14 +145,14 @@
     provision-dms-schema.ps1 to configure appsettings.Development.json.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly -DmsBaseUrl http://localhost:8080
     IDE health-wait continuation: same pre-DMS phase, then waits for the IDE-hosted DMS at
     http://localhost:8080/health to return HTTP 200 (300-second timeout).
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly -DmsBaseUrl http://localhost:8080 -LoadSeedData -SeedDataPath ./my-seed-xml/
     IDE full workflow: pre-DMS phase, health-wait for IDE DMS, then load seed data against

--- a/eng/docker-compose/bootstrap-local-dms.ps1
+++ b/eng/docker-compose/bootstrap-local-dms.ps1
@@ -121,7 +121,7 @@
     or validate the staged workspace before starting infrastructure.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1
     Expert mode (filesystem). Stage a local ApiSchema directory (which may include TPDM
@@ -130,14 +130,14 @@
     core, Sample, Homograph, and TPDM are all handled without it.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Expert mode with seed loading. Prepare the bootstrap manifest, then start the stack and
     load developer-supplied XML interchange files.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly
     IDE pre-DMS stop: start infrastructure, configure the data store, provision the schema,
@@ -145,14 +145,14 @@
     provision-dms-schema.ps1 to configure appsettings.Development.json.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly -DmsBaseUrl http://localhost:8080
     IDE health-wait continuation: same pre-DMS phase, then waits for the IDE-hosted DMS at
     http://localhost:8080/health to return HTTP 200 (300-second timeout).
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-local-dms.ps1 -InfraOnly -DmsBaseUrl http://localhost:8080 -LoadSeedData -SeedDataPath ./my-seed-xml/
     IDE full workflow: pre-DMS phase, health-wait for IDE DMS, then load seed data against

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -77,7 +77,7 @@
     workspace is staged), then starts the published stack and provisions schemas. No seed loading.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Expert mode with seed loading. Stage an extension-containing or custom schema set via

--- a/eng/docker-compose/bootstrap-published-dms.ps1
+++ b/eng/docker-compose/bootstrap-published-dms.ps1
@@ -77,7 +77,7 @@
     workspace is staged), then starts the published stack and provisions schemas. No seed loading.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
     pwsh ./prepare-dms-claims.ps1
     pwsh ./bootstrap-published-dms.ps1 -LoadSeedData -SeedDataPath ./my-seed-xml/
     Expert mode with seed loading. Stage an extension-containing or custom schema set via

--- a/eng/docker-compose/bootstrap-schema-catalog.psm1
+++ b/eng/docker-compose/bootstrap-schema-catalog.psm1
@@ -56,7 +56,10 @@ $script:StandardCoreEndpointName = "ed-fi"
 $script:StandardPackageVersion = "1.0.329"
 
 # Known extension claims metadata keyed by Title-cased project name (matching the projectName
-# field in bootstrap-api-schema-manifest.json, which sources its value from ApiSchema.json).
+# field in bootstrap-api-schema-manifest.json, which sources its value from ApiSchema.json). The map
+# is backed by an Ordinal (case-sensitive) comparer so the Title-cased contract holds through EVERY
+# access path - not just Get-StandardKnownExtensionInfo. A look-alike custom extension (e.g. "Tpdm")
+# never resolves to a built-in entry (a case-insensitive default @{} would let it silently map).
 #
 # NamespacePrefix is recorded ONLY for extensions whose resources carry a DISTINCT seed namespace,
 # which becomes an authorized vendor namespace on the SeedLoader credential. Per
@@ -66,53 +69,55 @@ $script:StandardPackageVersion = "1.0.329"
 # Homograph resources use the core uri://ed-fi.org namespace (HomographExtension.feature authorizes
 # Homograph with "uri://ed-fi.org" only) and its claims use NoFurtherAuthorizationRequired, so
 # Homograph intentionally records NO distinct namespace prefix.
-$script:KnownExtensionClaimsMetadata = @{
-    "Sample" = @{
-        FragmentFileName = "004-sample-extension-claimset.json"
-        NamespacePrefix  = "uri://sample.ed-fi.org"
-    }
-    "Homograph" = @{
-        # No NamespacePrefix by design: Homograph resources use the core uri://ed-fi.org namespace
-        # (see the block comment above). Recording uri://homograph.ed-fi.org would authorize a
-        # namespace no Homograph resource uses and would violate the "must not infer prefixes" rule.
-        FragmentFileName = "005-homograph-extension-claimset.json"
-    }
-    "TPDM" = @{
-        # No FragmentFileName by design. The DS 5.2 embedded Claims.json
-        # (Claims/Standards/ds52/Claims.json) already carries the complete TPDM claims hierarchy and
-        # its EdFiSandbox CRUD grants - TPDM resources are reachable through several core domains
-        # (e.g. tpdm resources via domains/tpdm, TPDM descriptors via domains/systemDescriptors,
-        # tpdm/candidate via domains/people, and the survey-response associations via
-        # domains/relationshipBasedData/surveyDomain) - so Embedded mode covers TPDM with no staged
-        # fragment; authoring one would only duplicate embedded claims and add nothing. DS 6.1 folds
-        # TPDM into core and ships no TPDM extension package, so this entry is only ever reached by a
-        # DS 5.2 bootstrap.
-        #
-        # NamespacePrefix IS recorded: TPDM descriptor data uses the distinct uri://tpdm.ed-fi.org
-        # namespace (TpdmExtension.feature authorizes EdFiSandbox with "uri://ed-fi.org,
-        # uri://tpdm.ed-fi.org" and posts descriptors under uri://tpdm.ed-fi.org/...), so the
-        # SeedLoader credential must carry that vendor namespace to load TPDM descriptor seed data.
-        # This mirrors Sample; unlike Homograph, whose resources stay on the core namespace.
-        NamespacePrefix = "uri://tpdm.ed-fi.org"
-        #
-        # VerificationChecks make the claims-ready gate confirm CMS actually composed TPDM claims
-        # into EdFiSandbox from the embedded claims. Both target leaf resource claims (never
-        # parents), so the gate asserts them directly against /authorizationMetadata: one TPDM
-        # descriptor leaf (reachable via domains/systemDescriptors) and one TPDM resource leaf
-        # (reachable via domains/tpdm).
-        VerificationChecks = @(
-            @{
-                ClaimSetName  = "EdFiSandbox"
-                ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor"
-                Action        = "Read"
-            },
-            @{
-                ClaimSetName  = "EdFiSandbox"
-                ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/evaluation"
-                Action        = "Read"
-            }
-        )
-    }
+$script:KnownExtensionClaimsMetadata = [System.Collections.Generic.Dictionary[string, object]]::new([System.StringComparer]::Ordinal)
+
+$script:KnownExtensionClaimsMetadata["Sample"] = @{
+    FragmentFileName = "004-sample-extension-claimset.json"
+    NamespacePrefix  = "uri://sample.ed-fi.org"
+}
+
+$script:KnownExtensionClaimsMetadata["Homograph"] = @{
+    # No NamespacePrefix by design: Homograph resources use the core uri://ed-fi.org namespace
+    # (see the block comment above). Recording uri://homograph.ed-fi.org would authorize a
+    # namespace no Homograph resource uses and would violate the "must not infer prefixes" rule.
+    FragmentFileName = "005-homograph-extension-claimset.json"
+}
+
+$script:KnownExtensionClaimsMetadata["TPDM"] = @{
+    # No FragmentFileName by design. The DS 5.2 embedded Claims.json
+    # (Claims/Standards/ds52/Claims.json) already carries the complete TPDM claims hierarchy and
+    # its EdFiSandbox CRUD grants - TPDM resources are reachable through several core domains
+    # (e.g. tpdm resources via domains/tpdm, TPDM descriptors via domains/systemDescriptors,
+    # tpdm/candidate via domains/people, and the survey-response associations via
+    # domains/relationshipBasedData/surveyDomain) - so Embedded mode covers TPDM with no staged
+    # fragment; authoring one would only duplicate embedded claims and add nothing. DS 6.1 folds
+    # TPDM into core and ships no TPDM extension package, so this entry is only ever reached by a
+    # DS 5.2 bootstrap.
+    #
+    # NamespacePrefix IS recorded: TPDM descriptor data uses the distinct uri://tpdm.ed-fi.org
+    # namespace (TpdmExtension.feature authorizes EdFiSandbox with "uri://ed-fi.org,
+    # uri://tpdm.ed-fi.org" and posts descriptors under uri://tpdm.ed-fi.org/...), so the
+    # SeedLoader credential must carry that vendor namespace to load TPDM descriptor seed data.
+    # This mirrors Sample; unlike Homograph, whose resources stay on the core namespace.
+    NamespacePrefix = "uri://tpdm.ed-fi.org"
+    #
+    # VerificationChecks make the claims-ready gate confirm CMS actually composed TPDM claims
+    # into EdFiSandbox from the embedded claims. Both target leaf resource claims (never
+    # parents), so the gate asserts them directly against /authorizationMetadata: one TPDM
+    # descriptor leaf (reachable via domains/systemDescriptors) and one TPDM resource leaf
+    # (reachable via domains/tpdm).
+    VerificationChecks = @(
+        @{
+            ClaimSetName  = "EdFiSandbox"
+            ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor"
+            Action        = "Read"
+        },
+        @{
+            ClaimSetName  = "EdFiSandbox"
+            ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/evaluation"
+            Action        = "Read"
+        }
+    )
 }
 
 function Get-StandardSchemaFeed {
@@ -168,13 +173,11 @@ function Get-StandardKnownExtensionInfo {
         $ProjectName
     )
 
-    # Case-sensitive match: the PowerShell @{} literal is case-insensitive, so a look-alike custom
-    # extension (e.g. "Tpdm") must not silently resolve to the built-in "TPDM" metadata and skip its
-    # required caller-supplied claims. Compare keys with -ceq to enforce the Title-cased contract.
-    foreach ($knownProjectName in $script:KnownExtensionClaimsMetadata.Keys) {
-        if ($knownProjectName -ceq $ProjectName) {
-            return $script:KnownExtensionClaimsMetadata[$knownProjectName]
-        }
+    # The metadata map is backed by an Ordinal (case-sensitive) comparer, so ContainsKey/indexing
+    # enforce the Title-cased contract directly: a look-alike custom extension (e.g. "Tpdm") does not
+    # resolve to a built-in entry and correctly falls through to the caller-supplied claims path.
+    if ($script:KnownExtensionClaimsMetadata.ContainsKey($ProjectName)) {
+        return $script:KnownExtensionClaimsMetadata[$ProjectName]
     }
 
     return $null

--- a/eng/docker-compose/bootstrap-schema-catalog.psm1
+++ b/eng/docker-compose/bootstrap-schema-catalog.psm1
@@ -77,6 +77,34 @@ $script:KnownExtensionClaimsMetadata = @{
         # namespace no Homograph resource uses and would violate the "must not infer prefixes" rule.
         FragmentFileName = "005-homograph-extension-claimset.json"
     }
+    "TPDM" = @{
+        # No FragmentFileName and no NamespacePrefix by design. The DS 5.2 embedded Claims.json
+        # (Claims/Standards/ds52/Claims.json) already carries the complete TPDM claims hierarchy
+        # and its EdFiSandbox CRUD grants (domains/tpdm directly, TPDM descriptors via
+        # domains/systemDescriptors, tpdm/candidate via domains/people), so Embedded mode covers
+        # TPDM with no staged fragment - authoring one would only duplicate embedded claims and add
+        # nothing. TPDM resources use the core uri://ed-fi.org namespace (like Homograph), so no
+        # distinct seed namespace prefix is recorded. DS 6.1 folds TPDM into core and ships no TPDM
+        # extension package, so this entry is only ever reached by a DS 5.2 bootstrap.
+        #
+        # VerificationChecks make the claims-ready gate confirm CMS actually composed TPDM claims
+        # into EdFiSandbox from the embedded claims. Both target leaf resource claims (never
+        # parents), so the gate asserts them directly against /authorizationMetadata: one TPDM
+        # descriptor leaf (reachable via domains/systemDescriptors) and one TPDM resource leaf
+        # (reachable via domains/tpdm).
+        VerificationChecks = @(
+            @{
+                ClaimSetName  = "EdFiSandbox"
+                ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor"
+                Action        = "Read"
+            },
+            @{
+                ClaimSetName  = "EdFiSandbox"
+                ResourceClaim = "http://ed-fi.org/identity/claims/tpdm/evaluation"
+                Action        = "Read"
+            }
+        )
+    }
 }
 
 function Get-StandardSchemaFeed {
@@ -110,9 +138,12 @@ function Get-StandardKnownExtensionInfo {
     extensions that don't have known metadata.
 
     .DESCRIPTION
-    Used by prepare-dms-claims.ps1 to auto-stage claim fragments for extensions present in a staged
+    Used by prepare-dms-claims.ps1 to resolve claims handling for extensions present in a staged
     schema set (notably expert -ApiSchemaPath schema sets that contain extensions). Known extensions
-    (Sample, Homograph) return a hashtable with FragmentFileName and optionally NamespacePrefix.
+    return a hashtable describing how bootstrap handles their claims: a FragmentFileName to stage
+    (Sample, Homograph), an optional NamespacePrefix (Sample), and/or optional VerificationChecks.
+    TPDM records no FragmentFileName and no NamespacePrefix - the DS 5.2 embedded Claims.json already
+    covers TPDM - only VerificationChecks so the claims-ready gate confirms CMS composed TPDM claims.
     Extensions absent from the known map return $null - this is by design and does not indicate an
     error; such an extension simply requires a caller-supplied ClaimsDirectoryPath. Note that
     standard mode is package-backed core-only and does not select extensions; this lookup serves the

--- a/eng/docker-compose/bootstrap-schema-catalog.psm1
+++ b/eng/docker-compose/bootstrap-schema-catalog.psm1
@@ -78,14 +78,22 @@ $script:KnownExtensionClaimsMetadata = @{
         FragmentFileName = "005-homograph-extension-claimset.json"
     }
     "TPDM" = @{
-        # No FragmentFileName and no NamespacePrefix by design. The DS 5.2 embedded Claims.json
-        # (Claims/Standards/ds52/Claims.json) already carries the complete TPDM claims hierarchy
-        # and its EdFiSandbox CRUD grants (domains/tpdm directly, TPDM descriptors via
-        # domains/systemDescriptors, tpdm/candidate via domains/people), so Embedded mode covers
-        # TPDM with no staged fragment - authoring one would only duplicate embedded claims and add
-        # nothing. TPDM resources use the core uri://ed-fi.org namespace (like Homograph), so no
-        # distinct seed namespace prefix is recorded. DS 6.1 folds TPDM into core and ships no TPDM
-        # extension package, so this entry is only ever reached by a DS 5.2 bootstrap.
+        # No FragmentFileName by design. The DS 5.2 embedded Claims.json
+        # (Claims/Standards/ds52/Claims.json) already carries the complete TPDM claims hierarchy and
+        # its EdFiSandbox CRUD grants - TPDM resources are reachable through several core domains
+        # (e.g. tpdm resources via domains/tpdm, TPDM descriptors via domains/systemDescriptors,
+        # tpdm/candidate via domains/people, and the survey-response associations via
+        # domains/relationshipBasedData/surveyDomain) - so Embedded mode covers TPDM with no staged
+        # fragment; authoring one would only duplicate embedded claims and add nothing. DS 6.1 folds
+        # TPDM into core and ships no TPDM extension package, so this entry is only ever reached by a
+        # DS 5.2 bootstrap.
+        #
+        # NamespacePrefix IS recorded: TPDM descriptor data uses the distinct uri://tpdm.ed-fi.org
+        # namespace (TpdmExtension.feature authorizes EdFiSandbox with "uri://ed-fi.org,
+        # uri://tpdm.ed-fi.org" and posts descriptors under uri://tpdm.ed-fi.org/...), so the
+        # SeedLoader credential must carry that vendor namespace to load TPDM descriptor seed data.
+        # This mirrors Sample; unlike Homograph, whose resources stay on the core namespace.
+        NamespacePrefix = "uri://tpdm.ed-fi.org"
         #
         # VerificationChecks make the claims-ready gate confirm CMS actually composed TPDM claims
         # into EdFiSandbox from the embedded claims. Both target leaf resource claims (never
@@ -141,9 +149,9 @@ function Get-StandardKnownExtensionInfo {
     Used by prepare-dms-claims.ps1 to resolve claims handling for extensions present in a staged
     schema set (notably expert -ApiSchemaPath schema sets that contain extensions). Known extensions
     return a hashtable describing how bootstrap handles their claims: a FragmentFileName to stage
-    (Sample, Homograph), an optional NamespacePrefix (Sample), and/or optional VerificationChecks.
-    TPDM records no FragmentFileName and no NamespacePrefix - the DS 5.2 embedded Claims.json already
-    covers TPDM - only VerificationChecks so the claims-ready gate confirms CMS composed TPDM claims.
+    (Sample, Homograph), an optional NamespacePrefix (Sample, TPDM), and/or optional
+    VerificationChecks. TPDM stages no FragmentFileName because its claims ship embedded; see the
+    KnownExtensionClaimsMetadata TPDM entry for the full rationale.
     Extensions absent from the known map return $null - this is by design and does not indicate an
     error; such an extension simply requires a caller-supplied ClaimsDirectoryPath. Note that
     standard mode is package-backed core-only and does not select extensions; this lookup serves the
@@ -160,8 +168,13 @@ function Get-StandardKnownExtensionInfo {
         $ProjectName
     )
 
-    if ($script:KnownExtensionClaimsMetadata.ContainsKey($ProjectName)) {
-        return $script:KnownExtensionClaimsMetadata[$ProjectName]
+    # Case-sensitive match: the PowerShell @{} literal is case-insensitive, so a look-alike custom
+    # extension (e.g. "Tpdm") must not silently resolve to the built-in "TPDM" metadata and skip its
+    # required caller-supplied claims. Compare keys with -ceq to enforce the Title-cased contract.
+    foreach ($knownProjectName in $script:KnownExtensionClaimsMetadata.Keys) {
+        if ($knownProjectName -ceq $ProjectName) {
+            return $script:KnownExtensionClaimsMetadata[$knownProjectName]
+        }
     }
 
     return $null

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -424,55 +424,11 @@ $targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
 $fragments = [System.Collections.ArrayList]::new()
 $namespacePrefixes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 $unmappedExtensionNames = [System.Collections.ArrayList]::new()
-$knownExtensionVerificationChecks = [System.Collections.ArrayList]::new()
-
-foreach ($extensionProject in $extensionProjects) {
-    $projectName = Get-ValueOrNull -Hashtable $extensionProject -Key "projectName"
-    if ([string]::IsNullOrWhiteSpace($projectName)) {
-        throw "Bootstrap ApiSchema manifest project entry is missing 'projectName'."
-    }
-
-    $knownExtension = Get-StandardKnownExtensionInfo -ProjectName $projectName
-    if ($null -ne $knownExtension) {
-        if ($knownExtension.ContainsKey("FragmentFileName")) {
-            $fragmentPath = Join-Path $shippedClaimsDirectory $knownExtension["FragmentFileName"]
-            if (-not (Test-Path -LiteralPath $fragmentPath -PathType Leaf)) {
-                throw "Shipped claimset fragment was not found for extension '$(Format-LogSafeText $projectName)': $(Format-LogSafeText $fragmentPath)"
-            }
-
-            Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $fragmentPath
-        }
-
-        if ($knownExtension.ContainsKey("NamespacePrefix")) {
-            $null = $namespacePrefixes.Add($knownExtension["NamespacePrefix"])
-        }
-
-        # Extensions whose claims are already covered by the embedded Claims.json (e.g. TPDM in
-        # DS 5.2) stage no fragment; their catalog-declared VerificationChecks are collected here
-        # and added to the readiness checks below so the claims-ready gate still confirms CMS
-        # composed those extension claims from the embedded base.
-        if ($knownExtension.ContainsKey("VerificationChecks")) {
-            foreach ($verificationCheck in @($knownExtension["VerificationChecks"])) {
-                $null = $knownExtensionVerificationChecks.Add($verificationCheck)
-            }
-        }
-    } else {
-        $null = $unmappedExtensionNames.Add($projectName)
-    }
-}
-
-$userFragmentFiles = @(Get-UserFragmentFile -Path $ClaimsDirectoryPath)
-if ($unmappedExtensionNames.Count -gt 0 -and $userFragmentFiles.Count -eq 0) {
-    throw "ClaimsDirectoryPath is required for unmapped extension project(s): $(Format-LogSafeText ($unmappedExtensionNames -join ', '))."
-}
-
-foreach ($userFragmentFile in $userFragmentFiles) {
-    Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $userFragmentFile
-}
-
-$effectiveClaimSetNames = Get-EffectiveClaimSetName
+# Readiness checks accumulate here across the baseline probe, known-extension entries, and fragment
+# extraction; Add-ExpectedVerificationCheck dedups on claimSet|resourceClaim|action.
 $expectedVerificationChecks = [System.Collections.ArrayList]::new()
 $seenChecks = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
 # Keep the core baseline probe even in Embedded mode; startup readiness owns verifying
 # that CMS applied the embedded base claims before checking staged extension entries.
 # The probe targets a LEAF resource claim: CMS /authorizationMetadata flattens the claims
@@ -486,17 +442,77 @@ Add-ExpectedVerificationCheck `
     -ResourceClaim "http://ed-fi.org/identity/claims/ed-fi/schoolYearType" `
     -Action "Read"
 
-# Add readiness checks for known extensions covered by the embedded claims (no staged fragment).
-# These target leaf resource claims, so they are asserted directly against /authorizationMetadata
-# rather than deferred like parent-derived checks.
-foreach ($verificationCheck in $knownExtensionVerificationChecks) {
-    Add-ExpectedVerificationCheck `
-        -Seen $seenChecks `
-        -Checks $expectedVerificationChecks `
-        -ClaimSetName $verificationCheck["ClaimSetName"] `
-        -ResourceClaim $verificationCheck["ResourceClaim"] `
-        -Action $verificationCheck["Action"]
+foreach ($extensionProject in $extensionProjects) {
+    $projectName = Get-ValueOrNull -Hashtable $extensionProject -Key "projectName"
+    if ([string]::IsNullOrWhiteSpace($projectName)) {
+        throw "Bootstrap ApiSchema manifest project entry is missing 'projectName'."
+    }
+
+    $knownExtension = Get-StandardKnownExtensionInfo -ProjectName $projectName
+    if ($null -eq $knownExtension) {
+        $null = $unmappedExtensionNames.Add($projectName)
+        continue
+    }
+
+    # A known-extension entry must carry at least one actionable key. An entry with none (e.g. a
+    # misspelled key) would otherwise be silently treated as fully mapped: it would stage nothing,
+    # contribute no checks, and suppress the unmapped-extension guard - yielding runtime 403s the
+    # claims-ready gate cannot detect.
+    $recognizedKeys = @("FragmentFileName", "NamespacePrefix", "VerificationChecks")
+    if (@($recognizedKeys | Where-Object { $knownExtension.ContainsKey($_) }).Count -eq 0) {
+        throw "Known extension '$(Format-LogSafeText $projectName)' has a claims metadata entry with no recognized keys (expected one or more of: $($recognizedKeys -join ', ')). Check KnownExtensionClaimsMetadata for a misspelled key."
+    }
+
+    if ($knownExtension.ContainsKey("FragmentFileName")) {
+        $fragmentPath = Join-Path $shippedClaimsDirectory $knownExtension["FragmentFileName"]
+        if (-not (Test-Path -LiteralPath $fragmentPath -PathType Leaf)) {
+            throw "Shipped claimset fragment was not found for extension '$(Format-LogSafeText $projectName)': $(Format-LogSafeText $fragmentPath)"
+        }
+
+        Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $fragmentPath
+    }
+
+    if ($knownExtension.ContainsKey("NamespacePrefix")) {
+        $null = $namespacePrefixes.Add($knownExtension["NamespacePrefix"])
+    }
+
+    # Extensions whose claims are already covered by the embedded Claims.json (e.g. TPDM in DS 5.2)
+    # stage no fragment; their catalog-declared VerificationChecks are added to the readiness checks
+    # directly so the claims-ready gate still confirms CMS composed those extension claims from the
+    # embedded base. Each targets a leaf resource claim, so it is asserted directly against
+    # /authorizationMetadata rather than deferred like parent-derived checks. Malformed entries throw
+    # here rather than being silently dropped by Add-ExpectedVerificationCheck's whitespace guard.
+    if ($knownExtension.ContainsKey("VerificationChecks")) {
+        foreach ($verificationCheck in @($knownExtension["VerificationChecks"])) {
+            $checkClaimSet = [string]$verificationCheck["ClaimSetName"]
+            $checkResourceClaim = [string]$verificationCheck["ResourceClaim"]
+            $checkAction = [string]$verificationCheck["Action"]
+            if ([string]::IsNullOrWhiteSpace($checkClaimSet) -or
+                [string]::IsNullOrWhiteSpace($checkResourceClaim) -or
+                [string]::IsNullOrWhiteSpace($checkAction)) {
+                throw "Known extension '$(Format-LogSafeText $projectName)' has a malformed VerificationChecks entry (ClaimSetName, ResourceClaim, and Action are all required)."
+            }
+
+            Add-ExpectedVerificationCheck `
+                -Seen $seenChecks `
+                -Checks $expectedVerificationChecks `
+                -ClaimSetName $checkClaimSet `
+                -ResourceClaim $checkResourceClaim `
+                -Action $checkAction
+        }
+    }
 }
+
+$userFragmentFiles = @(Get-UserFragmentFile -Path $ClaimsDirectoryPath)
+if ($unmappedExtensionNames.Count -gt 0 -and $userFragmentFiles.Count -eq 0) {
+    throw "ClaimsDirectoryPath is required for unmapped extension project(s): $(Format-LogSafeText ($unmappedExtensionNames -join ', '))."
+}
+
+foreach ($userFragmentFile in $userFragmentFiles) {
+    Add-FragmentInput -TargetSources $targetSources -Fragments $fragments -SourcePath $userFragmentFile
+}
+
+$effectiveClaimSetNames = Get-EffectiveClaimSetName
 
 foreach ($fragment in $fragments) {
     Assert-FragmentValidAndExtractCheck `

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -424,6 +424,7 @@ $targetSources = [System.Collections.Generic.Dictionary[string, string]]::new(
 $fragments = [System.Collections.ArrayList]::new()
 $namespacePrefixes = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
 $unmappedExtensionNames = [System.Collections.ArrayList]::new()
+$knownExtensionVerificationChecks = [System.Collections.ArrayList]::new()
 
 foreach ($extensionProject in $extensionProjects) {
     $projectName = Get-ValueOrNull -Hashtable $extensionProject -Key "projectName"
@@ -444,6 +445,16 @@ foreach ($extensionProject in $extensionProjects) {
 
         if ($knownExtension.ContainsKey("NamespacePrefix")) {
             $null = $namespacePrefixes.Add($knownExtension["NamespacePrefix"])
+        }
+
+        # Extensions whose claims are already covered by the embedded Claims.json (e.g. TPDM in
+        # DS 5.2) stage no fragment; their catalog-declared VerificationChecks are collected here
+        # and added to the readiness checks below so the claims-ready gate still confirms CMS
+        # composed those extension claims from the embedded base.
+        if ($knownExtension.ContainsKey("VerificationChecks")) {
+            foreach ($verificationCheck in @($knownExtension["VerificationChecks"])) {
+                $null = $knownExtensionVerificationChecks.Add($verificationCheck)
+            }
         }
     } else {
         $null = $unmappedExtensionNames.Add($projectName)
@@ -474,6 +485,18 @@ Add-ExpectedVerificationCheck `
     -ClaimSetName "EdFiSandbox" `
     -ResourceClaim "http://ed-fi.org/identity/claims/ed-fi/schoolYearType" `
     -Action "Read"
+
+# Add readiness checks for known extensions covered by the embedded claims (no staged fragment).
+# These target leaf resource claims, so they are asserted directly against /authorizationMetadata
+# rather than deferred like parent-derived checks.
+foreach ($verificationCheck in $knownExtensionVerificationChecks) {
+    Add-ExpectedVerificationCheck `
+        -Seen $seenChecks `
+        -Checks $expectedVerificationChecks `
+        -ClaimSetName $verificationCheck["ClaimSetName"] `
+        -ResourceClaim $verificationCheck["ResourceClaim"] `
+        -Action $verificationCheck["Action"]
+}
 
 foreach ($fragment in $fragments) {
     Assert-FragmentValidAndExtractCheck `

--- a/eng/docker-compose/prepare-dms-claims.ps1
+++ b/eng/docker-compose/prepare-dms-claims.ps1
@@ -200,13 +200,28 @@ function Add-ExpectedVerificationCheck {
         # observable in CMS /authorizationMetadata (which serializes leaf resource claims
         # only), so the claims-ready gate defers these instead of asserting them.
         [switch]
-        $IsParent
+        $IsParent,
+
+        # When set, an empty ClaimSetName/ResourceClaim/Action throws instead of being silently
+        # skipped. The catalog loop passes this so a malformed static KnownExtensionClaimsMetadata
+        # entry fails fast at prepare time; fragment-derived checks leave it off (default) because a
+        # fragment's own structural validation already owns those errors.
+        [switch]
+        $ThrowOnInvalid,
+
+        # Optional context surfaced in the -ThrowOnInvalid error message (e.g. the extension name).
+        [string]
+        $Source = ""
 
     )
 
     if ([string]::IsNullOrWhiteSpace($ClaimSetName) -or
         [string]::IsNullOrWhiteSpace($ResourceClaim) -or
         [string]::IsNullOrWhiteSpace($Action)) {
+        if ($ThrowOnInvalid) {
+            $sourceSuffix = if ([string]::IsNullOrWhiteSpace($Source)) { "" } else { " for $(Format-LogSafeText $Source)" }
+            throw "Malformed verification check$sourceSuffix (ClaimSetName, ResourceClaim, and Action are all required)."
+        }
         return
     }
 
@@ -454,13 +469,20 @@ foreach ($extensionProject in $extensionProjects) {
         continue
     }
 
-    # A known-extension entry must carry at least one actionable key. An entry with none (e.g. a
-    # misspelled key) would otherwise be silently treated as fully mapped: it would stage nothing,
-    # contribute no checks, and suppress the unmapped-extension guard - yielding runtime 403s the
-    # claims-ready gate cannot detect.
-    $recognizedKeys = @("FragmentFileName", "NamespacePrefix", "VerificationChecks")
-    if (@($recognizedKeys | Where-Object { $knownExtension.ContainsKey($_) }).Count -eq 0) {
-        throw "Known extension '$(Format-LogSafeText $projectName)' has a claims metadata entry with no recognized keys (expected one or more of: $($recognizedKeys -join ', ')). Check KnownExtensionClaimsMetadata for a misspelled key."
+    # A known-extension entry must contribute at least one piece of security metadata. An entry that
+    # contributes nothing - no fragment, no namespace prefix, and no (or an empty) VerificationChecks
+    # list - would otherwise be silently treated as fully mapped: it would stage nothing, suppress the
+    # unmapped-extension guard, and yield runtime 403s the claims-ready gate cannot detect. Checking
+    # for non-empty *values* (not just key presence) also catches a misspelled key and an empty
+    # VerificationChecks = @() no-op.
+    $hasFragment = $knownExtension.ContainsKey("FragmentFileName") -and
+        -not [string]::IsNullOrWhiteSpace([string]$knownExtension["FragmentFileName"])
+    $hasNamespacePrefix = $knownExtension.ContainsKey("NamespacePrefix") -and
+        -not [string]::IsNullOrWhiteSpace([string]$knownExtension["NamespacePrefix"])
+    $hasVerificationChecks = $knownExtension.ContainsKey("VerificationChecks") -and
+        @($knownExtension["VerificationChecks"]).Count -gt 0
+    if (-not ($hasFragment -or $hasNamespacePrefix -or $hasVerificationChecks)) {
+        throw "Known extension '$(Format-LogSafeText $projectName)' has a claims metadata entry that contributes no security metadata (expected a non-empty FragmentFileName, NamespacePrefix, or VerificationChecks). Check KnownExtensionClaimsMetadata for a misspelled or empty entry."
     }
 
     if ($knownExtension.ContainsKey("FragmentFileName")) {
@@ -480,25 +502,18 @@ foreach ($extensionProject in $extensionProjects) {
     # stage no fragment; their catalog-declared VerificationChecks are added to the readiness checks
     # directly so the claims-ready gate still confirms CMS composed those extension claims from the
     # embedded base. Each targets a leaf resource claim, so it is asserted directly against
-    # /authorizationMetadata rather than deferred like parent-derived checks. Malformed entries throw
-    # here rather than being silently dropped by Add-ExpectedVerificationCheck's whitespace guard.
+    # /authorizationMetadata rather than deferred like parent-derived checks. -ThrowOnInvalid makes a
+    # malformed static entry fail fast here (the sink owns the required-fields predicate, single source).
     if ($knownExtension.ContainsKey("VerificationChecks")) {
         foreach ($verificationCheck in @($knownExtension["VerificationChecks"])) {
-            $checkClaimSet = [string]$verificationCheck["ClaimSetName"]
-            $checkResourceClaim = [string]$verificationCheck["ResourceClaim"]
-            $checkAction = [string]$verificationCheck["Action"]
-            if ([string]::IsNullOrWhiteSpace($checkClaimSet) -or
-                [string]::IsNullOrWhiteSpace($checkResourceClaim) -or
-                [string]::IsNullOrWhiteSpace($checkAction)) {
-                throw "Known extension '$(Format-LogSafeText $projectName)' has a malformed VerificationChecks entry (ClaimSetName, ResourceClaim, and Action are all required)."
-            }
-
             Add-ExpectedVerificationCheck `
                 -Seen $seenChecks `
                 -Checks $expectedVerificationChecks `
-                -ClaimSetName $checkClaimSet `
-                -ResourceClaim $checkResourceClaim `
-                -Action $checkAction
+                -ClaimSetName ([string]$verificationCheck["ClaimSetName"]) `
+                -ResourceClaim ([string]$verificationCheck["ResourceClaim"]) `
+                -Action ([string]$verificationCheck["Action"]) `
+                -ThrowOnInvalid `
+                -Source "known extension '$projectName'"
         }
     }
 }

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -47,11 +47,12 @@
     and stages it into the bootstrap workspace.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
-    Expert mode. Stages ApiSchema*.json files from the in-repo directory (which includes TPDM).
-    Use this path when you have a custom or in-repo schema directory not published as a NuGet package.
-    After staging, run prepare-dms-claims.ps1 with -ClaimsDirectoryPath if the schema includes
-    extensions whose claim fragments are not auto-staged (e.g. TPDM).
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
+    Expert mode. Stages ApiSchema*.json files from a local directory (for example one containing the
+    DS 5.2 core plus the TPDM extension). Use this path for a custom or local schema directory not
+    published as a NuGet package. After staging, run prepare-dms-claims.ps1; -ClaimsDirectoryPath is
+    needed only for a custom extension outside the bootstrap map (core, Sample, Homograph, and TPDM
+    are handled without it).
 #>
 [CmdletBinding()]
 param(

--- a/eng/docker-compose/prepare-dms-schema.ps1
+++ b/eng/docker-compose/prepare-dms-schema.ps1
@@ -47,12 +47,13 @@
     and stages it into the bootstrap workspace.
 
 .EXAMPLE
-    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory> -SchemaToolPath $schemaToolExe
-    Expert mode. Stages ApiSchema*.json files from a local directory (for example one containing the
-    DS 5.2 core plus the TPDM extension). Use this path for a custom or local schema directory not
-    published as a NuGet package. After staging, run prepare-dms-claims.ps1; -ClaimsDirectoryPath is
-    needed only for a custom extension outside the bootstrap map (core, Sample, Homograph, and TPDM
-    are handled without it).
+    pwsh ./prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema -SchemaToolPath $schemaToolExe
+    Expert mode. Stages ApiSchema*.json files from a local directory.
+    ../../src/dms/EdFi.DataStandard52.ApiSchema is the conventional git-ignored local materialization
+    directory (absent on a fresh checkout - populate it with the DS 5.2 core plus any extension
+    ApiSchema*.json first), or point -ApiSchemaPath at any local directory that contains them. After
+    staging, run prepare-dms-claims.ps1; -ClaimsDirectoryPath is needed only for a custom extension
+    outside the bootstrap map (core, Sample, Homograph, and TPDM are handled without it).
 #>
 [CmdletBinding()]
 param(

--- a/eng/docker-compose/tests/BootstrapClaimsGate.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapClaimsGate.Tests.ps1
@@ -849,8 +849,8 @@ Describe "DMS-1153 Claims-ready gate (bootstrap-claims-gate.psm1)" {
             $script:error_h3_missing | Should -Not -BeNullOrEmpty
         }
 
-        It "queries /authorizationMetadata for the baseline and user-staged leaf checks" {
-            $script:authMetadataCalls_h3_missing | Should -Be 2
+        It "fetches /authorizationMetadata once for both EdFiSandbox checks (memoized per claim set)" {
+            $script:authMetadataCalls_h3_missing | Should -Be 1
         }
 
         It "error message reports the missing user-staged resource claim" {
@@ -902,8 +902,8 @@ Describe "DMS-1153 Claims-ready gate (bootstrap-claims-gate.psm1)" {
             $script:error_h3_present | Should -BeNullOrEmpty
         }
 
-        It "queries /authorizationMetadata for both leaf checks" {
-            $script:authMetadataCalls_h3_present | Should -Be 2
+        It "fetches /authorizationMetadata once for both EdFiSandbox checks (memoized per claim set)" {
+            $script:authMetadataCalls_h3_present | Should -Be 1
         }
     }
 
@@ -1086,8 +1086,8 @@ Describe "DMS-1153 Claims-ready gate (bootstrap-claims-gate.psm1)" {
             $script:error_j1 | Should -BeNullOrEmpty
         }
 
-        It "verifies all three leaf checks against /authorizationMetadata" {
-            $script:authMetadataCalls_j1 | Should -Be 3
+        It "fetches /authorizationMetadata once for the three EdFiSandbox checks (memoized per claim set)" {
+            $script:authMetadataCalls_j1 | Should -Be 1
         }
     }
 

--- a/eng/docker-compose/tests/BootstrapClaimsGate.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapClaimsGate.Tests.ps1
@@ -1032,4 +1032,110 @@ Describe "DMS-1153 Claims-ready gate (bootstrap-claims-gate.psm1)" {
             $script:capturedHeaders_i2.ContainsKey("Tenant") | Should -Be $false
         }
     }
+
+    # ===========================================================================
+    # Scenario (j): TPDM embedded-claims load verification (DMS-1247). A core + TPDM
+    # bootstrap stages Embedded mode with NO fragment, but the manifest still records
+    # the two TPDM leaf checks so this gate proves CMS actually composed the TPDM
+    # claims from the embedded DS 5.2 Claims.json into EdFiSandbox - i.e. it exercises
+    # CMS load verification against /authorizationMetadata, not just the manifest.
+    # ===========================================================================
+    Context "Scenario (j) - gate passes when CMS composed the TPDM leaf claims into EdFiSandbox" {
+        BeforeAll {
+            Import-Module $script:moduleUnderTest -Force
+
+            $tempDir = New-TempManifestDir
+            $script:manifestPath_j1 = New-ManifestFile `
+                -Dir $tempDir `
+                -Checks @(
+                    @{ claimSetName = $script:sandboxClaimSet; resourceClaim = $script:sandboxResourceClaim; action = $script:sandboxAction },
+                    @{ claimSetName = "EdFiSandbox"; resourceClaim = "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor"; action = "Read" },
+                    @{ claimSetName = "EdFiSandbox"; resourceClaim = "http://ed-fi.org/identity/claims/tpdm/evaluation"; action = "Read" }
+                ) `
+                -FileName "manifest-j1.json"
+
+            $script:authMetadataCalls_j1 = 0
+
+            Mock Invoke-RestMethod -ModuleName bootstrap-claims-gate {
+                param($Uri, $Method, $ContentType, $Headers, $Body)
+                if ($Uri -match "/v3/authorizationMetadata") {
+                    $script:authMetadataCalls_j1++
+                    return New-AuthMetadataResponse `
+                        -ClaimSetName "EdFiSandbox" `
+                        -Claims @(
+                            @{ name = "http://ed-fi.org/identity/claims/ed-fi/schoolYearType"; actions = @("Read") },
+                            @{ name = "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor"; actions = @("Read") },
+                            @{ name = "http://ed-fi.org/identity/claims/tpdm/evaluation"; actions = @("Read") }
+                        )
+                }
+            }
+
+            $script:error_j1 = $null
+            try {
+                Test-CmsClaimsReady `
+                    -CmsBaseUrl $script:cmsBaseUrl `
+                    -AccessToken $script:accessToken `
+                    -ManifestPath $script:manifestPath_j1
+            }
+            catch {
+                $script:error_j1 = $_.Exception.Message
+            }
+        }
+
+        It "does not throw when CMS serves both TPDM leaf claims for EdFiSandbox" {
+            $script:error_j1 | Should -BeNullOrEmpty
+        }
+
+        It "verifies all three leaf checks against /authorizationMetadata" {
+            $script:authMetadataCalls_j1 | Should -Be 3
+        }
+    }
+
+    Context "Scenario (j) - gate fails when CMS did not compose a TPDM leaf claim" {
+        BeforeAll {
+            Import-Module $script:moduleUnderTest -Force
+
+            $tempDir = New-TempManifestDir
+            $script:manifestPath_j2 = New-ManifestFile `
+                -Dir $tempDir `
+                -Checks @(
+                    @{ claimSetName = $script:sandboxClaimSet; resourceClaim = $script:sandboxResourceClaim; action = $script:sandboxAction },
+                    @{ claimSetName = "EdFiSandbox"; resourceClaim = "http://ed-fi.org/identity/claims/tpdm/evaluation"; action = "Read" }
+                ) `
+                -FileName "manifest-j2.json"
+
+            # CMS serves EdFiSandbox with the baseline claim but WITHOUT the TPDM claim - e.g. a
+            # stale Config image whose embedded DS 5.2 Claims.json lacks TPDM. The gate must catch
+            # this rather than pass on /health or claim-set-name presence alone.
+            Mock Invoke-RestMethod -ModuleName bootstrap-claims-gate {
+                param($Uri, $Method, $ContentType, $Headers, $Body)
+                if ($Uri -match "/v3/authorizationMetadata") {
+                    return New-AuthMetadataResponse `
+                        -ClaimSetName "EdFiSandbox" `
+                        -Claims @(
+                            @{ name = "http://ed-fi.org/identity/claims/ed-fi/schoolYearType"; actions = @("Read") }
+                        )
+                }
+            }
+
+            $script:error_j2 = $null
+            try {
+                Test-CmsClaimsReady `
+                    -CmsBaseUrl $script:cmsBaseUrl `
+                    -AccessToken $script:accessToken `
+                    -ManifestPath $script:manifestPath_j2
+            }
+            catch {
+                $script:error_j2 = $_.Exception.Message
+            }
+        }
+
+        It "throws because the TPDM leaf claim is absent from CMS authorization metadata" {
+            $script:error_j2 | Should -Not -BeNullOrEmpty
+        }
+
+        It "error message reports the missing TPDM resource claim" {
+            $script:error_j2 | Should -Match "tpdm/evaluation"
+        }
+    }
 }

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -146,26 +146,99 @@ exit $ExitCode
     function script:Add-KnownExtensionCatalogEntry {
         <#
         .SYNOPSIS
-        Injects an extra entry into the isolated repo's copy of KnownExtensionClaimsMetadata so tests can
-        exercise the catalog-validation branches in prepare-dms-claims.ps1 without touching the real (source)
-        catalog. Call after BeforeEach has staged $script:repo; the isolated repo is discarded in AfterEach.
+        Appends an extra KnownExtensionClaimsMetadata assignment to the isolated repo's copy of the catalog
+        module so tests can exercise the catalog-validation branches in prepare-dms-claims.ps1 without
+        touching the real (source) catalog. Call after BeforeEach has staged $script:repo; the isolated repo
+        is discarded in AfterEach.
         #>
         param(
             [Parameter(Mandatory)]
             [string]
-            $EntryDefinition
+            $Key,
+
+            # A hashtable literal for the entry body, e.g. '@{ FragmnetFileName = "x.json" }'.
+            [Parameter(Mandatory)]
+            [string]
+            $Body
         )
 
         $catalogPath = Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-catalog.psm1"
         $content = Get-Content -LiteralPath $catalogPath -Raw
-        $anchor = '$script:KnownExtensionClaimsMetadata = @{'
+        # Append the assignment after the built-in entries (which create the Ordinal-backed map) but
+        # before the first function, so the module-scope statement runs at import. Anchoring on the first
+        # function is stable across catalog edits and appends a self-contained statement rather than
+        # splicing into a literal.
+        $anchor = "function Get-StandardSchemaFeed"
         $index = $content.IndexOf($anchor)
         if ($index -lt 0) {
-            throw "Could not find KnownExtensionClaimsMetadata anchor in $catalogPath"
+            throw "Could not find catalog function anchor in $catalogPath"
         }
-        $insertAt = $index + $anchor.Length
-        $content = $content.Insert($insertAt, "`n    $EntryDefinition")
+        $statement = "`$script:KnownExtensionClaimsMetadata[`"$Key`"] = $Body`n`n"
+        $content = $content.Insert($index, $statement)
         Set-Content -LiteralPath $catalogPath -Value $content -Encoding utf8
+    }
+
+    function script:Resolve-EmbeddedClaimLeaf {
+        <#
+        .SYNOPSIS
+        Walks the embedded Claims.json claimsHierarchy for a resource-claim leaf and reports whether it
+        exists, whether it is a leaf (no child claims), and whether a named claim set's action reaches it
+        via claimSets on itself or any ancestor. Used to anchor the TPDM readiness-check literals to the
+        embedded claims - a stronger guard than a raw string match. The runtime claims-ready gate remains
+        authoritative for full composition; this is only the shift-left CI anchor.
+        #>
+        param(
+            [Parameter(Mandatory)]
+            $Nodes,
+
+            [Parameter(Mandatory)]
+            [string]
+            $LeafName,
+
+            [Parameter(Mandatory)]
+            [string]
+            $ClaimSetName,
+
+            [Parameter(Mandatory)]
+            [string]
+            $Action,
+
+            [bool]
+            $AncestorGrants = $false
+        )
+
+        foreach ($node in @($Nodes)) {
+            if ($null -eq $node) { continue }
+
+            $nodeGrants = $AncestorGrants
+            if ($node.PSObject.Properties['claimSets']) {
+                foreach ($claimSet in @($node.claimSets)) {
+                    if ($null -ne $claimSet -and [string]$claimSet.name -eq $ClaimSetName -and
+                        $claimSet.PSObject.Properties['actions']) {
+                        $actionNames = @($claimSet.actions | ForEach-Object { [string]$_.name })
+                        if ($actionNames -contains $Action) { $nodeGrants = $true }
+                    }
+                }
+            }
+
+            $children = if ($node.PSObject.Properties['claims']) { @($node.claims) } else { @() }
+
+            if ([string]$node.name -eq $LeafName) {
+                return [pscustomobject]@{
+                    Found        = $true
+                    IsLeaf       = ($children.Count -eq 0)
+                    GrantReaches = $nodeGrants
+                }
+            }
+
+            if ($children.Count -gt 0) {
+                $result = Resolve-EmbeddedClaimLeaf -Nodes $children -LeafName $LeafName `
+                    -ClaimSetName $ClaimSetName -Action $Action -AncestorGrants $nodeGrants
+                if ($result.Found) { return $result }
+            }
+        }
+
+        return [pscustomobject]@{ Found = $false; IsLeaf = $false; GrantReaches = $false }
     }
 
     function script:Invoke-PrepareSchema {
@@ -626,25 +699,35 @@ exit $ExitCode
                 Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*Acme*"
         }
 
-        It "throws when a known-extension catalog entry has no recognized keys" {
-            # A catalog entry whose only key is unrecognized (e.g. a misspelled 'FragmentFileName') must fail
-            # fast rather than be silently treated as fully mapped - which would stage nothing, contribute no
-            # checks, and suppress the unmapped-extension guard, yielding runtime 403s the gate can't detect.
-            Add-KnownExtensionCatalogEntry -EntryDefinition '"AcmeTypo" = @{ FragmnetFileName = "x.json" }'
+        It "throws when a known-extension catalog entry contributes no security metadata (misspelled key)" {
+            # A catalog entry whose only key is unrecognized (e.g. a misspelled 'FragmentFileName') contributes
+            # nothing and must fail fast rather than be silently treated as fully mapped - which would stage
+            # nothing, suppress the unmapped-extension guard, and yield runtime 403s the gate can't detect.
+            Add-KnownExtensionCatalogEntry -Key "AcmeTypo" -Body '@{ FragmnetFileName = "x.json" }'
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("AcmeTypo"))
 
             { Invoke-PrepareClaim } |
-                Should -Throw -ExpectedMessage "*AcmeTypo*no recognized keys*"
+                Should -Throw -ExpectedMessage "*AcmeTypo*contributes no security metadata*"
+        }
+
+        It "throws when a known-extension catalog entry contributes no security metadata (empty VerificationChecks)" {
+            # An entry with an empty VerificationChecks list and no fragment/prefix has a recognized key but
+            # still contributes nothing; the value-level guard must reject it, not just key presence.
+            Add-KnownExtensionCatalogEntry -Key "AcmeEmpty" -Body '@{ VerificationChecks = @() }'
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("AcmeEmpty"))
+
+            { Invoke-PrepareClaim } |
+                Should -Throw -ExpectedMessage "*AcmeEmpty*contributes no security metadata*"
         }
 
         It "throws when a known-extension catalog VerificationChecks entry is malformed" {
             # A VerificationChecks entry missing a field would be silently dropped by
-            # Add-ExpectedVerificationCheck's whitespace guard; the catalog loop must reject it up front.
-            Add-KnownExtensionCatalogEntry -EntryDefinition '"AcmeBadCheck" = @{ VerificationChecks = @(@{ ClaimSetName = "EdFiSandbox"; ResourceClaim = ""; Action = "Read" }) }'
+            # Add-ExpectedVerificationCheck's whitespace guard; -ThrowOnInvalid makes the catalog path reject it.
+            Add-KnownExtensionCatalogEntry -Key "AcmeBadCheck" -Body '@{ VerificationChecks = @(@{ ClaimSetName = "EdFiSandbox"; ResourceClaim = ""; Action = "Read" }) }'
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("AcmeBadCheck"))
 
             { Invoke-PrepareClaim } |
-                Should -Throw -ExpectedMessage "*AcmeBadCheck*malformed VerificationChecks*"
+                Should -Throw -ExpectedMessage "*Malformed verification check*AcmeBadCheck*"
         }
 
         It "stages core + TPDM in Embedded claims mode from embedded claims without a caller fragment" {
@@ -736,18 +819,24 @@ exit $ExitCode
             Get-StandardKnownExtensionInfo -ProjectName "tpdm" | Should -BeNullOrEmpty
         }
 
-        It "anchors TPDM catalog verification checks to leaf claims present in the embedded DS 5.2 Claims.json" {
-            # The two TPDM check URIs are hand-authored literals; tie them to the embedded claims so a
-            # future rename surfaces here rather than as a confusing claims-ready gate failure at bootstrap.
+        It "anchors TPDM catalog checks to leaf claims that EdFiSandbox reaches in the embedded DS 5.2 Claims.json" {
+            # The TPDM check URIs are hand-authored literals. Assert each is still (a) present, (b) a LEAF
+            # resource claim, and (c) reachable by its claim set's action via claimSets on itself or an
+            # ancestor - so a future claims rename OR restructure surfaces here, not as a confusing gate
+            # failure at bootstrap. The runtime claims-ready gate stays authoritative for full composition.
             Import-Module (Join-Path $script:sourceDockerComposeRoot "bootstrap-schema-catalog.psm1") -Force
             $tpdm = Get-StandardKnownExtensionInfo -ProjectName "TPDM"
             $claimsPath = Join-Path $script:sourceRepoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Standards/ds52/Claims.json"
-            $claimsText = Get-Content -LiteralPath $claimsPath -Raw
+            $hierarchy = @((Get-Content -LiteralPath $claimsPath -Raw | ConvertFrom-Json).claimsHierarchy)
 
             @($tpdm.VerificationChecks).Count | Should -BeGreaterThan 0
             foreach ($check in $tpdm.VerificationChecks) {
-                # Match the quoted claim name so e.g. tpdm/evaluation does not match tpdm/evaluationObjective.
-                $claimsText | Should -Match ([regex]::Escape('"' + $check.ResourceClaim + '"'))
+                $resolved = Resolve-EmbeddedClaimLeaf -Nodes $hierarchy -LeafName $check.ResourceClaim `
+                    -ClaimSetName $check.ClaimSetName -Action $check.Action
+
+                $resolved.Found | Should -BeTrue -Because "$($check.ResourceClaim) must exist in the embedded Claims.json"
+                $resolved.IsLeaf | Should -BeTrue -Because "$($check.ResourceClaim) must be a leaf resource claim (the gate asserts leaves directly)"
+                $resolved.GrantReaches | Should -BeTrue -Because "$($check.ClaimSetName)/$($check.Action) must reach $($check.ResourceClaim) via claimSets lineage"
             }
         }
 

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -143,6 +143,31 @@ exit $ExitCode
         return $schemaDir
     }
 
+    function script:Add-KnownExtensionCatalogEntry {
+        <#
+        .SYNOPSIS
+        Injects an extra entry into the isolated repo's copy of KnownExtensionClaimsMetadata so tests can
+        exercise the catalog-validation branches in prepare-dms-claims.ps1 without touching the real (source)
+        catalog. Call after BeforeEach has staged $script:repo; the isolated repo is discarded in AfterEach.
+        #>
+        param(
+            [Parameter(Mandatory)]
+            [string]
+            $EntryDefinition
+        )
+
+        $catalogPath = Join-Path $script:repo.DockerComposeRoot "bootstrap-schema-catalog.psm1"
+        $content = Get-Content -LiteralPath $catalogPath -Raw
+        $anchor = '$script:KnownExtensionClaimsMetadata = @{'
+        $index = $content.IndexOf($anchor)
+        if ($index -lt 0) {
+            throw "Could not find KnownExtensionClaimsMetadata anchor in $catalogPath"
+        }
+        $insertAt = $index + $anchor.Length
+        $content = $content.Insert($insertAt, "`n    $EntryDefinition")
+        Set-Content -LiteralPath $catalogPath -Value $content -Encoding utf8
+    }
+
     function script:Invoke-PrepareSchema {
         param(
             [Parameter(Mandatory)]
@@ -599,6 +624,27 @@ exit $ExitCode
 
             { Invoke-PrepareClaim } |
                 Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*Acme*"
+        }
+
+        It "throws when a known-extension catalog entry has no recognized keys" {
+            # A catalog entry whose only key is unrecognized (e.g. a misspelled 'FragmentFileName') must fail
+            # fast rather than be silently treated as fully mapped - which would stage nothing, contribute no
+            # checks, and suppress the unmapped-extension guard, yielding runtime 403s the gate can't detect.
+            Add-KnownExtensionCatalogEntry -EntryDefinition '"AcmeTypo" = @{ FragmnetFileName = "x.json" }'
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("AcmeTypo"))
+
+            { Invoke-PrepareClaim } |
+                Should -Throw -ExpectedMessage "*AcmeTypo*no recognized keys*"
+        }
+
+        It "throws when a known-extension catalog VerificationChecks entry is malformed" {
+            # A VerificationChecks entry missing a field would be silently dropped by
+            # Add-ExpectedVerificationCheck's whitespace guard; the catalog loop must reject it up front.
+            Add-KnownExtensionCatalogEntry -EntryDefinition '"AcmeBadCheck" = @{ VerificationChecks = @(@{ ClaimSetName = "EdFiSandbox"; ResourceClaim = ""; Action = "Read" }) }'
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("AcmeBadCheck"))
+
+            { Invoke-PrepareClaim } |
+                Should -Throw -ExpectedMessage "*AcmeBadCheck*malformed VerificationChecks*"
         }
 
         It "stages core + TPDM in Embedded claims mode from embedded claims without a caller fragment" {

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -594,15 +594,77 @@ exit $ExitCode
             $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://sample.ed-fi.org"
         }
 
-        It "requires caller-supplied claims for unmapped extensions such as TPDM" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+        It "requires caller-supplied claims for unmapped extensions" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
 
             { Invoke-PrepareClaim } |
-                Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*TPDM*"
+                Should -Throw -ExpectedMessage "*ClaimsDirectoryPath is required*Acme*"
+        }
+
+        It "stages core + TPDM in Embedded claims mode from embedded claims without a caller fragment" {
+            # TPDM is a bootstrap-mapped extension whose claims are already carried by the embedded
+            # DS 5.2 Claims.json, so a core + TPDM schema set needs no caller fragment and stages no
+            # claim files - claims.mode stays Embedded and no distinct namespace prefix is recorded.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+
+            { Invoke-PrepareClaim } | Should -Not -Throw
+            $manifest = Get-RootManifest
+
+            $manifest.claims.mode | Should -Be "Embedded"
+            @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File).Count |
+                Should -Be 0
+            $manifest.schema.selectedExtensions | Should -Contain "tpdm"
+            $manifest.seed.extensionNamespacePrefixes | Should -BeNullOrEmpty
+        }
+
+        It "records TPDM leaf verification checks so the claims-ready gate confirms CMS composed TPDM claims" {
+            # The catalog TPDM entry contributes leaf readiness checks (a TPDM descriptor reachable
+            # via domains/systemDescriptors and a TPDM resource reachable via domains/tpdm) so the
+            # gate verifies CMS actually flattened TPDM claims into EdFiSandbox in /authorizationMetadata.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareClaim
+            $manifest = Get-RootManifest
+
+            $checks = @($manifest.claims.expectedVerificationChecks)
+            $descriptorCheck = @($checks |
+                Where-Object { $_.resourceClaim -eq "http://ed-fi.org/identity/claims/tpdm/credentialStatusDescriptor" })[0]
+            $resourceCheck = @($checks |
+                Where-Object { $_.resourceClaim -eq "http://ed-fi.org/identity/claims/tpdm/evaluation" })[0]
+
+            $descriptorCheck.claimSetName | Should -Be "EdFiSandbox"
+            $descriptorCheck.action | Should -Be "Read"
+            # Leaf checks are asserted directly by the gate; they must not carry the parent-defer flag.
+            $descriptorCheck.PSObject.Properties.Name | Should -Not -Contain "isParent"
+            $resourceCheck.claimSetName | Should -Be "EdFiSandbox"
+            $resourceCheck.action | Should -Be "Read"
+            $resourceCheck.PSObject.Properties.Name | Should -Not -Contain "isParent"
+        }
+
+        It "keeps Hybrid claims mode for core + Sample + TPDM and still records TPDM verification checks" {
+            # Sample stages a fragment (Hybrid) and records its namespace prefix; TPDM stages nothing
+            # but still contributes its embedded-claims readiness checks.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample", "TPDM"))
+            Invoke-PrepareClaim
+            $manifest = Get-RootManifest
+            $claimFiles = @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File | ForEach-Object Name)
+
+            $manifest.claims.mode | Should -Be "Hybrid"
+            $claimFiles | Should -Contain "004-sample-extension-claimset.json"
+            $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://sample.ed-fi.org"
+            @($manifest.claims.expectedVerificationChecks |
+                Where-Object { $_.resourceClaim -eq "http://ed-fi.org/identity/claims/tpdm/evaluation" }).Count |
+                Should -Be 1
+        }
+
+        It "reuses an identical core + TPDM Embedded claims workspace on re-run" {
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareClaim
+            { Invoke-PrepareClaim } | Should -Not -Throw
+            (Get-RootManifest).claims.mode | Should -Be "Embedded"
         }
 
         It "stages caller fragments and records expected verification checks with the fragment's raw resource name" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
 
@@ -621,7 +683,7 @@ exit $ExitCode
         }
 
         It "records explicit parent claimSets readiness checks structurally" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "parent-explicit"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -676,7 +738,7 @@ exit $ExitCode
         }
 
         It "rejects explicit claimSets on non-parent resource claims because CMS does not compose them" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "non-parent-explicit"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -704,7 +766,7 @@ exit $ExitCode
         }
 
         It "rejects malformed, duplicate, or unknown claim fragments" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
 
             $badJsonDir = Join-Path $script:repo.RepoRoot "bad-json"
             New-Item -ItemType Directory -Path $badJsonDir -Force | Out-Null
@@ -719,7 +781,7 @@ exit $ExitCode
         }
 
         It "accepts parent-only fragments without a top-level claim-set name" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "parent-only"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -737,7 +799,7 @@ exit $ExitCode
         }
 
         It "reuses identical claims workspaces and rejects changed fragment sets" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "custom-claims"
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
 
@@ -754,7 +816,7 @@ exit $ExitCode
         }
 
         It "rejects a fragment whose resourceClaims contains a non-object entry" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "bad-resource-claims"
             $fragment = [ordered]@{
                 name = "EdFiSandbox"
@@ -768,7 +830,7 @@ exit $ExitCode
         }
 
         It "rejects a parent resourceClaim missing 'name'" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "parent-missing-name"
             $fragment = [ordered]@{
                 name = "FragLabel"
@@ -786,7 +848,7 @@ exit $ExitCode
         }
 
         It "requires a top-level name for implicit non-parent claim-set use" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "implicit"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -809,7 +871,7 @@ exit $ExitCode
         }
 
         It "rejects an implicit non-parent resourceClaim missing 'name'" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "implicit-missing-name"
             $fragment = [ordered]@{
                 name = "FragLabel"
@@ -829,7 +891,7 @@ exit $ExitCode
         It "discovers caller fragments recursively to match CMS ClaimsFragmentComposer" {
             # CMS scans -ClaimsDirectoryPath with SearchOption.AllDirectories. Bootstrap input
             # discovery must match so nested fragments are staged (and nested duplicates rejected).
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "nested-claims"
             $nestedDir = Join-Path $claimsDir "subdir"
             New-ExplicitClaimsetFragment -Path (Join-Path $nestedDir "010-tpdm-claimset.json")
@@ -841,7 +903,7 @@ exit $ExitCode
         }
 
         It "detects nested filename collisions across subdirectories" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "nested-collision"
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "a/010-tpdm-claimset.json")
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "b/010-tpdm-claimset.json")
@@ -851,7 +913,7 @@ exit $ExitCode
         }
 
         It "rejects a non-boolean isParent value because CMS deserializes IsParent as a strict bool" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "string-isparent"
             $fragment = [ordered]@{
                 name = "EdFiSandbox"
@@ -871,7 +933,7 @@ exit $ExitCode
         }
 
         It "rejects a resourceClaims value that is a single object instead of an array" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "scalar-resourceclaims"
             $fragment = [ordered]@{
                 name = "EdFiSandbox"
@@ -889,7 +951,7 @@ exit $ExitCode
         }
 
         It "rejects a claimSets value that is a single object instead of an array" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "scalar-claimsets"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -916,7 +978,7 @@ exit $ExitCode
         }
 
         It "rejects an actions value that is a single object instead of an array" {
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "scalar-actions"
             $fragment = [ordered]@{
                 resourceClaims = @(
@@ -946,7 +1008,7 @@ exit $ExitCode
             # Symmetric to the prepare-dms-schema.ps1 guard: a partial prior state (manifest
             # records claims/seed but .bootstrap/claims was removed) must not silently rewrite
             # the manifest sections; teardown is the required remediation.
-            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Acme"))
             $claimsDir = Join-Path $script:repo.RepoRoot "stale-claims-input"
             New-ExplicitClaimsetFragment -Path (Join-Path $claimsDir "010-tpdm-claimset.json")
             Invoke-PrepareClaim -ClaimsDirectoryPath $claimsDir

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -604,7 +604,8 @@ exit $ExitCode
         It "stages core + TPDM in Embedded claims mode from embedded claims without a caller fragment" {
             # TPDM is a bootstrap-mapped extension whose claims are already carried by the embedded
             # DS 5.2 Claims.json, so a core + TPDM schema set needs no caller fragment and stages no
-            # claim files - claims.mode stays Embedded and no distinct namespace prefix is recorded.
+            # claim files - claims.mode stays Embedded. TPDM descriptor data uses the distinct
+            # uri://tpdm.ed-fi.org namespace, so that prefix IS recorded for the SeedLoader credential.
             Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("TPDM"))
 
             { Invoke-PrepareClaim } | Should -Not -Throw
@@ -614,7 +615,7 @@ exit $ExitCode
             @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File).Count |
                 Should -Be 0
             $manifest.schema.selectedExtensions | Should -Contain "tpdm"
-            $manifest.seed.extensionNamespacePrefixes | Should -BeNullOrEmpty
+            $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://tpdm.ed-fi.org"
         }
 
         It "records TPDM leaf verification checks so the claims-ready gate confirms CMS composed TPDM claims" {
@@ -654,6 +655,54 @@ exit $ExitCode
             @($manifest.claims.expectedVerificationChecks |
                 Where-Object { $_.resourceClaim -eq "http://ed-fi.org/identity/claims/tpdm/evaluation" }).Count |
                 Should -Be 1
+        }
+
+        It "stages the full built-in set (core + Sample + Homograph + TPDM) without a caller fragment" {
+            # The documented headline scenario: the full in-repo DS 5.2 set bootstraps with no
+            # -ClaimsDirectoryPath. Sample and Homograph stage fragments (Hybrid) and Sample and TPDM
+            # record their descriptor namespace prefixes; TPDM stages nothing but still contributes
+            # its embedded-claims readiness checks.
+            Invoke-PrepareSchema -ApiSchemaPath (New-ApiSchemaSet -Extensions @("Sample", "Homograph", "TPDM"))
+
+            { Invoke-PrepareClaim } | Should -Not -Throw
+            $manifest = Get-RootManifest
+            $claimFiles = @(Get-ChildItem -LiteralPath (Join-Path $script:repo.BootstrapRoot "claims") -File | ForEach-Object Name)
+
+            $manifest.claims.mode | Should -Be "Hybrid"
+            $claimFiles | Should -Contain "004-sample-extension-claimset.json"
+            $claimFiles | Should -Contain "005-homograph-extension-claimset.json"
+            $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://sample.ed-fi.org"
+            $manifest.seed.extensionNamespacePrefixes | Should -Contain "uri://tpdm.ed-fi.org"
+            # Homograph resources stay on the core namespace, so it records no distinct prefix.
+            $manifest.seed.extensionNamespacePrefixes | Should -Not -Contain "uri://homograph.ed-fi.org"
+            @($manifest.claims.expectedVerificationChecks |
+                Where-Object { $_.resourceClaim -eq "http://ed-fi.org/identity/claims/tpdm/evaluation" }).Count |
+                Should -Be 1
+        }
+
+        It "resolves the TPDM catalog entry only for the exact Title-cased name (case-sensitive)" {
+            # A look-alike custom extension (e.g. "Tpdm") must not resolve to the built-in TPDM
+            # metadata and silently skip its required caller-supplied claims.
+            Import-Module (Join-Path $script:sourceDockerComposeRoot "bootstrap-schema-catalog.psm1") -Force
+
+            Get-StandardKnownExtensionInfo -ProjectName "TPDM" | Should -Not -BeNullOrEmpty
+            Get-StandardKnownExtensionInfo -ProjectName "Tpdm" | Should -BeNullOrEmpty
+            Get-StandardKnownExtensionInfo -ProjectName "tpdm" | Should -BeNullOrEmpty
+        }
+
+        It "anchors TPDM catalog verification checks to leaf claims present in the embedded DS 5.2 Claims.json" {
+            # The two TPDM check URIs are hand-authored literals; tie them to the embedded claims so a
+            # future rename surfaces here rather than as a confusing claims-ready gate failure at bootstrap.
+            Import-Module (Join-Path $script:sourceDockerComposeRoot "bootstrap-schema-catalog.psm1") -Force
+            $tpdm = Get-StandardKnownExtensionInfo -ProjectName "TPDM"
+            $claimsPath = Join-Path $script:sourceRepoRoot "src/config/backend/EdFi.DmsConfigurationService.Backend/Claims/Standards/ds52/Claims.json"
+            $claimsText = Get-Content -LiteralPath $claimsPath -Raw
+
+            @($tpdm.VerificationChecks).Count | Should -BeGreaterThan 0
+            foreach ($check in $tpdm.VerificationChecks) {
+                # Match the quoted claim name so e.g. tpdm/evaluation does not match tpdm/evaluationObjective.
+                $claimsText | Should -Match ([regex]::Escape('"' + $check.ResourceClaim + '"'))
+            }
         }
 
         It "reuses an identical core + TPDM Embedded claims workspace on re-run" {

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -689,10 +689,12 @@ in `prepare-dms-claims.ps1`, and optional seed package metadata in `load-dms-see
 loading participates only when the seed phase has a concrete built-in seed package for the selected
 extension.
 
-Story 00's v1 direct-filesystem claims lookup is intentionally narrow. It maps only extension projects that
-have current shipped security fragments in the repo, such as Sample and Homograph. TPDM and any other direct
-filesystem extension outside that lookup are treated as unmapped: bootstrap requires `-ClaimsDirectoryPath`
-for caller-supplied fragments and does not silently substitute `sample`, `homograph`, or any default mapping.
+Story 00's v1 direct-filesystem claims lookup is intentionally narrow. It maps the built-in extensions
+bootstrap knows how to handle: Sample and Homograph stage shipped security fragments, and TPDM is covered by
+the embedded DS 5.2 `Claims.json` (no fragment staged) while recording its descriptor seed namespace
+`uri://tpdm.ed-fi.org`. Any other direct filesystem extension outside that lookup is treated as unmapped:
+bootstrap requires `-ClaimsDirectoryPath` for caller-supplied fragments and does not silently substitute
+`sample`, `homograph`, or any default mapping.
 
 The bootstrap logic is:
 
@@ -1557,8 +1559,10 @@ seed-catalog-driven (Story 02), and custom seed payloads flow through `-SeedData
 2. `prepare-dms-claims.ps1` consumes the bootstrap manifest schema section and the staged schema files. For
    each project in the staged set with a matching bootstrap-managed security fragment (Sample, Homograph),
    it stages the corresponding JSON file(s) into `eng/docker-compose/.bootstrap/claims/` and resolves the
-   claims section to Hybrid mode; for a project without a bootstrap-managed fragment (e.g. TPDM), it requires
-   caller-supplied `-ClaimsDirectoryPath` fragments. Config Service startup consumes that staged host claims
+   claims section to Hybrid mode; TPDM is bootstrap-mapped without a fragment (its claims ship in the
+   embedded DS 5.2 `Claims.json`), so it stays Embedded mode and records only its descriptor seed namespace;
+   a project with no bootstrap-managed mapping requires caller-supplied `-ClaimsDirectoryPath` fragments.
+   Config Service startup consumes that staged host claims
    workspace through the claims section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json`. DMS gets
    claimsets from CMS authorization metadata, not from local fragment files, so DMS compose files do not
    mount the claims directory.
@@ -1632,8 +1636,10 @@ developer does not configure each separately:
 
 2. **Security fragments loaded (Section 4)** - When the extension has a bootstrap-managed security fragment
    (Sample, Homograph), the corresponding JSON file(s) are staged and the bootstrap manifest claims section
-   resolves to Hybrid mode automatically. An extension without a bootstrap-managed fragment (e.g. TPDM)
-   requires caller-supplied `-ClaimsDirectoryPath`. For built-in extension seed packages, those fragments
+   resolves to Hybrid mode automatically. TPDM is bootstrap-mapped without a fragment - its claims ship in
+   the embedded DS 5.2 `Claims.json`, so the claims section stays Embedded mode and only its descriptor seed
+   namespace (`uri://tpdm.ed-fi.org`) is recorded. An extension with no bootstrap-managed mapping requires
+   caller-supplied `-ClaimsDirectoryPath`. For built-in extension seed packages, those fragments
    must attach both `EdFiSandbox` and `SeedLoader` permissions to the extension resources they cover.
 
 3. **Extension seed data handling (Section 8.3)** - When seed delivery runs, bootstrap checks whether an

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -1829,7 +1829,7 @@ pwsh eng/docker-compose/bootstrap-local-dms.ps1
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedTemplate Minimal
 
 # Extension-containing schema set: stage via expert -ApiSchemaPath first, then run the wrapper
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
+pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seeds/
 
 # Keycloak-backed seed loading

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -567,13 +567,15 @@ only the metadata it owns: schema package fields in `prepare-dms-schema.ps1`, se
 - Standard mode (core-only): the schema and claims phase commands resolve their owned artifact types for the
   core package. The seed phase resolves seed artifacts from its seed catalog. If the core package cannot be
   resolved, schema staging fails before starting containers.
-- When `-ApiSchemaPath` is used (expert mode), including extension-containing schema sets: each project in
-  the staged set has its security fragment resolved by the claims phase (auto-staged when a bootstrap-managed
-  fragment exists, e.g. Sample/Homograph; otherwise `-ClaimsDirectoryPath` is required). Schema hashing and DDL validation still work because bootstrap
-  stages and hashes the exact files. What is disabled is bootstrap-managed seed-package selection, not
-  automatic base security selection from the claims inputs available for the run. If the staged set needs
-  additional non-core claims metadata, `-ClaimsDirectoryPath` is required and bootstrap validates those
-  fragments only structurally. Bootstrap emits a warning indicating that compatibility with custom claimset
+- When `-ApiSchemaPath` is used (expert mode), including extension-containing schema sets: the claims phase
+  resolves security metadata for each project in the staged set. Sample and Homograph auto-stage their claim
+  fragments, TPDM is covered by the embedded DS 5.2 claims (no fragment staged, no `-ClaimsDirectoryPath`),
+  and any project with no bootstrap-managed mapping requires `-ClaimsDirectoryPath`. Schema hashing and DDL
+  validation still work because bootstrap stages and hashes the exact files. What is disabled is
+  bootstrap-managed seed-package selection, not automatic base security selection from the claims inputs
+  available for the run. If the staged set includes an unmapped extension needing additional non-core claims
+  metadata, `-ClaimsDirectoryPath` is required and bootstrap validates those fragments only structurally.
+  Bootstrap emits a warning indicating that compatibility with custom claimset
   fragments and custom seed data is validated against the explicit companion inputs for this run. The exact
   warning text is an implementation detail.
 - When `-ApiSchemaPath` is used (expert mode): The staged directory must normalize to exactly one
@@ -1558,10 +1560,12 @@ seed-catalog-driven (Story 02), and custom seed payloads flow through `-SeedData
    `EffectiveSchemaHash`, and writes the schema section of the bootstrap manifest for downstream phases.
 2. `prepare-dms-claims.ps1` consumes the bootstrap manifest schema section and the staged schema files. For
    each project in the staged set with a matching bootstrap-managed security fragment (Sample, Homograph),
-   it stages the corresponding JSON file(s) into `eng/docker-compose/.bootstrap/claims/` and resolves the
-   claims section to Hybrid mode; TPDM is bootstrap-mapped without a fragment (its claims ship in the
-   embedded DS 5.2 `Claims.json`), so it stays Embedded mode and records only its descriptor seed namespace;
-   a project with no bootstrap-managed mapping requires caller-supplied `-ClaimsDirectoryPath` fragments.
+   it stages the corresponding JSON file(s) into `eng/docker-compose/.bootstrap/claims/`. TPDM is
+   bootstrap-mapped without a fragment (its claims ship in the embedded DS 5.2 `Claims.json`), so it stages
+   nothing but records its descriptor seed namespace (`uri://tpdm.ed-fi.org`) and its leaf readiness checks;
+   a project with no bootstrap-managed mapping requires caller-supplied `-ClaimsDirectoryPath` fragments. The
+   claims section resolves to Embedded mode when no fragment is staged (e.g. core + TPDM) and Hybrid mode when
+   one or more are (e.g. Sample + TPDM, or a custom fragment).
    Config Service startup consumes that staged host claims
    workspace through the claims section of `eng/docker-compose/.bootstrap/bootstrap-manifest.json`. DMS gets
    claimsets from CMS authorization metadata, not from local fragment files, so DMS compose files do not
@@ -1635,12 +1639,13 @@ developer does not configure each separately:
    later hashed and mounted/read by DMS.
 
 2. **Security fragments loaded (Section 4)** - When the extension has a bootstrap-managed security fragment
-   (Sample, Homograph), the corresponding JSON file(s) are staged and the bootstrap manifest claims section
-   resolves to Hybrid mode automatically. TPDM is bootstrap-mapped without a fragment - its claims ship in
-   the embedded DS 5.2 `Claims.json`, so the claims section stays Embedded mode and only its descriptor seed
-   namespace (`uri://tpdm.ed-fi.org`) is recorded. An extension with no bootstrap-managed mapping requires
-   caller-supplied `-ClaimsDirectoryPath`. For built-in extension seed packages, those fragments
-   must attach both `EdFiSandbox` and `SeedLoader` permissions to the extension resources they cover.
+   (Sample, Homograph), the corresponding JSON file(s) are staged. TPDM is bootstrap-mapped without a
+   fragment - its claims ship in the embedded DS 5.2 `Claims.json`, so it stages nothing but records its
+   descriptor seed namespace (`uri://tpdm.ed-fi.org`) and its leaf readiness checks. An extension with no
+   bootstrap-managed mapping requires caller-supplied `-ClaimsDirectoryPath`. The claims section resolves to
+   Hybrid mode when one or more fragments are staged and Embedded mode when none are. For built-in extension
+   seed packages, those fragments must attach both `EdFiSandbox` and `SeedLoader` permissions to the
+   extension resources they cover.
 
 3. **Extension seed data handling (Section 8.3)** - When seed delivery runs, bootstrap checks whether an
    extension recorded in the manifest has a built-in seed package in the seed catalog. If none does, the seed

--- a/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
+++ b/reference/design/backend-redesign/design-docs/bootstrap/bootstrap-design.md
@@ -1824,7 +1824,7 @@ pwsh eng/docker-compose/bootstrap-local-dms.ps1
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedTemplate Minimal
 
 # Extension-containing schema set: stage via expert -ApiSchemaPath first, then run the wrapper
-pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath ../../src/dms/EdFi.DataStandard52.ApiSchema
+pwsh eng/docker-compose/prepare-dms-schema.ps1 -ApiSchemaPath <path-to-apischema-directory>
 pwsh eng/docker-compose/bootstrap-local-dms.ps1 -LoadSeedData -SeedDataPath ./my-seeds/
 
 # Keycloak-backed seed loading

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -49,8 +49,8 @@ Bootstrap must not invent a second schema fingerprint or a second schema-resolut
 In this story, the selected schema set drives the DDL target, the hash-validation path, and the exact
 physical schema footprint for the run. A direct filesystem input containing only the core schema yields only
 core tables. Core plus a known mapped extension such as Sample yields the tables required by that combined
-schema set. Unmapped extension schemas, including TPDM when supplied through direct filesystem input, are not
-silently substituted by Sample, Homograph, or any default mapping. A database provisioned for a different
+schema set. Unmapped extension schemas (a custom extension outside the built-in map) are not
+silently substituted by Sample, Homograph, TPDM, or any default mapping. A database provisioned for a different
 extension selection is incompatible existing state for this story's bootstrap run.
 
 Within the composable bootstrap design, schema selection and asset-container staging are owned exclusively by the
@@ -189,16 +189,13 @@ schema contract and claims-staging contract rather than introducing a second pat
   unmapped: `-ClaimsDirectoryPath` is required and the caller-supplied fragments are the only security
   inputs for those projects. The lookup is a v1 implementation detail of the claims phase, not a separate
   catalog artifact in the repo.
-- TPDM is not part of the Story 00 v1 mapped security-fragment surface. If TPDM appears in a direct
-  filesystem ApiSchema input, bootstrap treats it as unmapped and requires caller-supplied security fragments
-  through `-ClaimsDirectoryPath`; it is not silently replaced by `sample`, `homograph`, or any default.
-  > **Update (DMS-1247):** TPDM is now bootstrap-mapped for Data Standard 5.2. Because the embedded DS 5.2
-  > `Claims.json` already carries the full TPDM claims hierarchy and its `EdFiSandbox` grants, the claims
-  > phase recognizes TPDM without staging a fragment (Embedded mode) and no longer requires
-  > `-ClaimsDirectoryPath`. It records leaf readiness checks so the claims-ready gate confirms CMS composed
-  > TPDM, and records TPDM's descriptor seed namespace (`uri://tpdm.ed-fi.org`) so the `SeedLoader` credential
-  > can load TPDM descriptor seed data. `-ClaimsDirectoryPath` remains required only for extensions still
-  > outside the bootstrap map.
+- TPDM is bootstrap-mapped for Data Standard 5.2 (added by DMS-1247). The embedded DS 5.2 `Claims.json`
+  already carries the full TPDM claims hierarchy and its `EdFiSandbox` grants, so the claims phase recognizes
+  TPDM without staging a fragment (Embedded mode) and does not require `-ClaimsDirectoryPath`. It records leaf
+  readiness checks so the claims-ready gate confirms CMS composed TPDM, and records TPDM's descriptor seed
+  namespace (`uri://tpdm.ed-fi.org`) so the `SeedLoader` credential can load TPDM descriptor seed data. Any
+  other direct filesystem extension outside the built-in map is treated as unmapped: it requires
+  caller-supplied `-ClaimsDirectoryPath` fragments and is never silently replaced by a built-in mapping.
 
 ## Tasks
 
@@ -213,10 +210,9 @@ schema contract and claims-staging contract rather than introducing a second pat
    uses schema identity fields from the direct filesystem input, and `prepare-dms-claims.ps1` uses
    security-fragment fields. `load-dms-seed-data.ps1` owns the separate seed catalog lookup when seed delivery
    runs. `EdFiSandbox` coverage is required for every bootstrap-managed extension fragment and `SeedLoader`
-   coverage is required only where a built-in seed package is advertised. Story 00's v1 mapped security
-   lookup covers Sample and Homograph only; any other direct filesystem extension not in the lookup
-   is treated as unmapped and requires `-ClaimsDirectoryPath` (TPDM later became bootstrap-mapped via the
-   embedded DS 5.2 claims - see the DMS-1247 update note above).
+   coverage is required only where a built-in seed package is advertised. The v1 mapped security lookup
+   covered Sample and Homograph; DMS-1247 additionally maps TPDM via the embedded DS 5.2 claims. Any other
+   direct filesystem extension not in the lookup is treated as unmapped and requires `-ClaimsDirectoryPath`.
 3. Implement direct filesystem schema-materialization logic in `prepare-dms-schema.ps1`: normalize
    `-ApiSchemaPath` inputs into the staged workspace, normalize one core schema plus zero or more extension
    schemas into the staged ApiSchema asset workspace, copy optional schema-adjacent static content into

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -192,6 +192,11 @@ schema contract and claims-staging contract rather than introducing a second pat
 - TPDM is not part of the Story 00 v1 mapped security-fragment surface. If TPDM appears in a direct
   filesystem ApiSchema input, bootstrap treats it as unmapped and requires caller-supplied security fragments
   through `-ClaimsDirectoryPath`; it is not silently replaced by `sample`, `homograph`, or any default.
+  > **Update (DMS-1247):** TPDM is now bootstrap-mapped for Data Standard 5.2. Because the embedded DS 5.2
+  > `Claims.json` already carries the full TPDM claims hierarchy and its `EdFiSandbox` grants, the claims
+  > phase recognizes TPDM without staging a fragment (Embedded mode) and no longer requires
+  > `-ClaimsDirectoryPath`. It records leaf readiness checks so the claims-ready gate confirms CMS composed
+  > TPDM. `-ClaimsDirectoryPath` remains required only for extensions still outside the bootstrap map.
 
 ## Tasks
 

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -196,7 +196,9 @@ schema contract and claims-staging contract rather than introducing a second pat
   > `Claims.json` already carries the full TPDM claims hierarchy and its `EdFiSandbox` grants, the claims
   > phase recognizes TPDM without staging a fragment (Embedded mode) and no longer requires
   > `-ClaimsDirectoryPath`. It records leaf readiness checks so the claims-ready gate confirms CMS composed
-  > TPDM. `-ClaimsDirectoryPath` remains required only for extensions still outside the bootstrap map.
+  > TPDM, and records TPDM's descriptor seed namespace (`uri://tpdm.ed-fi.org`) so the `SeedLoader` credential
+  > can load TPDM descriptor seed data. `-ClaimsDirectoryPath` remains required only for extensions still
+  > outside the bootstrap map.
 
 ## Tasks
 
@@ -212,8 +214,9 @@ schema contract and claims-staging contract rather than introducing a second pat
    security-fragment fields. `load-dms-seed-data.ps1` owns the separate seed catalog lookup when seed delivery
    runs. `EdFiSandbox` coverage is required for every bootstrap-managed extension fragment and `SeedLoader`
    coverage is required only where a built-in seed package is advertised. Story 00's v1 mapped security
-   lookup covers Sample and Homograph only; TPDM and any other direct filesystem extension not in the lookup
-   are treated as unmapped and require `-ClaimsDirectoryPath`.
+   lookup covers Sample and Homograph only; any other direct filesystem extension not in the lookup
+   is treated as unmapped and requires `-ClaimsDirectoryPath` (TPDM later became bootstrap-mapped via the
+   embedded DS 5.2 claims - see the DMS-1247 update note above).
 3. Implement direct filesystem schema-materialization logic in `prepare-dms-schema.ps1`: normalize
    `-ApiSchemaPath` inputs into the staged workspace, normalize one core schema plus zero or more extension
    schemas into the staged ApiSchema asset workspace, copy optional schema-adjacent static content into

--- a/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
+++ b/reference/design/backend-redesign/epics/16-bootstrap/00-schema-and-security-selection.md
@@ -174,15 +174,17 @@ schema contract and claims-staging contract rather than introducing a second pat
 - CMS claims mode is driven from the staged inputs:
   - Embedded mode for core-only bootstrap,
   - Hybrid mode when one or more staged fragments exist.
-- Automatic extension-fragment selection in `prepare-dms-claims.ps1` is deterministic and explicit. The
-  command holds a short in-script lookup keyed by extension project identity from the staged schema set
-  (`projectName` from each non-core `ApiSchema*.json`) that maps to the exact shipped fragment filename
-  under `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/` (for v1:
-  `Sample` → `004-sample-extension-claimset.json`, `Homograph` → `005-homograph-extension-claimset.json`).
-  The same lookup records any built-in extension seed namespace prefix known to the DMS-916 bootstrap
-  contract; v1 records `Sample` → `uri://sample.ed-fi.org`. Entries without a known built-in seed namespace
-  prefix write no prefix to the root bootstrap manifest, and bootstrap must not infer prefixes from arbitrary
-  direct filesystem schema content.
+- Automatic extension security-metadata selection in `prepare-dms-claims.ps1` is deterministic and explicit.
+  The command holds a short in-script lookup keyed by extension project identity from the staged schema set
+  (`projectName` from each non-core `ApiSchema*.json`) that records, per built-in extension, how bootstrap
+  handles its security metadata: an optional shipped fragment filename under
+  `src/config/backend/EdFi.DmsConfigurationService.Backend/Deploy/AdditionalClaimsets/`, an optional seed
+  namespace prefix, and optional leaf readiness checks. For v1: `Sample` stages
+  `004-sample-extension-claimset.json` and records `uri://sample.ed-fi.org`; `Homograph` stages
+  `005-homograph-extension-claimset.json` (no distinct namespace); and `TPDM` stages no fragment (its claims
+  ship in the embedded DS 5.2 `Claims.json`), records `uri://tpdm.ed-fi.org`, and contributes leaf readiness
+  checks. Entries without a known built-in seed namespace prefix write no prefix to the root bootstrap
+  manifest, and bootstrap must not infer prefixes from arbitrary direct filesystem schema content.
   Core-baseline fragments (`001-namespace-claimset.json`, `002-nofurtherauth-claimset.json`,
   `003-edorgsonly-claimset.json`) remain part of embedded `Claims.json` loading and are never staged into
   the additive workspace. Staged extensions whose `projectName` is not in the lookup are treated as
@@ -279,7 +281,7 @@ schema contract and claims-staging contract rather than introducing a second pat
    resources ahead of runtime.
 12. Add focused tests for the Story 00 staging contracts: schema workspace normalization and collision
     detection, schema and claims rerun fingerprint mismatch handling, selected-extension manifest identity,
-    automatic extension-fragment filtering, known namespace-prefix handoff, Story 00 deferral of the staged
+    automatic extension security-metadata mapping, known namespace-prefix handoff, Story 00 deferral of the staged
     Config Service claims mount source to Story 04, and structural claim-fragment validation failures.
 
 ## Out of Scope


### PR DESCRIPTION
## Summary

Enables a core + TPDM `-ApiSchemaPath` (Expert mode) bootstrap to stage and load TPDM security metadata without a caller-supplied `-ClaimsDirectoryPath` or any manual SQL/database edits.

Previously `prepare-dms-claims.ps1` treated TPDM as an *unmapped* extension and threw `ClaimsDirectoryPath is required ... TPDM`, blocking core + TPDM bootstrap. The embedded DS 5.2 `Claims.json` (introduced by DMS-1136, PR #1043) already carries the **full TPDM claims hierarchy and its `EdFiSandbox` CRUD grants** — `domains/tpdm` directly, TPDM descriptors via `domains/systemDescriptors`, `tpdm/candidate` via `domains/people`, and the survey-response associations via `domains/relationshipBasedData/surveyDomain`. So the fix is a metadata mapping, **not** a duplicated claims fragment.

## Changes

- **`bootstrap-schema-catalog.psm1`** — add a `TPDM` entry to `KnownExtensionClaimsMetadata`:
  - No fragment file (embedded DS 5.2 claims already cover TPDM; duplicating would be redundant).
  - `NamespacePrefix = "uri://tpdm.ed-fi.org"` — TPDM descriptor data uses the distinct namespace (unlike Homograph), so the auto-provisioned SeedLoader credential must carry it to load TPDM descriptor seed data.
  - Leaf `VerificationChecks` — one TPDM descriptor (`credentialStatusDescriptor`) and one TPDM resource (`evaluation`), both `EdFiSandbox`/`Read` — so the claims-ready gate confirms CMS actually composed TPDM.
  - The map is backed by an Ordinal (case-sensitive) dictionary so a look-alike custom extension (e.g. `Tpdm`) cannot resolve to built-in TPDM through any access path.
- **`prepare-dms-claims.ps1`** — fold known-extension `VerificationChecks` into the manifest `claims.expectedVerificationChecks`; validate each catalog entry (reject one that contributes no security metadata, and reject a malformed `VerificationChecks` entry via the sink's `-ThrowOnInvalid`) rather than silently dropping it. Core + TPDM stages **Embedded** claims mode with a deterministic (empty-claims) fingerprint and records the TPDM seed namespace prefix.
- **`bootstrap-claims-gate.psm1`** — memoize `/authorizationMetadata` per claim set so multiple checks on the same claim set make a single fetch (`Assert-SingleVerificationCheck` takes pre-fetched metadata).
- **Tests**
  - `BootstrapSchemaAndSecuritySelection.Tests.ps1` — TPDM-mapped staging, verification-check recording, namespace-prefix recording, Hybrid alongside Sample, full core + Sample + Homograph + TPDM, case-sensitive lookup, the catalog-validation guards, and an anchor asserting each TPDM check URI is a **leaf** reachable by an `EdFiSandbox`/`Read` grant in the embedded `Claims.json`.
  - `BootstrapClaimsGate.Tests.ps1` — CMS load verification: `Test-CmsClaimsReady` passes when CMS composed the TPDM leaf claims and fails when a TPDM leaf is absent from `/authorizationMetadata`.
- **Docs** — update `eng/docker-compose/README.md`, script help, and the bootstrap design docs for the TPDM mapping. The expert-mode `-ApiSchemaPath` example uses `../../src/dms/EdFi.DataStandard52.ApiSchema` — the `.gitignore`-reserved conventional local materialization directory — with a note that it is absent on a fresh checkout and must be populated first (or point `-ApiSchemaPath` at any local directory containing the `ApiSchema*.json` files).

## Version scope

DS 5.2 only — TPDM is a separate extension there. DS 6.1 folds TPDM into core and ships no TPDM extension package, so this path is only ever reached by a DS 5.2 bootstrap; CMS uses DS 5.2 claims via the default `DMS_CONFIG_DATA_STANDARD_VERSION=5.2`. No data-standard-versioning or embedded-claims rework.

## Non-goals

No new claimset fragment, no embedded `Claims.json` edits, no `eng/CmsHierarchy/ClaimSetFiles` changes, no DS 6.1 TPDM package, no `-Extensions` in standard mode, no claims-loading/schema/runtime-auth redesign.

## Testing

- `BootstrapSchemaAndSecuritySelection.Tests.ps1` and `BootstrapClaimsGate.Tests.ps1` Pester suites — see the CI job for authoritative results. (Two pre-existing `run.sh` cases that shell out to `chmod` fail only on Windows dev boxes without `chmod`; they are untouched by this change and pass on Linux CI.)
- The committed `BootstrapClaimsGate.Tests.ps1` coverage verifies the claims-ready gate confirms CMS serves the TPDM claims via `/authorizationMetadata`.
- Core-only, Sample, and Homograph behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
