### PR TITLE
[DMS-1133] Fixes for NuGet Package Security

### DIFF
--- a/.github/workflows/dependabot-lock-file.yml
+++ b/.github/workflows/dependabot-lock-file.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           # The restore step below evaluates Dependabot-bumped packages, so do not leave a
@@ -64,5 +64,9 @@ jobs:
             echo "No lock file changes to commit."
           else
             git -c core.hooksPath=/dev/null commit --no-verify -m "Update packages.lock.json after Dependabot package update"
-            git -c core.hooksPath=/dev/null push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "HEAD:${{ github.head_ref }}"
+            # Push the current branch (checked out at github.head_ref above) back to the
+            # same-named remote branch. Using the bare HEAD refspec keeps the untrusted
+            # github.head_ref out of this run step, which resolves the expression-injection
+            # code-scanning alert; the checkout leaves HEAD on the PR branch.
+            git -c core.hooksPath=/dev/null push --no-verify "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git" HEAD
           fi


### PR DESCRIPTION
## Summary

  - Resolve code-scanning alert 1409 (expression injection) in the Dependabot lock-file workflow. The final push step interpolated the attacker-influenceable ${{ github.head_ref }} directly into a run: shell command. Since the checkout step already leaves HEAD on the PR branch, the push now uses a bare HEAD refspec instead of HEAD:${{ github.head_ref }} — pushing to the same-named  remote branch with identical behavior, but keeping the untrusted input out of the shell. The checkout's with: ref: input is unchanged (action inputs aren't an injection vector).
  - Bump actions/checkout from v4.2.2 → v7.0.0 (latest stable). actions/checkout is a first-party actions/* action, so per the action-allowedlist policy it can track latest stable without an approved.json entry. Safe for this workflow: it triggers on plain pull_request, runs on ubuntu-latest (satisfies v5's