### PR TITLE
[DMS-1256] 401 authentication error contract diverges from design doc and ODS/API

### DIFF
--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -143,7 +143,8 @@ externally-issued tokens), the following compensating controls bound the risk:
   `detail` `The caller could not be authenticated.` — matching the design-doc and
   ODS/API contract. The `errors` array carries only a **coarse, approved
   classification** of the failure (a missing, unknown-scheme, empty, or malformed
-  `Authorization` header, or `Invalid token`); it never discloses a stack trace,
+  `Authorization` header, an absent client-authorization context, or `Invalid token`);
+  it never discloses a stack trace,
   cryptographic detail, or the specific reason a token failed validation —
   expiry, bad signature, and bad claims all collapse to `Invalid token`. Full
   specifics are logged server-side only. This preserves the ODS/API-compatible

--- a/docs/OWASP-AUTH-COVERAGE.md
+++ b/docs/OWASP-AUTH-COVERAGE.md
@@ -137,10 +137,17 @@ externally-issued tokens), the following compensating controls bound the risk:
 - **Server-side revocation (CMS self-contained only).** The per-request `jti`
   status check plus `/connect/revoke` provide immediate revocation for
   self-contained tokens.
-- **No internal-detail leakage on failure.** Authentication failures return a
-  generic `401` (`application/problem+json` for DMS) with no failure-reason or
-  stack-trace disclosure; specifics are logged server-side only. This avoids
-  giving an attacker oracles that would aid token forgery or replay.
+- **No sensitive-detail leakage on failure.** DMS authentication failures return
+  a fixed `application/problem+json` `401` body — `type`
+  `urn:ed-fi:api:security:authentication`, `title` `Authentication Failed`,
+  `detail` `The caller could not be authenticated.` — matching the design-doc and
+  ODS/API contract. The `errors` array carries only a **coarse, approved
+  classification** of the failure (a missing, unknown-scheme, empty, or malformed
+  `Authorization` header, or `Invalid token`); it never discloses a stack trace,
+  cryptographic detail, or the specific reason a token failed validation —
+  expiry, bad signature, and bad claims all collapse to `Invalid token`. Full
+  specifics are logged server-side only. This preserves the ODS/API-compatible
+  contract while avoiding oracles that would aid token forgery or replay.
 
 ## Test coverage map
 
@@ -163,8 +170,10 @@ The behaviors above are exercised by automated tests:
 
 - DMS — `EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature`:
   valid JWT replayed multiple times within its lifetime is accepted;
-  manipulated-signature tokens are rejected; authentication-failure responses do
-  not leak internal details. (The feature's "expired" scenario rewrites `exp`
+  manipulated-signature tokens are rejected; authentication failures return the
+  fixed problem-details contract (`urn:ed-fi:api:security:authentication`) with
+  only a coarse failure classification and no internal-detail leak. (The
+  feature's "expired" scenario rewrites `exp`
   without re-signing, so it is rejected on signature validation before expiry is
   evaluated; true-expiry rejection via the lifetime check is covered by the DMS
   unit test above.)

--- a/reference/design/backend-redesign/design-docs/auth.md
+++ b/reference/design/backend-redesign/design-docs/auth.md
@@ -1336,6 +1336,7 @@ Notice how the securable element paths got translated:
 | `Bearer` scheme present but token value is empty | `Missing Authorization header bearer token value.` |
 | Malformed or unparseable `Authorization` header | `Invalid Authorization header.` |
 | Token not found or expired | `Invalid token` |
+| Authorization stage reached without resolved client authorizations | `No authorization information found. Ensure valid JWT token is provided.` |
 
 #### 2. Authorization Denied (403 Forbidden)
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/AuthorizationHeaderParserTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/AuthorizationHeaderParserTests.cs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Middleware;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Middleware;
+
+/// <summary>
+/// Holds the full Authorization header classification matrix for the shared
+/// <see cref="AuthorizationHeaderParser"/>. The JWT authentication and JWT
+/// role-authentication middleware test suites each keep only a representative
+/// wiring case per error detail; classification cases belong here.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class AuthorizationHeaderParserTests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Malformed_Authorization_Header : AuthorizationHeaderParserTests
+    {
+        // Blank values: a present-but-blank header has no parseable scheme.
+        [TestCase("")]
+        [TestCase("   ")]
+        // Repeated-header folds: a comma in the scheme is the fold signature of a repeated
+        // Authorization header (unparseable per RFC 7235), including a blank first value.
+        [TestCase(",")]
+        [TestCase(",Bearer abc")]
+        [TestCase("Bearer,junk")]
+        // Comma in the token: not in the RFC 6750 token alphabet; also the fold signature
+        // when the first value is a well-formed Bearer credential.
+        [TestCase("Bearer valid,junk")]
+        [TestCase("Bearer valid,")]
+        // Whitespace in or before the token: a JWT never contains whitespace, and only
+        // space(s) are a valid scheme/token separator.
+        [TestCase("Bearer abc def")]
+        [TestCase("Bearer\tabc")]
+        [TestCase("Bearer ab\tc")]
+        [TestCase("Bearer \tabc")]
+        public void It_classifies_the_header_as_invalid(string authHeader)
+        {
+            AuthorizationHeaderResult result = AuthorizationHeaderParser.Parse(authHeader);
+
+            result.IsValid.Should().BeFalse();
+            result.ErrorDetail.Should().Be("Invalid Authorization header.");
+            result.Token.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Bearer_Header_Without_A_Token_Value : AuthorizationHeaderParserTests
+    {
+        [TestCase("Bearer")]
+        [TestCase("Bearer ")]
+        [TestCase("Bearer   ")]
+        [TestCase("bearer")]
+        public void It_classifies_the_token_value_as_missing(string authHeader)
+        {
+            AuthorizationHeaderResult result = AuthorizationHeaderParser.Parse(authHeader);
+
+            result.IsValid.Should().BeFalse();
+            result.ErrorDetail.Should().Be("Missing Authorization header bearer token value.");
+            result.Token.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Non_Bearer_Authorization_Header : AuthorizationHeaderParserTests
+    {
+        [TestCase("Basic dXNlcjpwYXNz")]
+        // No scheme/token separator: guards against Bearer prefix-match regressions.
+        [TestCase("BearerToken")]
+        // Commas in a single well-formed non-Bearer credential's auth-params are legitimate
+        // (RFC 7235); the scheme is unknown, the header is not malformed.
+        [TestCase("Digest username=\"u\", realm=\"r\", nonce=\"n\"")]
+        [TestCase("AWS4-HMAC-SHA256 Credential=abc, SignedHeaders=host, Signature=def")]
+        public void It_classifies_the_scheme_as_unknown(string authHeader)
+        {
+            AuthorizationHeaderResult result = AuthorizationHeaderParser.Parse(authHeader);
+
+            result.IsValid.Should().BeFalse();
+            result.ErrorDetail.Should().Be("Unknown Authorization header scheme.");
+            result.Token.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Well_Formed_Bearer_Header : AuthorizationHeaderParserTests
+    {
+        [TestCase("Bearer abc", "abc")]
+        // The scheme is case-insensitive.
+        [TestCase("bearer abc", "abc")]
+        // Multiple separating spaces are stripped; only the token remains.
+        [TestCase("Bearer   abc", "abc")]
+        // Surrounding optional whitespace is trimmed before parsing.
+        [TestCase(" Bearer abc ", "abc")]
+        public void It_extracts_the_bearer_token(string authHeader, string expectedToken)
+        {
+            AuthorizationHeaderResult result = AuthorizationHeaderParser.Parse(authHeader);
+
+            result.IsValid.Should().BeTrue();
+            result.Token.Should().Be(expectedToken);
+            result.ErrorDetail.Should().BeNull();
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -318,6 +318,8 @@ public class JwtAuthenticationMiddlewareTests
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
     [TestFixture("bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
+    [TestFixture("Bearer valid,junk", "Invalid Authorization header.")]
+    [TestFixture("Bearer valid,", "Invalid Authorization header.")]
     [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
     [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
     [TestFixture("Bearer \tabc", "Invalid Authorization header.")]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -73,8 +73,7 @@ public class JwtAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>._
                     )
                 )
@@ -141,8 +140,7 @@ public class JwtAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer invalid-token",
-                        "Bearer ".Length,
+                        "invalid-token",
                         A<CancellationToken>._
                     )
                 )
@@ -414,8 +412,7 @@ public class JwtAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>._
                     )
                 )

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -313,6 +313,67 @@ public class JwtAuthenticationMiddlewareTests
         }
     }
 
+    [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("   ", "Invalid Authorization header.")]
+    [Parallelizable]
+    public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(
+        string _authHeader,
+        string _expectedError
+    ) : JwtAuthenticationMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+        private bool _nextCalled = false;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var frontendRequest = new FrontendRequest(
+                Path: "/ed-fi/students",
+                Body: null,
+                Form: null,
+                Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Authorization"] = _authHeader,
+                },
+                QueryParameters: [],
+                TraceId: new TraceId("123"),
+                RouteQualifiers: []
+            );
+            _requestInfo = new RequestInfo(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+
+            var (middleware, _) = CreateMiddleware();
+
+            await middleware.Execute(
+                _requestInfo,
+                () =>
+                {
+                    _nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+        }
+
+        [Test]
+        public void It_does_not_call_the_next_middleware()
+        {
+            _nextCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_returns_401_unauthorized()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, _expectedError);
+        }
+    }
+
     [TestFixture]
     [Parallelizable]
     public class Given_A_Request_With_Case_Insensitive_Authorization_Header : JwtAuthenticationMiddlewareTests

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -313,18 +313,10 @@ public class JwtAuthenticationMiddlewareTests
         }
     }
 
-    [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
+    // One representative wiring case per error detail; the full header classification
+    // matrix lives in AuthorizationHeaderParserTests.
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
-    [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
-    [TestFixture("bearer", "Missing Authorization header bearer token value.")]
-    [TestFixture("Bearer abc def", "Invalid Authorization header.")]
-    [TestFixture("Bearer valid,junk", "Invalid Authorization header.")]
-    [TestFixture("Bearer valid,", "Invalid Authorization header.")]
-    [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
-    [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
-    [TestFixture("Bearer \tabc", "Invalid Authorization header.")]
     [TestFixture("", "Invalid Authorization header.")]
-    [TestFixture("   ", "Invalid Authorization header.")]
     [TestFixture("BearerToken", "Unknown Authorization header scheme.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -316,8 +316,13 @@ public class JwtAuthenticationMiddlewareTests
     [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
+    [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
+    [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
+    [TestFixture("", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
+    [TestFixture("BearerToken", "Unknown Authorization header scheme.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(
         string _authHeader,

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -198,6 +198,12 @@ public class JwtAuthenticationMiddlewareTests
             // Ensures the response body is a proper JsonNode object, not a serialized string.
             _requestInfo.FrontendResponse.Body.Should().BeOfType<JsonObject>();
         }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Invalid token");
+        }
     }
 
     [TestFixture]
@@ -249,6 +255,12 @@ public class JwtAuthenticationMiddlewareTests
         public void It_includes_error_detail_in_response_body()
         {
             _requestInfo.FrontendResponse.Body?.ToString().Should().Contain("Bearer token required");
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
         }
     }
 
@@ -304,6 +316,12 @@ public class JwtAuthenticationMiddlewareTests
         public void It_includes_error_detail_in_response_body()
         {
             _requestInfo.FrontendResponse.Body?.ToString().Should().Contain("Bearer token required");
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -320,6 +320,7 @@ public class JwtAuthenticationMiddlewareTests
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
     [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
     [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
+    [TestFixture("Bearer \tabc", "Invalid Authorization header.")]
     [TestFixture("", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
     [TestFixture("BearerToken", "Unknown Authorization header scheme.")]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -316,6 +316,7 @@ public class JwtAuthenticationMiddlewareTests
     [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer abc def", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtAuthenticationMiddlewareTests.cs
@@ -187,12 +187,6 @@ public class JwtAuthenticationMiddlewareTests
         }
 
         [Test]
-        public void It_includes_error_detail_in_response_body()
-        {
-            _requestInfo.FrontendResponse.Body?.ToString().Should().Contain("Invalid token");
-        }
-
-        [Test]
         public void It_returns_body_as_JsonObject_not_string()
         {
             // Ensures the response body is a proper JsonNode object, not a serialized string.
@@ -252,15 +246,12 @@ public class JwtAuthenticationMiddlewareTests
         }
 
         [Test]
-        public void It_includes_error_detail_in_response_body()
-        {
-            _requestInfo.FrontendResponse.Body?.ToString().Should().Contain("Bearer token required");
-        }
-
-        [Test]
         public void It_returns_the_authentication_failed_problem_details()
         {
-            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
+            AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse!,
+                "Authorization header is missing."
+            );
         }
     }
 
@@ -313,15 +304,12 @@ public class JwtAuthenticationMiddlewareTests
         }
 
         [Test]
-        public void It_includes_error_detail_in_response_body()
-        {
-            _requestInfo.FrontendResponse.Body?.ToString().Should().Contain("Bearer token required");
-        }
-
-        [Test]
         public void It_returns_the_authentication_failed_problem_details()
         {
-            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
+            AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse!,
+                "Unknown Authorization header scheme."
+            );
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -467,6 +467,7 @@ public class JwtRoleAuthenticationMiddlewareTests
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
     [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
     [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
+    [TestFixture("Bearer \tabc", "Invalid Authorization header.")]
     [TestFixture("", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
     [TestFixture("BearerToken", "Unknown Authorization header scheme.")]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -465,6 +465,8 @@ public class JwtRoleAuthenticationMiddlewareTests
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
     [TestFixture("bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
+    [TestFixture("Bearer valid,junk", "Invalid Authorization header.")]
+    [TestFixture("Bearer valid,", "Invalid Authorization header.")]
     [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
     [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
     [TestFixture("Bearer \tabc", "Invalid Authorization header.")]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -460,6 +460,67 @@ public class JwtRoleAuthenticationMiddlewareTests
         }
     }
 
+    [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("   ", "Invalid Authorization header.")]
+    [Parallelizable]
+    public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(
+        string _authHeader,
+        string _expectedError
+    ) : JwtRoleAuthenticationMiddlewareTests
+    {
+        private RequestInfo _requestInfo = No.RequestInfo();
+        private bool _nextCalled = false;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var frontendRequest = new FrontendRequest(
+                Path: "/test",
+                Body: "{}",
+                Form: null,
+                Headers: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["Authorization"] = _authHeader,
+                },
+                QueryParameters: [],
+                TraceId: new TraceId("trace123"),
+                RouteQualifiers: []
+            );
+            _requestInfo = new RequestInfo(frontendRequest, RequestMethod.GET, No.ServiceProvider);
+
+            var (middleware, _, _) = CreateMiddleware();
+
+            await middleware.Execute(
+                _requestInfo,
+                () =>
+                {
+                    _nextCalled = true;
+                    return Task.CompletedTask;
+                }
+            );
+        }
+
+        [Test]
+        public void It_does_not_call_the_next_middleware()
+        {
+            _nextCalled.Should().BeFalse();
+        }
+
+        [Test]
+        public void It_returns_401_unauthorized()
+        {
+            _requestInfo.FrontendResponse!.StatusCode.Should().Be(401);
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, _expectedError);
+        }
+    }
+
     [TestFixture]
     [Parallelizable]
     public class Given_A_Request_With_Case_Insensitive_Authorization_Header

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -460,18 +460,10 @@ public class JwtRoleAuthenticationMiddlewareTests
         }
     }
 
-    [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
+    // One representative wiring case per error detail; the full header classification
+    // matrix lives in AuthorizationHeaderParserTests.
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
-    [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
-    [TestFixture("bearer", "Missing Authorization header bearer token value.")]
-    [TestFixture("Bearer abc def", "Invalid Authorization header.")]
-    [TestFixture("Bearer valid,junk", "Invalid Authorization header.")]
-    [TestFixture("Bearer valid,", "Invalid Authorization header.")]
-    [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
-    [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
-    [TestFixture("Bearer \tabc", "Invalid Authorization header.")]
     [TestFixture("", "Invalid Authorization header.")]
-    [TestFixture("   ", "Invalid Authorization header.")]
     [TestFixture("BearerToken", "Unknown Authorization header scheme.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -463,8 +463,13 @@ public class JwtRoleAuthenticationMiddlewareTests
     [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer abc def", "Invalid Authorization header.")]
+    [TestFixture("Bearer\tabc", "Invalid Authorization header.")]
+    [TestFixture("Bearer ab\tc", "Invalid Authorization header.")]
+    [TestFixture("", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
+    [TestFixture("BearerToken", "Unknown Authorization header scheme.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(
         string _authHeader,

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -463,6 +463,7 @@ public class JwtRoleAuthenticationMiddlewareTests
     [TestFixture("Bearer ", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer", "Missing Authorization header bearer token value.")]
     [TestFixture("Bearer   ", "Missing Authorization header bearer token value.")]
+    [TestFixture("Bearer abc def", "Invalid Authorization header.")]
     [TestFixture("   ", "Invalid Authorization header.")]
     [Parallelizable]
     public class Given_A_Request_With_A_Malformed_Bearer_Authorization_Header(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -102,15 +102,12 @@ public class JwtRoleAuthenticationMiddlewareTests
         }
 
         [Test]
-        public void It_includes_error_detail_in_response_body()
-        {
-            _requestInfo.FrontendResponse!.Body?.ToString().Should().Contain("Bearer token required");
-        }
-
-        [Test]
         public void It_returns_the_authentication_failed_problem_details()
         {
-            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
+            AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse!,
+                "Authorization header is missing."
+            );
         }
     }
 
@@ -165,7 +162,10 @@ public class JwtRoleAuthenticationMiddlewareTests
         [Test]
         public void It_returns_the_authentication_failed_problem_details()
         {
-            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
+            AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse!,
+                "Unknown Authorization header scheme."
+            );
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -197,8 +197,7 @@ public class JwtRoleAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer invalid-token",
-                        "Bearer ".Length,
+                        "invalid-token",
                         A<CancellationToken>.Ignored
                     )
                 )
@@ -276,8 +275,7 @@ public class JwtRoleAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>.Ignored
                     )
                 )
@@ -361,8 +359,7 @@ public class JwtRoleAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>.Ignored
                     )
                 )
@@ -430,8 +427,7 @@ public class JwtRoleAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>.Ignored
                     )
                 )
@@ -566,8 +562,7 @@ public class JwtRoleAuthenticationMiddlewareTests
 
             A.CallTo(() =>
                     jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                        "Bearer valid-token",
-                        "Bearer ".Length,
+                        "valid-token",
                         A<CancellationToken>.Ignored
                     )
                 )

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/JwtRoleAuthenticationMiddlewareTests.cs
@@ -15,6 +15,7 @@ using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NUnit.Framework;
+using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
 
 namespace EdFi.DataManagementService.Core.Tests.Unit.Middleware;
 
@@ -105,6 +106,12 @@ public class JwtRoleAuthenticationMiddlewareTests
         {
             _requestInfo.FrontendResponse!.Body?.ToString().Should().Contain("Bearer token required");
         }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
+        }
     }
 
     [TestFixture]
@@ -153,6 +160,12 @@ public class JwtRoleAuthenticationMiddlewareTests
         public void It_returns_401_unauthorized()
         {
             _requestInfo.FrontendResponse!.StatusCode.Should().Be(401);
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Bearer token required");
         }
     }
 
@@ -211,6 +224,12 @@ public class JwtRoleAuthenticationMiddlewareTests
         public void It_returns_401_unauthorized()
         {
             _requestInfo.FrontendResponse!.StatusCode.Should().Be(401);
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(_requestInfo.FrontendResponse!, "Invalid token");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
@@ -179,7 +179,8 @@ public class ProvideAuthorizationFiltersMiddlewareTests
             _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
 
             JsonObject body = _requestInfo.FrontendResponse.Body!.AsObject();
-            body["title"]!.GetValue<string>().Should().Be("Unauthorized");
+            body["title"]!.GetValue<string>().Should().Be("Authentication Failed");
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:security:authentication");
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
@@ -3,7 +3,6 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.ApiSchema.Model;
 using EdFi.DataManagementService.Core.External.Frontend;
@@ -178,9 +177,12 @@ public class ProvideAuthorizationFiltersMiddlewareTests
             _requestInfo.FrontendResponse.StatusCode.Should().Be(401);
             _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
 
-            JsonObject body = _requestInfo.FrontendResponse.Body!.AsObject();
-            body["title"]!.GetValue<string>().Should().Be("Authentication Failed");
-            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:security:authentication");
+            // Pin the full authentication-failure body contract on the identical shared shape
+            // the sibling ResourceActionAuthorizationMiddleware path asserts.
+            TestHelper.AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse,
+                "No authorization information found. Ensure valid JWT token is provided."
+            );
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ProvideAuthorizationFiltersMiddlewareTests.cs
@@ -182,5 +182,15 @@ public class ProvideAuthorizationFiltersMiddlewareTests
             body["title"]!.GetValue<string>().Should().Be("Authentication Failed");
             body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:security:authentication");
         }
+
+        [Test]
+        public void It_includes_www_authenticate_header()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().ContainKey("WWW-Authenticate");
+            _requestInfo
+                .FrontendResponse.Headers["WWW-Authenticate"]
+                .Should()
+                .Be("Bearer error=\"invalid_token\"");
+        }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ResourceActionAuthorizationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ResourceActionAuthorizationMiddlewareTests.cs
@@ -265,6 +265,48 @@ public class ResourceActionAuthorizationMiddlewareTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_No_Client_Authorizations : ResourceActionAuthorizationMiddlewareTests
+    {
+        [SetUp]
+        public async Task Setup()
+        {
+            FrontendRequest frontEndRequest = new(
+                Path: "ed-fi/schools",
+                Body: """{ "schoolId":"12345", "nameOfInstitution":"School Test"}""",
+                Form: null,
+                Headers: [],
+                QueryParameters: [],
+                TraceId: new TraceId("traceId"),
+                RouteQualifiers: []
+            );
+
+            _requestInfo = new RequestInfo(frontEndRequest, RequestMethod.POST, No.ServiceProvider)
+            {
+                ClientAuthorizations = No.ClientAuthorizations,
+            };
+
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_returns_401_unauthorized()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(401);
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/problem+json");
+        }
+
+        [Test]
+        public void It_returns_the_authentication_failed_problem_details()
+        {
+            AssertUnauthorizedProblemDetails(
+                _requestInfo.FrontendResponse,
+                "No authorization information found. Ensure valid JWT token is provided."
+            );
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_No_Matching_ClaimSet : ResourceActionAuthorizationMiddlewareTests
     {
         [SetUp]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ResourceActionAuthorizationMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ResourceActionAuthorizationMiddlewareTests.cs
@@ -303,6 +303,16 @@ public class ResourceActionAuthorizationMiddlewareTests
                 "No authorization information found. Ensure valid JWT token is provided."
             );
         }
+
+        [Test]
+        public void It_includes_www_authenticate_header()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().ContainKey("WWW-Authenticate");
+            _requestInfo
+                .FrontendResponse.Headers["WWW-Authenticate"]
+                .Should()
+                .Be("Bearer error=\"invalid_token\"");
+        }
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
@@ -103,6 +103,9 @@ public static class TestHelper
         body["detail"]!.GetValue<string>().Should().Be("The caller could not be authenticated.");
         body["status"]!.GetValue<int>().Should().Be(401);
 
-        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Contain(expectedError);
+        // The contract carries exactly the one scenario message and, unlike the other
+        // problem-details factories, emits no validationErrors member.
+        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Equal(expectedError);
+        body["validationErrors"].Should().BeNull();
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
@@ -103,6 +103,11 @@ public static class TestHelper
         body["detail"]!.GetValue<string>().Should().Be("The caller could not be authenticated.");
         body["status"]!.GetValue<int>().Should().Be(401);
 
+        // correlationId is part of the DMS problem-details contract; assert it is present and
+        // non-empty so a silent drop from the factory is caught here (E2E strips it downstream).
+        body["correlationId"].Should().NotBeNull();
+        body["correlationId"]!.GetValue<string>().Should().NotBeNullOrEmpty();
+
         // The contract carries exactly the one scenario message and, unlike the other
         // problem-details factories, emits no validationErrors member.
         body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Equal(expectedError);

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/TestHelper.cs
@@ -3,15 +3,18 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Startup;
 using EdFi.DataManagementService.Core.Tests.Unit.Handler;
 using FakeItEasy;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -83,5 +86,23 @@ public static class TestHelper
         services.AddTransient<ILogger<ResolveMappingSetMiddleware>>(_ =>
             NullLogger<ResolveMappingSetMiddleware>.Instance
         );
+    }
+
+    /// <summary>
+    /// Asserts that a 401 response body matches the design-doc / ODS authentication
+    /// problem-details contract (urn:ed-fi:api:security:authentication), carrying the
+    /// given scenario message in the errors array.
+    /// </summary>
+    public static void AssertUnauthorizedProblemDetails(IFrontendResponse response, string expectedError)
+    {
+        response.Body.Should().NotBeNull();
+        JsonNode body = response.Body!;
+
+        body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:security:authentication");
+        body["title"]!.GetValue<string>().Should().Be("Authentication Failed");
+        body["detail"]!.GetValue<string>().Should().Be("The caller could not be authenticated.");
+        body["status"]!.GetValue<int>().Should().Be(401);
+
+        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Contain(expectedError);
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -28,24 +28,39 @@ internal static class AuthorizationHeaderParser
         }
 
         string trimmed = authHeader.Trim();
-        int separatorIndex = trimmed.IndexOf(' ');
 
-        string scheme = separatorIndex < 0 ? trimmed : trimmed[..separatorIndex];
-        string parameter = separatorIndex < 0 ? string.Empty : trimmed[(separatorIndex + 1)..].Trim();
+        // The scheme is the leading run of non-whitespace characters. Reading up to the first
+        // whitespace of any kind (not only a literal space) means a header whose scheme and
+        // token are separated by a tab or other whitespace (e.g. "Bearer\tabc") is recognized
+        // as the Bearer scheme with a malformed separator rather than as an unknown scheme.
+        int schemeEnd = 0;
+        while (schemeEnd < trimmed.Length && !char.IsWhiteSpace(trimmed[schemeEnd]))
+        {
+            schemeEnd++;
+        }
 
+        string scheme = trimmed[..schemeEnd];
         if (!string.Equals(scheme, BearerScheme, StringComparison.OrdinalIgnoreCase))
         {
             return AuthorizationHeaderResult.Error("Unknown Authorization header scheme.");
         }
 
-        if (string.IsNullOrWhiteSpace(parameter))
+        string remainder = trimmed[schemeEnd..];
+        if (remainder.Length == 0)
         {
             return AuthorizationHeaderResult.Error("Missing Authorization header bearer token value.");
         }
 
-        // A Bearer token (a JWT) never contains whitespace. An embedded space means the value
-        // did not parse as a single "Bearer <token>" credential, so treat it as a malformed header
-        // rather than passing a multi-token value through to JWT validation.
+        // A well-formed Bearer credential separates the scheme from the token with a single
+        // space and carries a whitespace-free token (a JWT never contains whitespace). A
+        // non-space separator (tab, newline) or a multi-token value is a malformed header,
+        // not a credential to pass through to JWT validation.
+        if (remainder[0] != ' ')
+        {
+            return AuthorizationHeaderResult.Error("Invalid Authorization header.");
+        }
+
+        string parameter = remainder.Trim();
         if (parameter.Any(char.IsWhiteSpace))
         {
             return AuthorizationHeaderResult.Error("Invalid Authorization header.");

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -40,6 +40,18 @@ internal static class AuthorizationHeaderParser
         }
 
         string scheme = trimmed[..schemeEnd];
+
+        // A comma in the scheme marks a repeated Authorization header folded into a single value
+        // (e.g. ",Bearer <token>" from a blank first value, or "Bearer,junk" with no separating
+        // space) — unparseable per RFC 7235 and malformed rather than an unknown scheme. The
+        // check is scoped to the scheme (and to the parameter below), NOT the whole value, so a
+        // single well-formed non-Bearer credential whose grammar legitimately carries commas in
+        // its auth-params (e.g. Digest, AWS SigV4) still classifies as an unknown scheme.
+        if (scheme.Contains(','))
+        {
+            return AuthorizationHeaderResult.Error("Invalid Authorization header.");
+        }
+
         if (!string.Equals(scheme, BearerScheme, StringComparison.OrdinalIgnoreCase))
         {
             return AuthorizationHeaderResult.Error("Unknown Authorization header scheme.");

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -51,16 +51,13 @@ internal static class AuthorizationHeaderParser
             return AuthorizationHeaderResult.Error("Missing Authorization header bearer token value.");
         }
 
-        // A well-formed Bearer credential separates the scheme from the token with a single
-        // space and carries a whitespace-free token (a JWT never contains whitespace). A
-        // non-space separator (tab, newline) or a multi-token value is a malformed header,
-        // not a credential to pass through to JWT validation.
-        if (remainder[0] != ' ')
-        {
-            return AuthorizationHeaderResult.Error("Invalid Authorization header.");
-        }
-
-        string parameter = remainder.Trim();
+        // A well-formed Bearer credential separates the scheme from the token with one or more
+        // spaces and carries a whitespace-free token (a JWT never contains whitespace). Only the
+        // separating space(s) are stripped — the token is NOT Trim()'d — so a non-space separator
+        // (e.g. "Bearer \t<token>") or any whitespace inside the token survives into the value and
+        // is rejected below as malformed, rather than being silently discarded and passed through
+        // to JWT validation as if the header were well formed.
+        string parameter = remainder.TrimStart(' ');
         if (parameter.Any(char.IsWhiteSpace))
         {
             return AuthorizationHeaderResult.Error("Invalid Authorization header.");

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -56,9 +56,11 @@ internal static class AuthorizationHeaderParser
         // separating space(s) are stripped — the token is NOT Trim()'d — so a non-space separator
         // (e.g. "Bearer \t<token>") or any whitespace inside the token survives into the value and
         // is rejected below as malformed, rather than being silently discarded and passed through
-        // to JWT validation as if the header were well formed.
+        // to JWT validation as if the header were well formed. A comma is rejected for the same
+        // reason: the RFC 6750 token alphabet has no comma, and a comma is how a repeated
+        // Authorization header — unparseable per RFC 7235 — is folded into a single value.
         string parameter = remainder.TrimStart(' ');
-        if (parameter.Any(char.IsWhiteSpace))
+        if (parameter.Any(c => char.IsWhiteSpace(c) || c == ','))
         {
             return AuthorizationHeaderResult.Error("Invalid Authorization header.");
         }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -43,6 +43,14 @@ internal static class AuthorizationHeaderParser
             return AuthorizationHeaderResult.Error("Missing Authorization header bearer token value.");
         }
 
+        // A Bearer token (a JWT) never contains whitespace. An embedded space means the value
+        // did not parse as a single "Bearer <token>" credential, so treat it as a malformed header
+        // rather than passing a multi-token value through to JWT validation.
+        if (parameter.Any(char.IsWhiteSpace))
+        {
+            return AuthorizationHeaderResult.Error("Invalid Authorization header.");
+        }
+
         return AuthorizationHeaderResult.Success(parameter);
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/AuthorizationHeaderParser.cs
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.Middleware;
+
+/// <summary>
+/// Classifies a present Authorization header value against the authentication error
+/// contract for 401 authentication failures. The JWT authentication and JWT
+/// role-authentication middleware share this parsing so their error details stay
+/// consistent with the design contract.
+/// </summary>
+internal static class AuthorizationHeaderParser
+{
+    private const string BearerScheme = "Bearer";
+
+    /// <summary>
+    /// Parses a present Authorization header value. Returns the extracted Bearer token
+    /// on success, or the error detail describing why classification failed.
+    /// </summary>
+    public static AuthorizationHeaderResult Parse(string authHeader)
+    {
+        // A present-but-blank header value has no parseable scheme.
+        if (string.IsNullOrWhiteSpace(authHeader))
+        {
+            return AuthorizationHeaderResult.Error("Invalid Authorization header.");
+        }
+
+        string trimmed = authHeader.Trim();
+        int separatorIndex = trimmed.IndexOf(' ');
+
+        string scheme = separatorIndex < 0 ? trimmed : trimmed[..separatorIndex];
+        string parameter = separatorIndex < 0 ? string.Empty : trimmed[(separatorIndex + 1)..].Trim();
+
+        if (!string.Equals(scheme, BearerScheme, StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthorizationHeaderResult.Error("Unknown Authorization header scheme.");
+        }
+
+        if (string.IsNullOrWhiteSpace(parameter))
+        {
+            return AuthorizationHeaderResult.Error("Missing Authorization header bearer token value.");
+        }
+
+        return AuthorizationHeaderResult.Success(parameter);
+    }
+}
+
+/// <summary>
+/// Result of parsing an Authorization header: either a valid Bearer token or an
+/// authentication error detail (never both).
+/// </summary>
+internal readonly record struct AuthorizationHeaderResult(string? Token, string? ErrorDetail)
+{
+    public bool IsValid => ErrorDetail is null;
+
+    public static AuthorizationHeaderResult Success(string token) => new(token, null);
+
+    public static AuthorizationHeaderResult Error(string errorDetail) => new(null, errorDetail);
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
@@ -41,25 +41,28 @@ internal class JwtAuthenticationMiddleware(
             return;
         }
 
-        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        AuthorizationHeaderResult headerResult = AuthorizationHeaderParser.Parse(authHeader);
+        if (!headerResult.IsValid)
         {
             logger.LogDebug(
-                "Unsupported Authorization header scheme - {TraceId}",
+                "Invalid Authorization header ({ErrorDetail}) - {TraceId}",
+                headerResult.ErrorDetail,
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
             requestInfo.FrontendResponse = CreateUnauthorizedResponse(
-                "Unknown Authorization header scheme.",
+                headerResult.ErrorDetail!,
                 requestInfo.FrontendRequest.TraceId
             );
             return;
         }
 
+        string token = headerResult.Token!;
+
         // Validate token and extract client authorizations
         (ClaimsPrincipal? principal, ClientAuthorizations? clientAuthorizations) =
             await jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-                authHeader,
-                "Bearer ".Length,
+                token,
                 CancellationToken.None
             );
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
@@ -85,9 +85,9 @@ internal class JwtAuthenticationMiddleware(
     {
         var problemDetails = new
         {
-            detail = "Authorization failed",
-            type = "urn:ed-fi:api:unauthorized",
-            title = "Unauthorized",
+            detail = "The caller could not be authenticated.",
+            type = "urn:ed-fi:api:security:authentication",
+            title = "Authentication Failed",
             status = 401,
             correlationId = traceId.Value,
             errors = new[] { errorDetail },

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtAuthenticationMiddleware.cs
@@ -4,10 +4,10 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Security.Claims;
-using System.Text.Json;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Core.Security;
 using Microsoft.Extensions.Logging;
 
@@ -27,18 +27,29 @@ internal class JwtAuthenticationMiddleware(
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         // Extract Authorization header
-        if (
-            !requestInfo.FrontendRequest.Headers.TryGetValue("Authorization", out var authHeader)
-            || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-        )
+        if (!requestInfo.FrontendRequest.Headers.TryGetValue("Authorization", out var authHeader))
         {
             logger.LogDebug(
-                "Missing or invalid Authorization header - {TraceId}",
+                "Missing Authorization header - {TraceId}",
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
             requestInfo.FrontendResponse = CreateUnauthorizedResponse(
-                "Bearer token required",
+                "Authorization header is missing.",
+                requestInfo.FrontendRequest.TraceId
+            );
+            return;
+        }
+
+        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Unsupported Authorization header scheme - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+
+            requestInfo.FrontendResponse = CreateUnauthorizedResponse(
+                "Unknown Authorization header scheme.",
                 requestInfo.FrontendRequest.TraceId
             );
             return;
@@ -83,19 +94,9 @@ internal class JwtAuthenticationMiddleware(
     /// </summary>
     private static FrontendResponse CreateUnauthorizedResponse(string errorDetail, TraceId traceId)
     {
-        var problemDetails = new
-        {
-            detail = "The caller could not be authenticated.",
-            type = "urn:ed-fi:api:security:authentication",
-            title = "Authentication Failed",
-            status = 401,
-            correlationId = traceId.Value,
-            errors = new[] { errorDetail },
-        };
-
         return new FrontendResponse(
             StatusCode: 401,
-            Body: JsonSerializer.SerializeToNode(problemDetails),
+            Body: FailureResponse.ForAuthenticationFailure(traceId, [errorDetail]),
             Headers: new Dictionary<string, string>
             {
                 ["WWW-Authenticate"] = $"Bearer error=\"invalid_token\"",

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
@@ -49,24 +49,27 @@ internal class JwtRoleAuthenticationMiddleware(
             return;
         }
 
-        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        AuthorizationHeaderResult headerResult = AuthorizationHeaderParser.Parse(authHeader);
+        if (!headerResult.IsValid)
         {
             logger.LogDebug(
-                "Unsupported Authorization header scheme - {TraceId}",
+                "Invalid Authorization header ({ErrorDetail}) - {TraceId}",
+                headerResult.ErrorDetail,
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
             requestInfo.FrontendResponse = CreateUnauthorizedResponse(
-                "Unknown Authorization header scheme.",
+                headerResult.ErrorDetail!,
                 requestInfo.FrontendRequest.TraceId
             );
             return;
         }
 
+        string token = headerResult.Token!;
+
         // Validate token (we only need the principal, not ClientAuthorizations)
         var (principal, _) = await jwtValidationService.ValidateAndExtractClientAuthorizationsAsync(
-            authHeader,
-            "Bearer ".Length,
+            token,
             CancellationToken.None
         );
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Core.Security;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -34,18 +35,29 @@ internal class JwtRoleAuthenticationMiddleware(
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         // Extract Authorization header
-        if (
-            !requestInfo.FrontendRequest.Headers.TryGetValue("Authorization", out var authHeader)
-            || !authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-        )
+        if (!requestInfo.FrontendRequest.Headers.TryGetValue("Authorization", out var authHeader))
         {
             logger.LogDebug(
-                "Missing or invalid Authorization header - {TraceId}",
+                "Missing Authorization header - {TraceId}",
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
             requestInfo.FrontendResponse = CreateUnauthorizedResponse(
-                "Bearer token required",
+                "Authorization header is missing.",
+                requestInfo.FrontendRequest.TraceId
+            );
+            return;
+        }
+
+        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Unsupported Authorization header scheme - {TraceId}",
+                requestInfo.FrontendRequest.TraceId.Value
+            );
+
+            requestInfo.FrontendResponse = CreateUnauthorizedResponse(
+                "Unknown Authorization header scheme.",
                 requestInfo.FrontendRequest.TraceId
             );
             return;
@@ -105,19 +117,9 @@ internal class JwtRoleAuthenticationMiddleware(
     /// </summary>
     private static FrontendResponse CreateUnauthorizedResponse(string errorDetail, TraceId traceId)
     {
-        var problemDetails = new
-        {
-            detail = "The caller could not be authenticated.",
-            type = "urn:ed-fi:api:security:authentication",
-            title = "Authentication Failed",
-            status = 401,
-            correlationId = traceId.Value,
-            errors = new[] { errorDetail },
-        };
-
         return new FrontendResponse(
             StatusCode: 401,
-            Body: JsonSerializer.SerializeToNode(problemDetails),
+            Body: FailureResponse.ForAuthenticationFailure(traceId, [errorDetail]),
             Headers: new Dictionary<string, string>
             {
                 ["WWW-Authenticate"] = $"Bearer error=\"invalid_token\"",

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/JwtRoleAuthenticationMiddleware.cs
@@ -107,9 +107,9 @@ internal class JwtRoleAuthenticationMiddleware(
     {
         var problemDetails = new
         {
-            detail = "Authorization failed",
-            type = "urn:ed-fi:api:unauthorized",
-            title = "Unauthorized",
+            detail = "The caller could not be authenticated.",
+            type = "urn:ed-fi:api:security:authentication",
+            title = "Authentication Failed",
             status = 401,
             correlationId = traceId.Value,
             errors = new[] { errorDetail },

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
@@ -39,7 +39,10 @@ internal class ProvideAuthorizationFiltersMiddleware(ILogger _logger) : IPipelin
                         requestInfo.FrontendRequest.TraceId,
                         ["No authorization information found. Ensure valid JWT token is provided."]
                     ),
-                    Headers: [],
+                    Headers: new Dictionary<string, string>
+                    {
+                        ["WWW-Authenticate"] = "Bearer error=\"invalid_token\"",
+                    },
                     ContentType: "application/problem+json"
                 );
                 return;

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ProvideAuthorizationFiltersMiddleware.cs
@@ -35,10 +35,9 @@ internal class ProvideAuthorizationFiltersMiddleware(ILogger _logger) : IPipelin
                 );
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: (int)HttpStatusCode.Unauthorized,
-                    Body: FailureResponse.ForUnauthorized(
+                    Body: FailureResponse.ForAuthenticationFailure(
                         requestInfo.FrontendRequest.TraceId,
-                        error: "Unauthorized",
-                        description: "No authorization information found. Ensure valid JWT token is provided."
+                        ["No authorization information found. Ensure valid JWT token is provided."]
                     ),
                     Headers: [],
                     ContentType: "application/problem+json"

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
@@ -326,7 +326,10 @@ internal class ResourceActionAuthorizationMiddleware(IClaimSetProvider _claimSet
                 requestInfo.FrontendRequest.TraceId,
                 ["No authorization information found. Ensure valid JWT token is provided."]
             ),
-            Headers: [],
+            Headers: new Dictionary<string, string>
+            {
+                ["WWW-Authenticate"] = "Bearer error=\"invalid_token\"",
+            },
             ContentType: "application/problem+json"
         );
     }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
@@ -322,10 +322,9 @@ internal class ResourceActionAuthorizationMiddleware(IClaimSetProvider _claimSet
     {
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: (int)HttpStatusCode.Unauthorized,
-            Body: FailureResponse.ForUnauthorized(
+            Body: FailureResponse.ForAuthenticationFailure(
                 requestInfo.FrontendRequest.TraceId,
-                error: "Unauthorized",
-                description: "No authorization information found. Ensure valid JWT token is provided."
+                ["No authorization information found. Ensure valid JWT token is provided."]
             ),
             Headers: [],
             ContentType: "application/problem+json"

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -21,6 +21,7 @@ public static class FailureResponse
     private static readonly string _typePrefix = "urn:ed-fi:api";
     private static readonly string _badRequestTypePrefix = $"{_typePrefix}:bad-request";
     private static readonly string _unauthorizedType = $"{_typePrefix}:unauthorized";
+    private static readonly string _authenticationType = $"{_typePrefix}:security:authentication";
     private static readonly string _gatewayType = $"{_typePrefix}:bad-gateway";
     private static readonly string _dataConflictTypePrefix = $"{_typePrefix}:data-conflict";
     private static readonly string _keyChangeNotSupported =
@@ -223,6 +224,24 @@ public static class FailureResponse
             validationErrors: [],
             errors: []
         );
+
+    /// <summary>
+    /// Produces the 401 authentication-failure problem details defined by the design doc
+    /// and the ODS/API contract (urn:ed-fi:api:security:authentication). The detail, type,
+    /// and title are fixed by the contract; scenario-specific messages are carried in the
+    /// errors array. Unlike <see cref="ForUnauthorized"/>, no validationErrors member is
+    /// emitted, keeping the body byte-for-byte compatible with the ODS/API response.
+    /// </summary>
+    public static JsonNode ForAuthenticationFailure(TraceId traceId, string[] errors) =>
+        new JsonObject
+        {
+            ["detail"] = "The caller could not be authenticated.",
+            ["type"] = _authenticationType,
+            ["title"] = "Authentication Failed",
+            ["status"] = 401,
+            ["correlationId"] = traceId.Value,
+            ["errors"] = JsonSerializer.SerializeToNode(errors, SerializerOptions),
+        };
 
     public static JsonNode ForForbidden(
         TraceId traceId,

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -227,10 +227,10 @@ public static class FailureResponse
 
     /// <summary>
     /// Produces the 401 authentication-failure problem details defined by the design doc
-    /// and the ODS/API contract (urn:ed-fi:api:security:authentication). The detail, type,
-    /// and title are fixed by the contract; scenario-specific messages are carried in the
-    /// errors array. Unlike <see cref="ForUnauthorized"/>, no validationErrors member is
-    /// emitted, keeping the body byte-for-byte compatible with the ODS/API response.
+    /// (urn:ed-fi:api:security:authentication), matching the ODS/API type, title, and detail.
+    /// Scenario-specific messages are carried in the errors array, and correlationId is
+    /// included per the DMS problem-details convention. Unlike <see cref="ForUnauthorized"/>,
+    /// no validationErrors member is emitted.
     /// </summary>
     public static JsonNode ForAuthenticationFailure(TraceId traceId, string[] errors) =>
         new JsonObject

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
@@ -6,6 +6,7 @@
 using System.Reflection;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit;
@@ -84,6 +85,41 @@ public class Given_AspNetCoreFrontend_Request_Header_Extraction
 
         headers.Should().ContainKey("Authorization");
         headers["Authorization"].Should().Be("   ");
+    }
+
+    [Test]
+    public void It_delivers_a_repeated_authorization_header_unreduced()
+    {
+        // A repeated Authorization header is unparseable per RFC 7235. Delivering the comma-joined
+        // value lets core reject it as malformed ("Invalid Authorization header.") instead of
+        // authenticating the first value.
+        var headers = ExtractHeaders(request =>
+            request.Headers["Authorization"] = new StringValues(["Bearer valid", "junk"])
+        );
+
+        headers["Authorization"].Should().Be("Bearer valid,junk");
+    }
+
+    [Test]
+    public void It_delivers_a_repeated_authorization_header_with_a_blank_value_unreduced()
+    {
+        // A blank duplicate must survive the join (StringValues.ToString() would drop it),
+        // otherwise a valid token sent alongside a blank Authorization line authenticates.
+        var headers = ExtractHeaders(request =>
+            request.Headers["Authorization"] = new StringValues(["Bearer valid", ""])
+        );
+
+        headers["Authorization"].Should().Be("Bearer valid,");
+    }
+
+    [Test]
+    public void It_delivers_a_repeated_content_type_unreduced()
+    {
+        var headers = ExtractHeaders(request =>
+            request.Headers["Content-Type"] = new StringValues(["application/json", "text/plain"])
+        );
+
+        headers["Content-Type"].Should().Be("application/json,text/plain");
     }
 
     [Test]

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
@@ -113,6 +113,18 @@ public class Given_AspNetCoreFrontend_Request_Header_Extraction
     }
 
     [Test]
+    public void It_delivers_a_repeated_authorization_header_with_a_leading_blank_value_unreduced()
+    {
+        // Ordering matters: a blank first value must survive the join in position, so core sees
+        // ",Bearer valid" (a fold artifact, rejected as malformed) rather than a lone valid token.
+        var headers = ExtractHeaders(request =>
+            request.Headers["Authorization"] = new StringValues(["", "Bearer valid"])
+        );
+
+        headers["Authorization"].Should().Be(",Bearer valid");
+    }
+
+    [Test]
     public void It_delivers_a_repeated_content_type_unreduced()
     {
         var headers = ExtractHeaders(request =>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/AspNetCoreFrontendRequestHeaderTests.cs
@@ -67,10 +67,41 @@ public class Given_AspNetCoreFrontend_Request_Header_Extraction
     }
 
     [Test]
+    public void It_preserves_an_explicit_empty_authorization_header()
+    {
+        // A blank Authorization must survive extraction so core classifies it as a malformed
+        // header ("Invalid Authorization header.") rather than a missing one.
+        var headers = ExtractHeaders(request => request.Headers["Authorization"] = "");
+
+        headers.Should().ContainKey("Authorization");
+        headers["Authorization"].Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_preserves_an_explicit_whitespace_authorization_header()
+    {
+        var headers = ExtractHeaders(request => request.Headers["Authorization"] = "   ");
+
+        headers.Should().ContainKey("Authorization");
+        headers["Authorization"].Should().Be("   ");
+    }
+
+    [Test]
+    public void It_omits_a_missing_authorization_header()
+    {
+        // A genuinely absent Authorization stays absent, so core reports it as missing rather
+        // than malformed.
+        var headers = ExtractHeaders(_ => { });
+
+        headers.Should().NotContainKey("Authorization");
+    }
+
+    [Test]
     public void It_still_drops_other_blank_headers()
     {
-        // The Content-Type preservation is intentionally scoped; blank values of other headers
-        // continue to be dropped as before.
+        // Blank-value preservation is intentionally scoped to the headers core must distinguish
+        // from missing (Content-Type, Authorization); blank values of other headers continue to
+        // be dropped as before.
         var headers = ExtractHeaders(request => request.Headers["X-Custom"] = "");
 
         headers.Should().NotContainKey("X-Custom");

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -339,12 +339,26 @@ public static class AspNetCoreFrontend
     }
 
     private const string ContentTypeHeaderName = "Content-Type";
+    private const string AuthorizationHeaderName = "Authorization";
+
+    /// <summary>
+    /// Headers whose explicit blank/whitespace value core must be able to distinguish from an
+    /// absent header, so the value must survive the blank-value filtering in
+    /// <see cref="ExtractHeadersFrom"/>: Content-Type (an explicit blank is rejected with 415)
+    /// and Authorization (an explicit blank is a malformed header rejected with 401, distinct
+    /// from a missing header, which reports "Authorization header is missing.").
+    /// </summary>
+    private static readonly string[] HeadersPreservedWhenExplicitlySent =
+    [
+        ContentTypeHeaderName,
+        AuthorizationHeaderName,
+    ];
 
     /// <summary>
     /// Takes an HttpRequest and returns its headers as a dictionary. Blank header values are
-    /// dropped, except for an explicitly supplied Content-Type. Core must distinguish a missing
-    /// Content-Type (exempt) from an explicit blank or whitespace value (rejected with 415), so
-    /// that value is preserved verbatim here instead of being discarded along with the header.
+    /// dropped, except for the headers in <see cref="HeadersPreservedWhenExplicitlySent"/>,
+    /// whose explicit blank/whitespace value is restored verbatim so core can distinguish it
+    /// from a missing header.
     /// </summary>
     private static Dictionary<string, string> ExtractHeadersFrom(HttpRequest request)
     {
@@ -357,14 +371,17 @@ public static class AspNetCoreFrontend
             .Where(h => h.Value != null)
             .ToDictionary(x => x.Key, x => x.Value!, StringComparer.OrdinalIgnoreCase);
 
-        // The filtering above discards a Content-Type that was sent but is blank/whitespace.
-        // Restore it so core can reject the explicit value rather than treat it as missing.
-        if (
-            !headers.ContainsKey(ContentTypeHeaderName)
-            && request.Headers.TryGetValue(ContentTypeHeaderName, out StringValues contentType)
-        )
+        // The filtering above discards headers that were sent but are blank/whitespace. Restore
+        // the ones core must treat as explicitly-present-but-invalid rather than as missing.
+        foreach (string headerName in HeadersPreservedWhenExplicitlySent)
         {
-            headers[ContentTypeHeaderName] = contentType.ToString();
+            if (
+                !headers.ContainsKey(headerName)
+                && request.Headers.TryGetValue(headerName, out StringValues value)
+            )
+            {
+                headers[headerName] = value.ToString();
+            }
         }
 
         return headers;

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -342,11 +342,11 @@ public static class AspNetCoreFrontend
     private const string AuthorizationHeaderName = "Authorization";
 
     /// <summary>
-    /// Headers whose explicit blank/whitespace value core must be able to distinguish from an
-    /// absent header, so the value must survive the blank-value filtering in
-    /// <see cref="ExtractHeadersFrom"/>: Content-Type (an explicit blank is rejected with 415)
-    /// and Authorization (an explicit blank is a malformed header rejected with 401, distinct
-    /// from a missing header, which reports "Authorization header is missing.").
+    /// Headers that must reach core verbatim rather than through the blank-dropping,
+    /// first-non-blank reduction in <see cref="ExtractHeadersFrom"/>: Content-Type (an explicit
+    /// blank is rejected with 415) and Authorization (an explicit blank or a repeated header is
+    /// a malformed header rejected with 401, distinct from a missing header, which reports
+    /// "Authorization header is missing.").
     /// </summary>
     private static readonly string[] HeadersPreservedWhenExplicitlySent =
     [
@@ -356,9 +356,10 @@ public static class AspNetCoreFrontend
 
     /// <summary>
     /// Takes an HttpRequest and returns its headers as a dictionary. Blank header values are
-    /// dropped, except for the headers in <see cref="HeadersPreservedWhenExplicitlySent"/>,
-    /// whose explicit blank/whitespace value is restored verbatim so core can distinguish it
-    /// from a missing header.
+    /// dropped and multi-valued headers are reduced to their first non-blank value, except for
+    /// the headers in <see cref="HeadersPreservedWhenExplicitlySent"/>, which are delivered
+    /// verbatim (blank preserved, multiple values comma-joined) so core can classify an
+    /// explicit blank or a repeated header as malformed rather than as missing or valid.
     /// </summary>
     private static Dictionary<string, string> ExtractHeadersFrom(HttpRequest request)
     {
@@ -371,16 +372,17 @@ public static class AspNetCoreFrontend
             .Where(h => h.Value != null)
             .ToDictionary(x => x.Key, x => x.Value!, StringComparer.OrdinalIgnoreCase);
 
-        // The filtering above discards headers that were sent but are blank/whitespace. Restore
-        // the ones core must treat as explicitly-present-but-invalid rather than as missing.
+        // The filtering above discards blank values and reduces a repeated header to its first
+        // non-blank value. Normalize the preserved headers to their full comma-joined value so
+        // an explicit blank reaches core as present-but-invalid and a repeated header is not
+        // reduced to a single authenticatable value. string.Join is used instead of
+        // StringValues.ToString() because ToString() drops empty entries, which would silently
+        // erase a blank duplicate sent alongside a valid value.
         foreach (string headerName in HeadersPreservedWhenExplicitlySent)
         {
-            if (
-                !headers.ContainsKey(headerName)
-                && request.Headers.TryGetValue(headerName, out StringValues value)
-            )
+            if (request.Headers.TryGetValue(headerName, out StringValues value))
             {
-                headers[headerName] = value.ToString();
+                headers[headerName] = string.Join(",", value.ToArray());
             }
         }
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -368,3 +368,31 @@ Feature: OWASP critical attack path protections
               And the response body should not contain "System."
               And the response body should not contain " at EdFi."
               And the response body should not contain "signature" ignoring case
+
+        # A 401 authentication failure returns the design-doc / ODS problem-details contract
+        # (urn:ed-fi:api:security:authentication / "Authentication Failed"), not the legacy
+        # urn:ed-fi:api:unauthorized / "Unauthorized" shape.
+        @e2e-ci-shard-3
+        Scenario: 23 Authentication failure returns the ODS/DMS problem-details contract
+            Given the SIS Vendor is authorized with namespacePrefixes "uri://ed-fi.org"
+              And the token signature is manipulated
+             When a GET request is made to "/ed-fi/schools"
+             Then it should respond with 401
+              And the response headers include
+                  """
+                  {
+                      "Content-Type": "application/problem+json"
+                  }
+                  """
+              And the response body is
+                  """
+                  {
+                      "detail": "The caller could not be authenticated.",
+                      "type": "urn:ed-fi:api:security:authentication",
+                      "title": "Authentication Failed",
+                      "status": 401,
+                      "errors": [
+                          "Invalid token"
+                      ]
+                  }
+                  """


### PR DESCRIPTION
## Summary

  - Fixes DMS-1256: DMS returned 401 authentication failures with the wrong problem-details contract (type: urn:ed-fi:api:unauthorized, title: Unauthorized, detail: Authorization failed). It now returns the design-doc / ODS-API-compatible contract: type: urn:ed-fi:api:security:authentication, title: Authentication Failed, detail: The caller could not be authenticated.
  - Adds a FailureResponse.ForAuthenticationFailure(traceId, errors) factory as the single source of the 401 authentication body — carries correlationId per DMS convention and, unlike ForUnauthorized, emits no validationErrors member.
  - Introduces a shared AuthorizationHeaderParser so JwtAuthenticationMiddleware and JwtRoleAuthenticationMiddleware classify a bad Authorization header into consistent, approved messages:
  missing header → Authorization header is missing., unknown scheme → Unknown Authorization header scheme., empty Bearer token → Missing Authorization header bearer token value., malformed header → Invalid Authorization header. (expired/tampered tokens still collapse to Invalid token).
  - Switches the two "no resolved client authorizations" 401 paths (ProvideAuthorizationFiltersMiddleware, ResourceActionAuthorizationMiddleware) from ForUnauthorized to ForAuthenticationFailure so every authentication-failure 401 shares one contract.
  - Updates auth.md (new error-message table row for the authorization-stage-without-context case) and OWASP-AUTH-COVERAGE.md (compensating-control bullet rewritten to describe the fixed contract + coarse, non-leaking failure classification).
  - Intentionally out of scope: the 403 role-check contract (urn:ed-fi:api:forbidden) is unchanged — DMS-1256 is 401-only. OAuth-endpoint / post-auth 401s (GetTokenInfoHandler, OAuthManager) are also left as-is since they aren't authentication failures.

  Test plan

  - [ ] Unit tests pass: dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit --no-build (parameterized fixtures cover all four invalid-header classifications across both JWT middlewares, plus Given_No_Client_Authorizations for ResourceActionAuthorizationMiddleware).
  - [ ] TestHelper.AssertUnauthorizedProblemDetails pins the exact contract (single-element errors, validationErrors absent) — confirm it's asserted by the It_returns_the_authentication_failed_problem_details tests.
  - [ ] E2E scenario 23 (OwaspCriticalPaths.feature) passes: a GET with a manipulated-signature token returns 401 with the full urn:ed-fi:api:security:authentication body and errors: ["Invalid token"].
  - [ ] Manual — request with no Authorization header → 401 body errors: ["Authorization header is missing."].
  - [ ] Manual — Authorization: Basic abc123 (non-Bearer) → errors: ["Unknown Authorization header scheme."].
  - [ ] Manual — Authorization: Bearer with empty token → errors: ["Missing Authorization header bearer token value."].
  - [ ] Manual — a valid token but a claim set with no resolvable authorizations → 401 urn:ed-fi:api:security:authentication with errors: ["No authorization information found. Ensure valid JWT token is provided."] (confirms the ProvideAuthorizationFilters / ResourceActionAuthorization paths switched contract).
  - [ ] Confirm every 401 authentication response sets Content-Type: application/problem+json and a WWW-Authenticate: Bearer header.