### PR TITLE
[DMS-1260] Scope CMS Application and ApiClient repositories by tenant

### DIFF
--- a/.github/workflows/on-config-pullrequest.yml
+++ b/.github/workflows/on-config-pullrequest.yml
@@ -68,7 +68,7 @@ jobs:
           fi
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
             changed_files="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             base_sha="${{ github.event.merge_group.base_sha }}"

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -91,7 +91,7 @@ jobs:
           fi
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
             changed_files="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"
           elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
             base_sha="${{ github.event.merge_group.base_sha }}"

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApiClientTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApiClientTests.cs
@@ -497,6 +497,16 @@ public class ApiClientTests : DatabaseTest
         }
 
         [Test]
+        public async Task It_should_get_and_delete_its_own_tenant_api_client()
+        {
+            var getResult = await _tenantBApiClientRepository.GetApiClientById(_tenantBApiClientId);
+            getResult.Should().BeOfType<ApiClientGetResult.Success>();
+
+            var deleteResult = await _tenantBApiClientRepository.DeleteApiClient(_tenantBApiClientId);
+            deleteResult.Should().BeOfType<ApiClientDeleteResult.Success>();
+        }
+
+        [Test]
         public async Task It_should_not_get_another_tenants_api_client_by_client_id()
         {
             var result = await _tenantBApiClientRepository.GetApiClientByClientId(_tenantAClientId);

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApiClientTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApiClientTests.cs
@@ -9,6 +9,8 @@ using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
+using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.Tenant;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,13 +22,15 @@ public class ApiClientTests : DatabaseTest
     private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
         MssqlTestConfiguration.DatabaseOptions,
         NullLogger<ApiClientRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
         MssqlTestConfiguration.DatabaseOptions,
         NullLogger<ApplicationRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     [TestFixture]
@@ -308,6 +312,309 @@ public class ApiClientTests : DatabaseTest
         public void It_should_return_failure_application_not_found()
         {
             _result.Should().BeOfType<ApiClientUpdateResult.FailureApplicationNotFound>();
+        }
+    }
+
+    [TestFixture]
+    public class Given_api_client_operations_from_another_tenant : ApiClientTests
+    {
+        private IApiClientRepository _tenantAApiClientRepository = null!;
+        private IApiClientRepository _tenantBApiClientRepository = null!;
+        private long _tenantAApplicationId;
+        private long _tenantBApplicationId;
+        private long _tenantAApiClientId;
+        private string _tenantAClientId = string.Empty;
+        private long _tenantBApiClientId;
+        private long _tenantADataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var tenantRepository = new TenantRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<TenantRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var tenantAProvider = await CreateTenantProvider(tenantRepository, "A");
+            var tenantBProvider = await CreateTenantProvider(tenantRepository, "B");
+
+            _tenantAApiClientRepository = CreateApiClientRepository(tenantAProvider);
+            _tenantBApiClientRepository = CreateApiClientRepository(tenantBProvider);
+
+            _tenantAApplicationId = await InsertVendorWithApplication(tenantAProvider, "Tenant A Company");
+            _tenantBApplicationId = await InsertVendorWithApplication(tenantBProvider, "Tenant B Company");
+
+            (_tenantAApiClientId, _tenantAClientId) = await InsertApiClient(
+                _tenantAApiClientRepository,
+                _tenantAApplicationId,
+                "Tenant A Client"
+            );
+            (_tenantBApiClientId, _) = await InsertApiClient(
+                _tenantBApiClientRepository,
+                _tenantBApplicationId,
+                "Tenant B Client"
+            );
+
+            _tenantADataStoreId = await InsertDataStore(tenantAProvider, "Tenant A Data Store");
+        }
+
+        private static async Task<TenantContextProvider> CreateTenantProvider(
+            TenantRepository tenantRepository,
+            string suffix
+        )
+        {
+            var tenantName = $"ApiClientTenant{suffix}-{Guid.NewGuid()}";
+            var tenantResult = await tenantRepository.InsertTenant(
+                new TenantInsertCommand { Name = tenantName }
+            );
+            tenantResult.Should().BeOfType<TenantInsertResult.Success>();
+            return new TenantContextProvider
+            {
+                Context = new TenantContext.Multitenant(
+                    ((TenantInsertResult.Success)tenantResult).Id,
+                    tenantName
+                ),
+            };
+        }
+
+        private static ApiClientRepository CreateApiClientRepository(
+            TenantContextProvider tenantContextProvider
+        ) =>
+            new(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<ApiClientRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+
+        private static async Task<long> InsertVendorWithApplication(
+            TenantContextProvider tenantContextProvider,
+            string company
+        )
+        {
+            IVendorRepository vendorRepository = new VendorRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<VendorRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var vendorResult = await vendorRepository.InsertVendor(
+                new VendorInsertCommand
+                {
+                    Company = company,
+                    ContactEmailAddress = "tenant@test.com",
+                    ContactName = "Tenant Tester",
+                    NamespacePrefixes = "uri://tenant-test.example",
+                }
+            );
+            vendorResult.Should().BeOfType<VendorInsertResult.Success>();
+            long vendorId = ((VendorInsertResult.Success)vendorResult).Id;
+
+            IApplicationRepository applicationRepository = new ApplicationRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<ApplicationRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var applicationResult = await applicationRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = $"{company} Application",
+                    VendorId = vendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            applicationResult.Should().BeOfType<ApplicationInsertResult.Success>();
+            return ((ApplicationInsertResult.Success)applicationResult).Id;
+        }
+
+        private static async Task<(long Id, string ClientId)> InsertApiClient(
+            IApiClientRepository apiClientRepository,
+            long applicationId,
+            string name
+        )
+        {
+            string clientId = Guid.NewGuid().ToString();
+            var result = await apiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = applicationId,
+                    Name = name,
+                    IsApproved = true,
+                    DataStoreIds = [],
+                },
+                new ApiClientCommand { ClientId = clientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.Success>();
+            return (((ApiClientInsertResult.Success)result).Id, clientId);
+        }
+
+        private static async Task<long> InsertDataStore(
+            TenantContextProvider tenantContextProvider,
+            string name
+        )
+        {
+            var dataStoreRepository = new DataStoreRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<DataStoreRepository>.Instance,
+                new ConnectionStringEncryptionService(MssqlTestConfiguration.DatabaseOptions),
+                new DataStoreContextRepository(
+                    MssqlTestConfiguration.DatabaseOptions,
+                    NullLogger<DataStoreContextRepository>.Instance,
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new DataStoreDerivativeRepository(
+                    MssqlTestConfiguration.DatabaseOptions,
+                    NullLogger<DataStoreDerivativeRepository>.Instance,
+                    new ConnectionStringEncryptionService(MssqlTestConfiguration.DatabaseOptions),
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var result = await dataStoreRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = name,
+                    ConnectionString = "Server=tenant;Database=TenantDb;",
+                }
+            );
+            result.Should().BeOfType<DataStoreInsertResult.Success>();
+            return ((DataStoreInsertResult.Success)result).Id;
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_api_client_by_id()
+        {
+            var result = await _tenantBApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_api_client_by_client_id()
+        {
+            var result = await _tenantBApiClientRepository.GetApiClientByClientId(_tenantAClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_api_clients_in_query()
+        {
+            var result = await _tenantBApiClientRepository.QueryApiClient(
+                new ApiClientQuery { Limit = 25, Offset = 0 }
+            );
+            result.Should().BeOfType<ApiClientQueryResult.Success>();
+            var responses = ((ApiClientQueryResult.Success)result).ApiClientResponses;
+            responses.Should().Contain(c => c.Id == _tenantBApiClientId);
+            responses.Should().NotContain(c => c.Id == _tenantAApiClientId);
+        }
+
+        [Test]
+        public async Task It_should_not_update_another_tenants_api_client()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantAApiClientId,
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Hijacked Client",
+                    IsApproved = false,
+                    DataStoreIds = [],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureNotFound>();
+
+            var unchanged = await _tenantAApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            unchanged.Should().BeOfType<ApiClientGetResult.Success>();
+            ((ApiClientGetResult.Success)unchanged).ApiClientResponse.Name.Should().Be("Tenant A Client");
+        }
+
+        [Test]
+        public async Task It_should_not_move_an_api_client_to_another_tenants_application()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantBApiClientId,
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Tenant B Client",
+                    IsApproved = true,
+                    DataStoreIds = [],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureApplicationNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_update_an_api_client_with_another_tenants_data_store()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantBApiClientId,
+                    ApplicationId = _tenantBApplicationId,
+                    Name = "Tenant B Client",
+                    IsApproved = true,
+                    DataStoreIds = [_tenantADataStoreId],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_delete_another_tenants_api_client()
+        {
+            var result = await _tenantBApiClientRepository.DeleteApiClient(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientDeleteResult.FailureNotFound>();
+
+            var stillThere = await _tenantAApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            stillThere.Should().BeOfType<ApiClientGetResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_api_client_under_another_tenants_application()
+        {
+            var result = await _tenantBApiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Cross Tenant Client",
+                    IsApproved = true,
+                    DataStoreIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.FailureApplicationNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_api_client_with_another_tenants_data_store()
+        {
+            var result = await _tenantBApiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = _tenantBApplicationId,
+                    Name = "Cross Tenant Data Store Client",
+                    IsApproved = true,
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_expose_tenant_scoped_api_clients_in_single_tenant_context()
+        {
+            var singleTenantRepository = CreateApiClientRepository(new TenantContextProvider());
+            var result = await singleTenantRepository.GetApiClientById(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApplicationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApplicationTests.cs
@@ -11,6 +11,7 @@ using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.Tenant;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,7 +23,8 @@ public class ApplicationTests : DatabaseTest
     private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
         MssqlTestConfiguration.DatabaseOptions,
         NullLogger<ApplicationRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     private long _vendorId;
@@ -690,7 +692,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             MssqlTestConfiguration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         [SetUp]
@@ -773,7 +776,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             MssqlTestConfiguration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly IDataStoreRepository _dataStoreRepository;
@@ -929,7 +933,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             MssqlTestConfiguration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly IDataStoreRepository _dataStoreRepository;
@@ -1080,7 +1085,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             MssqlTestConfiguration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly OpenIddictDataRepository _openIddictDataRepository = new(
@@ -1163,6 +1169,298 @@ public class ApplicationTests : DatabaseTest
             var result = await _openIddictDataRepository.GetApplicationByClientIdAsync(_clientId);
             result.Should().NotBeNull();
             result!.IsApproved.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class Given_application_operations_from_another_tenant : ApplicationTests
+    {
+        private IApplicationRepository _tenantARepository = null!;
+        private IApplicationRepository _tenantBRepository = null!;
+        private long _tenantAVendorId;
+        private long _tenantBVendorId;
+        private long _tenantAApplicationId;
+        private long _tenantBApplicationId;
+        private string _tenantBClientId = string.Empty;
+        private long _tenantADataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var tenantRepository = new TenantRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<TenantRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var tenantAProvider = await CreateTenantProvider(tenantRepository, "A");
+            var tenantBProvider = await CreateTenantProvider(tenantRepository, "B");
+
+            _tenantARepository = CreateApplicationRepository(tenantAProvider);
+            _tenantBRepository = CreateApplicationRepository(tenantBProvider);
+
+            _tenantAVendorId = await InsertVendor(tenantAProvider, "Tenant A Company");
+            _tenantBVendorId = await InsertVendor(tenantBProvider, "Tenant B Company");
+
+            (_tenantAApplicationId, _) = await InsertApplication(
+                _tenantARepository,
+                _tenantAVendorId,
+                "Tenant A Application"
+            );
+            (_tenantBApplicationId, _tenantBClientId) = await InsertApplication(
+                _tenantBRepository,
+                _tenantBVendorId,
+                "Tenant B Application"
+            );
+
+            _tenantADataStoreId = await InsertDataStore(tenantAProvider, "Tenant A Data Store");
+        }
+
+        private static async Task<TenantContextProvider> CreateTenantProvider(
+            TenantRepository tenantRepository,
+            string suffix
+        )
+        {
+            var tenantName = $"ApplicationTenant{suffix}-{Guid.NewGuid()}";
+            var tenantResult = await tenantRepository.InsertTenant(
+                new TenantInsertCommand { Name = tenantName }
+            );
+            tenantResult.Should().BeOfType<TenantInsertResult.Success>();
+            return new TenantContextProvider
+            {
+                Context = new TenantContext.Multitenant(
+                    ((TenantInsertResult.Success)tenantResult).Id,
+                    tenantName
+                ),
+            };
+        }
+
+        private static ApplicationRepository CreateApplicationRepository(
+            TenantContextProvider tenantContextProvider
+        ) =>
+            new(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<ApplicationRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+
+        private static async Task<long> InsertVendor(
+            TenantContextProvider tenantContextProvider,
+            string company
+        )
+        {
+            IVendorRepository vendorRepository = new VendorRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<VendorRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var vendorResult = await vendorRepository.InsertVendor(
+                new VendorInsertCommand
+                {
+                    Company = company,
+                    ContactEmailAddress = "tenant@test.com",
+                    ContactName = "Tenant Tester",
+                    NamespacePrefixes = "uri://tenant-test.example",
+                }
+            );
+            vendorResult.Should().BeOfType<VendorInsertResult.Success>();
+            return ((VendorInsertResult.Success)vendorResult).Id;
+        }
+
+        private static async Task<(long Id, string ClientId)> InsertApplication(
+            IApplicationRepository applicationRepository,
+            long vendorId,
+            string applicationName
+        )
+        {
+            string clientId = Guid.NewGuid().ToString();
+            var result = await applicationRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = applicationName,
+                    VendorId = vendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = clientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.Success>();
+            return (((ApplicationInsertResult.Success)result).Id, clientId);
+        }
+
+        private static async Task<long> InsertDataStore(
+            TenantContextProvider tenantContextProvider,
+            string name
+        )
+        {
+            var dataStoreRepository = new DataStoreRepository(
+                MssqlTestConfiguration.DatabaseOptions,
+                NullLogger<DataStoreRepository>.Instance,
+                new ConnectionStringEncryptionService(MssqlTestConfiguration.DatabaseOptions),
+                new DataStoreContextRepository(
+                    MssqlTestConfiguration.DatabaseOptions,
+                    NullLogger<DataStoreContextRepository>.Instance,
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new DataStoreDerivativeRepository(
+                    MssqlTestConfiguration.DatabaseOptions,
+                    NullLogger<DataStoreDerivativeRepository>.Instance,
+                    new ConnectionStringEncryptionService(MssqlTestConfiguration.DatabaseOptions),
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var result = await dataStoreRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = name,
+                    ConnectionString = "Server=tenant;Database=TenantDb;",
+                }
+            );
+            result.Should().BeOfType<DataStoreInsertResult.Success>();
+            return ((DataStoreInsertResult.Success)result).Id;
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_application()
+        {
+            var result = await _tenantBRepository.GetApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_applications_in_query()
+        {
+            var result = await _tenantBRepository.QueryApplication(
+                new ApplicationQuery { Limit = 25, Offset = 0 }
+            );
+            result.Should().BeOfType<ApplicationQueryResult.Success>();
+            var responses = ((ApplicationQueryResult.Success)result).ApplicationResponses;
+            responses.Should().Contain(a => a.Id == _tenantBApplicationId);
+            responses.Should().NotContain(a => a.Id == _tenantAApplicationId);
+        }
+
+        [Test]
+        public async Task It_should_not_update_another_tenants_application()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantAApplicationId,
+                    ApplicationName = "Hijacked Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureNotExists>();
+
+            var unchanged = await _tenantARepository.GetApplication(_tenantAApplicationId);
+            unchanged.Should().BeOfType<ApplicationGetResult.Success>();
+            ((ApplicationGetResult.Success)unchanged)
+                .ApplicationResponse.ApplicationName.Should()
+                .Be("Tenant A Application");
+        }
+
+        [Test]
+        public async Task It_should_not_move_an_application_to_another_tenants_vendor()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantBApplicationId,
+                    ApplicationName = "Tenant B Application",
+                    VendorId = _tenantAVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureVendorNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_delete_another_tenants_application()
+        {
+            var result = await _tenantBRepository.DeleteApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationDeleteResult.FailureNotExists>();
+
+            var stillThere = await _tenantARepository.GetApplication(_tenantAApplicationId);
+            stillThere.Should().BeOfType<ApplicationGetResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_application_api_clients()
+        {
+            var result = await _tenantBRepository.GetApplicationApiClients(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationApiClientsResult.Success>();
+            ((ApplicationApiClientsResult.Success)result).Clients.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_application_under_another_tenants_vendor()
+        {
+            var result = await _tenantBRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = "Cross Tenant Application",
+                    VendorId = _tenantAVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.FailureVendorNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_application_with_another_tenants_data_store()
+        {
+            var result = await _tenantBRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = "Cross Tenant Data Store Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_update_an_application_with_another_tenants_data_store()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantBApplicationId,
+                    ApplicationName = "Tenant B Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = _tenantBClientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_expose_tenant_scoped_applications_in_single_tenant_context()
+        {
+            var singleTenantRepository = CreateApplicationRepository(new TenantContextProvider());
+            var result = await singleTenantRepository.GetApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationGetResult.FailureNotFound>();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApplicationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ApplicationTests.cs
@@ -1335,6 +1335,16 @@ public class ApplicationTests : DatabaseTest
         }
 
         [Test]
+        public async Task It_should_get_and_delete_its_own_tenant_application()
+        {
+            var getResult = await _tenantBRepository.GetApplication(_tenantBApplicationId);
+            getResult.Should().BeOfType<ApplicationGetResult.Success>();
+
+            var deleteResult = await _tenantBRepository.DeleteApplication(_tenantBApplicationId);
+            deleteResult.Should().BeOfType<ApplicationDeleteResult.Success>();
+        }
+
+        [Test]
         public async Task It_should_not_list_another_tenants_applications_in_query()
         {
             var result = await _tenantBRepository.QueryApplication(

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ClaimSetTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/ClaimSetTests.cs
@@ -208,7 +208,8 @@ public class ClaimSetTests : DatabaseTest
             _applicationRepository = new ApplicationRepository(
                 MssqlTestConfiguration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             ApplicationInsertCommand application = new()

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/DataStoreTests.cs
@@ -551,7 +551,8 @@ public class DataStoreTests : DatabaseTest
             var applicationRepository = new ApplicationRepository(
                 MssqlTestConfiguration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             ApplicationInsertCommand application = new()

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/VendorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration/VendorTests.cs
@@ -217,7 +217,8 @@ namespace EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration
             private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
                 MssqlTestConfiguration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             [SetUp]
@@ -413,13 +414,15 @@ namespace EdFi.DmsConfigurationService.Backend.Mssql.Tests.Integration
             private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
                 MssqlTestConfiguration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
                 MssqlTestConfiguration.DatabaseOptions,
                 NullLogger<ApiClientRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             [SetUp]

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/ApiClientRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/ApiClientRepository.cs
@@ -3,8 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data.Common;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
@@ -18,9 +20,57 @@ namespace EdFi.DmsConfigurationService.Backend.Mssql.Repositories;
 public class ApiClientRepository(
     IOptions<DatabaseOptions> databaseOptions,
     ILogger<ApiClientRepository> logger,
-    IAuditContext auditContext
+    IAuditContext auditContext,
+    ITenantContextProvider tenantContextProvider
 ) : IApiClientRepository
 {
+    private TenantContext TenantContext => tenantContextProvider.Context;
+
+    private long? TenantId => TenantContext is TenantContext.Multitenant mt ? mt.TenantId : null;
+
+    /// <summary>
+    /// SQL condition constraining an ApiClient row to the current tenant through its
+    /// owning Application's Vendor.
+    /// </summary>
+    private string TenantScopedApplicationCondition(string? tableAlias = null)
+    {
+        var column = string.IsNullOrEmpty(tableAlias) ? "ApplicationId" : $"{tableAlias}.ApplicationId";
+        return $"""
+            {column} IN (
+                SELECT a.Id FROM dmscs.Application a
+                JOIN dmscs.Vendor v ON a.VendorId = v.Id
+                WHERE {TenantContext.TenantWhereClause("v")}
+            )
+            """;
+    }
+
+    private string ApplicationInTenantExistsCondition =>
+        $"""
+            EXISTS (
+                SELECT 1 FROM dmscs.Application a
+                JOIN dmscs.Vendor v ON a.VendorId = v.Id
+                WHERE a.Id = @ApplicationId AND {TenantContext.TenantWhereClause("v")}
+            )
+            """;
+
+    private async Task<bool> AllDataStoresInTenant(
+        SqlConnection connection,
+        DbTransaction? transaction,
+        long[] dataStoreIds
+    )
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM dmscs.DataStore
+            WHERE Id IN @DataStoreIds AND {TenantContext.TenantWhereClause()};
+            """;
+        int count = await connection.ExecuteScalarAsync<int>(
+            sql,
+            new { DataStoreIds = dataStoreIds, TenantId },
+            transaction
+        );
+        return count == dataStoreIds.Distinct().Count();
+    }
+
     public async Task<ApiClientInsertResult> InsertApiClient(
         ApiClientInsertCommand command,
         ApiClientCommand clientCommand
@@ -31,13 +81,14 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 INSERT INTO dmscs.ApiClient (ApplicationId, ClientId, ClientUuid, Name, IsApproved, CreatedBy)
                 OUTPUT INSERTED.Id
-                VALUES (@ApplicationId, @ClientId, @ClientUuid, @Name, @IsApproved, @CreatedBy);
+                SELECT @ApplicationId, @ClientId, @ClientUuid, @Name, @IsApproved, @CreatedBy
+                WHERE {ApplicationInTenantExistsCondition};
                 """;
 
-            long apiClientId = await connection.ExecuteScalarAsync<long>(
+            long? apiClientId = await connection.ExecuteScalarAsync<long?>(
                 sql,
                 new
                 {
@@ -47,12 +98,27 @@ public class ApiClientRepository(
                     command.Name,
                     command.IsApproved,
                     CreatedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
 
+            if (apiClientId is null)
+            {
+                logger.LogWarning("Application not found");
+                await transaction.RollbackAsync();
+                return new ApiClientInsertResult.FailureApplicationNotFound();
+            }
+
             if (command.DataStoreIds.Length > 0)
             {
+                if (!await AllDataStoresInTenant(connection, transaction, command.DataStoreIds))
+                {
+                    logger.LogWarning("Data store not found");
+                    await transaction.RollbackAsync();
+                    return new ApiClientInsertResult.FailureDataStoreNotFound();
+                }
+
                 sql = """
                     INSERT INTO dmscs.ApiClientDataStore (ApiClientId, DataStoreId, CreatedBy)
                     VALUES (@ApiClientId, @DataStoreId, @CreatedBy);
@@ -70,7 +136,7 @@ public class ApiClientRepository(
             }
 
             await transaction.CommitAsync();
-            return new ApiClientInsertResult.Success(apiClientId);
+            return new ApiClientInsertResult.Success(apiClientId.Value);
         }
         catch (SqlException ex) when (ex.IsForeignKeyViolation("FK_ApiClient_Application"))
         {
@@ -111,14 +177,14 @@ public class ApiClientRepository(
         return $"ORDER BY {col} {(query.IsDescending ? "DESC" : "ASC")}";
     }
 
-    private static string BuildFilterClause(ApiClientQuery query)
+    private string BuildFilterClause(ApiClientQuery query)
     {
-        var conditions = new List<string>();
+        var conditions = new List<string> { TenantScopedApplicationCondition() };
         if (query.ApplicationId.HasValue)
         {
             conditions.Add("ApplicationId = @ApplicationId");
         }
-        return conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : string.Empty;
+        return "WHERE " + string.Join(" AND ", conditions);
     }
 
     public async Task<ApiClientQueryResult> QueryApiClient(ApiClientQuery query)
@@ -154,6 +220,7 @@ public class ApiClientRepository(
                     query.Limit,
                     query.Offset,
                     query.ApplicationId,
+                    TenantId,
                 },
                 splitOn: "DataStoreId"
             );
@@ -183,12 +250,12 @@ public class ApiClientRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT ac.Id, ac.ApplicationId, ac.ClientId, ac.ClientUuid, ac.Name, ac.IsApproved,
                        acd.DataStoreId
                 FROM dmscs.ApiClient ac
                 LEFT OUTER JOIN dmscs.ApiClientDataStore acd ON ac.Id = acd.ApiClientId
-                WHERE ac.ClientId = @ClientId;
+                WHERE ac.ClientId = @ClientId AND {TenantScopedApplicationCondition("ac")};
                 """;
 
             var apiClients = await connection.QueryAsync<ApiClientResponse, long?, ApiClientResponse>(
@@ -201,7 +268,7 @@ public class ApiClientRepository(
                     }
                     return apiClient;
                 },
-                param: new { ClientId = clientId },
+                param: new { ClientId = clientId, TenantId },
                 splitOn: "DataStoreId"
             );
 
@@ -232,12 +299,12 @@ public class ApiClientRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT ac.Id, ac.ApplicationId, ac.ClientId, ac.ClientUuid, ac.Name, ac.IsApproved,
                        acd.DataStoreId
                 FROM dmscs.ApiClient ac
                 LEFT OUTER JOIN dmscs.ApiClientDataStore acd ON ac.Id = acd.ApiClientId
-                WHERE ac.Id = @Id;
+                WHERE ac.Id = @Id AND {TenantScopedApplicationCondition("ac")};
                 """;
 
             var apiClients = await connection.QueryAsync<ApiClientResponse, long?, ApiClientResponse>(
@@ -250,7 +317,7 @@ public class ApiClientRepository(
                     }
                     return apiClient;
                 },
-                param: new { Id = id },
+                param: new { Id = id, TenantId },
                 splitOn: "DataStoreId"
             );
 
@@ -282,25 +349,32 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            // Check if ApiClient exists
-            string checkSql = "SELECT COUNT(1) FROM dmscs.ApiClient WHERE Id = @Id;";
-            int exists = await connection.ExecuteScalarAsync<int>(checkSql, new { command.Id }, transaction);
+            // Check if ApiClient exists within the current tenant
+            string checkSql = $"""
+                SELECT COUNT(1) FROM dmscs.ApiClient
+                WHERE Id = @Id AND {TenantScopedApplicationCondition()};
+                """;
+            int exists = await connection.ExecuteScalarAsync<int>(
+                checkSql,
+                new { command.Id, TenantId },
+                transaction
+            );
             if (exists == 0)
             {
                 await transaction.RollbackAsync();
                 return new ApiClientUpdateResult.FailureNotFound();
             }
 
-            // Update ApiClient record
-            string updateSql = """
+            // Update ApiClient record; the target application must belong to the current tenant
+            string updateSql = $"""
                 UPDATE dmscs.ApiClient
                 SET ApplicationId = @ApplicationId, Name = @Name, IsApproved = @IsApproved,
                     ClientUuid = COALESCE(@ClientUuid, ClientUuid),
                     LastModifiedAt = @LastModifiedAt, ModifiedBy = @ModifiedBy
-                WHERE Id = @Id;
+                WHERE Id = @Id AND {ApplicationInTenantExistsCondition};
                 """;
 
-            await connection.ExecuteAsync(
+            int updatedRows = await connection.ExecuteAsync(
                 updateSql,
                 new
                 {
@@ -311,9 +385,27 @@ public class ApiClientRepository(
                     ClientUuid = command.ClientUuid,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
+
+            if (updatedRows == 0)
+            {
+                logger.LogWarning("Application not found");
+                await transaction.RollbackAsync();
+                return new ApiClientUpdateResult.FailureApplicationNotFound();
+            }
+
+            if (
+                command.DataStoreIds.Length > 0
+                && !await AllDataStoresInTenant(connection, transaction, command.DataStoreIds)
+            )
+            {
+                logger.LogWarning("Data store not found");
+                await transaction.RollbackAsync();
+                return new ApiClientUpdateResult.FailureDataStoreNotFound();
+            }
 
             // Delete existing data store mappings
             string deleteSql = "DELETE FROM dmscs.ApiClientDataStore WHERE ApiClientId = @Id;";
@@ -368,9 +460,16 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            // Check if ApiClient exists
-            string checkSql = "SELECT COUNT(1) FROM dmscs.ApiClient WHERE Id = @Id;";
-            int exists = await connection.ExecuteScalarAsync<int>(checkSql, new { Id = id }, transaction);
+            // Check if ApiClient exists within the current tenant
+            string checkSql = $"""
+                SELECT COUNT(1) FROM dmscs.ApiClient
+                WHERE Id = @Id AND {TenantScopedApplicationCondition()};
+                """;
+            int exists = await connection.ExecuteScalarAsync<int>(
+                checkSql,
+                new { Id = id, TenantId },
+                transaction
+            );
             if (exists == 0)
             {
                 await transaction.RollbackAsync();

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/ApplicationRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Mssql/Repositories/ApplicationRepository.cs
@@ -3,8 +3,10 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Data.Common;
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
@@ -17,9 +19,58 @@ namespace EdFi.DmsConfigurationService.Backend.Mssql.Repositories;
 public class ApplicationRepository(
     IOptions<DatabaseOptions> databaseOptions,
     ILogger<ApplicationRepository> logger,
-    IAuditContext auditContext
+    IAuditContext auditContext,
+    ITenantContextProvider tenantContextProvider
 ) : IApplicationRepository
 {
+    private TenantContext TenantContext => tenantContextProvider.Context;
+
+    private long? TenantId => TenantContext is TenantContext.Multitenant mt ? mt.TenantId : null;
+
+    /// <summary>
+    /// SQL condition constraining an Application row to the current tenant through its owning Vendor.
+    /// </summary>
+    private string TenantScopedVendorCondition(string? tableAlias = null)
+    {
+        var column = string.IsNullOrEmpty(tableAlias) ? "VendorId" : $"{tableAlias}.VendorId";
+        return $"""
+            {column} IN (
+                SELECT Id FROM dmscs.Vendor WHERE {TenantContext.TenantWhereClause()}
+            )
+            """;
+    }
+
+    private async Task<bool> AllDataStoresInTenant(
+        SqlConnection connection,
+        DbTransaction? transaction,
+        long[] dataStoreIds
+    )
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM dmscs.DataStore
+            WHERE Id IN @DataStoreIds AND {TenantContext.TenantWhereClause()};
+            """;
+        int count = await connection.ExecuteScalarAsync<int>(
+            sql,
+            new { DataStoreIds = dataStoreIds, TenantId },
+            transaction
+        );
+        return count == dataStoreIds.Distinct().Count();
+    }
+
+    private async Task<bool> ApplicationExistsForTenant(
+        SqlConnection connection,
+        DbTransaction? transaction,
+        long id
+    )
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM dmscs.Application
+            WHERE Id = @Id AND {TenantScopedVendorCondition()};
+            """;
+        return await connection.ExecuteScalarAsync<int>(sql, new { Id = id, TenantId }, transaction) > 0;
+    }
+
     public async Task<ApplicationInsertResult> InsertApplication(
         ApplicationInsertCommand command,
         ApiClientCommand clientCommand
@@ -30,13 +81,17 @@ public class ApplicationRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 INSERT INTO dmscs.Application (ApplicationName, VendorId, ClaimSetName, CreatedBy)
                 OUTPUT INSERTED.Id
-                VALUES (@ApplicationName, @VendorId, @ClaimSetName, @CreatedBy);
+                SELECT @ApplicationName, @VendorId, @ClaimSetName, @CreatedBy
+                WHERE EXISTS (
+                    SELECT 1 FROM dmscs.Vendor
+                    WHERE Id = @VendorId AND {TenantContext.TenantWhereClause()}
+                );
                 """;
 
-            long id = await connection.ExecuteScalarAsync<long>(
+            long? insertedId = await connection.ExecuteScalarAsync<long?>(
                 sql,
                 new
                 {
@@ -44,9 +99,19 @@ public class ApplicationRepository(
                     command.VendorId,
                     command.ClaimSetName,
                     CreatedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
+
+            if (insertedId is null)
+            {
+                logger.LogWarning("Vendor not found");
+                await transaction.RollbackAsync();
+                return new ApplicationInsertResult.FailureVendorNotFound();
+            }
+
+            long id = insertedId.Value;
 
             sql = """
                 INSERT INTO dmscs.ApplicationEducationOrganization (ApplicationId, EducationOrganizationId, CreatedBy)
@@ -85,6 +150,13 @@ public class ApplicationRepository(
 
             if (command.DataStoreIds.Length > 0)
             {
+                if (!await AllDataStoresInTenant(connection, transaction, command.DataStoreIds))
+                {
+                    logger.LogWarning("Data store not found");
+                    await transaction.RollbackAsync();
+                    return new ApplicationInsertResult.FailureDataStoreNotFound();
+                }
+
                 sql = """
                     INSERT INTO dmscs.ApiClientDataStore (ApiClientId, DataStoreId, CreatedBy)
                     VALUES (@ApiClientId, @DataStoreId, @CreatedBy);
@@ -180,9 +252,9 @@ public class ApplicationRepository(
         return $"ORDER BY {col} {(query.IsDescending ? "DESC" : "ASC")}";
     }
 
-    private static string BuildFilterClause(ApplicationQuery query, int[] parsedIds)
+    private string BuildFilterClause(ApplicationQuery query, int[] parsedIds)
     {
-        var conditions = new List<string>();
+        var conditions = new List<string> { TenantScopedVendorCondition() };
         if (query.Id.HasValue)
         {
             conditions.Add("Id = @Id");
@@ -199,7 +271,7 @@ public class ApplicationRepository(
         {
             conditions.Add("Id IN @ParsedIds");
         }
-        return conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : string.Empty;
+        return "WHERE " + string.Join(" AND ", conditions);
     }
 
     public async Task<ApplicationQueryResult> QueryApplication(ApplicationQuery query)
@@ -265,6 +337,7 @@ public class ApplicationRepository(
                     query.ApplicationName,
                     query.ClaimSetName,
                     ParsedIds = parsedIds,
+                    TenantId,
                 },
                 splitOn: "EducationOrganizationId,DataStoreId,ProfileId"
             );
@@ -298,7 +371,7 @@ public class ApplicationRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT a.Id, a.ApplicationName, a.VendorId, a.ClaimSetName,
                        (SELECT CAST(COALESCE(MIN(CAST(ac2.IsApproved AS INT)), 1) AS BIT)
                         FROM dmscs.ApiClient ac2
@@ -309,7 +382,7 @@ public class ApplicationRepository(
                 LEFT OUTER JOIN dmscs.ApiClient ac ON a.Id = ac.ApplicationId
                 LEFT OUTER JOIN dmscs.ApiClientDataStore acd ON ac.Id = acd.ApiClientId
                 LEFT OUTER JOIN dmscs.ApplicationProfile ap ON a.Id = ap.ApplicationId
-                WHERE a.Id = @Id;
+                WHERE a.Id = @Id AND {TenantScopedVendorCondition("a")};
                 """;
             var applications = await connection.QueryAsync<
                 ApplicationResponse,
@@ -335,7 +408,7 @@ public class ApplicationRepository(
                     }
                     return application;
                 },
-                param: new { Id = id },
+                param: new { Id = id, TenantId },
                 splitOn: "EducationOrganizationId,DataStoreId,ProfileId"
             );
 
@@ -374,11 +447,16 @@ public class ApplicationRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 UPDATE dmscs.Application
                 SET ApplicationName=@ApplicationName, VendorId=@VendorId, ClaimSetName=@ClaimSetName,
                     LastModifiedAt=@LastModifiedAt, ModifiedBy=@ModifiedBy
-                WHERE Id = @Id;
+                WHERE Id = @Id
+                  AND {TenantScopedVendorCondition()}
+                  AND EXISTS (
+                      SELECT 1 FROM dmscs.Vendor
+                      WHERE Id = @VendorId AND {TenantContext.TenantWhereClause()}
+                  );
                 """;
             int affectedRows = await connection.ExecuteAsync(
                 sql,
@@ -390,13 +468,31 @@ public class ApplicationRepository(
                     command.Id,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
 
             if (affectedRows == 0)
             {
-                return new ApplicationUpdateResult.FailureNotExists();
+                if (!await ApplicationExistsForTenant(connection, transaction, command.Id))
+                {
+                    return new ApplicationUpdateResult.FailureNotExists();
+                }
+
+                logger.LogWarning("Update application failure: Vendor not found");
+                await transaction.RollbackAsync();
+                return new ApplicationUpdateResult.FailureVendorNotFound();
+            }
+
+            if (
+                command.DataStoreIds.Length > 0
+                && !await AllDataStoresInTenant(connection, transaction, command.DataStoreIds)
+            )
+            {
+                logger.LogWarning("Update application failure: Data store not found");
+                await transaction.RollbackAsync();
+                return new ApplicationUpdateResult.FailureDataStoreNotFound();
             }
 
             sql = "DELETE FROM dmscs.ApplicationEducationOrganization WHERE ApplicationId = @ApplicationId";
@@ -420,7 +516,7 @@ public class ApplicationRepository(
             string updateApiClientsql = """
                 UPDATE dmscs.ApiClient
                 SET ClientUuid=@ClientUuid, LastModifiedAt=@LastModifiedAt, ModifiedBy=@ModifiedBy
-                WHERE ClientId = @ClientId;
+                WHERE ClientId = @ClientId AND ApplicationId = @ApplicationId;
                 """;
 
             await connection.ExecuteAsync(
@@ -429,6 +525,7 @@ public class ApplicationRepository(
                 {
                     clientCommand.ClientUuid,
                     clientCommand.ClientId,
+                    ApplicationId = command.Id,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = currentUser,
                 },
@@ -436,10 +533,11 @@ public class ApplicationRepository(
             );
 
             // Get ApiClient Id for DataStore relationship update
-            sql = "SELECT Id FROM dmscs.ApiClient WHERE ClientId = @ClientId;";
+            sql =
+                "SELECT Id FROM dmscs.ApiClient WHERE ClientId = @ClientId AND ApplicationId = @ApplicationId;";
             long apiClientId = await connection.ExecuteScalarAsync<long>(
                 sql,
-                new { clientCommand.ClientId },
+                new { clientCommand.ClientId, ApplicationId = command.Id },
                 transaction
             );
 
@@ -534,11 +632,11 @@ public class ApplicationRepository(
         await using var connection = new SqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
-            string sql = """
-                DELETE FROM dmscs.Application where Id = @Id;
+            string sql = $"""
+                DELETE FROM dmscs.Application where Id = @Id AND {TenantScopedVendorCondition()};
                 """;
 
-            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id });
+            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id, TenantId });
             return affectedRows > 0
                 ? new ApplicationDeleteResult.Success()
                 : new ApplicationDeleteResult.FailureNotExists();
@@ -555,14 +653,15 @@ public class ApplicationRepository(
         await using var connection = new SqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
-            string sql = """
-                SELECT ClientId, ClientUuid, IsApproved
-                FROM dmscs.ApiClient
-                WHERE ApplicationId = @Id
-                ORDER BY Id
+            string sql = $"""
+                SELECT ac.ClientId, ac.ClientUuid, ac.IsApproved
+                FROM dmscs.ApiClient ac
+                JOIN dmscs.Application a ON ac.ApplicationId = a.Id
+                WHERE ac.ApplicationId = @Id AND {TenantScopedVendorCondition("a")}
+                ORDER BY ac.Id
                 """;
 
-            var clients = await connection.QueryAsync<ApiClient>(sql, new { Id = @id });
+            var clients = await connection.QueryAsync<ApiClient>(sql, new { Id = @id, TenantId });
 
             return new ApplicationApiClientsResult.Success(clients.ToArray());
         }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApiClientTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApiClientTests.cs
@@ -399,6 +399,16 @@ public class ApiClientTests : DatabaseTest
         }
 
         [Test]
+        public async Task It_should_get_and_delete_its_own_tenant_api_client()
+        {
+            var getResult = await _tenantBApiClientRepository.GetApiClientById(_tenantBApiClientId);
+            getResult.Should().BeOfType<ApiClientGetResult.Success>();
+
+            var deleteResult = await _tenantBApiClientRepository.DeleteApiClient(_tenantBApiClientId);
+            deleteResult.Should().BeOfType<ApiClientDeleteResult.Success>();
+        }
+
+        [Test]
         public async Task It_should_not_get_another_tenants_api_client_by_client_id()
         {
             var result = await _tenantBApiClientRepository.GetApiClientByClientId(_tenantAClientId);

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApiClientTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApiClientTests.cs
@@ -9,6 +9,8 @@ using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
+using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.Tenant;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,13 +22,15 @@ public class ApiClientTests : DatabaseTest
     private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
         Configuration.DatabaseOptions,
         NullLogger<ApiClientRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
         Configuration.DatabaseOptions,
         NullLogger<ApplicationRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     [TestFixture]
@@ -210,6 +214,309 @@ public class ApiClientTests : DatabaseTest
                 .ToList();
             names.Should().HaveCount(3);
             names.Should().ContainInOrder("Charlie-Client", "Bravo-App", "Alpha-Client");
+        }
+    }
+
+    [TestFixture]
+    public class Given_api_client_operations_from_another_tenant : ApiClientTests
+    {
+        private IApiClientRepository _tenantAApiClientRepository = null!;
+        private IApiClientRepository _tenantBApiClientRepository = null!;
+        private long _tenantAApplicationId;
+        private long _tenantBApplicationId;
+        private long _tenantAApiClientId;
+        private string _tenantAClientId = string.Empty;
+        private long _tenantBApiClientId;
+        private long _tenantADataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var tenantRepository = new TenantRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<TenantRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var tenantAProvider = await CreateTenantProvider(tenantRepository, "A");
+            var tenantBProvider = await CreateTenantProvider(tenantRepository, "B");
+
+            _tenantAApiClientRepository = CreateApiClientRepository(tenantAProvider);
+            _tenantBApiClientRepository = CreateApiClientRepository(tenantBProvider);
+
+            _tenantAApplicationId = await InsertVendorWithApplication(tenantAProvider, "Tenant A Company");
+            _tenantBApplicationId = await InsertVendorWithApplication(tenantBProvider, "Tenant B Company");
+
+            (_tenantAApiClientId, _tenantAClientId) = await InsertApiClient(
+                _tenantAApiClientRepository,
+                _tenantAApplicationId,
+                "Tenant A Client"
+            );
+            (_tenantBApiClientId, _) = await InsertApiClient(
+                _tenantBApiClientRepository,
+                _tenantBApplicationId,
+                "Tenant B Client"
+            );
+
+            _tenantADataStoreId = await InsertDataStore(tenantAProvider, "Tenant A Data Store");
+        }
+
+        private static async Task<TenantContextProvider> CreateTenantProvider(
+            TenantRepository tenantRepository,
+            string suffix
+        )
+        {
+            var tenantName = $"ApiClientTenant{suffix}-{Guid.NewGuid()}";
+            var tenantResult = await tenantRepository.InsertTenant(
+                new TenantInsertCommand { Name = tenantName }
+            );
+            tenantResult.Should().BeOfType<TenantInsertResult.Success>();
+            return new TenantContextProvider
+            {
+                Context = new TenantContext.Multitenant(
+                    ((TenantInsertResult.Success)tenantResult).Id,
+                    tenantName
+                ),
+            };
+        }
+
+        private static ApiClientRepository CreateApiClientRepository(
+            TenantContextProvider tenantContextProvider
+        ) =>
+            new(
+                Configuration.DatabaseOptions,
+                NullLogger<ApiClientRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+
+        private static async Task<long> InsertVendorWithApplication(
+            TenantContextProvider tenantContextProvider,
+            string company
+        )
+        {
+            IVendorRepository vendorRepository = new VendorRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<VendorRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var vendorResult = await vendorRepository.InsertVendor(
+                new VendorInsertCommand
+                {
+                    Company = company,
+                    ContactEmailAddress = "tenant@test.com",
+                    ContactName = "Tenant Tester",
+                    NamespacePrefixes = "uri://tenant-test.example",
+                }
+            );
+            vendorResult.Should().BeOfType<VendorInsertResult.Success>();
+            long vendorId = ((VendorInsertResult.Success)vendorResult).Id;
+
+            IApplicationRepository applicationRepository = new ApplicationRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<ApplicationRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var applicationResult = await applicationRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = $"{company} Application",
+                    VendorId = vendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            applicationResult.Should().BeOfType<ApplicationInsertResult.Success>();
+            return ((ApplicationInsertResult.Success)applicationResult).Id;
+        }
+
+        private static async Task<(long Id, string ClientId)> InsertApiClient(
+            IApiClientRepository apiClientRepository,
+            long applicationId,
+            string name
+        )
+        {
+            string clientId = Guid.NewGuid().ToString();
+            var result = await apiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = applicationId,
+                    Name = name,
+                    IsApproved = true,
+                    DataStoreIds = [],
+                },
+                new ApiClientCommand { ClientId = clientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.Success>();
+            return (((ApiClientInsertResult.Success)result).Id, clientId);
+        }
+
+        private static async Task<long> InsertDataStore(
+            TenantContextProvider tenantContextProvider,
+            string name
+        )
+        {
+            var dataStoreRepository = new DataStoreRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<DataStoreRepository>.Instance,
+                new ConnectionStringEncryptionService(Configuration.DatabaseOptions),
+                new DataStoreContextRepository(
+                    Configuration.DatabaseOptions,
+                    NullLogger<DataStoreContextRepository>.Instance,
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new DataStoreDerivativeRepository(
+                    Configuration.DatabaseOptions,
+                    NullLogger<DataStoreDerivativeRepository>.Instance,
+                    new ConnectionStringEncryptionService(Configuration.DatabaseOptions),
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var result = await dataStoreRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = name,
+                    ConnectionString = "Server=tenant;Database=TenantDb;",
+                }
+            );
+            result.Should().BeOfType<DataStoreInsertResult.Success>();
+            return ((DataStoreInsertResult.Success)result).Id;
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_api_client_by_id()
+        {
+            var result = await _tenantBApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_api_client_by_client_id()
+        {
+            var result = await _tenantBApiClientRepository.GetApiClientByClientId(_tenantAClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_api_clients_in_query()
+        {
+            var result = await _tenantBApiClientRepository.QueryApiClient(
+                new ApiClientQuery { Limit = 25, Offset = 0 }
+            );
+            result.Should().BeOfType<ApiClientQueryResult.Success>();
+            var responses = ((ApiClientQueryResult.Success)result).ApiClientResponses;
+            responses.Should().Contain(c => c.Id == _tenantBApiClientId);
+            responses.Should().NotContain(c => c.Id == _tenantAApiClientId);
+        }
+
+        [Test]
+        public async Task It_should_not_update_another_tenants_api_client()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantAApiClientId,
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Hijacked Client",
+                    IsApproved = false,
+                    DataStoreIds = [],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureNotFound>();
+
+            var unchanged = await _tenantAApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            unchanged.Should().BeOfType<ApiClientGetResult.Success>();
+            ((ApiClientGetResult.Success)unchanged).ApiClientResponse.Name.Should().Be("Tenant A Client");
+        }
+
+        [Test]
+        public async Task It_should_not_move_an_api_client_to_another_tenants_application()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantBApiClientId,
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Tenant B Client",
+                    IsApproved = true,
+                    DataStoreIds = [],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureApplicationNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_update_an_api_client_with_another_tenants_data_store()
+        {
+            var result = await _tenantBApiClientRepository.UpdateApiClient(
+                new ApiClientUpdateCommand
+                {
+                    Id = _tenantBApiClientId,
+                    ApplicationId = _tenantBApplicationId,
+                    Name = "Tenant B Client",
+                    IsApproved = true,
+                    DataStoreIds = [_tenantADataStoreId],
+                }
+            );
+            result.Should().BeOfType<ApiClientUpdateResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_delete_another_tenants_api_client()
+        {
+            var result = await _tenantBApiClientRepository.DeleteApiClient(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientDeleteResult.FailureNotFound>();
+
+            var stillThere = await _tenantAApiClientRepository.GetApiClientById(_tenantAApiClientId);
+            stillThere.Should().BeOfType<ApiClientGetResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_api_client_under_another_tenants_application()
+        {
+            var result = await _tenantBApiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = _tenantAApplicationId,
+                    Name = "Cross Tenant Client",
+                    IsApproved = true,
+                    DataStoreIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.FailureApplicationNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_api_client_with_another_tenants_data_store()
+        {
+            var result = await _tenantBApiClientRepository.InsertApiClient(
+                new ApiClientInsertCommand
+                {
+                    ApplicationId = _tenantBApplicationId,
+                    Name = "Cross Tenant Data Store Client",
+                    IsApproved = true,
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApiClientInsertResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_expose_tenant_scoped_api_clients_in_single_tenant_context()
+        {
+            var singleTenantRepository = CreateApiClientRepository(new TenantContextProvider());
+            var result = await singleTenantRepository.GetApiClientById(_tenantAApiClientId);
+            result.Should().BeOfType<ApiClientGetResult.FailureNotFound>();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
@@ -1335,6 +1335,16 @@ public class ApplicationTests : DatabaseTest
         }
 
         [Test]
+        public async Task It_should_get_and_delete_its_own_tenant_application()
+        {
+            var getResult = await _tenantBRepository.GetApplication(_tenantBApplicationId);
+            getResult.Should().BeOfType<ApplicationGetResult.Success>();
+
+            var deleteResult = await _tenantBRepository.DeleteApplication(_tenantBApplicationId);
+            deleteResult.Should().BeOfType<ApplicationDeleteResult.Success>();
+        }
+
+        [Test]
         public async Task It_should_not_list_another_tenants_applications_in_query()
         {
             var result = await _tenantBRepository.QueryApplication(

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ApplicationTests.cs
@@ -11,6 +11,7 @@ using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
 using EdFi.DmsConfigurationService.DataModel.Model.DataStore;
+using EdFi.DmsConfigurationService.DataModel.Model.Tenant;
 using EdFi.DmsConfigurationService.DataModel.Model.Vendor;
 using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,7 +23,8 @@ public class ApplicationTests : DatabaseTest
     private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
         Configuration.DatabaseOptions,
         NullLogger<ApplicationRepository>.Instance,
-        new TestAuditContext()
+        new TestAuditContext(),
+        new TenantContextProvider()
     );
 
     private long _vendorId;
@@ -690,7 +692,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             Configuration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         [SetUp]
@@ -773,7 +776,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             Configuration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly IDataStoreRepository _dataStoreRepository;
@@ -929,7 +933,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             Configuration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly IDataStoreRepository _dataStoreRepository;
@@ -1080,7 +1085,8 @@ public class ApplicationTests : DatabaseTest
         private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
             Configuration.DatabaseOptions,
             NullLogger<ApiClientRepository>.Instance,
-            new TestAuditContext()
+            new TestAuditContext(),
+            new TenantContextProvider()
         );
 
         private readonly OpenIddictDataRepository _openIddictDataRepository = new(
@@ -1163,6 +1169,298 @@ public class ApplicationTests : DatabaseTest
             var result = await _openIddictDataRepository.GetApplicationByClientIdAsync(_clientId);
             result.Should().NotBeNull();
             result!.IsApproved.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    public class Given_application_operations_from_another_tenant : ApplicationTests
+    {
+        private IApplicationRepository _tenantARepository = null!;
+        private IApplicationRepository _tenantBRepository = null!;
+        private long _tenantAVendorId;
+        private long _tenantBVendorId;
+        private long _tenantAApplicationId;
+        private long _tenantBApplicationId;
+        private string _tenantBClientId = string.Empty;
+        private long _tenantADataStoreId;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var tenantRepository = new TenantRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<TenantRepository>.Instance,
+                new TestAuditContext()
+            );
+
+            var tenantAProvider = await CreateTenantProvider(tenantRepository, "A");
+            var tenantBProvider = await CreateTenantProvider(tenantRepository, "B");
+
+            _tenantARepository = CreateApplicationRepository(tenantAProvider);
+            _tenantBRepository = CreateApplicationRepository(tenantBProvider);
+
+            _tenantAVendorId = await InsertVendor(tenantAProvider, "Tenant A Company");
+            _tenantBVendorId = await InsertVendor(tenantBProvider, "Tenant B Company");
+
+            (_tenantAApplicationId, _) = await InsertApplication(
+                _tenantARepository,
+                _tenantAVendorId,
+                "Tenant A Application"
+            );
+            (_tenantBApplicationId, _tenantBClientId) = await InsertApplication(
+                _tenantBRepository,
+                _tenantBVendorId,
+                "Tenant B Application"
+            );
+
+            _tenantADataStoreId = await InsertDataStore(tenantAProvider, "Tenant A Data Store");
+        }
+
+        private static async Task<TenantContextProvider> CreateTenantProvider(
+            TenantRepository tenantRepository,
+            string suffix
+        )
+        {
+            var tenantName = $"ApplicationTenant{suffix}-{Guid.NewGuid()}";
+            var tenantResult = await tenantRepository.InsertTenant(
+                new TenantInsertCommand { Name = tenantName }
+            );
+            tenantResult.Should().BeOfType<TenantInsertResult.Success>();
+            return new TenantContextProvider
+            {
+                Context = new TenantContext.Multitenant(
+                    ((TenantInsertResult.Success)tenantResult).Id,
+                    tenantName
+                ),
+            };
+        }
+
+        private static ApplicationRepository CreateApplicationRepository(
+            TenantContextProvider tenantContextProvider
+        ) =>
+            new(
+                Configuration.DatabaseOptions,
+                NullLogger<ApplicationRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+
+        private static async Task<long> InsertVendor(
+            TenantContextProvider tenantContextProvider,
+            string company
+        )
+        {
+            IVendorRepository vendorRepository = new VendorRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<VendorRepository>.Instance,
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var vendorResult = await vendorRepository.InsertVendor(
+                new VendorInsertCommand
+                {
+                    Company = company,
+                    ContactEmailAddress = "tenant@test.com",
+                    ContactName = "Tenant Tester",
+                    NamespacePrefixes = "uri://tenant-test.example",
+                }
+            );
+            vendorResult.Should().BeOfType<VendorInsertResult.Success>();
+            return ((VendorInsertResult.Success)vendorResult).Id;
+        }
+
+        private static async Task<(long Id, string ClientId)> InsertApplication(
+            IApplicationRepository applicationRepository,
+            long vendorId,
+            string applicationName
+        )
+        {
+            string clientId = Guid.NewGuid().ToString();
+            var result = await applicationRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = applicationName,
+                    VendorId = vendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = clientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.Success>();
+            return (((ApplicationInsertResult.Success)result).Id, clientId);
+        }
+
+        private static async Task<long> InsertDataStore(
+            TenantContextProvider tenantContextProvider,
+            string name
+        )
+        {
+            var dataStoreRepository = new DataStoreRepository(
+                Configuration.DatabaseOptions,
+                NullLogger<DataStoreRepository>.Instance,
+                new ConnectionStringEncryptionService(Configuration.DatabaseOptions),
+                new DataStoreContextRepository(
+                    Configuration.DatabaseOptions,
+                    NullLogger<DataStoreContextRepository>.Instance,
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new DataStoreDerivativeRepository(
+                    Configuration.DatabaseOptions,
+                    NullLogger<DataStoreDerivativeRepository>.Instance,
+                    new ConnectionStringEncryptionService(Configuration.DatabaseOptions),
+                    new TestAuditContext(),
+                    tenantContextProvider
+                ),
+                new TestAuditContext(),
+                tenantContextProvider
+            );
+            var result = await dataStoreRepository.InsertDataStore(
+                new DataStoreInsertCommand
+                {
+                    DataStoreType = "Production",
+                    Name = name,
+                    ConnectionString = "Server=tenant;Database=TenantDb;",
+                }
+            );
+            result.Should().BeOfType<DataStoreInsertResult.Success>();
+            return ((DataStoreInsertResult.Success)result).Id;
+        }
+
+        [Test]
+        public async Task It_should_not_get_another_tenants_application()
+        {
+            var result = await _tenantBRepository.GetApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationGetResult.FailureNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_applications_in_query()
+        {
+            var result = await _tenantBRepository.QueryApplication(
+                new ApplicationQuery { Limit = 25, Offset = 0 }
+            );
+            result.Should().BeOfType<ApplicationQueryResult.Success>();
+            var responses = ((ApplicationQueryResult.Success)result).ApplicationResponses;
+            responses.Should().Contain(a => a.Id == _tenantBApplicationId);
+            responses.Should().NotContain(a => a.Id == _tenantAApplicationId);
+        }
+
+        [Test]
+        public async Task It_should_not_update_another_tenants_application()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantAApplicationId,
+                    ApplicationName = "Hijacked Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureNotExists>();
+
+            var unchanged = await _tenantARepository.GetApplication(_tenantAApplicationId);
+            unchanged.Should().BeOfType<ApplicationGetResult.Success>();
+            ((ApplicationGetResult.Success)unchanged)
+                .ApplicationResponse.ApplicationName.Should()
+                .Be("Tenant A Application");
+        }
+
+        [Test]
+        public async Task It_should_not_move_an_application_to_another_tenants_vendor()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantBApplicationId,
+                    ApplicationName = "Tenant B Application",
+                    VendorId = _tenantAVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureVendorNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_delete_another_tenants_application()
+        {
+            var result = await _tenantBRepository.DeleteApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationDeleteResult.FailureNotExists>();
+
+            var stillThere = await _tenantARepository.GetApplication(_tenantAApplicationId);
+            stillThere.Should().BeOfType<ApplicationGetResult.Success>();
+        }
+
+        [Test]
+        public async Task It_should_not_list_another_tenants_application_api_clients()
+        {
+            var result = await _tenantBRepository.GetApplicationApiClients(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationApiClientsResult.Success>();
+            ((ApplicationApiClientsResult.Success)result).Clients.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_application_under_another_tenants_vendor()
+        {
+            var result = await _tenantBRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = "Cross Tenant Application",
+                    VendorId = _tenantAVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.FailureVendorNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_insert_an_application_with_another_tenants_data_store()
+        {
+            var result = await _tenantBRepository.InsertApplication(
+                new ApplicationInsertCommand
+                {
+                    ApplicationName = "Cross Tenant Data Store Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = Guid.NewGuid().ToString(), ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationInsertResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_update_an_application_with_another_tenants_data_store()
+        {
+            var result = await _tenantBRepository.UpdateApplication(
+                new ApplicationUpdateCommand
+                {
+                    Id = _tenantBApplicationId,
+                    ApplicationName = "Tenant B Application",
+                    VendorId = _tenantBVendorId,
+                    ClaimSetName = "Test Claim set",
+                    EducationOrganizationIds = [],
+                    DataStoreIds = [_tenantADataStoreId],
+                },
+                new ApiClientCommand { ClientId = _tenantBClientId, ClientUuid = Guid.NewGuid() }
+            );
+            result.Should().BeOfType<ApplicationUpdateResult.FailureDataStoreNotFound>();
+        }
+
+        [Test]
+        public async Task It_should_not_expose_tenant_scoped_applications_in_single_tenant_context()
+        {
+            var singleTenantRepository = CreateApplicationRepository(new TenantContextProvider());
+            var result = await singleTenantRepository.GetApplication(_tenantAApplicationId);
+            result.Should().BeOfType<ApplicationGetResult.FailureNotFound>();
         }
     }
 }

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/ClaimSetTests.cs
@@ -208,7 +208,8 @@ public class ClaimSetTests : DatabaseTest
             _applicationRepository = new ApplicationRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             ApplicationInsertCommand application = new()

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/DataStoreTests.cs
@@ -550,7 +550,8 @@ public class DataStoreTests : DatabaseTest
             var applicationRepository = new ApplicationRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             ApplicationInsertCommand application = new()

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/VendorTests.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration/VendorTests.cs
@@ -217,7 +217,8 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration
             private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             [SetUp]
@@ -427,13 +428,15 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Tests.Integration
             private readonly IApplicationRepository _applicationRepository = new ApplicationRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApplicationRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             private readonly IApiClientRepository _apiClientRepository = new ApiClientRepository(
                 Configuration.DatabaseOptions,
                 NullLogger<ApiClientRepository>.Instance,
-                new TestAuditContext()
+                new TestAuditContext(),
+                new TenantContextProvider()
             );
 
             [SetUp]

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApiClientRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApiClientRepository.cs
@@ -5,6 +5,7 @@
 
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.ApiClient;
@@ -18,9 +19,59 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories;
 public class ApiClientRepository(
     IOptions<DatabaseOptions> databaseOptions,
     ILogger<ApiClientRepository> logger,
-    IAuditContext auditContext
+    IAuditContext auditContext,
+    ITenantContextProvider tenantContextProvider
 ) : IApiClientRepository
 {
+    private TenantContext TenantContext => tenantContextProvider.Context;
+
+    private long? TenantId => TenantContext is TenantContext.Multitenant mt ? mt.TenantId : null;
+
+    /// <summary>
+    /// SQL condition constraining an ApiClient row to the current tenant through its
+    /// owning Application's Vendor.
+    /// </summary>
+    private string TenantScopedApplicationCondition(string? tableAlias = null)
+    {
+        var column = string.IsNullOrEmpty(tableAlias)
+            ? "\"ApplicationId\""
+            : $"{tableAlias}.\"ApplicationId\"";
+        return $"""
+            {column} IN (
+                SELECT a."Id" FROM "dmscs"."Application" a
+                JOIN "dmscs"."Vendor" v ON a."VendorId" = v."Id"
+                WHERE {TenantContext.TenantWhereClause("v")}
+            )
+            """;
+    }
+
+    private string ApplicationInTenantExistsCondition =>
+        $"""
+            EXISTS (
+                SELECT 1 FROM "dmscs"."Application" a
+                JOIN "dmscs"."Vendor" v ON a."VendorId" = v."Id"
+                WHERE a."Id" = @ApplicationId AND {TenantContext.TenantWhereClause("v")}
+            )
+            """;
+
+    private async Task<bool> AllDataStoresInTenant(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        long[] dataStoreIds
+    )
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM "dmscs"."DataStore"
+            WHERE "Id" = ANY(@DataStoreIds) AND {TenantContext.TenantWhereClause()};
+            """;
+        int count = await connection.ExecuteScalarAsync<int>(
+            sql,
+            new { DataStoreIds = dataStoreIds, TenantId },
+            transaction
+        );
+        return count == dataStoreIds.Distinct().Count();
+    }
+
     public async Task<ApiClientInsertResult> InsertApiClient(
         ApiClientInsertCommand command,
         ApiClientCommand clientCommand
@@ -31,13 +82,14 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 INSERT INTO "dmscs"."ApiClient" ("ApplicationId", "ClientId", "ClientUuid", "Name", "IsApproved", "CreatedBy")
-                VALUES (@ApplicationId, @ClientId, @ClientUuid, @Name, @IsApproved, @CreatedBy)
+                SELECT @ApplicationId, @ClientId, @ClientUuid, @Name, @IsApproved, @CreatedBy
+                WHERE {ApplicationInTenantExistsCondition}
                 RETURNING "Id";
                 """;
 
-            long apiClientId = await connection.ExecuteScalarAsync<long>(
+            long? apiClientId = await connection.ExecuteScalarAsync<long?>(
                 sql,
                 new
                 {
@@ -47,12 +99,27 @@ public class ApiClientRepository(
                     command.Name,
                     command.IsApproved,
                     CreatedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
 
+            if (apiClientId is null)
+            {
+                logger.LogWarning("Application not found");
+                await transaction.RollbackAsync();
+                return new ApiClientInsertResult.FailureApplicationNotFound();
+            }
+
             if (command.DataStoreIds.Length > 0)
             {
+                if (!await AllDataStoresInTenant(connection, transaction, command.DataStoreIds))
+                {
+                    logger.LogWarning("Data store not found");
+                    await transaction.RollbackAsync();
+                    return new ApiClientInsertResult.FailureDataStoreNotFound();
+                }
+
                 sql = """
                     INSERT INTO "dmscs"."ApiClientDataStore" ("ApiClientId", "DataStoreId", "CreatedBy")
                     VALUES (@ApiClientId, @DataStoreId, @CreatedBy);
@@ -70,7 +137,7 @@ public class ApiClientRepository(
             }
 
             await transaction.CommitAsync();
-            return new ApiClientInsertResult.Success(apiClientId);
+            return new ApiClientInsertResult.Success(apiClientId.Value);
         }
         catch (PostgresException ex)
             when (ex.SqlState == PostgresErrorCodes.ForeignKeyViolation
@@ -114,14 +181,14 @@ public class ApiClientRepository(
     private static string BuildOrderByClause(ApiClientQuery query, string? tableAlias = null) =>
         PostgresqlIdentifier.OrderBy(ResolveOrderByColumnName(query), query.IsDescending, tableAlias);
 
-    private static string BuildFilterClause(ApiClientQuery query)
+    private string BuildFilterClause(ApiClientQuery query)
     {
-        var conditions = new List<string>();
+        var conditions = new List<string> { TenantScopedApplicationCondition() };
         if (query.ApplicationId.HasValue)
         {
             conditions.Add("\"ApplicationId\" = @ApplicationId");
         }
-        return conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : string.Empty;
+        return "WHERE " + string.Join(" AND ", conditions);
     }
 
     public async Task<ApiClientQueryResult> QueryApiClient(ApiClientQuery query)
@@ -156,6 +223,7 @@ public class ApiClientRepository(
                     query.Limit,
                     query.Offset,
                     query.ApplicationId,
+                    TenantId,
                 },
                 splitOn: "DataStoreId"
             );
@@ -185,12 +253,12 @@ public class ApiClientRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT ac."Id", ac."ApplicationId", ac."ClientId", ac."ClientUuid", ac."Name", ac."IsApproved",
                        acd."DataStoreId"
                 FROM "dmscs"."ApiClient" ac
                 LEFT OUTER JOIN "dmscs"."ApiClientDataStore" acd ON ac."Id" = acd."ApiClientId"
-                WHERE ac."ClientId" = @ClientId;
+                WHERE ac."ClientId" = @ClientId AND {TenantScopedApplicationCondition("ac")};
                 """;
 
             var apiClients = await connection.QueryAsync<ApiClientResponse, long?, ApiClientResponse>(
@@ -203,7 +271,7 @@ public class ApiClientRepository(
                     }
                     return apiClient;
                 },
-                param: new { ClientId = clientId },
+                param: new { ClientId = clientId, TenantId },
                 splitOn: "DataStoreId"
             );
 
@@ -234,12 +302,12 @@ public class ApiClientRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT ac."Id", ac."ApplicationId", ac."ClientId", ac."ClientUuid", ac."Name", ac."IsApproved",
                        acd."DataStoreId"
                 FROM "dmscs"."ApiClient" ac
                 LEFT OUTER JOIN "dmscs"."ApiClientDataStore" acd ON ac."Id" = acd."ApiClientId"
-                WHERE ac."Id" = @Id;
+                WHERE ac."Id" = @Id AND {TenantScopedApplicationCondition("ac")};
                 """;
 
             var apiClients = await connection.QueryAsync<ApiClientResponse, long?, ApiClientResponse>(
@@ -252,7 +320,7 @@ public class ApiClientRepository(
                     }
                     return apiClient;
                 },
-                param: new { Id = id },
+                param: new { Id = id, TenantId },
                 splitOn: "DataStoreId"
             );
 
@@ -284,25 +352,32 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            // Check if ApiClient exists
-            string checkSql = """SELECT COUNT(1) FROM "dmscs"."ApiClient" WHERE "Id" = @Id;""";
-            int exists = await connection.ExecuteScalarAsync<int>(checkSql, new { command.Id }, transaction);
+            // Check if ApiClient exists within the current tenant
+            string checkSql = $"""
+                SELECT COUNT(1) FROM "dmscs"."ApiClient"
+                WHERE "Id" = @Id AND {TenantScopedApplicationCondition()};
+                """;
+            int exists = await connection.ExecuteScalarAsync<int>(
+                checkSql,
+                new { command.Id, TenantId },
+                transaction
+            );
             if (exists == 0)
             {
                 await transaction.RollbackAsync();
                 return new ApiClientUpdateResult.FailureNotFound();
             }
 
-            // Update ApiClient record
-            string updateSql = """
+            // Update ApiClient record; the target application must belong to the current tenant
+            string updateSql = $"""
                 UPDATE "dmscs"."ApiClient"
                 SET "ApplicationId" = @ApplicationId, "Name" = @Name, "IsApproved" = @IsApproved,
                     "ClientUuid" = COALESCE(@ClientUuid, "ClientUuid"),
                     "LastModifiedAt" = @LastModifiedAt, "ModifiedBy" = @ModifiedBy
-                WHERE "Id" = @Id;
+                WHERE "Id" = @Id AND {ApplicationInTenantExistsCondition};
                 """;
 
-            await connection.ExecuteAsync(
+            int updatedRows = await connection.ExecuteAsync(
                 updateSql,
                 new
                 {
@@ -313,9 +388,27 @@ public class ApiClientRepository(
                     ClientUuid = command.ClientUuid,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 },
                 transaction
             );
+
+            if (updatedRows == 0)
+            {
+                logger.LogWarning("Application not found");
+                await transaction.RollbackAsync();
+                return new ApiClientUpdateResult.FailureApplicationNotFound();
+            }
+
+            if (
+                command.DataStoreIds.Length > 0
+                && !await AllDataStoresInTenant(connection, transaction, command.DataStoreIds)
+            )
+            {
+                logger.LogWarning("Data store not found");
+                await transaction.RollbackAsync();
+                return new ApiClientUpdateResult.FailureDataStoreNotFound();
+            }
 
             // Delete existing data store mappings
             string deleteSql = """DELETE FROM "dmscs"."ApiClientDataStore" WHERE "ApiClientId" = @Id;""";
@@ -376,9 +469,16 @@ public class ApiClientRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            // Check if ApiClient exists
-            string checkSql = """SELECT COUNT(1) FROM "dmscs"."ApiClient" WHERE "Id" = @Id;""";
-            int exists = await connection.ExecuteScalarAsync<int>(checkSql, new { Id = id }, transaction);
+            // Check if ApiClient exists within the current tenant
+            string checkSql = $"""
+                SELECT COUNT(1) FROM "dmscs"."ApiClient"
+                WHERE "Id" = @Id AND {TenantScopedApplicationCondition()};
+                """;
+            int exists = await connection.ExecuteScalarAsync<int>(
+                checkSql,
+                new { Id = id, TenantId },
+                transaction
+            );
             if (exists == 0)
             {
                 await transaction.RollbackAsync();

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
@@ -39,7 +39,11 @@ public class ApplicationRepository(
             """;
     }
 
-    private async Task<bool> AllDataStoresInTenant(NpgsqlConnection connection, long[] dataStoreIds)
+    private async Task<bool> AllDataStoresInTenant(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        long[] dataStoreIds
+    )
     {
         string sql = $"""
             SELECT COUNT(1) FROM "dmscs"."DataStore"
@@ -47,18 +51,23 @@ public class ApplicationRepository(
             """;
         int count = await connection.ExecuteScalarAsync<int>(
             sql,
-            new { DataStoreIds = dataStoreIds, TenantId }
+            new { DataStoreIds = dataStoreIds, TenantId },
+            transaction
         );
         return count == dataStoreIds.Distinct().Count();
     }
 
-    private async Task<bool> ApplicationExistsForTenant(NpgsqlConnection connection, long id)
+    private async Task<bool> ApplicationExistsForTenant(
+        NpgsqlConnection connection,
+        NpgsqlTransaction transaction,
+        long id
+    )
     {
         string sql = $"""
             SELECT COUNT(1) FROM "dmscs"."Application"
             WHERE "Id" = @Id AND {TenantScopedVendorCondition()};
             """;
-        return await connection.ExecuteScalarAsync<int>(sql, new { Id = id, TenantId }) > 0;
+        return await connection.ExecuteScalarAsync<int>(sql, new { Id = id, TenantId }, transaction) > 0;
     }
 
     public async Task<ApplicationInsertResult> InsertApplication(
@@ -138,7 +147,7 @@ public class ApplicationRepository(
 
             if (command.DataStoreIds.Length > 0)
             {
-                if (!await AllDataStoresInTenant(connection, command.DataStoreIds))
+                if (!await AllDataStoresInTenant(connection, transaction, command.DataStoreIds))
                 {
                     logger.LogWarning("Data store not found");
                     await transaction.RollbackAsync();
@@ -469,7 +478,7 @@ public class ApplicationRepository(
 
             if (affectedRows == 0)
             {
-                if (!await ApplicationExistsForTenant(connection, command.Id))
+                if (!await ApplicationExistsForTenant(connection, transaction, command.Id))
                 {
                     return new ApplicationUpdateResult.FailureNotExists();
                 }
@@ -481,7 +490,7 @@ public class ApplicationRepository(
 
             if (
                 command.DataStoreIds.Length > 0
-                && !await AllDataStoresInTenant(connection, command.DataStoreIds)
+                && !await AllDataStoresInTenant(connection, transaction, command.DataStoreIds)
             )
             {
                 logger.LogWarning("Update application failure: Data store not found");

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
@@ -99,7 +99,8 @@ public class ApplicationRepository(
                     command.ClaimSetName,
                     CreatedBy = auditContext.GetCurrentUser(),
                     TenantId,
-                }
+                },
+                transaction
             );
 
             if (insertedId is null)
@@ -124,7 +125,7 @@ public class ApplicationRepository(
                 CreatedBy = currentUser,
             });
 
-            await connection.ExecuteAsync(sql, educationOrganizations);
+            await connection.ExecuteAsync(sql, educationOrganizations, transaction);
 
             sql = """
                 INSERT INTO "dmscs"."ApiClient" ("ApplicationId", "ClientId", "ClientUuid", "Name", "IsApproved", "CreatedBy")
@@ -142,7 +143,8 @@ public class ApplicationRepository(
                     Name = command.ApplicationName,
                     IsApproved = true,
                     CreatedBy = currentUser,
-                }
+                },
+                transaction
             );
 
             if (command.DataStoreIds.Length > 0)
@@ -166,7 +168,7 @@ public class ApplicationRepository(
                     CreatedBy = currentUser,
                 });
 
-                await connection.ExecuteAsync(sql, dataStoreMappings);
+                await connection.ExecuteAsync(sql, dataStoreMappings, transaction);
             }
 
             if (command.ProfileIds.Length > 0)
@@ -185,7 +187,7 @@ public class ApplicationRepository(
                         CreatedBy = currentUser,
                     });
 
-                await connection.ExecuteAsync(sql, profileMappings);
+                await connection.ExecuteAsync(sql, profileMappings, transaction);
             }
 
             await transaction.CommitAsync();
@@ -473,7 +475,8 @@ public class ApplicationRepository(
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = auditContext.GetCurrentUser(),
                     TenantId,
-                }
+                },
+                transaction
             );
 
             if (affectedRows == 0)
@@ -500,7 +503,7 @@ public class ApplicationRepository(
 
             sql =
                 "DELETE FROM \"dmscs\".\"ApplicationEducationOrganization\" WHERE \"ApplicationId\" = @ApplicationId";
-            await connection.ExecuteAsync(sql, new { ApplicationId = command.Id });
+            await connection.ExecuteAsync(sql, new { ApplicationId = command.Id }, transaction);
 
             sql = """
                 INSERT INTO "dmscs"."ApplicationEducationOrganization" ("ApplicationId", "EducationOrganizationId", "CreatedBy")
@@ -515,7 +518,7 @@ public class ApplicationRepository(
                 CreatedBy = currentUser,
             });
 
-            await connection.ExecuteAsync(sql, educationOrganizations);
+            await connection.ExecuteAsync(sql, educationOrganizations, transaction);
 
             string updateApiClientsql = """
                 UPDATE "dmscs"."ApiClient"
@@ -532,7 +535,8 @@ public class ApplicationRepository(
                     ApplicationId = command.Id,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = currentUser,
-                }
+                },
+                transaction
             );
 
             // Get ApiClient Id for DataStore relationship update
@@ -540,12 +544,13 @@ public class ApplicationRepository(
                 "SELECT \"Id\" FROM \"dmscs\".\"ApiClient\" WHERE \"ClientId\" = @ClientId AND \"ApplicationId\" = @ApplicationId;";
             long apiClientId = await connection.ExecuteScalarAsync<long>(
                 sql,
-                new { clientCommand.ClientId, ApplicationId = command.Id }
+                new { clientCommand.ClientId, ApplicationId = command.Id },
+                transaction
             );
 
             // Delete existing DataStore relationship
             sql = "DELETE FROM \"dmscs\".\"ApiClientDataStore\" WHERE \"ApiClientId\" = @ApiClientId";
-            await connection.ExecuteAsync(sql, new { ApiClientId = apiClientId });
+            await connection.ExecuteAsync(sql, new { ApiClientId = apiClientId }, transaction);
 
             // Insert new DataStore relationships if provided
             if (command.DataStoreIds.Length > 0)
@@ -562,12 +567,12 @@ public class ApplicationRepository(
                     CreatedBy = currentUser,
                 });
 
-                await connection.ExecuteAsync(sql, dataStoreMappings);
+                await connection.ExecuteAsync(sql, dataStoreMappings, transaction);
             }
 
             // Delete existing Profile relationships
             sql = "DELETE FROM \"dmscs\".\"ApplicationProfile\" WHERE \"ApplicationId\" = @ApplicationId";
-            await connection.ExecuteAsync(sql, new { ApplicationId = command.Id });
+            await connection.ExecuteAsync(sql, new { ApplicationId = command.Id }, transaction);
 
             // Insert new Profile relationships if provided
             if (command.ProfileIds.Length > 0)
@@ -586,7 +591,7 @@ public class ApplicationRepository(
                         CreatedBy = currentUser,
                     });
 
-                await connection.ExecuteAsync(sql, profileMappings);
+                await connection.ExecuteAsync(sql, profileMappings, transaction);
             }
 
             await transaction.CommitAsync();

--- a/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
+++ b/src/config/backend/EdFi.DmsConfigurationService.Backend.Postgresql/Repositories/ApplicationRepository.cs
@@ -5,6 +5,7 @@
 
 using Dapper;
 using EdFi.DmsConfigurationService.Backend.Repositories;
+using EdFi.DmsConfigurationService.Backend.Services;
 using EdFi.DmsConfigurationService.DataModel.Infrastructure;
 using EdFi.DmsConfigurationService.DataModel.Model;
 using EdFi.DmsConfigurationService.DataModel.Model.Application;
@@ -17,9 +18,49 @@ namespace EdFi.DmsConfigurationService.Backend.Postgresql.Repositories;
 public class ApplicationRepository(
     IOptions<DatabaseOptions> databaseOptions,
     ILogger<ApplicationRepository> logger,
-    IAuditContext auditContext
+    IAuditContext auditContext,
+    ITenantContextProvider tenantContextProvider
 ) : IApplicationRepository
 {
+    private TenantContext TenantContext => tenantContextProvider.Context;
+
+    private long? TenantId => TenantContext is TenantContext.Multitenant mt ? mt.TenantId : null;
+
+    /// <summary>
+    /// SQL condition constraining an Application row to the current tenant through its owning Vendor.
+    /// </summary>
+    private string TenantScopedVendorCondition(string? tableAlias = null)
+    {
+        var column = string.IsNullOrEmpty(tableAlias) ? "\"VendorId\"" : $"{tableAlias}.\"VendorId\"";
+        return $"""
+            {column} IN (
+                SELECT "Id" FROM "dmscs"."Vendor" WHERE {TenantContext.TenantWhereClause()}
+            )
+            """;
+    }
+
+    private async Task<bool> AllDataStoresInTenant(NpgsqlConnection connection, long[] dataStoreIds)
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM "dmscs"."DataStore"
+            WHERE "Id" = ANY(@DataStoreIds) AND {TenantContext.TenantWhereClause()};
+            """;
+        int count = await connection.ExecuteScalarAsync<int>(
+            sql,
+            new { DataStoreIds = dataStoreIds, TenantId }
+        );
+        return count == dataStoreIds.Distinct().Count();
+    }
+
+    private async Task<bool> ApplicationExistsForTenant(NpgsqlConnection connection, long id)
+    {
+        string sql = $"""
+            SELECT COUNT(1) FROM "dmscs"."Application"
+            WHERE "Id" = @Id AND {TenantScopedVendorCondition()};
+            """;
+        return await connection.ExecuteScalarAsync<int>(sql, new { Id = id, TenantId }) > 0;
+    }
+
     public async Task<ApplicationInsertResult> InsertApplication(
         ApplicationInsertCommand command,
         ApiClientCommand clientCommand
@@ -30,13 +71,17 @@ public class ApplicationRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 INSERT INTO "dmscs"."Application" ("ApplicationName", "VendorId", "ClaimSetName", "CreatedBy")
-                VALUES (@ApplicationName, @VendorId, @ClaimSetName, @CreatedBy)
+                SELECT @ApplicationName, @VendorId, @ClaimSetName, @CreatedBy
+                WHERE EXISTS (
+                    SELECT 1 FROM "dmscs"."Vendor"
+                    WHERE "Id" = @VendorId AND {TenantContext.TenantWhereClause()}
+                )
                 RETURNING "Id";
                 """;
 
-            long id = await connection.ExecuteScalarAsync<long>(
+            long? insertedId = await connection.ExecuteScalarAsync<long?>(
                 sql,
                 new
                 {
@@ -44,8 +89,18 @@ public class ApplicationRepository(
                     command.VendorId,
                     command.ClaimSetName,
                     CreatedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 }
             );
+
+            if (insertedId is null)
+            {
+                logger.LogWarning("Vendor not found");
+                await transaction.RollbackAsync();
+                return new ApplicationInsertResult.FailureVendorNotFound();
+            }
+
+            long id = insertedId.Value;
 
             sql = """
                 INSERT INTO "dmscs"."ApplicationEducationOrganization" ("ApplicationId", "EducationOrganizationId", "CreatedBy")
@@ -83,6 +138,13 @@ public class ApplicationRepository(
 
             if (command.DataStoreIds.Length > 0)
             {
+                if (!await AllDataStoresInTenant(connection, command.DataStoreIds))
+                {
+                    logger.LogWarning("Data store not found");
+                    await transaction.RollbackAsync();
+                    return new ApplicationInsertResult.FailureDataStoreNotFound();
+                }
+
                 sql = """
                     INSERT INTO "dmscs"."ApiClientDataStore" ("ApiClientId", "DataStoreId", "CreatedBy")
                     VALUES (@ApiClientId, @DataStoreId, @CreatedBy);
@@ -187,9 +249,9 @@ public class ApplicationRepository(
     private static string BuildOrderByClause(ApplicationQuery query, string? tableAlias = null) =>
         PostgresqlIdentifier.OrderBy(ResolveOrderByColumnName(query), query.IsDescending, tableAlias);
 
-    private static string BuildFilterClause(ApplicationQuery query, int[] parsedIds)
+    private string BuildFilterClause(ApplicationQuery query, int[] parsedIds)
     {
-        var conditions = new List<string>();
+        var conditions = new List<string> { TenantScopedVendorCondition() };
         if (query.Id.HasValue)
         {
             conditions.Add("\"Id\" = @Id");
@@ -206,7 +268,7 @@ public class ApplicationRepository(
         {
             conditions.Add("\"Id\" = ANY(@ParsedIds)");
         }
-        return conditions.Count > 0 ? "WHERE " + string.Join(" AND ", conditions) : string.Empty;
+        return "WHERE " + string.Join(" AND ", conditions);
     }
 
     public async Task<ApplicationQueryResult> QueryApplication(ApplicationQuery query)
@@ -270,6 +332,7 @@ public class ApplicationRepository(
                     query.ApplicationName,
                     query.ClaimSetName,
                     ParsedIds = parsedIds,
+                    TenantId,
                 },
                 splitOn: "EducationOrganizationId,DataStoreId,ProfileId"
             );
@@ -303,7 +366,7 @@ public class ApplicationRepository(
         await connection.OpenAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 SELECT a."Id", a."ApplicationName", a."VendorId", a."ClaimSetName",
                        (SELECT COALESCE(BOOL_AND(ac2."IsApproved"), true)
                         FROM "dmscs"."ApiClient" ac2
@@ -314,7 +377,7 @@ public class ApplicationRepository(
                 LEFT OUTER JOIN "dmscs"."ApiClient" ac ON a."Id" = ac."ApplicationId"
                 LEFT OUTER JOIN "dmscs"."ApiClientDataStore" acd ON ac."Id" = acd."ApiClientId"
                 LEFT OUTER JOIN "dmscs"."ApplicationProfile" ap ON a."Id" = ap."ApplicationId"
-                WHERE a."Id" = @Id;
+                WHERE a."Id" = @Id AND {TenantScopedVendorCondition("a")};
                 """;
             var applications = await connection.QueryAsync<
                 ApplicationResponse,
@@ -340,7 +403,7 @@ public class ApplicationRepository(
                     }
                     return application;
                 },
-                param: new { Id = id },
+                param: new { Id = id, TenantId },
                 splitOn: "EducationOrganizationId,DataStoreId,ProfileId"
             );
 
@@ -379,11 +442,16 @@ public class ApplicationRepository(
         await using var transaction = await connection.BeginTransactionAsync();
         try
         {
-            string sql = """
+            string sql = $"""
                 UPDATE "dmscs"."Application"
                 SET "ApplicationName"=@ApplicationName, "VendorId"=@VendorId, "ClaimSetName"=@ClaimSetName,
                     "LastModifiedAt"=@LastModifiedAt, "ModifiedBy"=@ModifiedBy
-                WHERE "Id" = @Id;
+                WHERE "Id" = @Id
+                  AND {TenantScopedVendorCondition()}
+                  AND EXISTS (
+                      SELECT 1 FROM "dmscs"."Vendor"
+                      WHERE "Id" = @VendorId AND {TenantContext.TenantWhereClause()}
+                  );
                 """;
             int affectedRows = await connection.ExecuteAsync(
                 sql,
@@ -395,12 +463,30 @@ public class ApplicationRepository(
                     command.Id,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = auditContext.GetCurrentUser(),
+                    TenantId,
                 }
             );
 
             if (affectedRows == 0)
             {
-                return new ApplicationUpdateResult.FailureNotExists();
+                if (!await ApplicationExistsForTenant(connection, command.Id))
+                {
+                    return new ApplicationUpdateResult.FailureNotExists();
+                }
+
+                logger.LogWarning("Update application failure: Vendor not found");
+                await transaction.RollbackAsync();
+                return new ApplicationUpdateResult.FailureVendorNotFound();
+            }
+
+            if (
+                command.DataStoreIds.Length > 0
+                && !await AllDataStoresInTenant(connection, command.DataStoreIds)
+            )
+            {
+                logger.LogWarning("Update application failure: Data store not found");
+                await transaction.RollbackAsync();
+                return new ApplicationUpdateResult.FailureDataStoreNotFound();
             }
 
             sql =
@@ -425,7 +511,7 @@ public class ApplicationRepository(
             string updateApiClientsql = """
                 UPDATE "dmscs"."ApiClient"
                 SET "ClientUuid"=@ClientUuid, "LastModifiedAt"=@LastModifiedAt, "ModifiedBy"=@ModifiedBy
-                WHERE "ClientId" = @ClientId;
+                WHERE "ClientId" = @ClientId AND "ApplicationId" = @ApplicationId;
                 """;
 
             await connection.ExecuteAsync(
@@ -434,14 +520,19 @@ public class ApplicationRepository(
                 {
                     clientCommand.ClientUuid,
                     clientCommand.ClientId,
+                    ApplicationId = command.Id,
                     LastModifiedAt = auditContext.GetCurrentTimestamp(),
                     ModifiedBy = currentUser,
                 }
             );
 
             // Get ApiClient Id for DataStore relationship update
-            sql = "SELECT \"Id\" FROM \"dmscs\".\"ApiClient\" WHERE \"ClientId\" = @ClientId;";
-            long apiClientId = await connection.ExecuteScalarAsync<long>(sql, new { clientCommand.ClientId });
+            sql =
+                "SELECT \"Id\" FROM \"dmscs\".\"ApiClient\" WHERE \"ClientId\" = @ClientId AND \"ApplicationId\" = @ApplicationId;";
+            long apiClientId = await connection.ExecuteScalarAsync<long>(
+                sql,
+                new { clientCommand.ClientId, ApplicationId = command.Id }
+            );
 
             // Delete existing DataStore relationship
             sql = "DELETE FROM \"dmscs\".\"ApiClientDataStore\" WHERE \"ApiClientId\" = @ApiClientId";
@@ -546,11 +637,11 @@ public class ApplicationRepository(
         await using var connection = new NpgsqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
-            string sql = """
-                DELETE FROM "dmscs"."Application" where "Id" = @Id;
+            string sql = $"""
+                DELETE FROM "dmscs"."Application" where "Id" = @Id AND {TenantScopedVendorCondition()};
                 """;
 
-            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id });
+            int affectedRows = await connection.ExecuteAsync(sql, new { Id = id, TenantId });
             return affectedRows > 0
                 ? new ApplicationDeleteResult.Success()
                 : new ApplicationDeleteResult.FailureNotExists();
@@ -567,14 +658,15 @@ public class ApplicationRepository(
         await using var connection = new NpgsqlConnection(databaseOptions.Value.DatabaseConnection);
         try
         {
-            string sql = """
-                SELECT "ClientId", "ClientUuid", "IsApproved"
-                FROM "dmscs"."ApiClient"
-                WHERE "ApplicationId" = @Id
-                ORDER BY "Id"
+            string sql = $"""
+                SELECT ac."ClientId", ac."ClientUuid", ac."IsApproved"
+                FROM "dmscs"."ApiClient" ac
+                JOIN "dmscs"."Application" a ON ac."ApplicationId" = a."Id"
+                WHERE ac."ApplicationId" = @Id AND {TenantScopedVendorCondition("a")}
+                ORDER BY ac."Id"
                 """;
 
-            var clients = await connection.QueryAsync<ApiClient>(sql, new { Id = @id });
+            var clients = await connection.QueryAsync<ApiClient>(sql, new { Id = @id, TenantId });
 
             return new ApplicationApiClientsResult.Success(clients.ToArray());
         }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -534,6 +534,40 @@ public class ApplicationModuleTests
             deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
             resetCredentialsResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+
+        [Test]
+        public async Task Should_return_not_found_before_validating_references_on_update()
+        {
+            // Arrange - the requested data store ids do not exist for this tenant either
+            A.CallTo(() => _dataStoreRepository.GetExistingDataStoreIds(A<long[]>.Ignored))
+                .Returns(new DataStoreIdsExistResult.Success([]));
+
+            using var client = SetUpClient();
+
+            // Act
+            var updateResponse = await client.PutAsync(
+                "/v3/applications/1",
+                new StringContent(
+                    """
+                    {
+                        "id": 1,
+                        "applicationName": "Application 101",
+                        "claimSetName": "Test",
+                        "vendorId": 1,
+                        "educationOrganizationIds": [1],
+                        "dataStoreIds": [999]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            // Assert - a missing or foreign-tenant application responds 404, not 400
+            updateResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            string responseBody = await updateResponse.Content.ReadAsStringAsync();
+            responseBody.Should().Contain("Application not found");
+        }
     }
 
     [TestFixture]
@@ -909,6 +943,57 @@ public class ApplicationModuleTests
             );
             JsonNode.DeepEquals(actualResponse, expectedResponse).Should().Be(true);
         }
+
+        [Test]
+        public async Task Should_not_update_identity_provider_when_update_vendor_id_is_invalid()
+        {
+            // Arrange
+            A.CallTo(() => _vendorRepository.GetVendor(A<long>.Ignored))
+                .Returns(new VendorGetResult.FailureNotFound());
+
+            using var client = SetUpClient();
+
+            // Act
+            var updateResponse = await client.PutAsync(
+                "/v3/applications/1",
+                new StringContent(
+                    """
+                    {
+                        "id": 1,
+                        "applicationName": "Application 101",
+                        "claimSetName": "Test",
+                        "vendorId": 999,
+                        "educationOrganizationIds": [1],
+                        "dataStoreIds": [1]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            // Assert
+            updateResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            A.CallTo(() =>
+                    _clientRepository.UpdateClientAsync(
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<long[]?>.Ignored,
+                        A<bool>.Ignored,
+                        A<string>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+            A.CallTo(() =>
+                    _applicationRepository.UpdateApplication(
+                        A<ApplicationUpdateCommand>.Ignored,
+                        A<ApiClientCommand>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+        }
     }
 
     [TestFixture]
@@ -1265,6 +1350,62 @@ public class ApplicationModuleTests
                 """.Replace("{correlationId}", actualResponse!["correlationId"]!.GetValue<string>())
             );
             JsonNode.DeepEquals(actualResponse, expectedResponse).Should().Be(true);
+        }
+
+        [Test]
+        public async Task Should_not_create_identity_provider_client_when_insert_data_store_id_is_invalid()
+        {
+            // Arrange
+            A.CallTo(() =>
+                    _dataStoreRepository.GetExistingDataStoreIds(
+                        A<long[]>.That.Matches(ids => ids.Length == 1 && ids[0] == 999L)
+                    )
+                )
+                .Returns(new DataStoreIdsExistResult.Success([]));
+
+            using var client = SetUpClient();
+
+            // Act
+            var insertResponse = await client.PostAsync(
+                "/v3/applications",
+                new StringContent(
+                    """
+                    {
+                        "ApplicationName": "Test Application",
+                        "ClaimSetName": "TestClaimSet",
+                        "VendorId": 1,
+                        "EducationOrganizationIds": [1],
+                        "DataStoreIds": [999]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            // Assert
+            insertResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            A.CallTo(() =>
+                    _clientRepository.CreateClientAsync(
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<long[]?>.Ignored,
+                        A<bool>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+            A.CallTo(() =>
+                    _applicationRepository.InsertApplication(
+                        A<ApplicationInsertCommand>.Ignored,
+                        A<ApiClientCommand>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
         }
 
         [Test]

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -32,6 +32,7 @@ public class ApplicationModuleTests
     private readonly IIdentityProviderRepository _clientRepository = A.Fake<IIdentityProviderRepository>();
     private readonly IDataStoreRepository _dataStoreRepository = A.Fake<IDataStoreRepository>();
     private readonly IVendorRepository _vendorRepository = A.Fake<IVendorRepository>();
+    private readonly IProfileRepository _profileRepository = A.Fake<IProfileRepository>();
 
     public ApplicationModuleTests()
     {
@@ -43,6 +44,18 @@ public class ApplicationModuleTests
                     new DataStoreIdsExistResult.Success([.. ids])
                 );
             });
+
+        A.CallTo(() => _profileRepository.GetProfile(A<long>.Ignored))
+            .Returns(
+                new ProfileGetResult.Success(
+                    new EdFi.DmsConfigurationService.DataModel.Model.Profile.ProfileResponse
+                    {
+                        Id = 1,
+                        Name = "Test Profile",
+                        Definition = "<Profile/>",
+                    }
+                )
+            );
     }
 
     private HttpClient SetUpClient(int? clientSecretMinimumLength = null)
@@ -80,7 +93,8 @@ public class ApplicationModuleTests
                     .AddTransient((_) => _applicationRepository)
                     .AddTransient((_) => _clientRepository)
                     .AddTransient((_) => _dataStoreRepository)
-                    .AddTransient((_) => _vendorRepository);
+                    .AddTransient((_) => _vendorRepository)
+                    .AddTransient((_) => _profileRepository);
             });
         });
         var client = factory.CreateClient();
@@ -1551,6 +1565,11 @@ public class ApplicationModuleTests
                     new ApplicationApiClientsResult.Success([new ApiClient("clientId", Guid.NewGuid(), true)])
                 );
 
+            // The update path pre-validates profile references at the module layer, so a
+            // missing profile is reported before the identity provider client is touched.
+            A.CallTo(() => _profileRepository.GetProfile(A<long>.Ignored))
+                .Returns(new ProfileGetResult.FailureNotFound());
+
             A.CallTo(() =>
                     _clientRepository.UpdateClientAsync(
                         A<string>.Ignored,
@@ -1662,6 +1681,58 @@ public class ApplicationModuleTests
                 """.Replace("{correlationId}", actualResponse!["correlationId"]!.GetValue<string>())
             );
             JsonNode.DeepEquals(actualResponse, expectedResponse).Should().Be(true);
+        }
+
+        [Test]
+        public async Task Should_not_update_identity_provider_when_update_profile_id_is_invalid()
+        {
+            // Arrange
+            using var client = SetUpClient();
+
+            // Act
+            var updateResponse = await client.PutAsync(
+                "/v3/applications/1",
+                new StringContent(
+                    """
+                    {
+                        "Id": 1,
+                        "ApplicationName": "Test Application",
+                        "ClaimSetName": "TestClaimSet",
+                        "VendorId": 1,
+                        "EducationOrganizationIds": [1],
+                        "DataStoreIds": [1],
+                        "ProfileIds": [999]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            // Assert
+            updateResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+            // Assert - the identity provider client was never mutated for an invalid
+            // profile reference, so a rejected update cannot leave the client out of sync
+            A.CallTo(() =>
+                    _clientRepository.UpdateClientAsync(
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<long[]?>.Ignored,
+                        A<bool>.Ignored,
+                        A<string>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+            A.CallTo(() =>
+                    _applicationRepository.UpdateApplication(
+                        A<ApplicationUpdateCommand>.Ignored,
+                        A<ApiClientCommand>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
         }
     }
 
@@ -1901,7 +1972,8 @@ public class ApplicationModuleTests
                         .AddTransient((_) => _applicationRepository)
                         .AddTransient((_) => _clientRepository)
                         .AddTransient((_) => _dataStoreRepository)
-                        .AddTransient((_) => _vendorRepository);
+                        .AddTransient((_) => _vendorRepository)
+                        .AddTransient((_) => _profileRepository);
                 });
             });
             var client = factory.CreateClient();

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -30,7 +30,20 @@ public class ApplicationModuleTests
 {
     private readonly IApplicationRepository _applicationRepository = A.Fake<IApplicationRepository>();
     private readonly IIdentityProviderRepository _clientRepository = A.Fake<IIdentityProviderRepository>();
+    private readonly IDataStoreRepository _dataStoreRepository = A.Fake<IDataStoreRepository>();
     private readonly IVendorRepository _vendorRepository = A.Fake<IVendorRepository>();
+
+    public ApplicationModuleTests()
+    {
+        A.CallTo(() => _dataStoreRepository.GetExistingDataStoreIds(A<long[]>.Ignored))
+            .ReturnsLazily(call =>
+            {
+                long[] ids = call.GetArgument<long[]>(0) ?? [];
+                return Task.FromResult<DataStoreIdsExistResult>(
+                    new DataStoreIdsExistResult.Success([.. ids])
+                );
+            });
+    }
 
     private HttpClient SetUpClient(int? clientSecretMinimumLength = null)
     {
@@ -66,6 +79,7 @@ public class ApplicationModuleTests
                 collection
                     .AddTransient((_) => _applicationRepository)
                     .AddTransient((_) => _clientRepository)
+                    .AddTransient((_) => _dataStoreRepository)
                     .AddTransient((_) => _vendorRepository);
             });
         });
@@ -1252,6 +1266,61 @@ public class ApplicationModuleTests
             );
             JsonNode.DeepEquals(actualResponse, expectedResponse).Should().Be(true);
         }
+
+        [Test]
+        public async Task Should_not_update_identity_provider_when_update_data_store_id_is_invalid()
+        {
+            // Arrange
+            A.CallTo(() =>
+                    _dataStoreRepository.GetExistingDataStoreIds(
+                        A<long[]>.That.Matches(ids => ids.Length == 1 && ids[0] == 999L)
+                    )
+                )
+                .Returns(new DataStoreIdsExistResult.Success([]));
+
+            using var client = SetUpClient();
+
+            // Act
+            var updateResponse = await client.PutAsync(
+                "/v3/applications/1",
+                new StringContent(
+                    """
+                    {
+                        "Id": 1,
+                        "ApplicationName": "Test Application",
+                        "ClaimSetName": "TestClaimSet",
+                        "VendorId": 1,
+                        "EducationOrganizationIds": [1],
+                        "DataStoreIds": [999]
+                    }
+                    """,
+                    Encoding.UTF8,
+                    "application/json"
+                )
+            );
+
+            // Assert
+            updateResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+            A.CallTo(() =>
+                    _clientRepository.UpdateClientAsync(
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<long[]?>.Ignored,
+                        A<bool>.Ignored,
+                        A<string>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+            A.CallTo(() =>
+                    _applicationRepository.UpdateApplication(
+                        A<ApplicationUpdateCommand>.Ignored,
+                        A<ApiClientCommand>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+        }
     }
 
     [TestFixture]
@@ -1658,6 +1727,7 @@ public class ApplicationModuleTests
                     collection
                         .AddTransient((_) => _applicationRepository)
                         .AddTransient((_) => _clientRepository)
+                        .AddTransient((_) => _dataStoreRepository)
                         .AddTransient((_) => _vendorRepository);
                 });
             });

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ApplicationModuleTests.cs
@@ -567,6 +567,38 @@ public class ApplicationModuleTests
             updateResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
             string responseBody = await updateResponse.Content.ReadAsStringAsync();
             responseBody.Should().Contain("Application not found");
+
+            // Assert - the identity provider client was never touched for an application
+            // that does not resolve for this tenant
+            A.CallTo(() =>
+                    _clientRepository.UpdateClientAsync(
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<string>.Ignored,
+                        A<long[]?>.Ignored,
+                        A<bool>.Ignored,
+                        A<string>.Ignored
+                    )
+                )
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task Should_not_delete_identity_provider_client_when_application_does_not_resolve()
+        {
+            // Arrange
+            using var client = SetUpClient();
+
+            // Act
+            var deleteResponse = await client.DeleteAsync("/v3/applications/1");
+
+            // Assert - a missing or foreign-tenant application responds 404
+            deleteResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+
+            // Assert - the identity provider client was never deleted for an application
+            // that does not resolve for this tenant
+            A.CallTo(() => _clientRepository.DeleteClientAsync(A<string>.Ignored)).MustNotHaveHappened();
         }
     }
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
@@ -206,12 +206,32 @@ public class ApplicationModule : IEndpointModule
         ApplicationUpdateCommand command,
         HttpContext httpContext,
         IApplicationRepository repository,
+        IDataStoreRepository dataStoreRepository,
         IIdentityProviderRepository clientRepository,
         IOptions<IdentitySettings> identitySettings,
         ILogger<ApplicationModule> logger
     )
     {
         await validator.GuardAsync(command);
+        if (command.DataStoreIds.Length > 0)
+        {
+            var existingIdsResult = await dataStoreRepository.GetExistingDataStoreIds(command.DataStoreIds);
+            switch (existingIdsResult)
+            {
+                case DataStoreIdsExistResult.Success success
+                    when success.ExistingIds.Count != command.DataStoreIds.Distinct().Count():
+                    throw new ValidationException([
+                        new ValidationFailure("DataStoreId", "Data store does not exist."),
+                    ]);
+                case DataStoreIdsExistResult.FailureUnknown failure:
+                    logger.LogError(
+                        "Error validating DataStoreIds: {Message}",
+                        SanitizeForLog(failure.FailureMessage)
+                    );
+                    return FailureResults.Unknown(httpContext.TraceIdentifier);
+            }
+        }
+
         var apiClientsResult = await repository.GetApplicationApiClients(id);
 
         switch (apiClientsResult)

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
@@ -48,6 +48,7 @@ public class ApplicationModule : IEndpointModule
         HttpContext httpContext,
         IApplicationRepository applicationRepository,
         IVendorRepository vendorRepository,
+        IDataStoreRepository dataStoreRepository,
         IIdentityProviderRepository clientRepository,
         IOptions<IdentitySettings> identitySettings,
         IOptions<ClientSecretValidationOptions> clientSecretValidationOptionsAccessor,
@@ -72,6 +73,16 @@ public class ApplicationModule : IEndpointModule
                 throw new ValidationException([
                     new ValidationFailure("VendorId", "Reference 'VendorId' does not exist."),
                 ]);
+        }
+
+        // Validate references before creating the identity provider client so a failed
+        // repository insert cannot leave an orphaned client behind.
+        if (
+            await ValidateDataStoreIdsExist(command.DataStoreIds, dataStoreRepository, httpContext, logger) is
+            { } dataStoreFailure
+        )
+        {
+            return dataStoreFailure;
         }
 
         var clientCreateResult = await clientRepository.CreateClientAsync(
@@ -200,12 +211,49 @@ public class ApplicationModule : IEndpointModule
         return LoggingUtility.SanitizeForLog(input);
     }
 
+    /// <summary>
+    /// Validates that every requested data store id exists within the current tenant.
+    /// Throws a ValidationException when one is missing, returns a failure result for
+    /// infrastructure errors, and returns null when the request is valid.
+    /// </summary>
+    private static async Task<IResult?> ValidateDataStoreIdsExist(
+        long[] dataStoreIds,
+        IDataStoreRepository dataStoreRepository,
+        HttpContext httpContext,
+        ILogger<ApplicationModule> logger
+    )
+    {
+        if (dataStoreIds.Length == 0)
+        {
+            return null;
+        }
+
+        var existingIdsResult = await dataStoreRepository.GetExistingDataStoreIds(dataStoreIds);
+        switch (existingIdsResult)
+        {
+            case DataStoreIdsExistResult.Success success
+                when success.ExistingIds.Count != dataStoreIds.Distinct().Count():
+                throw new ValidationException([
+                    new ValidationFailure("DataStoreId", "Data store does not exist."),
+                ]);
+            case DataStoreIdsExistResult.FailureUnknown failure:
+                logger.LogError(
+                    "Error validating DataStoreIds: {Message}",
+                    SanitizeForLog(failure.FailureMessage)
+                );
+                return FailureResults.Unknown(httpContext.TraceIdentifier);
+        }
+
+        return null;
+    }
+
     private static async Task<IResult> Update(
         long id,
         ApplicationUpdateCommand.Validator validator,
         ApplicationUpdateCommand command,
         HttpContext httpContext,
         IApplicationRepository repository,
+        IVendorRepository vendorRepository,
         IDataStoreRepository dataStoreRepository,
         IIdentityProviderRepository clientRepository,
         IOptions<IdentitySettings> identitySettings,
@@ -213,25 +261,10 @@ public class ApplicationModule : IEndpointModule
     )
     {
         await validator.GuardAsync(command);
-        if (command.DataStoreIds.Length > 0)
-        {
-            var existingIdsResult = await dataStoreRepository.GetExistingDataStoreIds(command.DataStoreIds);
-            switch (existingIdsResult)
-            {
-                case DataStoreIdsExistResult.Success success
-                    when success.ExistingIds.Count != command.DataStoreIds.Distinct().Count():
-                    throw new ValidationException([
-                        new ValidationFailure("DataStoreId", "Data store does not exist."),
-                    ]);
-                case DataStoreIdsExistResult.FailureUnknown failure:
-                    logger.LogError(
-                        "Error validating DataStoreIds: {Message}",
-                        SanitizeForLog(failure.FailureMessage)
-                    );
-                    return FailureResults.Unknown(httpContext.TraceIdentifier);
-            }
-        }
 
+        // Resolve the application before validating references so a request for a
+        // missing or foreign-tenant application is answered with 404 regardless of
+        // what references the request body carries.
         var apiClientsResult = await repository.GetApplicationApiClients(id);
 
         switch (apiClientsResult)
@@ -240,6 +273,37 @@ public class ApplicationModule : IEndpointModule
                 var client = success.Clients.FirstOrDefault();
                 if (client != null)
                 {
+                    // Validate references before mutating the identity provider so a
+                    // failed repository update cannot leave an orphaned client change.
+                    switch (await vendorRepository.GetVendor(command.VendorId))
+                    {
+                        case VendorGetResult.Success:
+                            break;
+                        case VendorGetResult.FailureUnknown vendorFailure:
+                            logger.LogError(
+                                "Error validating VendorId: {Message}",
+                                SanitizeForLog(vendorFailure.FailureMessage)
+                            );
+                            return FailureResults.Unknown(httpContext.TraceIdentifier);
+                        default:
+                            throw new ValidationException([
+                                new ValidationFailure("VendorId", "Reference 'VendorId' does not exist."),
+                            ]);
+                    }
+
+                    if (
+                        await ValidateDataStoreIdsExist(
+                            command.DataStoreIds,
+                            dataStoreRepository,
+                            httpContext,
+                            logger
+                        ) is
+                        { } dataStoreFailure
+                    )
+                    {
+                        return dataStoreFailure;
+                    }
+
                     logger.LogInformation("Updating client {ClientId}", client.ClientId);
                     var clientUpdateResult = await clientRepository.UpdateClientAsync(
                         client.ClientUuid.ToString(),
@@ -334,7 +398,7 @@ public class ApplicationModule : IEndpointModule
                 }
                 else
                 {
-                    return FailureResults.NotFound("ApiClient not found", httpContext.TraceIdentifier);
+                    return FailureResults.NotFound("Application not found", httpContext.TraceIdentifier);
                 }
                 break;
             case ApplicationApiClientsResult.FailureUnknown failure:

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ApplicationModule.cs
@@ -247,6 +247,38 @@ public class ApplicationModule : IEndpointModule
         return null;
     }
 
+    /// <summary>
+    /// Validates that every requested profile id exists. Throws a ValidationException
+    /// when one is missing, returns a failure result for infrastructure errors, and
+    /// returns null when the request is valid. Profiles are not tenant-scoped, so this
+    /// existence check mirrors the repository's foreign-key validation exactly.
+    /// </summary>
+    private static async Task<IResult?> ValidateProfileIdsExist(
+        long[] profileIds,
+        IProfileRepository profileRepository,
+        HttpContext httpContext,
+        ILogger<ApplicationModule> logger
+    )
+    {
+        foreach (var profileId in profileIds.Distinct())
+        {
+            switch (await profileRepository.GetProfile(profileId))
+            {
+                case ProfileGetResult.Success:
+                    break;
+                case ProfileGetResult.FailureNotFound:
+                    throw new ValidationException([
+                        new ValidationFailure("ProfileId", "Profile does not exist."),
+                    ]);
+                case ProfileGetResult.FailureUnknown failure:
+                    logger.LogError("Error validating ProfileId: {Message}", SanitizeForLog(failure.Message));
+                    return FailureResults.Unknown(httpContext.TraceIdentifier);
+            }
+        }
+
+        return null;
+    }
+
     private static async Task<IResult> Update(
         long id,
         ApplicationUpdateCommand.Validator validator,
@@ -255,6 +287,7 @@ public class ApplicationModule : IEndpointModule
         IApplicationRepository repository,
         IVendorRepository vendorRepository,
         IDataStoreRepository dataStoreRepository,
+        IProfileRepository profileRepository,
         IIdentityProviderRepository clientRepository,
         IOptions<IdentitySettings> identitySettings,
         ILogger<ApplicationModule> logger
@@ -273,8 +306,12 @@ public class ApplicationModule : IEndpointModule
                 var client = success.Clients.FirstOrDefault();
                 if (client != null)
                 {
-                    // Validate references before mutating the identity provider so a
-                    // failed repository update cannot leave an orphaned client change.
+                    // Validate the request's references (vendor, data stores, profiles)
+                    // before mutating the identity provider so a rejected reference cannot
+                    // leave the client update stranded ahead of a failed repository update.
+                    // The duplicate-application-name constraint is still enforced by the
+                    // repository after this point; a collision there is reconciled by the
+                    // next successful update rather than pre-validated here.
                     switch (await vendorRepository.GetVendor(command.VendorId))
                     {
                         case VendorGetResult.Success:
@@ -302,6 +339,19 @@ public class ApplicationModule : IEndpointModule
                     )
                     {
                         return dataStoreFailure;
+                    }
+
+                    if (
+                        await ValidateProfileIdsExist(
+                            command.ProfileIds,
+                            profileRepository,
+                            httpContext,
+                            logger
+                        ) is
+                        { } profileFailure
+                    )
+                    {
+                        return profileFailure;
                     }
 
                     logger.LogInformation("Updating client {ClientId}", client.ClientId);

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/Tenants.feature
@@ -30,3 +30,74 @@ Feature: Tenants endpoints
                         "name": "Tenant_{scenarioRunId}"
                     }
                   """
+
+        # Exercises the full request pipeline (tenant resolution middleware, module
+        # handlers, and tenant-scoped repositories) to prove one tenant's application
+        # is invisible to another tenant, even when the request body references the
+        # owning tenant's vendor and data store ids.
+        @MssqlMultitenantRepresentative @MultitenantOnly
+        Scenario: 02 Ensure applications are not accessible from another tenant
+             When a POST request is made to "/v3/tenants" with
+                  """
+                    {
+                        "name": "TenantA_{scenarioRunId}"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/tenants" with
+                  """
+                    {
+                        "name": "TenantB_{scenarioRunId}"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/vendors" with header "Tenant" value "TenantA_{scenarioRunId}" and
+                  """
+                    {
+                        "company": "Cross Tenant Vendor {scenarioRunId}",
+                        "contactName": "Test",
+                        "contactEmailAddress": "test@gmail.com",
+                        "namespacePrefixes": "uri://ed-fi-e2e.org"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/dataStores" with header "Tenant" value "TenantA_{scenarioRunId}" and
+                  """
+                    {
+                        "dataStoreType": "Test",
+                        "name": "Cross Tenant Data Store {scenarioRunId}",
+                        "connectionString": "Server=test;Database=TestDb;"
+                    }
+                  """
+             Then it should respond with 201
+             When a POST request is made to "/v3/applications" with header "Tenant" value "TenantA_{scenarioRunId}" and
+                  """
+                    {
+                        "vendorId": {vendorId},
+                        "applicationName": "CrossTenantApplication",
+                        "claimSetName": "CrossTenantClaimSet",
+                        "educationOrganizationIds": [],
+                        "dataStoreIds": [{dataStoreId}]
+                    }
+                  """
+             Then it should respond with 201
+             When a GET request is made to "/v3/applications/{applicationId}" with header "Tenant" value "TenantB_{scenarioRunId}"
+             Then it should respond with 404
+             When a PUT request is made to "/v3/applications/{applicationId}" with header "Tenant" value "TenantB_{scenarioRunId}" and
+                  """
+                    {
+                        "id": {applicationId},
+                        "vendorId": {vendorId},
+                        "applicationName": "CrossTenantApplication",
+                        "claimSetName": "CrossTenantClaimSet",
+                        "educationOrganizationIds": [],
+                        "dataStoreIds": [{dataStoreId}]
+                    }
+                  """
+             Then it should respond with 404
+             When an "DELETE" request is made to "/v3/applications/{applicationId}" with headers
+                  | Key    | Value                   |
+                  | Tenant | TenantB_{scenarioRunId} |
+             Then it should respond with 404
+             When a GET request is made to "/v3/applications/{applicationId}" with header "Tenant" value "TenantA_{scenarioRunId}"
+             Then it should respond with 200

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -168,7 +168,7 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
 
         var headers = new Dictionary<string, string>(_authHeaders, StringComparer.OrdinalIgnoreCase)
         {
-            [header] = value,
+            [header] = await ReplaceIdsAsync(value),
         };
 
         _apiResponse = await playwrightContext.ApiRequestContext?.GetAsync(url, new() { Headers = headers })!;
@@ -188,13 +188,59 @@ public partial class StepDefinitions(PlaywrightContext playwrightContext, Scenar
         var headers = new Dictionary<string, string>(_authHeaders, StringComparer.OrdinalIgnoreCase);
         foreach (var row in headersTable.Rows)
         {
-            headers[row["Key"]] = row["Value"];
+            headers[row["Key"]] = await ReplaceIdsAsync(row["Value"]);
         }
 
         _apiResponse = await playwrightContext.ApiRequestContext!.FetchAsync(
             url,
             new() { Method = method, Headers = headers }
         );
+    }
+
+    [When("a POST request is made to {string} with header {string} value {string} and")]
+    public async Task WhenAPostRequestIsMadeToWithHeaderAnd(
+        string url,
+        string header,
+        string value,
+        string body
+    )
+    {
+        url = await ReplaceIdsAsync(url);
+        body = await ReplaceIdsAsync(body);
+
+        var headers = new Dictionary<string, string>(_authHeaders, StringComparer.OrdinalIgnoreCase)
+        {
+            [header] = await ReplaceIdsAsync(value),
+        };
+
+        _apiResponse = await playwrightContext.ApiRequestContext?.PostAsync(
+            url,
+            new() { Headers = headers, Data = body }
+        )!;
+        await ExtractIdFromHeader(_apiResponse);
+    }
+
+    [When("a PUT request is made to {string} with header {string} value {string} and")]
+    public async Task WhenAPutRequestIsMadeToWithHeaderAnd(
+        string url,
+        string header,
+        string value,
+        string body
+    )
+    {
+        url = await ReplaceIdsAsync(url);
+        body = await ReplaceIdsAsync(body);
+
+        var headers = new Dictionary<string, string>(_authHeaders, StringComparer.OrdinalIgnoreCase)
+        {
+            [header] = await ReplaceIdsAsync(value),
+        };
+
+        _apiResponse = await playwrightContext.ApiRequestContext?.PutAsync(
+            url,
+            new() { Headers = headers, Data = body }
+        )!;
+        await ExtractIdFromHeader(_apiResponse);
     }
 
     [When("a GET request is made to {string} for first {int} items")]


### PR DESCRIPTION
Fixes [DMS-1260](https://edfi.atlassian.net/browse/DMS-1260).

## Problem

`ApplicationRepository` and `ApiClientRepository` in the Configuration Service never scope queries by tenant, in either the PostgreSQL or SQL Server backend. In a multitenant deployment a caller resolved to tenant B can read or mutate tenant A's applications and API clients by id, and can remap datastores across tenants. The `0025_Add_TenantId_To_Tables` migration left `Application`/`ApiClient` to be scoped transitively through their owning `Vendor`, but that scoping was never implemented at the repository layer.

## Fix

Both repositories (both engines) now inject `ITenantContextProvider` and constrain every operation through the owning Vendor's `TenantId` (`Application → Vendor`, `ApiClient → Application → Vendor`), modeled on the `DataStoreDerivativeRepository` fix from DMS-1243:

- **Reads** (`GetApplication`, `QueryApplication`, `GetApplicationApiClients`, `GetApiClientById`, `GetApiClientByClientId`, `QueryApiClient`) filter by a tenant-scoped vendor/application subquery — cross-tenant ids resolve as not-found/empty, so the API returns 404.
- **Deletes and the `UpdateApiClient` existence check** carry the same constraint (`FailureNotExists`/`FailureNotFound` for cross-tenant ids).
- **Inserts** are guarded `INSERT … SELECT … WHERE EXISTS`; a referenced vendor/application outside the tenant yields `FailureVendorNotFound`/`FailureApplicationNotFound` instead of inserting.
- **Datastore references** on insert/update are validated against tenant-owned `DataStore` rows before mappings are written (`FailureDataStoreNotFound`), so `ApiClientDataStore` mappings cannot cross tenants.
- `UpdateApplication` distinguishes an application outside the tenant (`FailureNotExists` → 404) from a cross-tenant target vendor (`FailureVendorNotFound` → 400), and its inner ApiClient update/select are additionally constrained by `ApplicationId`.

Single-tenant behavior is unchanged: with no tenant context the scoping clause degrades to `TenantId IS NULL`.

## Tests

New cross-tenant isolation fixtures per engine — `Given_application_operations_from_another_tenant` and `Given_api_client_operations_from_another_tenant` (10 tests each) — covering get/query/update/delete/insert isolation, cross-tenant vendor/application/datastore reference rejection, and single-tenant-context behavior. Written test-first: all 20 failed per engine (cross-tenant operations returned `Success`) before the repository changes.

Verified locally: PostgreSQL integration 272/272, SQL Server integration 276/276, frontend unit 443/443, backend unit 331/331.


[DMS-1260]: https://edfi.atlassian.net/browse/DMS-1260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ