### PR TITLE
Report license/cla status on merge group commits

### DIFF
--- a/.github/workflows/on-merge-group-cla.yml
+++ b/.github/workflows/on-merge-group-cla.yml
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+name: CLA Merge Group Shim
+
+on:
+  merge_group:
+
+permissions:
+  statuses: write
+
+jobs:
+  report-cla-status:
+    name: Report license/cla for merge group
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post license/cla success status
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            // cla-assistant.io only responds to pull_request events, so the
+            // required "license/cla" status never appears on merge group
+            // commits and the queue times out waiting for it. A pull request
+            // cannot enter the merge queue until the real CLA check has passed
+            // on its head commit, so reporting success here is safe.
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.merge_group.head_sha,
+              state: "success",
+              context: "license/cla",
+              description: "CLA verified on the underlying pull request(s)",
+            });


### PR DESCRIPTION
## Problem

With the merge queue enabled on `main` (#1097), every queue entry stalls in `AWAITING_CHECKS` and fails after the 60-minute check-response timeout. The `license/cla` status check is required on `main`, but it is posted by cla-assistant.io, which only responds to `pull_request` events — it never reports on merge group commits, so the queue waits for a check that cannot arrive.

## Fix

Adds a small workflow triggered on `merge_group` that posts a `license/cla` success commit status on the merge group head SHA.

This is safe because a pull request cannot enter the merge queue until the real CLA check has passed on its own head commit; the merge group is composed only of already-verified PRs. This is the standard shim for CLA Assistant + merge queue repositories.

## Notes

- `actions/github-script` is pinned to the same SHA (v7.0.1) already used by `on-issue-opened.yml`, so the action-allowedlist scan passes.
- The workflow requests only `statuses: write`.
- Covers any future merge queue on `patch-*` branches too, since `merge_group` fires regardless of target branch.
