### PR TITLE
[DMS-1261] Exclude DS 6.1 scenarios from scheduled DS 5.2 E2E runs

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -83,7 +83,11 @@ jobs:
         id: e2e
         if: success()
         continue-on-error: true
-        run: ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e'
+        # This lane runs against the default DS 5.2 stack, so exclude the DS 6.1 version-coupled
+        # scenarios (@StandardVersion-6_1); those are covered on every PR by the run-e2e-tests-ds61
+        # lane and in full by the scheduled smoke test workflow. The non-empty filter makes
+        # build-dms.ps1 write the ...E2E.filtered.trx result file (see the upload step below).
+        run: ./build-dms.ps1 E2ETest -Configuration ${{ env.CONFIGURATION }} -SkipDockerBuild -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@StandardVersion-6_1'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e.outcome == 'failure'
@@ -118,7 +122,7 @@ jobs:
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
           name: scheduled-build-e2e-results-${{ matrix.identityprovider }}
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.e2e.trx
+          path: TestResults/EdFi.DataManagementService.Tests.E2E.filtered.trx
           if-no-files-found: ignore
 
       - name: Fail if DMS E2E failed
@@ -352,13 +356,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "❌ GitHub Action build result: ${{ job.status }}\n${{ github.event.head_commit.url }}",
+              "text": "❌ GitHub Action build result: failure\n${{ github.event.head_commit.url }}",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "❌ GitHub Action build result: ${{ job.status }}\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Commit Message:* ${{ github.event.head_commit.message || 'No commit message available' }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "❌ GitHub Action build result: failure\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Commit Message:* ${{ github.event.head_commit.message || 'No commit message available' }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/scheduled-pre-image-test.yml
+++ b/.github/workflows/scheduled-pre-image-test.yml
@@ -48,7 +48,11 @@ jobs:
         id: e2e
         if: success()
         continue-on-error: true
-        run: ./build-dms.ps1 E2ETest -UsePublishedImage -Configuration Release -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e'
+        # This lane runs against the default DS 5.2 stack, so exclude the DS 6.1 version-coupled
+        # scenarios (@StandardVersion-6_1); those are covered on every PR by the run-e2e-tests-ds61
+        # lane and in full by the scheduled smoke test workflow. The non-empty filter makes
+        # build-dms.ps1 write the ...E2E.filtered.trx result file (see the upload step below).
+        run: ./build-dms.ps1 E2ETest -UsePublishedImage -Configuration Release -IdentityProvider ${{ matrix.identityprovider }} -EnvironmentFile './.env.e2e' -TestFilter 'Category!=@StandardVersion-6_1'
 
       - name: Export DMS E2E Docker Logs
         if: always() && steps.e2e.outcome == 'failure'
@@ -83,7 +87,7 @@ jobs:
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
           name: scheduled-pre-image-e2e-results-${{ matrix.identityprovider }}
-          path: TestResults/EdFi.DataManagementService.Tests.E2E.e2e.trx
+          path: TestResults/EdFi.DataManagementService.Tests.E2E.filtered.trx
           if-no-files-found: ignore
 
       - name: Fail if DMS E2E failed


### PR DESCRIPTION
## Summary

The scheduled workflows (`scheduled-build.yml`, `scheduled-pre-image-test.yml`) ran the DMS E2E suite with **no `-TestFilter`**, so the DS 6.1 version-coupled scenarios (`@StandardVersion-6_1`) executed against the default **DS 5.2** stack and failed — they assert Ed-Fi 6.1.0 but the 5.2 stack returns Ed-Fi 5.2.0 / TPDM 1.1.0. This turned both scheduled runs red. Per-PR CI is unaffected: its DS 5.2 shards filter on `@e2e-ci-shard-N` (the 6.1 variants carry no shard tag) and the dedicated `run-e2e-tests-ds61` lane runs the 6.1 scenarios on a real 6.1 stack.

Introduced by DMS-1136 (Data Standard 6 Support), which added the 6.1 version-coupled scenarios.

## Changes

- Add `-TestFilter 'Category!=@StandardVersion-6_1'` to the E2E step in both scheduled workflows so the default DS 5.2 lanes skip the 6.1-only scenarios. No coverage is lost: those scenarios run on every PR (`run-e2e-tests-ds61`) and in full in the scheduled smoke test workflow.
- Update both workflows' "Upload Test Results" path from `...E2E.e2e.trx` to `...E2E.filtered.trx`. `build-dms.ps1`'s `Get-E2ETestResultSuffix` only emits the `.e2e` suffix for an empty filter; any non-empty filter yields `.filtered`, so without this the upload would silently find no file.
- Fix the `scheduled-build.yml` `notify-results` Slack-on-failure message, which interpolated `${{ job.status }}` — the notify job's own status (always `success`) — so a failed run reported "result: success". Now reports the failure explicitly. (The pre-image workflow's notify runs inside the failing job, so its `job.status` is already accurate and is left unchanged.)

## Deferred

A dedicated DS 6.1 scheduled lane (mirroring the per-PR lane) was considered and deferred: `scheduled-pre-image-test.yml` uses `-UsePublishedImage`, and the last published image may predate DS 6.1 support, which would reintroduce a red run.

## Validation

These workflows don't run on PRs (schedule + `workflow_dispatch` only), so this change is best validated with a manual `workflow_dispatch` on the branch. Both YAML files parse and the job graphs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
