### PR TITLE
ETag contract consolidation + PR #1091 review follow-ups (findings 2–5, 8–12)

### DIFF
--- a/reference/adr-etag-from-content-version.md
+++ b/reference/adr-etag-from-content-version.md
@@ -9,6 +9,8 @@ compatibility — see [Amendment (2026-07-04)](#amendment-2026-07-04-profilecode
 compatibility — see [Amendment (2026-07-05)](#amendment-2026-07-05-unquoted-if-match-values-accepted-as-equivalent-to-quoted). \
 **Amended 2026-07-05:** bare `If-Match: *` honored as an existence precondition per RFC 7232 §3.1 —
 see [Amendment (2026-07-05, wildcard)](#amendment-2026-07-05-if-match-wildcard-matching). \
+**Amended 2026-07-07:** the served descriptor `_etag` is now profile-sensitive for conditional-GET
+correctness — see [Amendment (2026-07-07, descriptor profile etag)](#amendment-2026-07-07-descriptor-served-etag-varies-by-readable-profile). \
 **Date:** 2026-06-30 (accepted 2026-07-03) \
 **Deciders:** Development team (signed off 2026-07-03). \
 **Author:** Stephen Fuqua, with analysis assistance from Claude Opus 4.8 (Claude Code).
@@ -333,3 +335,34 @@ Unlike the 2026-07-04 (`profileCode`) and earlier 2026-07-05 (unquoted) amendmen
 ### Consequence
 
 `If-Match: *` becomes a working existence precondition — succeeding on any current version of an existing resource and returning `412` when the resource does not exist — instead of an unconditional `412` in all cases. Optimistic-concurrency behavior for specific-tag `If-Match` is unchanged.
+
+## Amendment (2026-07-07): descriptor served `_etag` varies by readable profile
+
+**Status:** Accepted — closes a gap left open when the profile-sensitive served etag (see "ETag format and HTTP validator semantics (RFC 7232)") was implemented only for non-descriptor resources. \
+**Date:** 2026-07-07 \
+**Deciders:** Development team (pending sign-off). \
+**Author:** Stephen Fuqua, with analysis assistance from Claude Opus 4.8 (Claude Code).
+
+> **AI-use disclosure.** This amendment and its supporting analysis were drafted with substantial AI assistance. Findings reflect the source code as understood on 2026-07-07 and must be human-reviewed before merge. Accountability for the decision rests with the development team.
+
+### What changed
+
+A feasibility spike confirmed that descriptors **are** subject to readable-profile projection on GET: `ProfileResolutionMiddleware` runs on the descriptor GET pipelines, `Handler/Utility.CreateReadableProfileProjectionContext` special-cases `IsDescriptor` to seed the identity-property allow-list, and `DescriptorReadHandler.MaterializeDescriptorDocument` already applied `IReadableProfileProjector.Project(...)` to the served descriptor body when a projection context was present. Despite that, the served descriptor `_etag` was composed via the fixed `DescriptorVariantKey.For(effectiveSchemaHash)`, whose `profileCode` is hardcoded to the no-profile sentinel `_` regardless of whether a profile actually projected the body. Two profile-different descriptor representations therefore shared one strong `ETag` — a violation of RFC 7232 §2.1 for the same reason the main ADR text gives for non-descriptor resources.
+
+`DescriptorReadHandler` now composes the served descriptor etag through `IServedEtagComposer`, passing the active readable profile's name (when one actually projects the read) instead of the fixed descriptor variant key. `DescriptorDocumentMaterializer.Materialize` no longer composes the etag itself; it accepts the caller's precomposed string, so the handler alone decides profile-sensitivity — mirroring the pattern already used by the non-descriptor path (`RelationalReadMaterializer.ComposeEtag`). The condition that selects the profile name mirrors `RelationalDocumentStoreRepository.ShouldApplyReadableProfileProjection` exactly (`ExternalResponse` read mode **and** a non-null projection context), so the descriptor and non-descriptor read paths stay in lockstep.
+
+### What did not change
+
+- **Descriptor `If-Match` remains profile-insensitive.** `EtagMatchProjection.Of` (unaffected by this change) drops `profileCode` — along with `format` and `linkFlag` — from every precondition comparison, descriptor or not (see [Amendment (2026-07-04)](#amendment-2026-07-04-profilecode-removed-from-if-match-comparison)). A descriptor PUT/DELETE using an `If-Match` value obtained from a profiled GET still succeeds whenever `ContentVersion` and `schemaEpoch` agree, exactly as for non-descriptor resources.
+- **Descriptor write-response etags remain unprofiled.** `DescriptorWriteHandler` already composed its response etag via `IServedEtagComposer` with `ProfileName: null` before this change and continues to do so; only the *read* path changes.
+- `DescriptorVariantKey` is left in place: it remains the correct, still-used shorthand for the fixed "no profile, no links, JSON" variant in the descriptor *write*-side tests (`DescriptorWriteHandlerPreconditionTests`, `DescriptorWriteHandlerResponseEtagTests`), where the represented etag genuinely is always profile-insensitive. It is simply no longer invoked from descriptor *read* production code.
+
+### Scope of the code change
+
+- `DescriptorReadHandler` (`src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs`): constructor now takes `IServedEtagComposer` instead of `IEtagComposer`; the descriptor GET-by-id and query materialization paths compose the served etag from `ServedEtagContext` with the resolved profile name (or `null`) rather than the fixed `DescriptorVariantKey`.
+- `DescriptorDocumentMaterializer` (`src/dms/backend/EdFi.DataManagementService.Backend/DescriptorDocumentMaterializer.cs`): `Materialize` now takes a precomposed `string? composedEtag` instead of `IEtagComposer` + `VariantKey`, and throws if an `ExternalResponse` read is materialized without one.
+- Test updates: `DescriptorReadHandlerTests`, `DescriptorDocumentMaterializerTests`, and `DescriptorReadHandlerNamespaceAuthorizationTests` updated for the new signatures; the previous pinning test (which asserted a profiled and unprofiled descriptor read shared one `_etag`) was flipped to assert they now differ, and a case was added proving unprofiled descriptor reads still yield the `_` profile code. `DescriptorWriteHandlerPreconditionTests` gained PUT and DELETE cases proving a profile-obtained descriptor etag still satisfies `If-Match` against an unprofiled write.
+
+### Consequence
+
+Two profile-different descriptor GET representations now carry distinct strong `ETag` values, closing the RFC 7232 §2.1 gap for descriptors specifically (the main ADR text already closed it for non-descriptor resources). `If-Match` / `If-None-Match` semantics for descriptor writes are unaffected — a client may still read a descriptor under one profile and write it back unprofiled using the same etag.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
@@ -846,6 +846,274 @@ public class Given_A_Mssql_Unprofiled_Put_Using_The_Current_Profiled_Get_Etag
         _unprofiledPutResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
 }
 
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category(MssqlCiShards.Shard2)]
+public class Given_A_Mssql_Unprofiled_Delete_Using_The_Current_Profiled_Get_Etag
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("b1c2d3e4-0006-4a1b-9c2d-1a2b3c4d5e06")
+    );
+
+    private const int NamingStressItemId = 7611;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private DeleteResult _unprofiledDeleteResult = null!;
+    private GetResult _getAfterDelete = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileIfMatchEtagTestSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+
+        (
+            await MssqlProfileIfMatchEtagTestSupport.SeedAsync(
+                _serviceProvider,
+                _database,
+                _mappingSet,
+                NamingStressItemId,
+                seedBody,
+                DocumentUuid,
+                "mssql-unprofiled-delete-profiled-etag-seed"
+            )
+        )
+            .Should()
+            .BeOfType<UpsertResult.InsertSuccess>();
+
+        var profiledGet = await MssqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-unprofiled-delete-profiled-etag-get",
+            MssqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext()
+        );
+
+        var profiledEtag = MssqlProfileIfMatchEtagTestSupport.GetEtag(
+            MssqlProfileIfMatchEtagTestSupport.GetSuccessDocument(profiledGet)
+        );
+
+        // DELETE has no profile lens (unprofiled is the only DELETE path), guarded by the etag
+        // captured from the profiled read.
+        _unprofiledDeleteResult = await MssqlProfileIfMatchEtagTestSupport.ExecuteDeleteAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-unprofiled-delete-profiled-etag-delete",
+            profiledEtag
+        );
+
+        _getAfterDelete = await MssqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-unprofiled-delete-profiled-etag-get-after"
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public void It_accepts_the_profiled_get_etag_for_an_unprofiled_delete() =>
+        _unprofiledDeleteResult.Should().BeOfType<DeleteResult.DeleteSuccess>();
+
+    [Test]
+    public void It_removes_the_document() =>
+        _getAfterDelete.Should().BeOfType<GetResult.GetFailureNotExists>();
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category(MssqlCiShards.Shard2)]
+public class Given_A_Mssql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden_Field_Change
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("b1c2d3e4-0007-4a1b-9c2d-1a2b3c4d5e07")
+    );
+
+    private const int NamingStressItemId = 7622;
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private GetResult _profiledGetBeforeHiddenChange = null!;
+    private GetResult _profiledGetAfterHiddenChange = null!;
+    private DeleteResult _staleDeleteResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            MssqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await MssqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = MssqlProfileIfMatchEtagTestSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+
+        (
+            await MssqlProfileIfMatchEtagTestSupport.SeedAsync(
+                _serviceProvider,
+                _database,
+                _mappingSet,
+                NamingStressItemId,
+                seedBody,
+                DocumentUuid,
+                "mssql-delete-stale-profiled-etag-seed"
+            )
+        )
+            .Should()
+            .BeOfType<UpsertResult.InsertSuccess>();
+
+        var readableProfileProjectionContext =
+            MssqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext();
+
+        _profiledGetBeforeHiddenChange = await MssqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-delete-stale-profiled-etag-get-before",
+            readableProfileProjectionContext
+        );
+
+        var staleProfiledEtag = MssqlProfileIfMatchEtagTestSupport.GetEtag(
+            MssqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetBeforeHiddenChange)
+        );
+
+        var hiddenFieldChangeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 43,
+        };
+
+        (
+            await MssqlProfileIfMatchEtagTestSupport.ExecuteUnprofiledUpdateAsync(
+                _serviceProvider,
+                _database.ConnectionString,
+                _mappingSet,
+                NamingStressItemId,
+                DocumentUuid,
+                hiddenFieldChangeBody,
+                "mssql-delete-stale-profiled-etag-hidden-field-change"
+            )
+        )
+            .Should()
+            .BeOfType<UpdateResult.UpdateSuccess>();
+
+        // Capture the profiled etag after the hidden-field change, before the DELETE removes the
+        // document, so we can independently prove the profiled etag actually changed (rather than
+        // just observing a 412 that could also result from a "DELETE always fails" bug).
+        _profiledGetAfterHiddenChange = await MssqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-delete-stale-profiled-etag-get-after",
+            readableProfileProjectionContext
+        );
+
+        // DELETE has no profile lens (unprofiled is the only DELETE path), guarded by the now-stale
+        // etag captured before the hidden-field change bumped ContentVersion.
+        _staleDeleteResult = await MssqlProfileIfMatchEtagTestSupport.ExecuteDeleteAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "mssql-delete-stale-profiled-etag-delete",
+            staleProfiledEtag
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public void It_returns_412_for_a_delete_using_the_stale_profiled_etag() =>
+        _staleDeleteResult.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+
+    [Test]
+    public void It_changes_the_profiled_etag_when_the_hidden_field_changes()
+    {
+        var staleProfiledEtag = MssqlProfileIfMatchEtagTestSupport.GetEtag(
+            MssqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetBeforeHiddenChange)
+        );
+        var currentProfiledEtag = MssqlProfileIfMatchEtagTestSupport.GetEtag(
+            MssqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetAfterHiddenChange)
+        );
+
+        currentProfiledEtag.Should().NotBe(staleProfiledEtag);
+    }
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 //  RFC 7232 wildcard (If-Match: *) end-to-end behavior against a real database.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
@@ -1148,7 +1148,11 @@ public class Given_A_Mssql_Wildcard_IfMatch_Put_Against_A_Missing_Document
 
     [Test]
     public void It_returns_412_and_not_404_for_a_wildcard_put_against_a_missing_document() =>
-        _wildcardPutResult.Should().BeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+        _wildcardPutResult
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }
 
 [TestFixture]
@@ -1213,7 +1217,11 @@ public class Given_A_Mssql_Wildcard_IfMatch_Delete_Against_A_Missing_Document
 
     [Test]
     public void It_returns_412_and_not_404_for_a_wildcard_delete_against_a_missing_document() =>
-        _wildcardDeleteResult.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        _wildcardDeleteResult
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }
 
 [TestFixture]
@@ -1289,5 +1297,9 @@ public class Given_A_Mssql_Wildcard_IfMatch_Post_Resolving_To_Insert
 
     [Test]
     public void It_returns_412_for_a_wildcard_post_resolving_to_insert() =>
-        _wildcardPostResult.Should().BeOfType<UpsertResult.UpsertFailureETagMisMatch>();
+        _wildcardPostResult
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
@@ -117,7 +117,9 @@ internal sealed class RecordingRelationalReadMaterializer(MssqlRelationalQueryEx
     private readonly RelationalReadMaterializer _inner = new(
         new IntegrationFixtureSlugResolver(),
         Microsoft.Extensions.Options.Options.Create(new ResourceLinksOptions()),
-        new EdFi.DataManagementService.Backend.Etag.EtagComposer()
+        new EdFi.DataManagementService.Backend.Etag.ServedEtagComposer(
+            new EdFi.DataManagementService.Backend.Etag.EtagComposer()
+        )
     );
 
     public JsonNode Materialize(RelationalReadMaterializationRequest request)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
@@ -948,6 +948,8 @@ public class Given_A_Postgresql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden
     private MappingSet _mappingSet = null!;
     private PostgresqlGeneratedDdlTestDatabase _database = null!;
     private ServiceProvider _serviceProvider = null!;
+    private GetResult _profiledGetBeforeHiddenChange = null!;
+    private GetResult _profiledGetAfterHiddenChange = null!;
     private DeleteResult _staleDeleteResult = null!;
 
     [OneTimeSetUp]
@@ -981,17 +983,20 @@ public class Given_A_Postgresql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden
             .Should()
             .BeOfType<UpsertResult.InsertSuccess>();
 
-        var profiledGetBeforeHiddenChange = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+        var readableProfileProjectionContext =
+            PostgresqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext();
+
+        _profiledGetBeforeHiddenChange = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
             _serviceProvider,
             _database.ConnectionString,
             _mappingSet,
             DocumentUuid,
             "pg-delete-stale-profiled-etag-get-before",
-            PostgresqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext()
+            readableProfileProjectionContext
         );
 
         var staleProfiledEtag = PostgresqlProfileIfMatchEtagTestSupport.GetEtag(
-            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(profiledGetBeforeHiddenChange)
+            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetBeforeHiddenChange)
         );
 
         var hiddenFieldChangeBody = new JsonObject
@@ -1014,6 +1019,18 @@ public class Given_A_Postgresql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden
         )
             .Should()
             .BeOfType<UpdateResult.UpdateSuccess>();
+
+        // Capture the profiled etag after the hidden-field change, before the DELETE removes the
+        // document, so we can independently prove the profiled etag actually changed (rather than
+        // just observing a 412 that could also result from a "DELETE always fails" bug).
+        _profiledGetAfterHiddenChange = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-delete-stale-profiled-etag-get-after",
+            readableProfileProjectionContext
+        );
 
         // DELETE has no profile lens (unprofiled is the only DELETE path), guarded by the now-stale
         // etag captured before the hidden-field change bumped ContentVersion.
@@ -1046,6 +1063,19 @@ public class Given_A_Postgresql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden
     [Test]
     public void It_returns_412_for_a_delete_using_the_stale_profiled_etag() =>
         _staleDeleteResult.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+
+    [Test]
+    public void It_changes_the_profiled_etag_when_the_hidden_field_changes()
+    {
+        var staleProfiledEtag = PostgresqlProfileIfMatchEtagTestSupport.GetEtag(
+            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetBeforeHiddenChange)
+        );
+        var currentProfiledEtag = PostgresqlProfileIfMatchEtagTestSupport.GetEtag(
+            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(_profiledGetAfterHiddenChange)
+        );
+
+        currentProfiledEtag.Should().NotBe(staleProfiledEtag);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
@@ -826,6 +826,228 @@ public class Given_A_Postgresql_Unprofiled_Put_Using_The_Current_Profiled_Get_Et
         _unprofiledPutResult.Should().BeOfType<UpdateResult.UpdateSuccess>();
 }
 
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_Unprofiled_Delete_Using_The_Current_Profiled_Get_Etag
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("b1c2d3e4-0006-4a1b-9c2d-1a2b3c4d5e06")
+    );
+
+    private const int NamingStressItemId = 7611;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private DeleteResult _unprofiledDeleteResult = null!;
+    private GetResult _getAfterDelete = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileIfMatchEtagTestSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+
+        (
+            await PostgresqlProfileIfMatchEtagTestSupport.SeedAsync(
+                _serviceProvider,
+                _database,
+                _mappingSet,
+                NamingStressItemId,
+                seedBody,
+                DocumentUuid,
+                "pg-unprofiled-delete-profiled-etag-seed"
+            )
+        )
+            .Should()
+            .BeOfType<UpsertResult.InsertSuccess>();
+
+        var profiledGet = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-unprofiled-delete-profiled-etag-get",
+            PostgresqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext()
+        );
+
+        var profiledEtag = PostgresqlProfileIfMatchEtagTestSupport.GetEtag(
+            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(profiledGet)
+        );
+
+        // DELETE has no profile lens (unprofiled is the only DELETE path), guarded by the etag
+        // captured from the profiled read.
+        _unprofiledDeleteResult = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteDeleteAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-unprofiled-delete-profiled-etag-delete",
+            profiledEtag
+        );
+
+        _getAfterDelete = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-unprofiled-delete-profiled-etag-get-after"
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public void It_accepts_the_profiled_get_etag_for_an_unprofiled_delete() =>
+        _unprofiledDeleteResult.Should().BeOfType<DeleteResult.DeleteSuccess>();
+
+    [Test]
+    public void It_removes_the_document() =>
+        _getAfterDelete.Should().BeOfType<GetResult.GetFailureNotExists>();
+}
+
+[TestFixture]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_Delete_With_A_Stale_Profiled_Etag_After_A_Hidden_Field_Change
+{
+    private static readonly DocumentUuid DocumentUuid = new(
+        Guid.Parse("b1c2d3e4-0007-4a1b-9c2d-1a2b3c4d5e07")
+    );
+
+    private const int NamingStressItemId = 7622;
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private DeleteResult _staleDeleteResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            PostgresqlProfileRootTableOnlyMergeSupport.NamingStressFixtureRelativePath
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = PostgresqlProfileIfMatchEtagTestSupport.CreateServiceProvider();
+
+        var seedBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 42,
+        };
+
+        (
+            await PostgresqlProfileIfMatchEtagTestSupport.SeedAsync(
+                _serviceProvider,
+                _database,
+                _mappingSet,
+                NamingStressItemId,
+                seedBody,
+                DocumentUuid,
+                "pg-delete-stale-profiled-etag-seed"
+            )
+        )
+            .Should()
+            .BeOfType<UpsertResult.InsertSuccess>();
+
+        var profiledGetBeforeHiddenChange = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteGetByIdAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-delete-stale-profiled-etag-get-before",
+            PostgresqlProfileIfMatchEtagTestSupport.CreateReadableProfileProjectionContext()
+        );
+
+        var staleProfiledEtag = PostgresqlProfileIfMatchEtagTestSupport.GetEtag(
+            PostgresqlProfileIfMatchEtagTestSupport.GetSuccessDocument(profiledGetBeforeHiddenChange)
+        );
+
+        var hiddenFieldChangeBody = new JsonObject
+        {
+            ["namingStressItemId"] = NamingStressItemId,
+            ["shortName"] = "Original",
+            ["order"] = 43,
+        };
+
+        (
+            await PostgresqlProfileIfMatchEtagTestSupport.ExecuteUnprofiledUpdateAsync(
+                _serviceProvider,
+                _database.ConnectionString,
+                _mappingSet,
+                NamingStressItemId,
+                DocumentUuid,
+                hiddenFieldChangeBody,
+                "pg-delete-stale-profiled-etag-hidden-field-change"
+            )
+        )
+            .Should()
+            .BeOfType<UpdateResult.UpdateSuccess>();
+
+        // DELETE has no profile lens (unprofiled is the only DELETE path), guarded by the now-stale
+        // etag captured before the hidden-field change bumped ContentVersion.
+        _staleDeleteResult = await PostgresqlProfileIfMatchEtagTestSupport.ExecuteDeleteAsync(
+            _serviceProvider,
+            _database.ConnectionString,
+            _mappingSet,
+            DocumentUuid,
+            "pg-delete-stale-profiled-etag-delete",
+            staleProfiledEtag
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+            _serviceProvider = null!;
+        }
+
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+            _database = null!;
+        }
+    }
+
+    [Test]
+    public void It_returns_412_for_a_delete_using_the_stale_profiled_etag() =>
+        _staleDeleteResult.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 //  RFC 7232 wildcard (If-Match: *) end-to-end behavior against a real database.
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
@@ -1104,7 +1104,11 @@ public class Given_A_Postgresql_Wildcard_IfMatch_Put_Against_A_Missing_Document
 
     [Test]
     public void It_returns_412_and_not_404_for_a_wildcard_put_against_a_missing_document() =>
-        _wildcardPutResult.Should().BeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+        _wildcardPutResult
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }
 
 [TestFixture]
@@ -1161,7 +1165,11 @@ public class Given_A_Postgresql_Wildcard_IfMatch_Delete_Against_A_Missing_Docume
 
     [Test]
     public void It_returns_412_and_not_404_for_a_wildcard_delete_against_a_missing_document() =>
-        _wildcardDeleteResult.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        _wildcardDeleteResult
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }
 
 [TestFixture]
@@ -1229,5 +1237,9 @@ public class Given_A_Postgresql_Wildcard_IfMatch_Post_Resolving_To_Insert
 
     [Test]
     public void It_returns_412_for_a_wildcard_post_resolving_to_insert() =>
-        _wildcardPostResult.Should().BeOfType<UpsertResult.UpsertFailureETagMisMatch>();
+        _wildcardPostResult
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
@@ -114,7 +114,9 @@ internal sealed class RecordingRelationalReadMaterializer(PostgresqlRelationalQu
     private readonly RelationalReadMaterializer _inner = new(
         new IntegrationFixtureSlugResolver(),
         Microsoft.Extensions.Options.Options.Create(new ResourceLinksOptions()),
-        new EdFi.DataManagementService.Backend.Etag.EtagComposer()
+        new EdFi.DataManagementService.Backend.Etag.ServedEtagComposer(
+            new EdFi.DataManagementService.Backend.Etag.EtagComposer()
+        )
     );
 
     public JsonNode Materialize(RelationalReadMaterializationRequest request)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -78,7 +78,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator()
         );
     }
 
@@ -666,7 +667,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator(),
             parameterConfigurator
         );
         var documentReference = RelationalAccessTestData.CreateDocumentReference(
@@ -750,7 +752,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator(),
             relationshipAuthorizationProviderFailureExtractor: providerFailureExtractor
         );
         _writeSessionFactory.Session.RelationshipAuthorizationCommandExecutor =
@@ -807,7 +810,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator(),
             relationshipAuthorizationProviderFailureExtractor: providerFailureExtractor,
             logger: logger
         );
@@ -1509,7 +1513,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator()
         );
 
         var result = await _sut.ExecuteAsync(request);
@@ -5787,7 +5792,8 @@ public class Given_Default_Relational_Write_Executor
             _writeExceptionClassifier,
             _writeConstraintResolver,
             _readMaterializer,
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator(),
             relationshipAuthorizationProviderFailureExtractor: new StubRelationshipAuthorizationProviderFailureExtractor(
                 NamespaceAuthorizationAuth1FailurePayloadCodec.ProviderFailureCode,
                 providerMessage

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DefaultRelationalWriteExecutorTests.cs
@@ -1573,11 +1573,14 @@ public class Given_Default_Relational_Write_Executor
 
         // UpdateFailureNotExists and UpdateFailureETagMisMatch are both memberless records, so
         // BeEquivalentTo cannot tell them apart; assert on the concrete inner result type instead.
+        // The target is missing, so the reason is TargetDoesNotExist rather than a Concurrency mismatch.
         result
             .Should()
             .BeOfType<RelationalWriteExecutorResult.Update>()
             .Which.Result.Should()
-            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _currentEtagPreconditionChecker.CheckCallCount.Should().Be(1);
         _writeFlattener.FlattenCallCount.Should().Be(0);
         _currentStateLoader.LoadCallCount.Should().Be(0);
@@ -1629,11 +1632,15 @@ public class Given_Default_Relational_Write_Executor
 
         var result = await _sut.ExecuteAsync(request);
 
+        // The target exists but its current etag does not match the specific-tag If-Match precondition,
+        // so the reason is Concurrency rather than TargetDoesNotExist.
         result
             .Should()
-            .BeEquivalentTo(
-                new RelationalWriteExecutorResult.Update(new UpdateResult.UpdateFailureETagMisMatch())
-            );
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
         _currentEtagPreconditionChecker.CheckCallCount.Should().Be(1);
         _referenceResolverAdapterFactory.CreateSessionAdapterCallCount.Should().Be(0);
         _writeFlattener.FlattenCallCount.Should().Be(0);
@@ -1708,11 +1715,16 @@ public class Given_Default_Relational_Write_Executor
 
         var result = await _sut.ExecuteAsync(request);
 
+        // Re-resolving the advisory POST target as CreateNew means there is no current representation
+        // to satisfy the If-Match precondition against, so the reason is TargetDoesNotExist rather than
+        // a Concurrency mismatch.
         result
             .Should()
-            .BeEquivalentTo(
-                new RelationalWriteExecutorResult.Upsert(new UpsertResult.UpsertFailureETagMisMatch())
-            );
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _targetLookupResolver.ResolveForPostCallCount.Should().Be(1);
         _targetLookupResolver.CapturedWriteSession.Should().NotBeNull();
         _targetLookupResolver
@@ -1740,11 +1752,16 @@ public class Given_Default_Relational_Write_Executor
 
         var result = await _sut.ExecuteAsync(request);
 
+        // Authoritative target resolution proving a new insert means there is no current
+        // representation to satisfy the If-Match precondition against, so the reason is
+        // TargetDoesNotExist rather than a Concurrency mismatch.
         result
             .Should()
-            .BeEquivalentTo(
-                new RelationalWriteExecutorResult.Upsert(new UpsertResult.UpsertFailureETagMisMatch())
-            );
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _targetLookupResolver.ResolveForPostCallCount.Should().Be(1);
         _currentEtagPreconditionChecker.CheckCallCount.Should().Be(0);
         _referenceResolverAdapterFactory.CreateSessionAdapterCallCount.Should().Be(0);
@@ -5177,11 +5194,15 @@ public class Given_Default_Relational_Write_Executor
             }
         );
 
+        // The deferred If-Match check runs against a CreateNew target, which has no current
+        // representation, so the reason is TargetDoesNotExist rather than a Concurrency mismatch.
         result
             .Should()
-            .BeEquivalentTo(
-                new RelationalWriteExecutorResult.Upsert(new UpsertResult.UpsertFailureETagMisMatch())
-            );
+            .BeOfType<RelationalWriteExecutorResult.Upsert>()
+            .Which.Result.Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _targetLookupResolver.ResolveForPostCallCount.Should().Be(1);
         _currentEtagPreconditionChecker.CheckCallCount.Should().Be(0);
         _writeFlattener.FlattenCallCount.Should().Be(1);
@@ -6095,11 +6116,15 @@ public class Given_Default_Relational_Write_Executor
             }
         );
 
+        // The deferred If-Match check runs against a loaded current state, so a mismatch is a
+        // Concurrency reason rather than TargetDoesNotExist.
         result
             .Should()
-            .BeEquivalentTo(
-                new RelationalWriteExecutorResult.Update(new UpdateResult.UpdateFailureETagMisMatch())
-            );
+            .BeOfType<RelationalWriteExecutorResult.Update>()
+            .Which.Result.Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
         _currentEtagPreconditionChecker.CheckCallCount.Should().Be(0);
         _currentStateLoader.LoadCallCount.Should().Be(1);
         _noProfilePersister.AuthorizeProposedRelationshipCallCount.Should().Be(1);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorDocumentMaterializerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorDocumentMaterializerTests.cs
@@ -28,12 +28,12 @@ public class Given_DescriptorDocumentMaterializer
             effectiveEndDate: new DateOnly(2025, 12, 31),
             discriminator: "SchoolTypeDescriptor"
         );
+        var composedEtag = _etagComposer.Compose(row.ContentVersion, _descriptorVariantKey);
 
         var result = DescriptorDocumentMaterializer.Materialize(
             row,
             RelationalGetRequestReadMode.ExternalResponse,
-            _etagComposer,
-            _descriptorVariantKey
+            composedEtag
         );
 
         result["namespace"]!.GetValue<string>().Should().Be("uri://ed-fi.org/SchoolTypeDescriptor");
@@ -44,10 +44,7 @@ public class Given_DescriptorDocumentMaterializer
         result["effectiveEndDate"]!.GetValue<string>().Should().Be("2025-12-31");
         result["id"]!.GetValue<string>().Should().Be("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb");
         result["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-05-05T14:30:45Z");
-        result["_etag"]!
-            .GetValue<string>()
-            .Should()
-            .Be(_etagComposer.Compose(row.ContentVersion, _descriptorVariantKey));
+        result["_etag"]!.GetValue<string>().Should().Be(composedEtag);
         result["Uri"].Should().BeNull();
         result["Discriminator"].Should().BeNull();
         result["ChangeVersion"].Should().BeNull();
@@ -68,8 +65,7 @@ public class Given_DescriptorDocumentMaterializer
         var result = DescriptorDocumentMaterializer.Materialize(
             row,
             RelationalGetRequestReadMode.StoredDocument,
-            _etagComposer,
-            _descriptorVariantKey
+            composedEtag: null
         );
 
         result
@@ -87,7 +83,7 @@ public class Given_DescriptorDocumentMaterializer
     }
 
     [Test]
-    public void It_composes_the_external_response_etag_from_content_version_and_variant_key()
+    public void It_carries_the_callers_precomposed_etag_through_unchanged()
     {
         var row = CreateDescriptorRow(
             documentUuid: Guid.Parse("aaaaaaaa-1111-2222-3333-dddddddddddd"),
@@ -99,18 +95,38 @@ public class Given_DescriptorDocumentMaterializer
             contentVersion: 7L
         );
 
+        // The materializer no longer composes the etag itself: it is the caller's responsibility
+        // (DescriptorReadHandler, via IServedEtagComposer) to decide profile-sensitivity and pass
+        // the final string through.
         var externalResponse = DescriptorDocumentMaterializer.Materialize(
             row,
             RelationalGetRequestReadMode.ExternalResponse,
-            _etagComposer,
-            _descriptorVariantKey
+            "7-deadbeef.j.somecode.n"
         );
 
-        // The composed _etag is derived from ContentVersion + variant key, not from the body.
-        externalResponse["_etag"]!
-            .GetValue<string>()
-            .Should()
-            .Be(_etagComposer.Compose(row.ContentVersion, _descriptorVariantKey));
+        externalResponse["_etag"]!.GetValue<string>().Should().Be("7-deadbeef.j.somecode.n");
+    }
+
+    [Test]
+    public void It_throws_when_an_external_response_read_has_no_composed_etag()
+    {
+        var row = CreateDescriptorRow(
+            documentUuid: Guid.Parse("aaaaaaaa-1111-2222-3333-eeeeeeeeeeee"),
+            contentLastModifiedAt: new DateTimeOffset(2026, 5, 5, 14, 30, 45, TimeSpan.Zero),
+            description: "Alternative school type",
+            effectiveBeginDate: null,
+            effectiveEndDate: null,
+            discriminator: "SchoolTypeDescriptor"
+        );
+
+        var act = () =>
+            DescriptorDocumentMaterializer.Materialize(
+                row,
+                RelationalGetRequestReadMode.ExternalResponse,
+                composedEtag: null
+            );
+
+        act.Should().Throw<InvalidOperationException>();
     }
 
     private static DescriptorReadRow CreateDescriptorRow(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerNamespaceAuthorizationTests.cs
@@ -712,7 +712,9 @@ public class Given_Descriptor_Read_Handler_Namespace_Authorization
         new(
             commandExecutor,
             A.Fake<Core.Profile.IReadableProfileProjector>(),
-            new EdFi.DataManagementService.Backend.Etag.EtagComposer(),
+            new EdFi.DataManagementService.Backend.Etag.ServedEtagComposer(
+                new EdFi.DataManagementService.Backend.Etag.EtagComposer()
+            ),
             NullLogger<DescriptorReadHandler>.Instance
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorReadHandlerTests.cs
@@ -24,6 +24,7 @@ public class Given_DescriptorReadHandler
     private static readonly QualifiedResourceName _descriptorResource = new("Ed-Fi", "SchoolTypeDescriptor");
     private static readonly QualifiedResourceName _requestResource = new("Ed-Fi", "Student");
     private static readonly IEtagComposer _etagComposer = new EtagComposer();
+    private static readonly IServedEtagComposer _servedEtagComposer = new ServedEtagComposer(_etagComposer);
 
     [TestCase(SqlDialect.Pgsql, "dms.\"Document\"", "dms.\"Descriptor\"")]
     [TestCase(SqlDialect.Mssql, "[dms].[Document]", "[dms].[Descriptor]")]
@@ -163,10 +164,11 @@ public class Given_DescriptorReadHandler
     }
 
     [Test]
-    public async Task It_applies_readable_profile_projection_to_external_descriptor_reads_without_recomputing_etag()
+    public async Task It_applies_readable_profile_projection_and_varies_the_etag_by_profile()
     {
         var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-111111111111"));
         var projectionContext = CreateReadableProfileProjectionContext();
+        var mappingSet = CreateMappingSet(SqlDialect.Pgsql);
         var commandExecutor = new InMemoryRelationalCommandExecutor([
             new InMemoryRelationalCommandExecution([
                 InMemoryRelationalResultSet.Create(
@@ -178,16 +180,28 @@ public class Given_DescriptorReadHandler
                 ),
             ]),
         ]);
-        var unprojectedDocument = DescriptorDocumentMaterializer.Materialize(
-            CreateDescriptorReadRow(
-                documentUuid.Value,
-                description: "Alternative school type",
-                effectiveBeginDate: new DateOnly(2025, 1, 15)
-            ),
-            RelationalGetRequestReadMode.ExternalResponse,
-            _etagComposer,
-            DescriptorVariantKey.For(CreateMappingSet(SqlDialect.Pgsql).Key.EffectiveSchemaHash)
+        // The full/unprofiled representation still carries the profile-insensitive "_" etag.
+        var unprofiledEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                ProfileName: null,
+                LinksEnabled: false,
+                ContentVersion: 42L
+            )
         );
+        // The profile-reduced representation the client actually sees must carry a distinct etag
+        // (RFC 7232 strong-validator semantics: distinct byte-representations, distinct etags).
+        var profiledEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                projectionContext.ProfileName,
+                LinksEnabled: false,
+                ContentVersion: 42L
+            )
+        );
+        profiledEtag.Should().NotBe(unprofiledEtag);
         var projectedDocument = JsonNode.Parse(
             """
             {
@@ -200,7 +214,9 @@ public class Given_DescriptorReadHandler
             }
             """
         )!;
-        projectedDocument["_etag"] = unprojectedDocument["_etag"]!.DeepClone();
+        // Mirrors real IReadableProfileProjector behavior: projection only drops/keeps business
+        // fields, it never touches the _etag the materializer already composed.
+        projectedDocument["_etag"] = profiledEtag;
         var readableProfileProjector = A.Fake<IReadableProfileProjector>();
         A.CallTo(() =>
                 readableProfileProjector.Project(
@@ -224,10 +240,8 @@ public class Given_DescriptorReadHandler
         success.EdfiDoc["_lastModifiedDate"]!.GetValue<string>().Should().Be("2026-05-05T14:30:45Z");
         success.EdfiDoc["shortDescription"].Should().BeNull();
         success.EdfiDoc["effectiveBeginDate"].Should().BeNull();
-        success.EdfiDoc["_etag"]!
-            .GetValue<string>()
-            .Should()
-            .Be(unprojectedDocument["_etag"]!.GetValue<string>());
+        success.EdfiDoc["_etag"]!.GetValue<string>().Should().Be(profiledEtag);
+        success.EdfiDoc["_etag"]!.GetValue<string>().Should().NotBe(unprofiledEtag);
         A.CallTo(() =>
                 readableProfileProjector.Project(
                     A<JsonNode>._,
@@ -236,6 +250,34 @@ public class Given_DescriptorReadHandler
                 )
             )
             .MustHaveHappenedOnceExactly();
+    }
+
+    [Test]
+    public async Task It_composes_a_profile_insensitive_etag_for_unprofiled_descriptor_reads()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa"));
+        var mappingSet = CreateMappingSet(SqlDialect.Pgsql);
+        var commandExecutor = new InMemoryRelationalCommandExecutor([
+            new InMemoryRelationalCommandExecution([
+                InMemoryRelationalResultSet.Create(CreateDescriptorRow(documentUuid.Value)),
+            ]),
+        ]);
+        var expectedEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                ProfileName: null,
+                LinksEnabled: false,
+                ContentVersion: 42L
+            )
+        );
+        var sut = CreateHandler(commandExecutor);
+
+        var result = await sut.HandleGetByIdAsync(CreateRequest(SqlDialect.Pgsql, documentUuid));
+
+        var success = result.Should().BeOfType<GetResult.GetSuccess>().Subject;
+        success.EdfiDoc["_etag"]!.GetValue<string>().Should().Be(expectedEtag);
+        success.EdfiDoc["_etag"]!.GetValue<string>().Should().EndWith("._.n");
     }
 
     [Test]
@@ -550,10 +592,11 @@ public class Given_DescriptorReadHandler
     }
 
     [Test]
-    public async Task It_applies_readable_profile_projection_to_descriptor_query_items_without_recomputing_etags()
+    public async Task It_applies_readable_profile_projection_and_varies_the_etag_by_profile_for_query_items()
     {
         var documentUuid = Guid.Parse("aaaaaaaa-1111-2222-3333-888888888888");
         var projectionContext = CreateReadableProfileProjectionContext();
+        var mappingSet = CreateMappingSet(SqlDialect.Pgsql);
         var commandExecutor = new InMemoryRelationalCommandExecutor([
             new InMemoryRelationalCommandExecution([
                 InMemoryRelationalResultSet.Create(
@@ -565,16 +608,25 @@ public class Given_DescriptorReadHandler
                 ),
             ]),
         ]);
-        var unprojectedDocument = DescriptorDocumentMaterializer.Materialize(
-            CreateDescriptorReadRow(
-                documentUuid,
-                description: "Alternative school type",
-                effectiveBeginDate: new DateOnly(2025, 1, 15)
-            ),
-            RelationalGetRequestReadMode.ExternalResponse,
-            _etagComposer,
-            DescriptorVariantKey.For(CreateMappingSet(SqlDialect.Pgsql).Key.EffectiveSchemaHash)
+        var unprofiledEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                ProfileName: null,
+                LinksEnabled: false,
+                ContentVersion: 42L
+            )
         );
+        var profiledEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                projectionContext.ProfileName,
+                LinksEnabled: false,
+                ContentVersion: 42L
+            )
+        );
+        profiledEtag.Should().NotBe(unprofiledEtag);
         var projectedDocument = JsonNode.Parse(
             """
             {
@@ -587,7 +639,7 @@ public class Given_DescriptorReadHandler
             }
             """
         )!;
-        projectedDocument["_etag"] = unprojectedDocument["_etag"]!.DeepClone();
+        projectedDocument["_etag"] = profiledEtag;
         var readableProfileProjector = A.Fake<IReadableProfileProjector>();
         A.CallTo(() =>
                 readableProfileProjector.Project(
@@ -615,10 +667,8 @@ public class Given_DescriptorReadHandler
         projectedItem["description"]!.GetValue<string>().Should().Be("Alternative school type");
         projectedItem["shortDescription"].Should().BeNull();
         projectedItem["effectiveBeginDate"].Should().BeNull();
-        projectedItem["_etag"]!
-            .GetValue<string>()
-            .Should()
-            .Be(unprojectedDocument["_etag"]!.GetValue<string>());
+        projectedItem["_etag"]!.GetValue<string>().Should().Be(profiledEtag);
+        projectedItem["_etag"]!.GetValue<string>().Should().NotBe(unprofiledEtag);
 
         A.CallTo(() =>
                 readableProfileProjector.Project(
@@ -691,7 +741,7 @@ public class Given_DescriptorReadHandler
         return new DescriptorReadHandler(
             commandExecutor,
             readableProfileProjector ?? A.Fake<IReadableProfileProjector>(),
-            _etagComposer,
+            _servedEtagComposer,
             NullLogger<DescriptorReadHandler>.Instance
         );
     }
@@ -707,7 +757,10 @@ public class Given_DescriptorReadHandler
                 []
             ),
             new HashSet<string>(StringComparer.Ordinal) { "namespace", "codeValue" }
-        );
+        )
+        {
+            ProfileName = "Sample-Profile",
+        };
     }
 
     private static MappingSet CreateMappingSet(SqlDialect dialect)
@@ -823,34 +876,6 @@ public class Given_DescriptorReadHandler
             contentVersion,
             DescriptorVariantKey.For(CreateMappingSet(SqlDialect.Pgsql).Key.EffectiveSchemaHash)
         );
-
-    private static DescriptorReadRow CreateDescriptorReadRow(
-        Guid documentUuid,
-        long documentId = 101L,
-        string? ns = "uri://ed-fi.org/SchoolTypeDescriptor",
-        string? codeValue = "Alternative",
-        string? shortDescription = "Alternative",
-        string? description = "Alternative school type",
-        DateOnly? effectiveBeginDate = null,
-        DateOnly? effectiveEndDate = null,
-        string? discriminator = "SchoolTypeDescriptor"
-    )
-    {
-        return new DescriptorReadRow(
-            DocumentId: documentId,
-            DocumentUuid: documentUuid,
-            ContentVersion: 42L,
-            ContentLastModifiedAt: new DateTimeOffset(2026, 5, 5, 14, 30, 45, TimeSpan.Zero),
-            ResourceKeyId: 13,
-            Namespace: ns!,
-            CodeValue: codeValue!,
-            ShortDescription: shortDescription!,
-            Description: description,
-            EffectiveBeginDate: effectiveBeginDate,
-            EffectiveEndDate: effectiveEndDate,
-            Discriminator: discriminator
-        );
-    }
 
     private static QueryElement CreateQueryElement(
         string queryFieldName,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerDeleteTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerDeleteTests.cs
@@ -208,7 +208,8 @@ public class Given_Descriptor_Write_Handler_Delete
                 Resolver,
                 SessionFactory,
                 Logger,
-                new EtagComposer()
+                new ServedEtagComposer(new EtagComposer()),
+                new IfMatchEvaluator()
             );
         }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerNamespaceAuthorizationTests.cs
@@ -1195,7 +1195,8 @@ public class Given_Descriptor_Write_Handler_Namespace_Authorization
             A.Fake<IRelationalDeleteConstraintResolver>(),
             sessionFactory,
             NullLogger<DescriptorWriteHandler>.Instance,
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator(),
             providerFailureExtractor
         );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
@@ -25,6 +25,7 @@ public class Given_Descriptor_Write_Preconditions
 {
     private static readonly QualifiedResourceName _descriptorResource = new("Ed-Fi", "SchoolTypeDescriptor");
     private static readonly IEtagComposer _etagComposer = new EtagComposer();
+    private static readonly IServedEtagComposer _servedEtagComposer = new ServedEtagComposer(_etagComposer);
 
     [Test]
     public async Task It_re_resolves_descriptor_post_creates_inside_the_write_session_before_returning_precondition_failed()
@@ -470,6 +471,60 @@ public class Given_Descriptor_Write_Preconditions
     }
 
     [Test]
+    public async Task It_updates_descriptor_put_when_if_match_uses_an_etag_obtained_under_a_readable_profile()
+    {
+        // The served descriptor _etag is now profile-sensitive on GET (DescriptorReadHandler composes
+        // it with the active readable profile's name, per IServedEtagComposer). If-Match, however,
+        // remains profile-insensitive (EtagMatchProjection.Of drops profileCode): a client that read a
+        // descriptor through a profile lens, then PUTs unprofiled using that same etag, must still
+        // succeed as long as ContentVersion/schemaEpoch agree.
+        var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
+        var targetLookupService = new StubRelationalWriteTargetLookupService
+        {
+            PutResult = new RelationalWriteTargetLookupResult.ExistingDocument(345L, documentUuid, 44L),
+        };
+        var sessionFactory = new RecordingRelationalWriteSessionFactory(SqlDialect.Pgsql);
+        var mappingSet = CreateMappingSet(SqlDialect.Pgsql);
+        var profileObtainedEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                ProfileName: "Some-Readable-Profile",
+                LinksEnabled: false,
+                ContentVersion: 44L
+            )
+        );
+        var unprofiledEtag = ExpectedComposedDescriptorEtag(44L);
+        profileObtainedEtag.Should().NotBe(unprofiledEtag);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow(documentUuid)]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            CreatePersistedDescriptorRow(description: "Current Charter"),
+        ]);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateContentVersionRow(45L)]);
+        var sut = CreateSut(targetLookupService, sessionFactory);
+        var request = CreatePutRequest(mappingSet, documentUuid, description: "Updated Charter") with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch(profileObtainedEtag),
+        };
+
+        var result = await sut.HandlePutAsync(request);
+
+        result.Should().NotBeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+        result
+            .Should()
+            .BeEquivalentTo(
+                new UpdateResult.UpdateSuccess(documentUuid, ExpectedComposedDescriptorEtag(45L))
+            );
+        sessionFactory.CreateAsyncCallCount.Should().Be(1);
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+        sessionFactory.Session.RollbackCallCount.Should().Be(0);
+        sessionFactory.Session.DisposeCallCount.Should().Be(1);
+        sessionFactory.Session.Executor.Commands.Should().HaveCount(3);
+        sessionFactory.Session.Executor.Commands[2].CommandText.Should().Contain("UPDATE dms.\"Descriptor\"");
+    }
+
+    [Test]
     public async Task It_updates_descriptor_put_when_if_match_is_a_wildcard_against_an_existing_descriptor()
     {
         // RFC 7232 If-Match: * succeeds against any existing target, even when the supplied opaque
@@ -609,6 +664,49 @@ public class Given_Descriptor_Write_Preconditions
         var request = CreateDeleteRequest(CreateMappingSet(SqlDialect.Pgsql), documentUuid) with
         {
             WritePrecondition = new WritePrecondition.IfMatch(currentEtag),
+        };
+
+        var result = await sut.HandleDeleteAsync(request);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        sessionFactory.CreateAsyncCallCount.Should().Be(1);
+        sessionFactory.Session.CommitCallCount.Should().Be(1);
+        sessionFactory.Session.RollbackCallCount.Should().Be(0);
+        sessionFactory.Session.Executor.Commands.Should().HaveCount(3);
+        sessionFactory
+            .Session.Executor.Commands[2]
+            .CommandText.Should()
+            .Contain("DELETE FROM dms.\"Document\"");
+    }
+
+    [Test]
+    public async Task It_deletes_the_descriptor_when_delete_if_match_uses_an_etag_obtained_under_a_readable_profile()
+    {
+        // Mirrors the PUT invariant test above: a descriptor DELETE using an If-Match value obtained
+        // from a profiled GET must still succeed against the (always profile-insensitive) write path.
+        var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
+        var sessionFactory = new RecordingRelationalWriteSessionFactory(SqlDialect.Pgsql);
+        var mappingSet = CreateMappingSet(SqlDialect.Pgsql);
+        var profileObtainedEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                ProfileName: "Some-Readable-Profile",
+                LinksEnabled: false,
+                ContentVersion: 44L
+            )
+        );
+        profileObtainedEtag.Should().NotBe(ExpectedComposedDescriptorEtag(44L));
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow(documentUuid)]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreatePersistedDescriptorRow()]);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            InMemoryRelationalResultSet.Create(new Dictionary<string, object?> { ["DocumentId"] = 345L }),
+        ]);
+        var sut = CreateSut(new StubRelationalWriteTargetLookupService(), sessionFactory);
+        var request = CreateDeleteRequest(mappingSet, documentUuid) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch(profileObtainedEtag),
         };
 
         var result = await sut.HandleDeleteAsync(request);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
@@ -828,7 +828,8 @@ public class Given_Descriptor_Write_Preconditions
             deleteConstraintResolver ?? A.Fake<IRelationalDeleteConstraintResolver>(),
             sessionFactory,
             NullLogger<DescriptorWriteHandler>.Instance,
-            _etagComposer
+            new ServedEtagComposer(_etagComposer),
+            new IfMatchEvaluator()
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerPreconditionTests.cs
@@ -44,7 +44,13 @@ public class Given_Descriptor_Write_Preconditions
 
         var result = await sut.HandlePostAsync(request);
 
-        result.Should().BeOfType<UpsertResult.UpsertFailureETagMisMatch>();
+        // The advisory target re-resolves as CreateNew, so there is no current representation to
+        // satisfy If-Match against, and the reason is TargetDoesNotExist rather than Concurrency.
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         sessionFactory.CreateAsyncCallCount.Should().Be(1);
         sessionFactory.Session.CommitCallCount.Should().Be(0);
         sessionFactory.Session.RollbackCallCount.Should().Be(1);
@@ -123,12 +129,57 @@ public class Given_Descriptor_Write_Preconditions
 
         var result = await sut.HandlePostAsync(request);
 
-        result.Should().BeOfType<UpsertResult.UpsertFailureETagMisMatch>();
+        // The target exists but its current etag does not match the specific-tag If-Match precondition,
+        // so the reason is Concurrency rather than TargetDoesNotExist.
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
         sessionFactory.CreateAsyncCallCount.Should().Be(1);
         sessionFactory.Session.CommitCallCount.Should().Be(0);
         sessionFactory.Session.RollbackCallCount.Should().Be(1);
         sessionFactory.Session.DisposeCallCount.Should().Be(1);
         sessionFactory.Session.Executor.Commands.Should().HaveCount(2);
+        sessionFactory
+            .Session.Executor.Commands.Should()
+            .NotContain(command =>
+                command.CommandText.Contains("UPDATE dms.\"Descriptor\"", StringComparison.Ordinal)
+            );
+        sessionFactory.Session.ScalarCommands.Should().ContainSingle();
+        sessionFactory.Session.ScalarCommands[0].CommandText.Should().Contain("FOR UPDATE");
+    }
+
+    [Test]
+    public async Task It_returns_precondition_failed_for_descriptor_put_when_if_match_mismatches()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"));
+        var sessionFactory = new RecordingRelationalWriteSessionFactory(SqlDialect.Pgsql);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateResolvedExistingDocumentRow(documentUuid)]);
+        sessionFactory.Session.ScalarResults.Enqueue(44L);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([
+            CreatePersistedDescriptorRow(description: "Current Charter"),
+        ]);
+        sessionFactory.Session.Executor.ResultSets.Enqueue([CreateContentVersionRow(45L)]);
+        var sut = CreateSut(new StubRelationalWriteTargetLookupService(), sessionFactory);
+        var request = CreatePutRequest(CreateMappingSet(SqlDialect.Pgsql), documentUuid) with
+        {
+            WritePrecondition = new WritePrecondition.IfMatch("\"stale-etag\""),
+        };
+
+        var result = await sut.HandlePutAsync(request);
+
+        // The target exists but its current etag does not match the specific-tag If-Match precondition,
+        // so the reason is Concurrency rather than TargetDoesNotExist.
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
+        sessionFactory.CreateAsyncCallCount.Should().Be(1);
+        sessionFactory.Session.CommitCallCount.Should().Be(0);
+        sessionFactory.Session.RollbackCallCount.Should().Be(1);
+        sessionFactory.Session.DisposeCallCount.Should().Be(1);
         sessionFactory
             .Session.Executor.Commands.Should()
             .NotContain(command =>
@@ -364,7 +415,12 @@ public class Given_Descriptor_Write_Preconditions
 
         var result = await sut.HandlePutAsync(request);
 
-        result.Should().BeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+        // The PUT target does not exist, so the reason is TargetDoesNotExist rather than Concurrency.
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         sessionFactory.CreateAsyncCallCount.Should().Be(1);
         sessionFactory.Session.CommitCallCount.Should().Be(0);
         sessionFactory.Session.RollbackCallCount.Should().Be(1);
@@ -634,7 +690,13 @@ public class Given_Descriptor_Write_Preconditions
 
         var result = await sut.HandleDeleteAsync(request);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        // The target exists but its current etag does not match the specific-tag If-Match precondition,
+        // so the reason is Concurrency rather than TargetDoesNotExist.
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
         sessionFactory.CreateAsyncCallCount.Should().Be(1);
         sessionFactory.Session.CommitCallCount.Should().Be(0);
         sessionFactory.Session.RollbackCallCount.Should().Be(1);
@@ -815,7 +877,12 @@ public class Given_Descriptor_Write_Preconditions
 
         var result = await sut.HandleDeleteAsync(request);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        // The DELETE target does not exist, so the reason is TargetDoesNotExist rather than Concurrency.
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         sessionFactory.CreateAsyncCallCount.Should().Be(1);
         sessionFactory.Session.CommitCallCount.Should().Be(0);
         sessionFactory.Session.RollbackCallCount.Should().Be(1);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerResponseEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/DescriptorWriteHandlerResponseEtagTests.cs
@@ -267,7 +267,8 @@ public class Given_Descriptor_Write_Response_Etags
             A.Fake<IRelationalDeleteConstraintResolver>(),
             writeSessionFactory ?? A.Fake<IRelationalWriteSessionFactory>(),
             NullLogger<DescriptorWriteHandler>.Instance,
-            _etagComposer
+            new ServedEtagComposer(_etagComposer),
+            new IfMatchEvaluator()
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/IfMatchEvaluatorTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/IfMatchEvaluatorTests.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Etag;
+using EdFi.DataManagementService.Core.External.Backend;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Etag;
+
+[TestFixture]
+[Parallelizable]
+public class Given_IfMatchEvaluator
+{
+    private readonly IIfMatchEvaluator _sut = new IfMatchEvaluator();
+    private const string Current = "5-a1b2c3d4.j._.l";
+
+    [Test]
+    public void It_matches_a_wildcard_regardless_of_value()
+    {
+        // Construct the wildcard the same way WritePreconditionFactory.Create does for a bare "*".
+        _sut.Evaluate(new WritePrecondition.IfMatch("*", IsWildcard: true), Current)
+            .IsMatch.Should()
+            .BeTrue();
+    }
+
+    [Test]
+    public void It_matches_when_the_state_significant_projection_is_equal()
+    {
+        // Different format/profile/link, same version+epoch.
+        _sut.Evaluate(new WritePrecondition.IfMatch("5-a1b2c3d4.x.3.n"), Current).IsMatch.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_does_not_match_a_different_version_or_epoch()
+    {
+        _sut.Evaluate(new WritePrecondition.IfMatch("6-a1b2c3d4.j._.l"), Current).IsMatch.Should().BeFalse();
+        _sut.Evaluate(new WritePrecondition.IfMatch("5-ffffffff.j._.l"), Current).IsMatch.Should().BeFalse();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/ServedEtagComposerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/ServedEtagComposerTests.cs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Etag;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit.Etag;
+
+[TestFixture]
+[Parallelizable]
+public class Given_ServedEtagComposer
+{
+    private readonly IServedEtagComposer _sut = new ServedEtagComposer(new EtagComposer());
+
+    [Test]
+    public void It_composes_the_same_value_as_the_factory_plus_composer()
+    {
+        var context = new ServedEtagContext(
+            "A1B2C3D4E5",
+            ResponseFormat.Json,
+            ProfileName: null,
+            LinksEnabled: true,
+            ContentVersion: 5
+        );
+
+        var expected = new EtagComposer().Compose(
+            5,
+            VariantKeyFactory.Create(
+                "A1B2C3D4E5",
+                ResponseFormat.Json,
+                ProfileVariantCode.Of(null),
+                linksEnabled: true
+            )
+        );
+
+        _sut.Compose(context).Should().Be(expected);
+    }
+
+    [Test]
+    public void It_derives_the_profile_code_from_the_profile_name()
+    {
+        var profiled = _sut.Compose(
+            new ServedEtagContext(
+                "A1B2C3D4E5",
+                ResponseFormat.Json,
+                "Sample-Profile",
+                LinksEnabled: false,
+                ContentVersion: 9
+            )
+        );
+        var unprofiled = _sut.Compose(
+            new ServedEtagContext(
+                "A1B2C3D4E5",
+                ResponseFormat.Json,
+                ProfileName: null,
+                LinksEnabled: false,
+                ContentVersion: 9
+            )
+        );
+        profiled.Should().NotBe(unprofiled);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/VariantKeyTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/VariantKeyTests.cs
@@ -69,6 +69,6 @@ public class Given_VariantKey
     [Test]
     public void It_formats_components_back_into_the_wire_value()
     {
-        VariantKey.Format("a1b2c3d4", "j", "_", "l").Value.Should().Be("a1b2c3d4.j._.l");
+        VariantKey.FromComponents("a1b2c3d4", "j", "_", "l").Value.Should().Be("a1b2c3d4.j._.l");
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/VariantKeyTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/Etag/VariantKeyTests.cs
@@ -42,3 +42,33 @@ public class Given_VariantKeyFactory
         key.Value.Should().StartWith("a1b2c3d4.");
     }
 }
+
+[TestFixture]
+[Parallelizable]
+public class Given_VariantKey
+{
+    [Test]
+    public void It_parses_a_well_formed_key_into_components()
+    {
+        new VariantKey("a1b2c3d4.j._.l").TryParseComponents(out var components).Should().BeTrue();
+        components.SchemaEpoch.Should().Be("a1b2c3d4");
+        components.Format.Should().Be("j");
+        components.ProfileCode.Should().Be("_");
+        components.LinkFlag.Should().Be("l");
+        components.IfMatchSignificant().Should().Be("a1b2c3d4");
+    }
+
+    [TestCase("a1b2c3d4.j._")] // 3 parts
+    [TestCase("a1b2c3d4.j._.l.extra")] // 5 parts
+    [TestCase("")]
+    public void It_rejects_keys_without_exactly_four_components(string value)
+    {
+        new VariantKey(value).TryParseComponents(out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_formats_components_back_into_the_wire_value()
+    {
+        VariantKey.Format("a1b2c3d4", "j", "_", "l").Value.Should().Be("a1b2c3d4.j._.l");
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCommittedRepresentationReaderTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCommittedRepresentationReaderTests.cs
@@ -26,7 +26,7 @@ public class Given_RelationalCommittedRepresentationReader
     public async Task It_composes_the_committed_etag_from_the_stamped_content_version()
     {
         var sut = new RelationalCommittedRepresentationReader(
-            new EtagComposer(),
+            new ServedEtagComposer(new EtagComposer()),
             Options.Create(new ResourceLinksOptions())
         );
         var writePlan = AdapterFactoryTestFixtures.BuildRootOnlyPlan();

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
@@ -36,7 +36,11 @@ public class Given_RelationalCurrentEtagPreconditionChecker
     {
         _currentStateLoader = A.Fake<IRelationalWriteCurrentStateLoader>();
         _writeSession = A.Fake<IRelationalWriteSession>();
-        _sut = new RelationalCurrentEtagPreconditionChecker(_currentStateLoader, new EtagComposer());
+        _sut = new RelationalCurrentEtagPreconditionChecker(
+            _currentStateLoader,
+            new ServedEtagComposer(new EtagComposer()),
+            new IfMatchEvaluator()
+        );
 
         A.CallTo(() => _writeSession.CreateCommand(A<RelationalCommand>._))
             .Invokes(call => _capturedLockCommand = call.GetArgument<RelationalCommand>(0)!)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
@@ -14,6 +14,7 @@ using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
 using FakeItEasy;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Backend.Tests.Unit;
@@ -39,7 +40,8 @@ public class Given_RelationalCurrentEtagPreconditionChecker
         _sut = new RelationalCurrentEtagPreconditionChecker(
             _currentStateLoader,
             new ServedEtagComposer(new EtagComposer()),
-            new IfMatchEvaluator()
+            new IfMatchEvaluator(),
+            NullLogger<RelationalCurrentEtagPreconditionChecker>.Instance
         );
 
         A.CallTo(() => _writeSession.CreateCommand(A<RelationalCommand>._))

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalCurrentEtagPreconditionCheckerTests.cs
@@ -132,6 +132,24 @@ public class Given_RelationalCurrentEtagPreconditionChecker
     }
 
     [Test]
+    public async Task It_reports_mismatch_when_only_the_schema_epoch_differs()
+    {
+        // Same ContentVersion, same format/profile/link, but a different schema epoch. schemaEpoch IS
+        // state-significant for If-Match (only format/profileCode/linkFlag are projected out), so this
+        // must 412. Guards against a refactor accidentally dropping schemaEpoch from the comparison.
+        var differentEpochEtag = new EtagComposer().Compose(
+            LockedContentVersion,
+            new VariantKey($"ffffffff.j._.l")
+        );
+        var request = CreateRequest(SqlDialect.Pgsql, new WritePrecondition.IfMatch(differentEpochEtag));
+
+        var result = await _sut.CheckAsync(request, _writeSession);
+
+        result.Should().NotBeNull();
+        result!.IsMatch.Should().BeFalse();
+    }
+
+    [Test]
     public async Task It_matches_when_the_if_match_value_was_obtained_under_a_profile()
     {
         // Amended 2026-07-04: profileCode is not state-significant for If-Match. An etag captured under

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -6374,7 +6374,13 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.UpdateDocumentById(updateRequest);
 
-        result.Should().BeOfType<UpdateResult.UpdateFailureETagMisMatch>();
+        // The PUT target does not exist at all, so the reason is TargetDoesNotExist rather than a
+        // Concurrency mismatch.
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _capturedExecutorRequests.Should().BeEmpty();
         _targetLookupService.ResolveForPutCallCount.Should().Be(1);
         A.CallTo(() =>
@@ -8916,7 +8922,13 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        // The target exists but its current etag does not match the specific-tag If-Match precondition,
+        // so the reason is Concurrency rather than TargetDoesNotExist.
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.Concurrency);
         _currentEtagPreconditionChecker.CallCount.Should().Be(1);
         _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
@@ -8974,7 +8986,13 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        // The wildcard recheck could not re-lock the target (a concurrent delete), so there is no
+        // current representation and the reason is TargetDoesNotExist rather than Concurrency.
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _currentEtagPreconditionChecker.CallCount.Should().Be(1);
         _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
@@ -8999,7 +9017,45 @@ public class Given_RelationalDocumentStoreRepositoryTests
 
         var result = await _sut.DeleteDocumentById(deleteRequest);
 
-        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        // The DELETE target is entirely unresolvable, so there is no current representation and the
+        // reason is TargetDoesNotExist rather than Concurrency.
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
+        _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
+        _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
+    }
+
+    [TestCase(SqlDialect.Pgsql)]
+    [TestCase(SqlDialect.Mssql)]
+    public async Task It_returns_relational_delete_failure_etag_mismatch_when_a_wildcard_if_match_target_vanishes_before_locking(
+        SqlDialect dialect
+    )
+    {
+        // RFC 7232 If-Match: * requires the target to exist; the initial lookup resolves a document,
+        // but the target vanishes (a concurrent delete) before the DELETE lock can be acquired. The
+        // wildcard still yields 412 rather than 404, with reason TargetDoesNotExist since there is no
+        // current representation left to compare against.
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+        var writePrecondition = new WritePrecondition.IfMatch("some-wrong-value", IsWildcard: true);
+        ConfigureResolvedDocument(documentId: 123L, documentUuid);
+        A.CallTo(_commandExecutor).WithReturnType<Task<long?>>().Returns(Task.FromResult<long?>(null));
+
+        var deleteRequest = CreateNonDescriptorDeleteRequest(
+            CreateSupportedMappingSet(_schoolResourceInfo, dialect),
+            writePrecondition,
+            documentUuid
+        );
+
+        var result = await _sut.DeleteDocumentById(deleteRequest);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>()
+            .Which.Reason.Should()
+            .Be(ETagPreconditionFailureReason.TargetDoesNotExist);
         _writeSessionFactory.Session.CommitCallCount.Should().Be(0);
         _writeSessionFactory.Session.RollbackCallCount.Should().Be(1);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalReadMaterializerTests.cs
@@ -262,7 +262,7 @@ public class Given_RelationalReadMaterializer
         new(
             new NoLinkSlugResolver(),
             Microsoft.Extensions.Options.Options.Create(linksOptions ?? new ResourceLinksOptions()),
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer())
         );
 
     // ExternalResponse materialization now requires both EtagVariant and MappingSet to compose the
@@ -742,7 +742,7 @@ public class Given_RelationalReadMaterializer_With_Link_Injection_And_External_R
         var sut = new RelationalReadMaterializer(
             new ThrowingSlugResolver(),
             Microsoft.Extensions.Options.Options.Create(new ResourceLinksOptions { Enabled = true }),
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer())
         );
         var readPlan = BuildReadPlanWithDocumentReferenceBinding();
         object?[] row = [1L, (object?)SchoolDocumentId, 255901];
@@ -803,7 +803,7 @@ public class Given_RelationalReadMaterializer_With_Link_Injection_And_External_R
         var sut = new RelationalReadMaterializer(
             new ThrowingSlugResolver(),
             Microsoft.Extensions.Options.Options.Create(new ResourceLinksOptions { Enabled = true }),
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer())
         );
         var readPlan = BuildReadPlanWithDocumentReferenceBinding();
         object?[] row = [1L, (object?)SchoolDocumentId, 255901];
@@ -972,7 +972,7 @@ public class Given_RelationalReadMaterializer_With_Link_Injection_And_External_R
         new(
             new StubSlugResolver(_schoolSlug),
             Microsoft.Extensions.Options.Options.Create(linksOptions),
-            new EtagComposer()
+            new ServedEtagComposer(new EtagComposer())
         );
 
     /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -156,7 +156,8 @@ internal sealed class DefaultRelationalWriteExecutor(
                 {
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
                     return RelationalWriteExecutorResults.BuildPreconditionFailureResult(
-                        executionRequest.OperationKind
+                        executionRequest.OperationKind,
+                        ETagPreconditionFailureReason.TargetDoesNotExist
                     );
                 }
             }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -26,7 +26,8 @@ internal sealed class DefaultRelationalWriteExecutor(
     IRelationalWriteExceptionClassifier writeExceptionClassifier,
     IRelationalWriteConstraintResolver writeConstraintResolver,
     IRelationalReadMaterializer readMaterializer,
-    IEtagComposer etagComposer,
+    IServedEtagComposer servedEtagComposer,
+    IIfMatchEvaluator ifMatchEvaluator,
     IRelationalParameterConfigurator? relationalParameterConfigurator = null,
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
@@ -54,7 +55,8 @@ internal sealed class DefaultRelationalWriteExecutor(
         targetLookupResolver,
         currentStateLoader,
         currentEtagPreconditionChecker,
-        etagComposer
+        servedEtagComposer,
+        ifMatchEvaluator
     );
 
     private readonly RelationalWriteMergeOrchestrator _mergeOrchestrator = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DefaultRelationalWriteExecutor.cs
@@ -8,6 +8,7 @@ using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Backend.Profile;
 using EdFi.DataManagementService.Core.External.Backend;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace EdFi.DataManagementService.Backend;
 
@@ -31,7 +32,8 @@ internal sealed class DefaultRelationalWriteExecutor(
     IRelationalParameterConfigurator? relationalParameterConfigurator = null,
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null,
-    ILogger<DefaultRelationalWriteExecutor>? logger = null
+    ILogger<DefaultRelationalWriteExecutor>? logger = null,
+    ILoggerFactory? loggerFactory = null
 ) : IRelationalWriteExecutor
 {
     private readonly IRelationalWriteSessionFactory _writeSessionFactory =
@@ -56,7 +58,8 @@ internal sealed class DefaultRelationalWriteExecutor(
         currentStateLoader,
         currentEtagPreconditionChecker,
         servedEtagComposer,
-        ifMatchEvaluator
+        ifMatchEvaluator,
+        (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<RelationalWriteExecutionStateResolver>()
     );
 
     private readonly RelationalWriteMergeOrchestrator _mergeOrchestrator = new(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorDocumentMaterializer.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorDocumentMaterializer.cs
@@ -5,7 +5,6 @@
 
 using System.Globalization;
 using System.Text.Json.Nodes;
-using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Backend.External;
 
 namespace EdFi.DataManagementService.Backend;
@@ -18,15 +17,20 @@ internal static class DescriptorDocumentMaterializer
     private const string EtagPropertyName = "_etag";
     private const string LastModifiedDatePropertyName = "_lastModifiedDate";
 
+    /// <summary>
+    /// Materializes a descriptor document. <paramref name="composedEtag"/> must be the fully composed
+    /// served <c>_etag</c> string (see <see cref="EdFi.DataManagementService.Backend.Etag.IServedEtagComposer"/>)
+    /// for <see cref="RelationalGetRequestReadMode.ExternalResponse"/> reads; the caller decides the
+    /// profile-sensitivity of that value, so this materializer performs no etag composition itself. Ignored
+    /// (and may be <see langword="null"/>) for <see cref="RelationalGetRequestReadMode.StoredDocument"/> reads.
+    /// </summary>
     public static JsonObject Materialize(
         DescriptorReadRow descriptorRow,
         RelationalGetRequestReadMode readMode,
-        IEtagComposer etagComposer,
-        VariantKey variantKey
+        string? composedEtag
     )
     {
         ArgumentNullException.ThrowIfNull(descriptorRow);
-        ArgumentNullException.ThrowIfNull(etagComposer);
 
         var descriptorBody = BuildDescriptorBody(descriptorRow);
 
@@ -35,10 +39,17 @@ internal static class DescriptorDocumentMaterializer
             return descriptorBody;
         }
 
+        if (composedEtag is null)
+        {
+            throw new InvalidOperationException(
+                "Descriptor external response materialization requires a composed etag."
+            );
+        }
+
         var externalResponse = (JsonObject)descriptorBody.DeepClone();
 
         externalResponse[IdPropertyName] = descriptorRow.DocumentUuid.ToString();
-        externalResponse[EtagPropertyName] = etagComposer.Compose(descriptorRow.ContentVersion, variantKey);
+        externalResponse[EtagPropertyName] = composedEtag;
         externalResponse[LastModifiedDatePropertyName] =
             descriptorRow.ContentLastModifiedAt.UtcDateTime.ToString(
                 LastModifiedDateFormat,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorReadHandler.cs
@@ -22,7 +22,7 @@ internal sealed record DescriptorQueryRowsPage(long? TotalCount, IReadOnlyList<D
 internal sealed class DescriptorReadHandler(
     IRelationalCommandExecutor commandExecutor,
     IReadableProfileProjector readableProfileProjector,
-    IEtagComposer etagComposer,
+    IServedEtagComposer servedEtagComposer,
     ILogger<DescriptorReadHandler> logger
 ) : IDescriptorReadHandler
 {
@@ -36,8 +36,8 @@ internal sealed class DescriptorReadHandler(
         commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor));
     private readonly IReadableProfileProjector _readableProfileProjector =
         readableProfileProjector ?? throw new ArgumentNullException(nameof(readableProfileProjector));
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
     private readonly ILogger<DescriptorReadHandler> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -444,9 +444,6 @@ internal sealed class DescriptorReadHandler(
 
         JsonArray edfiDocs = [];
 
-        // Build the fixed descriptor variant key once per request rather than per row.
-        var variantKey = DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash);
-
         foreach (var descriptorRow in descriptorRows)
         {
             edfiDocs.Add(
@@ -454,7 +451,7 @@ internal sealed class DescriptorReadHandler(
                     descriptorRow,
                     RelationalGetRequestReadMode.ExternalResponse,
                     request.ReadableProfileProjectionContext,
-                    variantKey
+                    request.MappingSet.Key.EffectiveSchemaHash
                 )
             );
         }
@@ -462,31 +459,55 @@ internal sealed class DescriptorReadHandler(
         return edfiDocs;
     }
 
+    // Descriptors carry no reference links and are always served as JSON, so the served etag's
+    // linkFlag/format components are the fixed descriptor values ("n" / "j"); only the profile
+    // component varies, and only for ExternalResponse reads that a readable profile actually
+    // projects. This condition mirrors RelationalDocumentStoreRepository.ShouldApplyReadableProfileProjection
+    // so the descriptor and non-descriptor read paths stay in lockstep.
     private JsonNode MaterializeDescriptorDocument(
         DescriptorReadRow descriptorRow,
         RelationalGetRequestReadMode readMode,
         ReadableProfileProjectionContext? readableProfileProjectionContext,
-        VariantKey variantKey
+        string effectiveSchemaHash
     )
     {
+        var appliesReadableProfileProjection =
+            readMode == RelationalGetRequestReadMode.ExternalResponse
+            && readableProfileProjectionContext is not null;
+
+        string? composedEtag = null;
+
+        if (readMode == RelationalGetRequestReadMode.ExternalResponse)
+        {
+            string? etagProfileName = appliesReadableProfileProjection
+                ? readableProfileProjectionContext!.ProfileName
+                : null;
+
+            composedEtag = _servedEtagComposer.Compose(
+                new ServedEtagContext(
+                    effectiveSchemaHash,
+                    ResponseFormat.Json,
+                    etagProfileName,
+                    LinksEnabled: false,
+                    descriptorRow.ContentVersion
+                )
+            );
+        }
+
         var materializedDocument = DescriptorDocumentMaterializer.Materialize(
             descriptorRow,
             readMode,
-            _etagComposer,
-            variantKey
+            composedEtag
         );
 
-        if (
-            readMode != RelationalGetRequestReadMode.ExternalResponse
-            || readableProfileProjectionContext is null
-        )
+        if (!appliesReadableProfileProjection)
         {
             return materializedDocument;
         }
 
         var projectedDocument = _readableProfileProjector.Project(
             materializedDocument,
-            readableProfileProjectionContext.ContentTypeDefinition,
+            readableProfileProjectionContext!.ContentTypeDefinition,
             readableProfileProjectionContext.IdentityPropertyNames
         );
 
@@ -501,7 +522,7 @@ internal sealed class DescriptorReadHandler(
             descriptorRow,
             request.ReadMode,
             request.ReadableProfileProjectionContext,
-            DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash)
+            request.MappingSet.Key.EffectiveSchemaHash
         );
 
     private static RelationalCommand BuildQueryCommand(SqlDialect dialect, PageKeysetSpec.Query plannedQuery)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -971,15 +971,18 @@ internal sealed class DescriptorWriteHandler(
         {
             var evaluation = _ifMatchEvaluator.Evaluate(ifMatch, currentEtag);
 
-            _logger.LogDebug(
-                "Descriptor If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
-                    + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
-                existingTargetContext.DocumentId,
-                ifMatch.IsWildcard,
-                LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
-                currentEtag,
-                evaluation.IsMatch
-            );
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Descriptor If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
+                        + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
+                    existingTargetContext.DocumentId,
+                    ifMatch.IsWildcard,
+                    LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
+                    currentEtag,
+                    evaluation.IsMatch
+                );
+            }
 
             return evaluation.IsMatch
                 ? new DescriptorLockedPreconditionResult.Loaded(existingTargetContext, persisted, currentEtag)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -181,7 +181,9 @@ internal sealed class DescriptorWriteHandler(
             {
                 case DescriptorLockedPreconditionResult.CreateNew:
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
-                    return new UpsertResult.UpsertFailureETagMisMatch();
+                    return new UpsertResult.UpsertFailureETagMisMatch(
+                        ETagPreconditionFailureReason.TargetDoesNotExist
+                    );
 
                 case DescriptorLockedPreconditionResult.MissingDocument:
                     await writeSession.RollbackAsync(cancellationToken).ConfigureAwait(false);
@@ -366,7 +368,9 @@ internal sealed class DescriptorWriteHandler(
                         // missing PUT target yields the precondition-failed (412) result rather than
                         // not-exists (404).
                         return ifMatch.IsWildcard
-                            ? new UpdateResult.UpdateFailureETagMisMatch()
+                            ? new UpdateResult.UpdateFailureETagMisMatch(
+                                ETagPreconditionFailureReason.TargetDoesNotExist
+                            )
                             : new UpdateResult.UpdateFailureNotExists();
 
                     case DescriptorLockedPreconditionResult.MissingDescriptor(
@@ -687,7 +691,9 @@ internal sealed class DescriptorWriteHandler(
                         // than not-exists (404).
                         DescriptorLockedPreconditionResult.NotFound
                         or DescriptorLockedPreconditionResult.MissingDocument => ifMatch.IsWildcard
-                            ? new DeleteResult.DeleteFailureETagMisMatch()
+                            ? new DeleteResult.DeleteFailureETagMisMatch(
+                                ETagPreconditionFailureReason.TargetDoesNotExist
+                            )
                             : new DeleteResult.DeleteFailureNotExists(),
                         DescriptorLockedPreconditionResult.MissingDescriptor(var documentId) =>
                             new DeleteResult.UnknownFailure(

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -967,6 +967,25 @@ internal sealed class DescriptorWriteHandler(
             }
         }
 
+        if (lockedCurrentState is DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag))
+        {
+            var evaluation = _ifMatchEvaluator.Evaluate(ifMatch, currentEtag);
+
+            _logger.LogDebug(
+                "Descriptor If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
+                    + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
+                existingTargetContext.DocumentId,
+                ifMatch.IsWildcard,
+                LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
+                currentEtag,
+                evaluation.IsMatch
+            );
+
+            return evaluation.IsMatch
+                ? new DescriptorLockedPreconditionResult.Loaded(existingTargetContext, persisted, currentEtag)
+                : DescriptorLockedPreconditionResult.Mismatch.Instance;
+        }
+
         return lockedCurrentState switch
         {
             DescriptorCurrentStateLoadResult.MissingDocument => DescriptorLockedPreconditionResult
@@ -974,11 +993,6 @@ internal sealed class DescriptorWriteHandler(
                 .Instance,
             DescriptorCurrentStateLoadResult.MissingDescriptor =>
                 new DescriptorLockedPreconditionResult.MissingDescriptor(existingTargetContext.DocumentId),
-            DescriptorCurrentStateLoadResult.Loaded(_, var currentEtag)
-                when !_ifMatchEvaluator.Evaluate(ifMatch, currentEtag).IsMatch =>
-                DescriptorLockedPreconditionResult.Mismatch.Instance,
-            DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag) =>
-                new DescriptorLockedPreconditionResult.Loaded(existingTargetContext, persisted, currentEtag),
             _ => throw new InvalidOperationException(
                 $"Unexpected locked descriptor state result type '{lockedCurrentState.GetType().Name}'."
             ),

--- a/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/DescriptorWriteHandler.cs
@@ -24,7 +24,8 @@ internal sealed class DescriptorWriteHandler(
     IRelationalDeleteConstraintResolver deleteConstraintResolver,
     IRelationalWriteSessionFactory writeSessionFactory,
     ILogger<DescriptorWriteHandler> logger,
-    IEtagComposer etagComposer,
+    IServedEtagComposer servedEtagComposer,
+    IIfMatchEvaluator ifMatchEvaluator,
     IRelationshipAuthorizationProviderFailureExtractor? relationshipAuthorizationProviderFailureExtractor =
         null
 ) : IDescriptorWriteHandler
@@ -39,8 +40,10 @@ internal sealed class DescriptorWriteHandler(
         writeSessionFactory ?? throw new ArgumentNullException(nameof(writeSessionFactory));
     private readonly ILogger<DescriptorWriteHandler> _logger =
         logger ?? throw new ArgumentNullException(nameof(logger));
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
+    private readonly IIfMatchEvaluator _ifMatchEvaluator =
+        ifMatchEvaluator ?? throw new ArgumentNullException(nameof(ifMatchEvaluator));
     private readonly IRelationshipAuthorizationProviderFailureExtractor _relationshipAuthorizationProviderFailureExtractor =
         relationshipAuthorizationProviderFailureExtractor
         ?? DefaultRelationshipAuthorizationProviderFailureExtractor.Instance;
@@ -908,7 +911,7 @@ internal sealed class DescriptorWriteHandler(
 
         var lockedCurrentState = await LoadLockedDescriptorCurrentStateAsync(
                 mappingSet.Key.Dialect,
-                DescriptorVariantKey.For(mappingSet.Key.EffectiveSchemaHash),
+                mappingSet.Key.EffectiveSchemaHash,
                 existingTargetContext.DocumentId,
                 writeSession,
                 cancellationToken
@@ -966,7 +969,7 @@ internal sealed class DescriptorWriteHandler(
             DescriptorCurrentStateLoadResult.MissingDescriptor =>
                 new DescriptorLockedPreconditionResult.MissingDescriptor(existingTargetContext.DocumentId),
             DescriptorCurrentStateLoadResult.Loaded(_, var currentEtag)
-                when !ifMatch.IsWildcard && !IfMatchMatchesCurrentEtag(ifMatch.Value, currentEtag) =>
+                when !_ifMatchEvaluator.Evaluate(ifMatch, currentEtag).IsMatch =>
                 DescriptorLockedPreconditionResult.Mismatch.Instance,
             DescriptorCurrentStateLoadResult.Loaded(var persisted, var currentEtag) =>
                 new DescriptorLockedPreconditionResult.Loaded(existingTargetContext, persisted, currentEtag),
@@ -975,23 +978,6 @@ internal sealed class DescriptorWriteHandler(
             ),
         };
     }
-
-    /// <summary>
-    /// Compares the client's If-Match against the composed current etag on their state-significant
-    /// projections (ContentVersion + schemaEpoch) rather than byte-for-byte, so representation-encoding
-    /// differences (format, profileCode, linkFlag) do not spuriously fail the precondition. For a
-    /// descriptor the fixed variant key already reduces to those components, so a stale ContentVersion
-    /// (or a schema change) still yields the 412 mismatch path. The frontend has already stripped the
-    /// surrounding quotes from <paramref name="ifMatchValue"/>. A wildcard precondition (If-Match: *) is
-    /// handled by the caller's switch guard and never reaches this comparison, since it matches whenever
-    /// the target exists.
-    /// </summary>
-    private static bool IfMatchMatchesCurrentEtag(string ifMatchValue, string currentEtag) =>
-        string.Equals(
-            EtagMatchProjection.Of(ifMatchValue),
-            EtagMatchProjection.Of(currentEtag),
-            StringComparison.Ordinal
-        );
 
     private static RelationalWriteTargetContext TranslateDescriptorTargetContext(
         RelationalWriteTargetLookupResult targetLookupResult,
@@ -1404,11 +1390,17 @@ internal sealed class DescriptorWriteHandler(
             )
             .ConfigureAwait(false);
 
-        var variantKey = DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash);
-
         return new UpsertResult.InsertSuccess(
             documentUuid,
-            _etagComposer.Compose(persistedContentVersion, variantKey)
+            _servedEtagComposer.Compose(
+                new ServedEtagContext(
+                    request.MappingSet.Key.EffectiveSchemaHash,
+                    ResponseFormat.Json,
+                    ProfileName: null,
+                    LinksEnabled: false,
+                    persistedContentVersion
+                )
+            )
         );
     }
 
@@ -1455,11 +1447,17 @@ internal sealed class DescriptorWriteHandler(
             )
             .ConfigureAwait(false);
 
-        var variantKey = DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash);
-
         return new UpsertResult.UpdateSuccess(
             existingDocumentUuid,
-            _etagComposer.Compose(persistedContentVersion, variantKey)
+            _servedEtagComposer.Compose(
+                new ServedEtagContext(
+                    request.MappingSet.Key.EffectiveSchemaHash,
+                    ResponseFormat.Json,
+                    ProfileName: null,
+                    LinksEnabled: false,
+                    persistedContentVersion
+                )
+            )
         );
     }
 
@@ -1561,10 +1559,17 @@ internal sealed class DescriptorWriteHandler(
 
         await writeSession.CommitAsync(cancellationToken).ConfigureAwait(false);
 
-        var variantKey = DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash);
         return new UpdateResult.UpdateSuccess(
             documentUuid,
-            _etagComposer.Compose(persistedContentVersion, variantKey)
+            _servedEtagComposer.Compose(
+                new ServedEtagContext(
+                    request.MappingSet.Key.EffectiveSchemaHash,
+                    ResponseFormat.Json,
+                    ProfileName: null,
+                    LinksEnabled: false,
+                    persistedContentVersion
+                )
+            )
         );
     }
 
@@ -1674,7 +1679,7 @@ internal sealed class DescriptorWriteHandler(
         {
             var lockedCurrentState = await LoadLockedDescriptorCurrentStateAsync(
                     request.MappingSet.Key.Dialect,
-                    DescriptorVariantKey.For(request.MappingSet.Key.EffectiveSchemaHash),
+                    request.MappingSet.Key.EffectiveSchemaHash,
                     documentId,
                     writeSession,
                     cancellationToken
@@ -2314,7 +2319,7 @@ internal sealed class DescriptorWriteHandler(
 
     private async Task<DescriptorCurrentStateLoadResult> LoadLockedDescriptorCurrentStateAsync(
         SqlDialect dialect,
-        VariantKey variantKey,
+        string effectiveSchemaHash,
         long documentId,
         IRelationalWriteSession writeSession,
         CancellationToken cancellationToken
@@ -2341,11 +2346,20 @@ internal sealed class DescriptorWriteHandler(
             return DescriptorCurrentStateLoadResult.MissingDescriptor.Instance;
         }
 
-        // The current etag is composed from the locked ContentVersion and the fixed descriptor variant
-        // key so the If-Match comparison projects the same state-significant components as the served GET.
+        // The current etag is composed from the locked ContentVersion and the fixed descriptor
+        // representation (no profile, links disabled, JSON) so the If-Match comparison projects the
+        // same state-significant components as the served GET.
         return new DescriptorCurrentStateLoadResult.Loaded(
             persistedDescriptor,
-            _etagComposer.Compose(lockedContentVersion.Value, variantKey)
+            _servedEtagComposer.Compose(
+                new ServedEtagContext(
+                    effectiveSchemaHash,
+                    ResponseFormat.Json,
+                    ProfileName: null,
+                    LinksEnabled: false,
+                    lockedContentVersion.Value
+                )
+            )
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Etag/EtagMatchProjection.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Etag/EtagMatchProjection.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.Utilities;
+
 namespace EdFi.DataManagementService.Backend.Etag;
 
 /// <summary>
@@ -11,7 +13,8 @@ namespace EdFi.DataManagementService.Backend.Etag;
 /// (as amended 2026-07-04), If-Match ignores the representation-selector components (format,
 /// profileCode, linkFlag) and retains only ContentVersion and schemaEpoch. Two tags match iff their
 /// projections are equal (ordinal). A malformed tag yields a sentinel that cannot equal any
-/// well-formed projection.
+/// well-formed projection. Parsing is delegated to <see cref="EtagValue"/> (ContentVersion / variantKey
+/// split) and <see cref="VariantKey"/> (variantKey component split).
 /// </summary>
 public static class EtagMatchProjection
 {
@@ -20,30 +23,18 @@ public static class EtagMatchProjection
 
     public static string Of(string? etagValue)
     {
-        if (string.IsNullOrEmpty(etagValue))
+        if (!EtagValue.TryParse(etagValue, out var contentVersion, out var variantKeyValue))
         {
             return Malformed;
         }
 
-        // ContentVersion "-" variantKey: ContentVersion is digits-only and variantKey components are
-        // [a-z0-9_], so the first '-' is the unambiguous separator.
-        var dash = etagValue.IndexOf('-', StringComparison.Ordinal);
-        if (dash <= 0 || dash == etagValue.Length - 1)
+        if (!new VariantKey(variantKeyValue).TryParseComponents(out var components))
         {
             return Malformed;
         }
 
-        var contentVersion = etagValue[..dash];
-        var variantKey = etagValue[(dash + 1)..];
-        var parts = variantKey.Split('.');
-        if (parts.Length != 4)
-        {
-            return Malformed;
-        }
-
-        var schemaEpoch = parts[0];
-        // parts[1] = format, parts[2] = profileCode, parts[3] = linkFlag are intentionally dropped
-
-        return $"{contentVersion}-{schemaEpoch}";
+        // The projection is "{ContentVersion}-{schemaEpoch}", which is exactly EtagValue.Compose of the
+        // ContentVersion with the state-significant component. Format/profileCode/linkFlag are dropped.
+        return EtagValue.Compose(contentVersion, components.IfMatchSignificant());
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Etag/IfMatchEvaluator.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Etag/IfMatchEvaluator.cs
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Backend;
+
+namespace EdFi.DataManagementService.Backend.Etag;
+
+/// <summary>Outcome of an If-Match evaluation. Only <see cref="IsMatch"/> today; a Reason field is
+/// added by later follow-up plans without changing callers.</summary>
+public readonly record struct IfMatchResult(bool IsMatch);
+
+/// <summary>
+/// Single home for "evaluate If-Match against the current served etag". A wildcard precondition
+/// (If-Match: *) matches unconditionally (existence is proven by the caller before calling). A
+/// specific tag matches iff its state-significant projection equals the current tag's projection.
+/// </summary>
+public interface IIfMatchEvaluator
+{
+    IfMatchResult Evaluate(WritePrecondition.IfMatch precondition, string currentServedEtag);
+}
+
+public sealed class IfMatchEvaluator : IIfMatchEvaluator
+{
+    public IfMatchResult Evaluate(WritePrecondition.IfMatch precondition, string currentServedEtag)
+    {
+        ArgumentNullException.ThrowIfNull(precondition);
+
+        if (precondition.IsWildcard)
+        {
+            return new IfMatchResult(true);
+        }
+
+        var isMatch = string.Equals(
+            EtagMatchProjection.Of(precondition.Value),
+            EtagMatchProjection.Of(currentServedEtag),
+            StringComparison.Ordinal
+        );
+        return new IfMatchResult(isMatch);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Etag/ServedEtagComposer.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Etag/ServedEtagComposer.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Backend.Etag;
+
+/// <summary>
+/// The representation context needed to compose a served etag. <see cref="ProfileName"/> is
+/// <see langword="null"/> when no readable profile applies. Descriptor callers pass
+/// <c>ProfileName: null</c>, <c>Format: Json</c>, <c>LinksEnabled: false</c>.
+/// </summary>
+public readonly record struct ServedEtagContext(
+    string EffectiveSchemaHash,
+    ResponseFormat Format,
+    string? ProfileName,
+    bool LinksEnabled,
+    long ContentVersion
+);
+
+/// <summary>
+/// Single home for "compose the served etag". Wraps <see cref="VariantKeyFactory"/> +
+/// <see cref="ProfileVariantCode"/> + <see cref="IEtagComposer"/> so callers supply only context.
+/// </summary>
+public interface IServedEtagComposer
+{
+    string Compose(ServedEtagContext context);
+}
+
+public sealed class ServedEtagComposer(IEtagComposer etagComposer) : IServedEtagComposer
+{
+    private readonly IEtagComposer _etagComposer =
+        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+
+    public string Compose(ServedEtagContext context) =>
+        _etagComposer.Compose(
+            context.ContentVersion,
+            VariantKeyFactory.Create(
+                context.EffectiveSchemaHash,
+                context.Format,
+                ProfileVariantCode.Of(context.ProfileName),
+                context.LinksEnabled
+            )
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Etag/VariantKey.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Etag/VariantKey.cs
@@ -24,7 +24,64 @@ public readonly record struct VariantKey(string Value)
     /// <summary>The <c>profileCode</c> used when no readable profile applies.</summary>
     public const string NoProfileCode = "_";
 
+    /// <summary>Separator between the four variantKey components.</summary>
+    public const char ComponentSeparator = '.';
+
+    /// <summary>Number of components: schemaEpoch, format, profileCode, linkFlag.</summary>
+    public const int ComponentCount = 4;
+
+    /// <summary>Builds a variantKey wire value from its four components (fixed order).</summary>
+    public static VariantKey Format(
+        string schemaEpoch,
+        string formatCode,
+        string profileCode,
+        string linkFlag
+    ) => new(string.Join(ComponentSeparator, schemaEpoch, formatCode, profileCode, linkFlag));
+
+    /// <summary>
+    /// Splits <see cref="Value"/> into its four components. Returns <see langword="false"/> when the
+    /// value does not have exactly <see cref="ComponentCount"/> dot-delimited parts.
+    /// </summary>
+    public bool TryParseComponents(out Components components)
+    {
+        components = default;
+        if (string.IsNullOrEmpty(Value))
+        {
+            return false;
+        }
+
+        var parts = Value.Split(ComponentSeparator);
+        if (parts.Length != ComponentCount)
+        {
+            return false;
+        }
+
+        components = new Components(parts[0], parts[1], parts[2], parts[3]);
+        return true;
+    }
+
     public override string ToString() => Value;
+
+    /// <summary>The parsed components of a variantKey, in fixed order.</summary>
+    // The nested Format property intentionally shares its name with the enclosing type's static
+    // builder method; they are unrelated members, and the shared name mirrors the wire grammar term
+    // used throughout this file's documentation.
+#pragma warning disable S3218 // Format property does not shadow the outer type's static Format method.
+    public readonly record struct Components(
+        string SchemaEpoch,
+        string Format,
+        string ProfileCode,
+        string LinkFlag
+    )
+    {
+#pragma warning restore S3218
+        /// <summary>
+        /// The subset that remains significant for RFC 7232 If-Match comparison. Per the 2026-07-04
+        /// ADR amendment this is <see cref="SchemaEpoch"/> only; format, profileCode, and linkFlag are
+        /// projected out. This is the single definition of "what If-Match compares".
+        /// </summary>
+        public string IfMatchSignificant() => SchemaEpoch;
+    }
 }
 
 /// <summary>
@@ -52,7 +109,7 @@ public static class VariantKeyFactory
         var formatCode = FormatCode(format);
         var linkFlag = linksEnabled ? "l" : "n";
 
-        return new VariantKey($"{schemaEpoch}.{formatCode}.{profileCode}.{linkFlag}");
+        return VariantKey.Format(schemaEpoch, formatCode, profileCode, linkFlag);
     }
 
     // First 8 lowercase hex characters of the in-force EffectiveSchemaHash (already lowercase hex,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/Etag/VariantKey.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/Etag/VariantKey.cs
@@ -31,7 +31,7 @@ public readonly record struct VariantKey(string Value)
     public const int ComponentCount = 4;
 
     /// <summary>Builds a variantKey wire value from its four components (fixed order).</summary>
-    public static VariantKey Format(
+    public static VariantKey FromComponents(
         string schemaEpoch,
         string formatCode,
         string profileCode,
@@ -63,10 +63,6 @@ public readonly record struct VariantKey(string Value)
     public override string ToString() => Value;
 
     /// <summary>The parsed components of a variantKey, in fixed order.</summary>
-    // The nested Format property intentionally shares its name with the enclosing type's static
-    // builder method; they are unrelated members, and the shared name mirrors the wire grammar term
-    // used throughout this file's documentation.
-#pragma warning disable S3218 // Format property does not shadow the outer type's static Format method.
     public readonly record struct Components(
         string SchemaEpoch,
         string Format,
@@ -74,7 +70,6 @@ public readonly record struct VariantKey(string Value)
         string LinkFlag
     )
     {
-#pragma warning restore S3218
         /// <summary>
         /// The subset that remains significant for RFC 7232 If-Match comparison. Per the 2026-07-04
         /// ADR amendment this is <see cref="SchemaEpoch"/> only; format, profileCode, and linkFlag are
@@ -109,7 +104,7 @@ public static class VariantKeyFactory
         var formatCode = FormatCode(format);
         var linkFlag = linksEnabled ? "l" : "n";
 
-        return VariantKey.Format(schemaEpoch, formatCode, profileCode, linkFlag);
+        return VariantKey.FromComponents(schemaEpoch, formatCode, profileCode, linkFlag);
     }
 
     // First 8 lowercase hex characters of the in-force EffectiveSchemaHash (already lowercase hex,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/ReferenceResolverServiceCollectionExtensions.cs
@@ -67,6 +67,8 @@ public static class ReferenceResolverServiceCollectionExtensions
         services.TryAdd(ServiceDescriptor.Scoped<ISessionDocumentHydrator, TSessionDocumentHydrator>());
         // Stateless composer for the ContentVersion-based _etag; singleton so it is reused.
         services.TryAdd(ServiceDescriptor.Singleton<IEtagComposer, EtagComposer>());
+        services.TryAdd(ServiceDescriptor.Singleton<IServedEtagComposer, ServedEtagComposer>());
+        services.TryAdd(ServiceDescriptor.Singleton<IIfMatchEvaluator, IfMatchEvaluator>());
         services.TryAdd(ServiceDescriptor.Scoped<IRelationalReadMaterializer, RelationalReadMaterializer>());
         services.TryAdd(
             ServiceDescriptor.Scoped<IRelationalReadTargetLookupService, RelationalReadTargetLookupService>()

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCommittedRepresentationReader.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCommittedRepresentationReader.cs
@@ -20,14 +20,14 @@ internal interface IRelationalCommittedRepresentationReader
 }
 
 internal sealed class RelationalCommittedRepresentationReader(
-    IEtagComposer etagComposer,
+    IServedEtagComposer servedEtagComposer,
     IOptions<ResourceLinksOptions> linksOptions
 ) : IRelationalCommittedRepresentationReader
 {
     private const string EtagPropertyName = "_etag";
 
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
     private readonly ResourceLinksOptions _linksOptions =
         linksOptions?.Value ?? throw new ArgumentNullException(nameof(linksOptions));
 
@@ -44,18 +44,16 @@ internal sealed class RelationalCommittedRepresentationReader(
         ArgumentNullException.ThrowIfNull(persistedTarget);
         cancellationToken.ThrowIfCancellationRequested();
 
-        var variantKey = VariantKeyFactory.Create(
-            request.MappingSet.Key.EffectiveSchemaHash,
-            ResponseFormat.Json,
-            ProfileVariantCode.Of(request.ProfileWriteContext?.ProfileName),
-            _linksOptions.Enabled
+        var etag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                request.MappingSet.Key.EffectiveSchemaHash,
+                ResponseFormat.Json,
+                request.ProfileWriteContext?.ProfileName,
+                _linksOptions.Enabled,
+                persistedTarget.ContentVersion
+            )
         );
 
-        return Task.FromResult<JsonNode>(
-            new JsonObject
-            {
-                [EtagPropertyName] = _etagComposer.Compose(persistedTarget.ContentVersion, variantKey),
-            }
-        );
+        return Task.FromResult<JsonNode>(new JsonObject { [EtagPropertyName] = etag });
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
@@ -62,14 +62,18 @@ internal interface IRelationalCurrentEtagPreconditionChecker
 
 internal sealed class RelationalCurrentEtagPreconditionChecker(
     IRelationalWriteCurrentStateLoader currentStateLoader,
-    IEtagComposer etagComposer
+    IServedEtagComposer servedEtagComposer,
+    IIfMatchEvaluator ifMatchEvaluator
 ) : IRelationalCurrentEtagPreconditionChecker, IRelationalDeleteEtagPreconditionChecker
 {
     private readonly IRelationalWriteCurrentStateLoader _currentStateLoader =
         currentStateLoader ?? throw new ArgumentNullException(nameof(currentStateLoader));
 
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
+
+    private readonly IIfMatchEvaluator _ifMatchEvaluator =
+        ifMatchEvaluator ?? throw new ArgumentNullException(nameof(ifMatchEvaluator));
 
     public async Task<RelationalDeleteEtagPreconditionCheckResult?> CheckAsync(
         MappingSet mappingSet,
@@ -141,15 +145,16 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
         // Compose the current served etag (it still carries profileCode from the request's profile, for
         // the returned CurrentEtag). If-Match then compares only the state-significant projection
         // (ContentVersion, schemaEpoch); format, linkFlag, and profileCode are projected out — profileCode
-        // as of the 2026-07-04 ADR amendment. A wildcard precondition (If-Match: *) short-circuits to a
-        // match here because reaching this point means the target row exists and is locked.
-        var currentEtag = _etagComposer.Compose(
-            currentState.DocumentMetadata.ContentVersion,
-            VariantKeyFactory.Create(
+        // as of the 2026-07-04 ADR amendment. A wildcard precondition (If-Match: *) is handled inside the
+        // evaluator, which matches unconditionally because reaching this point means the target row
+        // exists and is locked.
+        var currentEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
                 request.MappingSet.Key.EffectiveSchemaHash,
                 ResponseFormat.Json,
-                ProfileVariantCode.Of(request.ProfileName),
-                linksEnabled: true
+                request.ProfileName,
+                LinksEnabled: true,
+                currentState.DocumentMetadata.ContentVersion
             )
         );
         var refreshedTargetContext = request.TargetContext with
@@ -161,12 +166,7 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
             currentState,
             refreshedTargetContext,
             currentEtag,
-            request.Precondition.IsWildcard
-                || string.Equals(
-                    EtagMatchProjection.Of(request.Precondition.Value),
-                    EtagMatchProjection.Of(currentEtag),
-                    StringComparison.Ordinal
-                )
+            _ifMatchEvaluator.Evaluate(request.Precondition, currentEtag).IsMatch
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
@@ -170,15 +170,18 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
 
         var evaluation = _ifMatchEvaluator.Evaluate(request.Precondition, currentEtag);
 
-        _logger.LogDebug(
-            "If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, clientTag={ClientTag}, "
-                + "currentTag={CurrentTag}, matched={IsMatch}",
-            request.TargetContext.DocumentId,
-            request.Precondition.IsWildcard,
-            LoggingSanitizer.SanitizeForLogging(request.Precondition.Value),
-            currentEtag,
-            evaluation.IsMatch
-        );
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            _logger.LogDebug(
+                "If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, clientTag={ClientTag}, "
+                    + "currentTag={CurrentTag}, matched={IsMatch}",
+                request.TargetContext.DocumentId,
+                request.Precondition.IsWildcard,
+                LoggingSanitizer.SanitizeForLogging(request.Precondition.Value),
+                currentEtag,
+                evaluation.IsMatch
+            );
+        }
 
         return new RelationalCurrentEtagPreconditionCheckResult(
             currentState,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
@@ -7,6 +7,7 @@ using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Core.External.Backend;
+using Microsoft.Extensions.Logging;
 
 namespace EdFi.DataManagementService.Backend;
 
@@ -63,7 +64,8 @@ internal interface IRelationalCurrentEtagPreconditionChecker
 internal sealed class RelationalCurrentEtagPreconditionChecker(
     IRelationalWriteCurrentStateLoader currentStateLoader,
     IServedEtagComposer servedEtagComposer,
-    IIfMatchEvaluator ifMatchEvaluator
+    IIfMatchEvaluator ifMatchEvaluator,
+    ILogger<RelationalCurrentEtagPreconditionChecker> logger
 ) : IRelationalCurrentEtagPreconditionChecker, IRelationalDeleteEtagPreconditionChecker
 {
     private readonly IRelationalWriteCurrentStateLoader _currentStateLoader =
@@ -74,6 +76,9 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
 
     private readonly IIfMatchEvaluator _ifMatchEvaluator =
         ifMatchEvaluator ?? throw new ArgumentNullException(nameof(ifMatchEvaluator));
+
+    private readonly ILogger<RelationalCurrentEtagPreconditionChecker> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
 
     public async Task<RelationalDeleteEtagPreconditionCheckResult?> CheckAsync(
         MappingSet mappingSet,
@@ -162,11 +167,23 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
             ObservedContentVersion = currentState.DocumentMetadata.ContentVersion,
         };
 
+        var evaluation = _ifMatchEvaluator.Evaluate(request.Precondition, currentEtag);
+
+        _logger.LogDebug(
+            "If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, clientTag={ClientTag}, "
+                + "currentTag={CurrentTag}, matched={IsMatch}",
+            request.TargetContext.DocumentId,
+            request.Precondition.IsWildcard,
+            request.Precondition.Value,
+            currentEtag,
+            evaluation.IsMatch
+        );
+
         return new RelationalCurrentEtagPreconditionCheckResult(
             currentState,
             refreshedTargetContext,
             currentEtag,
-            _ifMatchEvaluator.Evaluate(request.Precondition, currentEtag).IsMatch
+            evaluation.IsMatch
         );
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalCurrentEtagPreconditionChecker.cs
@@ -7,6 +7,7 @@ using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.External.Plans;
 using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace EdFi.DataManagementService.Backend;
@@ -174,7 +175,7 @@ internal sealed class RelationalCurrentEtagPreconditionChecker(
                 + "currentTag={CurrentTag}, matched={IsMatch}",
             request.TargetContext.DocumentId,
             request.Precondition.IsWildcard,
-            request.Precondition.Value,
+            LoggingSanitizer.SanitizeForLogging(request.Precondition.Value),
             currentEtag,
             evaluation.IsMatch
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -431,7 +431,9 @@ public sealed class RelationalDocumentStoreRepository(
                     // RFC 7232 If-Match: * requires the target to exist; a wildcard against a missing
                     // DELETE target yields the precondition-failed (412) result rather than 404.
                     outcome = writePrecondition is WritePrecondition.IfMatch { IsWildcard: true }
-                        ? new DeleteResult.DeleteFailureETagMisMatch()
+                        ? new DeleteResult.DeleteFailureETagMisMatch(
+                            ETagPreconditionFailureReason.TargetDoesNotExist
+                        )
                         : new DeleteResult.DeleteFailureNotExists();
                 }
                 else
@@ -448,7 +450,9 @@ public sealed class RelationalDocumentStoreRepository(
                         // RFC 7232 If-Match: * requires the target to exist; a wildcard against a
                         // target that vanished before locking yields 412 rather than 404.
                         outcome = writePrecondition is WritePrecondition.IfMatch { IsWildcard: true }
-                            ? new DeleteResult.DeleteFailureETagMisMatch()
+                            ? new DeleteResult.DeleteFailureETagMisMatch(
+                                ETagPreconditionFailureReason.TargetDoesNotExist
+                            )
                             : new DeleteResult.DeleteFailureNotExists();
                     }
                     else
@@ -591,7 +595,9 @@ public sealed class RelationalDocumentStoreRepository(
                 // RFC 7232 If-Match: * requires the target to exist; a wildcard whose recheck cannot
                 // re-lock the target (a concurrent delete) yields 412 rather than 404.
                 return ifMatch.IsWildcard
-                    ? new DeleteResult.DeleteFailureETagMisMatch()
+                    ? new DeleteResult.DeleteFailureETagMisMatch(
+                        ETagPreconditionFailureReason.TargetDoesNotExist
+                    )
                     : new DeleteResult.DeleteFailureNotExists();
             }
 
@@ -2265,7 +2271,10 @@ public sealed class RelationalDocumentStoreRepository(
             return new TargetContextResolution(
                 null,
                 writePrecondition is WritePrecondition.IfMatch { IsWildcard: true }
-                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(operationKind)
+                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(
+                        operationKind,
+                        ETagPreconditionFailureReason.TargetDoesNotExist
+                    )
                     : new RelationalWriteExecutorResult.Update(new UpdateResult.UpdateFailureNotExists())
             );
         }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadMaterializer.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadMaterializer.cs
@@ -93,7 +93,7 @@ public interface IRelationalReadMaterializer
 internal sealed class RelationalReadMaterializer(
     IDocumentLinkSlugResolver slugResolver,
     IOptions<ResourceLinksOptions> linksOptions,
-    IEtagComposer etagComposer
+    IServedEtagComposer servedEtagComposer
 ) : IRelationalReadMaterializer
 {
     private const string IdPropertyName = "id";
@@ -105,8 +105,8 @@ internal sealed class RelationalReadMaterializer(
         slugResolver ?? throw new ArgumentNullException(nameof(slugResolver));
     private readonly ResourceLinksOptions _linksOptions =
         linksOptions?.Value ?? throw new ArgumentNullException(nameof(linksOptions));
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
 
     public JsonNode Materialize(RelationalReadMaterializationRequest request)
     {
@@ -269,13 +269,14 @@ internal sealed class RelationalReadMaterializer(
             );
         }
 
-        var variantKey = VariantKeyFactory.Create(
-            mappingSetValue.Key.EffectiveSchemaHash,
-            variant.Format,
-            ProfileVariantCode.Of(variant.ProfileName),
-            _linksOptions.Enabled
+        return _servedEtagComposer.Compose(
+            new ServedEtagContext(
+                mappingSetValue.Key.EffectiveSchemaHash,
+                variant.Format,
+                variant.ProfileName,
+                _linksOptions.Enabled,
+                documentMetadata.ContentVersion
+            )
         );
-
-        return _etagComposer.Compose(documentMetadata.ContentVersion, variantKey);
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadMaterializer.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalReadMaterializer.cs
@@ -40,11 +40,12 @@ public sealed record RelationalReadMaterializationRequest(
     public HydratedDocumentReferenceLookup? DocumentReferenceLookup { get; init; }
 
     /// <summary>
-    /// Representation inputs for composing a ContentVersion-based <c>_etag</c>. When set (and
-    /// <see cref="MappingSet"/> is present) on an <see cref="RelationalGetRequestReadMode.ExternalResponse"/>
-    /// materialization, the served <c>_etag</c> is composed as <c>"{ContentVersion}-{variantKey}"</c>.
-    /// <see langword="null"/> on callers that have not yet been converted; those fall back to the
-    /// legacy content hash.
+    /// Representation inputs for composing a ContentVersion-based <c>_etag</c>, required on every
+    /// <see cref="RelationalGetRequestReadMode.ExternalResponse"/> materialization (together with
+    /// <see cref="MappingSet"/>); the served <c>_etag</c> is composed as
+    /// <c>"{ContentVersion}-{variantKey}"</c>. <c>ComposeEtag</c> throws when this is
+    /// <see langword="null"/> on an external response — absence indicates a wiring bug in the caller,
+    /// not a fallback. There is no legacy content-hash path.
     /// </summary>
     public EtagVariantInputs? EtagVariant { get; init; }
 }
@@ -66,8 +67,9 @@ public sealed record RelationalReadPageMaterializationRequest(
 
     /// <summary>
     /// Representation inputs for composing a ContentVersion-based <c>_etag</c>; see
-    /// <see cref="RelationalReadMaterializationRequest.EtagVariant"/>. <see langword="null"/> callers
-    /// fall back to the legacy content hash.
+    /// <see cref="RelationalReadMaterializationRequest.EtagVariant"/>. Required on every external-response
+    /// materialization; absence is a wiring bug in the caller, not a fallback. There is no legacy
+    /// content-hash path.
     /// </summary>
     public EtagVariantInputs? EtagVariant { get; init; }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -146,7 +146,8 @@ internal sealed class RelationalWriteExecutionStateResolver(
                 var missingTarget = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
                 _logger.LogDebug(
                     "Deferred If-Match precondition for document {DocumentId}: no current representation "
-                        + "(operation={OperationKind}, wildcard={IsWildcard}, clientTag={ClientTag}); precondition fails",
+                        + "(operation={OperationKind}, wildcard={IsWildcard}, clientTag={ClientTag}); "
+                        + "resolving missing-target outcome",
                     missingTarget.DocumentId,
                     request.OperationKind,
                     ifMatch.IsWildcard,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -14,7 +14,8 @@ internal sealed class RelationalWriteExecutionStateResolver(
     IRelationalWriteTargetLookupResolver targetLookupResolver,
     IRelationalWriteCurrentStateLoader currentStateLoader,
     IRelationalCurrentEtagPreconditionChecker currentEtagPreconditionChecker,
-    IEtagComposer etagComposer
+    IServedEtagComposer servedEtagComposer,
+    IIfMatchEvaluator ifMatchEvaluator
 )
 {
     private readonly IRelationalWriteTargetLookupResolver _targetLookupResolver =
@@ -27,8 +28,11 @@ internal sealed class RelationalWriteExecutionStateResolver(
         currentEtagPreconditionChecker
         ?? throw new ArgumentNullException(nameof(currentEtagPreconditionChecker));
 
-    private readonly IEtagComposer _etagComposer =
-        etagComposer ?? throw new ArgumentNullException(nameof(etagComposer));
+    private readonly IServedEtagComposer _servedEtagComposer =
+        servedEtagComposer ?? throw new ArgumentNullException(nameof(servedEtagComposer));
+
+    private readonly IIfMatchEvaluator _ifMatchEvaluator =
+        ifMatchEvaluator ?? throw new ArgumentNullException(nameof(ifMatchEvaluator));
 
     public static IfMatchPreconditionEvaluation GetIfMatchPreconditionEvaluation(
         RelationalWriteExecutorRequest request
@@ -144,26 +148,20 @@ internal sealed class RelationalWriteExecutionStateResolver(
 
         // If-Match compares the state-significant projection of the composed etag (ContentVersion,
         // schemaEpoch). format, linkFlag, and profileCode are projected out (profileCode as of the
-        // 2026-07-04 ADR amendment), so the values passed for them here are not significant. A wildcard
-        // precondition (If-Match: *) short-circuits to a match because currentState being non-null means
-        // the target row exists.
-        var currentEtag = _etagComposer.Compose(
-            currentState.DocumentMetadata.ContentVersion,
-            VariantKeyFactory.Create(
+        // 2026-07-04 ADR amendment), so the values passed for them here are not significant. The
+        // evaluator handles the wildcard precondition (If-Match: *) internally, short-circuiting to a
+        // match because currentState being non-null means the target row exists.
+        var currentEtag = _servedEtagComposer.Compose(
+            new ServedEtagContext(
                 request.MappingSet.Key.EffectiveSchemaHash,
                 ResponseFormat.Json,
-                ProfileVariantCode.Of(request.ProfileWriteContext?.ProfileName),
-                linksEnabled: true
+                request.ProfileWriteContext?.ProfileName,
+                LinksEnabled: true,
+                currentState.DocumentMetadata.ContentVersion
             )
         );
 
-        return
-            ifMatch.IsWildcard
-            || string.Equals(
-                EtagMatchProjection.Of(ifMatch.Value),
-                EtagMatchProjection.Of(currentEtag),
-                StringComparison.Ordinal
-            )
+        return _ifMatchEvaluator.Evaluate(ifMatch, currentEtag).IsMatch
             ? null
             : RelationalWriteExecutorResults.BuildPreconditionFailureResult(request.OperationKind);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -7,6 +7,8 @@ using EdFi.DataManagementService.Backend.Etag;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace EdFi.DataManagementService.Backend;
 
@@ -15,7 +17,8 @@ internal sealed class RelationalWriteExecutionStateResolver(
     IRelationalWriteCurrentStateLoader currentStateLoader,
     IRelationalCurrentEtagPreconditionChecker currentEtagPreconditionChecker,
     IServedEtagComposer servedEtagComposer,
-    IIfMatchEvaluator ifMatchEvaluator
+    IIfMatchEvaluator ifMatchEvaluator,
+    ILogger<RelationalWriteExecutionStateResolver> logger
 )
 {
     private readonly IRelationalWriteTargetLookupResolver _targetLookupResolver =
@@ -33,6 +36,9 @@ internal sealed class RelationalWriteExecutionStateResolver(
 
     private readonly IIfMatchEvaluator _ifMatchEvaluator =
         ifMatchEvaluator ?? throw new ArgumentNullException(nameof(ifMatchEvaluator));
+
+    private readonly ILogger<RelationalWriteExecutionStateResolver> _logger =
+        logger ?? throw new ArgumentNullException(nameof(logger));
 
     public static IfMatchPreconditionEvaluation GetIfMatchPreconditionEvaluation(
         RelationalWriteExecutorRequest request
@@ -135,6 +141,15 @@ internal sealed class RelationalWriteExecutionStateResolver(
 
         if (currentState is null)
         {
+            var missingTarget = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
+            _logger.LogDebug(
+                "Deferred If-Match precondition for document {DocumentId}: no current representation "
+                    + "(operation={OperationKind}, wildcard={IsWildcard}, clientTag={ClientTag}); precondition fails",
+                missingTarget.DocumentId,
+                request.OperationKind,
+                ifMatch.IsWildcard,
+                LoggingSanitizer.SanitizeForLogging(ifMatch.Value)
+            );
             return request.OperationKind switch
             {
                 RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
@@ -167,7 +182,20 @@ internal sealed class RelationalWriteExecutionStateResolver(
             )
         );
 
-        return _ifMatchEvaluator.Evaluate(ifMatch, currentEtag).IsMatch
+        var existing = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
+        var evaluation = _ifMatchEvaluator.Evaluate(ifMatch, currentEtag);
+
+        _logger.LogDebug(
+            "Deferred If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
+                + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
+            existing.DocumentId,
+            ifMatch.IsWildcard,
+            LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
+            currentEtag,
+            evaluation.IsMatch
+        );
+
+        return evaluation.IsMatch
             ? null
             : RelationalWriteExecutorResults.BuildPreconditionFailureResult(request.OperationKind);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -141,15 +141,18 @@ internal sealed class RelationalWriteExecutionStateResolver(
 
         if (currentState is null)
         {
-            var missingTarget = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
-            _logger.LogDebug(
-                "Deferred If-Match precondition for document {DocumentId}: no current representation "
-                    + "(operation={OperationKind}, wildcard={IsWildcard}, clientTag={ClientTag}); precondition fails",
-                missingTarget.DocumentId,
-                request.OperationKind,
-                ifMatch.IsWildcard,
-                LoggingSanitizer.SanitizeForLogging(ifMatch.Value)
-            );
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                var missingTarget = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
+                _logger.LogDebug(
+                    "Deferred If-Match precondition for document {DocumentId}: no current representation "
+                        + "(operation={OperationKind}, wildcard={IsWildcard}, clientTag={ClientTag}); precondition fails",
+                    missingTarget.DocumentId,
+                    request.OperationKind,
+                    ifMatch.IsWildcard,
+                    LoggingSanitizer.SanitizeForLogging(ifMatch.Value)
+                );
+            }
             return request.OperationKind switch
             {
                 RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
@@ -182,18 +185,21 @@ internal sealed class RelationalWriteExecutionStateResolver(
             )
         );
 
-        var existing = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
         var evaluation = _ifMatchEvaluator.Evaluate(ifMatch, currentEtag);
 
-        _logger.LogDebug(
-            "Deferred If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
-                + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
-            existing.DocumentId,
-            ifMatch.IsWildcard,
-            LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
-            currentEtag,
-            evaluation.IsMatch
-        );
+        if (_logger.IsEnabled(LogLevel.Debug))
+        {
+            var existing = (RelationalWriteTargetContext.ExistingDocument)request.TargetContext;
+            _logger.LogDebug(
+                "Deferred If-Match precondition for document {DocumentId}: wildcard={IsWildcard}, "
+                    + "clientTag={ClientTag}, currentTag={CurrentTag}, matched={IsMatch}",
+                existing.DocumentId,
+                ifMatch.IsWildcard,
+                LoggingSanitizer.SanitizeForLogging(ifMatch.Value),
+                currentEtag,
+                evaluation.IsMatch
+            );
+        }
 
         return evaluation.IsMatch
             ? null

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutionStateResolver.cs
@@ -115,7 +115,10 @@ internal sealed class RelationalWriteExecutionStateResolver(
 
         if (request.TargetContext is RelationalWriteTargetContext.CreateNew)
         {
-            return RelationalWriteExecutorResults.BuildPreconditionFailureResult(request.OperationKind);
+            return RelationalWriteExecutorResults.BuildPreconditionFailureResult(
+                request.OperationKind,
+                ETagPreconditionFailureReason.TargetDoesNotExist
+            );
         }
 
         if (request.TargetContext is not RelationalWriteTargetContext.ExistingDocument)
@@ -140,7 +143,10 @@ internal sealed class RelationalWriteExecutionStateResolver(
                 // RFC 7232 If-Match: * requires the target to exist; a wildcard against a missing PUT
                 // target yields the precondition-failed (412) result rather than not-exists (404).
                 RelationalWriteOperationKind.Put => ifMatch.IsWildcard
-                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(request.OperationKind)
+                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(
+                        request.OperationKind,
+                        ETagPreconditionFailureReason.TargetDoesNotExist
+                    )
                     : new RelationalWriteExecutorResult.Update(new UpdateResult.UpdateFailureNotExists()),
                 _ => throw new ArgumentOutOfRangeException(nameof(request), request.OperationKind, null),
             };
@@ -337,7 +343,10 @@ internal sealed class RelationalWriteExecutionStateResolver(
                 // target yields the precondition-failed (412) result rather than not-exists (404).
                 request.WritePrecondition
                     is WritePrecondition.IfMatch { IsWildcard: true }
-                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(request.OperationKind)
+                    ? RelationalWriteExecutorResults.BuildPreconditionFailureResult(
+                        request.OperationKind,
+                        ETagPreconditionFailureReason.TargetDoesNotExist
+                    )
                     : new RelationalWriteExecutorResult.Update(new UpdateResult.UpdateFailureNotExists())
             ),
             RelationalWriteTargetRequest.Post(var referentialId, var candidateDocumentUuid) =>

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalWriteExecutorResults.cs
@@ -301,16 +301,17 @@ internal static class RelationalWriteExecutorResults
     }
 
     public static RelationalWriteExecutorResult BuildPreconditionFailureResult(
-        RelationalWriteOperationKind operationKind
+        RelationalWriteOperationKind operationKind,
+        ETagPreconditionFailureReason reason = ETagPreconditionFailureReason.Concurrency
     )
     {
         return operationKind switch
         {
             RelationalWriteOperationKind.Post => new RelationalWriteExecutorResult.Upsert(
-                new UpsertResult.UpsertFailureETagMisMatch()
+                new UpsertResult.UpsertFailureETagMisMatch(reason)
             ),
             RelationalWriteOperationKind.Put => new RelationalWriteExecutorResult.Update(
-                new UpdateResult.UpdateFailureETagMisMatch()
+                new UpdateResult.UpdateFailureETagMisMatch(reason)
             ),
             _ => throw new ArgumentOutOfRangeException(nameof(operationKind), operationKind, null),
         };

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/DeleteResult.cs
@@ -72,7 +72,10 @@ public abstract record DeleteResult
     /// <summary>
     /// A failure because the Etag mismatch
     /// </summary>
-    public record DeleteFailureETagMisMatch() : DeleteResult();
+    /// <param name="Reason">Machine-readable reason for the precondition failure</param>
+    public record DeleteFailureETagMisMatch(
+        ETagPreconditionFailureReason Reason = ETagPreconditionFailureReason.Concurrency
+    ) : DeleteResult();
 
     private DeleteResult() { }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/ETagPreconditionFailureReason.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/ETagPreconditionFailureReason.cs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Backend;
+
+/// <summary>Why an If-Match precondition failed, so the API can return an actionable 412 detail.</summary>
+public enum ETagPreconditionFailureReason
+{
+    /// <summary>The target exists but its current etag does not match the client's specific tag.</summary>
+    Concurrency,
+
+    /// <summary>No current representation exists to satisfy the precondition (bare If-Match: * on a
+    /// missing target, or If-Match on a resource that resolves to an insert).</summary>
+    TargetDoesNotExist,
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpdateResult.cs
@@ -35,7 +35,10 @@ public record UpdateResult
     /// <summary>
     /// A failure because the Etag mismatch
     /// </summary>
-    public record UpdateFailureETagMisMatch() : UpdateResult();
+    /// <param name="Reason">Machine-readable reason for the precondition failure</param>
+    public record UpdateFailureETagMisMatch(
+        ETagPreconditionFailureReason Reason = ETagPreconditionFailureReason.Concurrency
+    ) : UpdateResult();
 
     /// <summary>
     /// A failure because referenced documents and/or descriptors in the updated document are invalid

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/UpsertResult.cs
@@ -72,7 +72,10 @@ public record UpsertResult
     /// <summary>
     /// A failure because the current ETag does not exactly match the request's If-Match precondition
     /// </summary>
-    public record UpsertFailureETagMisMatch() : UpsertResult();
+    /// <param name="Reason">Machine-readable reason for the precondition failure</param>
+    public record UpsertFailureETagMisMatch(
+        ETagPreconditionFailureReason Reason = ETagPreconditionFailureReason.Concurrency
+    ) : UpsertResult();
 
     /// <summary>
     /// A failure because the client is not authorized to upsert the document

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/DeleteByIdHandlerTests.cs
@@ -259,6 +259,106 @@ public class DeleteByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Failure_Etag_Mismatch : DeleteByIdHandlerTests
+    {
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<DeleteResult> DeleteDocumentById(IDeleteRequest deleteRequest)
+            {
+                return Task.FromResult<DeleteResult>(new DeleteFailureETagMisMatch());
+            }
+        }
+
+        private readonly RequestInfo _requestInfo = RequestInfoWithRelationalMappingSet("trace-id");
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var projectSchemaNode = new JsonObject
+            {
+                ["educationOrganizationTypes"] = new JsonArray { "Type1", "Type2" },
+            };
+            _requestInfo.ProjectSchema = new ProjectSchema(projectSchemaNode, NullLogger.Instance);
+            var (deleteByIdHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+            _requestInfo.ResourceSchema = GetResourceSchema();
+            await deleteByIdHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_has_the_correct_response()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(412);
+            JsonNode
+                .DeepEquals(
+                    _requestInfo.FrontendResponse.Body,
+                    FailureResponse.ForETagMisMatch(
+                        "The item has been modified by another user.",
+                        new TraceId("trace-id"),
+                        [
+                            "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
+                        ]
+                    )
+                )
+                .Should()
+                .BeTrue();
+            _requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Repository_That_Returns_Failure_Etag_Mismatch_Target_Does_Not_Exist
+        : DeleteByIdHandlerTests
+    {
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<DeleteResult> DeleteDocumentById(IDeleteRequest deleteRequest)
+            {
+                return Task.FromResult<DeleteResult>(
+                    new DeleteFailureETagMisMatch(ETagPreconditionFailureReason.TargetDoesNotExist)
+                );
+            }
+        }
+
+        private readonly RequestInfo _requestInfo = RequestInfoWithRelationalMappingSet("trace-id");
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var projectSchemaNode = new JsonObject
+            {
+                ["educationOrganizationTypes"] = new JsonArray { "Type1", "Type2" },
+            };
+            _requestInfo.ProjectSchema = new ProjectSchema(projectSchemaNode, NullLogger.Instance);
+            var (deleteByIdHandler, serviceProvider) = Handler(new Repository());
+            _requestInfo.ScopedServiceProvider = serviceProvider;
+            _requestInfo.ResourceSchema = GetResourceSchema();
+            await deleteByIdHandler.Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_has_the_correct_response()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(412);
+
+            var body = _requestInfo.FrontendResponse.Body!.AsObject();
+            body["detail"]!
+                .GetValue<string>()
+                .Should()
+                .Be("The If-Match precondition failed because the resource does not exist.");
+            body["errors"]![0]!
+                .GetValue<string>()
+                .Should()
+                .Be(
+                    "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match."
+                );
+            _requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Relationship_Not_Authorized : DeleteByIdHandlerTests
     {
         internal class Repository : NotImplementedDocumentStoreRepository

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpdateByIdHandlerTests.cs
@@ -185,6 +185,94 @@ public class UpdateByIdHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Failure_Etag_Mismatch : UpdateByIdHandlerTests
+    {
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpdateResult> UpdateDocumentById(IUpdateRequest updateRequest)
+            {
+                return Task.FromResult<UpdateResult>(new UpdateFailureETagMisMatch());
+            }
+        }
+
+        private readonly RequestInfo requestInfo = RequestInfoWithRelationalMappingSet("trace-id");
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (updateByIdHandler, serviceProvider) = Handler(new Repository());
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            await updateByIdHandler.Execute(requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_has_the_correct_response()
+        {
+            requestInfo.FrontendResponse.StatusCode.Should().Be(412);
+            JsonNode
+                .DeepEquals(
+                    requestInfo.FrontendResponse.Body,
+                    FailureResponse.ForETagMisMatch(
+                        "The item has been modified by another user.",
+                        new TraceId("trace-id"),
+                        [
+                            "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
+                        ]
+                    )
+                )
+                .Should()
+                .BeTrue();
+            requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Repository_That_Returns_Failure_Etag_Mismatch_Target_Does_Not_Exist
+        : UpdateByIdHandlerTests
+    {
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpdateResult> UpdateDocumentById(IUpdateRequest updateRequest)
+            {
+                return Task.FromResult<UpdateResult>(
+                    new UpdateFailureETagMisMatch(ETagPreconditionFailureReason.TargetDoesNotExist)
+                );
+            }
+        }
+
+        private readonly RequestInfo requestInfo = RequestInfoWithRelationalMappingSet("trace-id");
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (updateByIdHandler, serviceProvider) = Handler(new Repository());
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            await updateByIdHandler.Execute(requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_has_the_correct_response()
+        {
+            requestInfo.FrontendResponse.StatusCode.Should().Be(412);
+
+            var body = requestInfo.FrontendResponse.Body!.AsObject();
+            body["detail"]!
+                .GetValue<string>()
+                .Should()
+                .Be("The If-Match precondition failed because the resource does not exist.");
+            body["errors"]![0]!
+                .GetValue<string>()
+                .Should()
+                .Be(
+                    "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match."
+                );
+            requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Profiled_Request : UpdateByIdHandlerTests
     {
         internal sealed class Repository : NotImplementedDocumentStoreRepository

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/UpsertHandlerTests.cs
@@ -757,6 +757,52 @@ public class UpsertHandlerTests
 
     [TestFixture]
     [Parallelizable]
+    public class Given_A_Repository_That_Returns_Failure_Etag_Mismatch_Target_Does_Not_Exist
+        : UpsertHandlerTests
+    {
+        internal class Repository : NotImplementedDocumentStoreRepository
+        {
+            public override Task<UpsertResult> UpsertDocument(IUpsertRequest upsertRequest)
+            {
+                return Task.FromResult<UpsertResult>(
+                    new UpsertFailureETagMisMatch(ETagPreconditionFailureReason.TargetDoesNotExist)
+                );
+            }
+        }
+
+        private readonly RequestInfo requestInfo = RequestInfoWithRelationalMappingSet("trace-id");
+
+        [SetUp]
+        public async Task Setup()
+        {
+            var (upsertHandler, serviceProvider) = Handler(new Repository());
+            requestInfo.ScopedServiceProvider = serviceProvider;
+            await upsertHandler.Execute(requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_has_the_correct_response()
+        {
+            requestInfo.FrontendResponse.StatusCode.Should().Be(412);
+
+            var body = requestInfo.FrontendResponse.Body!.AsObject();
+            body["detail"]!
+                .GetValue<string>()
+                .Should()
+                .Be("The If-Match precondition failed because the resource does not exist.");
+            body["errors"]![0]!
+                .GetValue<string>()
+                .Should()
+                .Be(
+                    "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match."
+                );
+            requestInfo.FrontendResponse.Headers.Should().BeEmpty();
+            requestInfo.FrontendResponse.LocationHeaderPath.Should().BeNull();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
     public class Given_A_Repository_That_Returns_Relationship_Not_Authorized : UpsertHandlerTests
     {
         internal class Repository : NotImplementedDocumentStoreRepository

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Utilities/EtagValueTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Utilities/EtagValueTests.cs
@@ -51,4 +51,25 @@ public class Given_EtagValue
         EtagValue.TryParseHeaderValue(null, out _).Should().BeFalse();
         EtagValue.TryParseHeaderValue(string.Empty, out _).Should().BeFalse();
     }
+
+    [Test]
+    public void It_round_trips_compose_and_parse()
+    {
+        var etag = EtagValue.Compose("5", "a1b2c3d4.j._.l");
+        EtagValue.TryParse(etag, out var contentVersion, out var variantKey).Should().BeTrue();
+        contentVersion.Should().Be("5");
+        variantKey.Should().Be("a1b2c3d4.j._.l");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("-a1b2c3d4.j._.l")] // empty content version
+    [TestCase("5-")] // empty variant key
+    [TestCase("nodash")]
+    public void It_rejects_malformed_values(string? value)
+    {
+        EtagValue.TryParse(value, out var contentVersion, out var variantKey).Should().BeFalse();
+        contentVersion.Should().BeEmpty();
+        variantKey.Should().BeEmpty();
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/DeleteByIdHandler.cs
@@ -118,16 +118,9 @@ internal class DeleteByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                 Body: FailureResponse.ForSystemError(requestInfo.FrontendRequest.TraceId),
                 Headers: []
             ),
-            DeleteFailureETagMisMatch => new FrontendResponse(
+            DeleteFailureETagMisMatch mismatch => new FrontendResponse(
                 StatusCode: 412,
-                Body: FailureResponse.ForETagMisMatch(
-                    "The item has been modified by another user.",
-                    traceId: requestInfo.FrontendRequest.TraceId,
-                    errors: new[]
-                    {
-                        "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
-                    }
-                ),
+                Body: FailureResponse.ForETagMisMatch(mismatch.Reason, requestInfo.FrontendRequest.TraceId),
                 Headers: []
             ),
             UnknownFailure failure => new(

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpdateByIdHandler.cs
@@ -80,16 +80,9 @@ internal class UpdateByIdHandler(ILogger _logger, ResiliencePipeline _resilience
                     updateSuccess.ExistingDocumentUuid
                 )
             ),
-            UpdateFailureETagMisMatch => new FrontendResponse(
+            UpdateFailureETagMisMatch mismatch => new FrontendResponse(
                 StatusCode: 412,
-                Body: FailureResponse.ForETagMisMatch(
-                    "The item has been modified by another user.",
-                    traceId: requestInfo.FrontendRequest.TraceId,
-                    errors: new[]
-                    {
-                        "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
-                    }
-                ),
+                Body: FailureResponse.ForETagMisMatch(mismatch.Reason, requestInfo.FrontendRequest.TraceId),
                 Headers: []
             ),
             UpdateFailureNotExists => new FrontendResponse(

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/UpsertHandler.cs
@@ -137,16 +137,9 @@ internal class UpsertHandler(ILogger _logger, ResiliencePipeline _resiliencePipe
                 Body: ForSystemError(requestInfo.FrontendRequest.TraceId),
                 Headers: []
             ),
-            UpsertFailureETagMisMatch => new(
+            UpsertFailureETagMisMatch mismatch => new(
                 StatusCode: 412,
-                Body: ForETagMisMatch(
-                    "The item has been modified by another user.",
-                    traceId: requestInfo.FrontendRequest.TraceId,
-                    errors: new[]
-                    {
-                        "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
-                    }
-                ),
+                Body: ForETagMisMatch(mismatch.Reason, requestInfo.FrontendRequest.TraceId),
                 Headers: []
             ),
             UpsertFailureNotAuthorized failure => new(

--- a/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Response/FailureResponse.cs
@@ -122,6 +122,27 @@ public static class FailureResponse
             errors: errors
         );
 
+    public static JsonNode ForETagMisMatch(ETagPreconditionFailureReason reason, TraceId traceId) =>
+        reason switch
+        {
+            ETagPreconditionFailureReason.TargetDoesNotExist => ForETagMisMatch(
+                "The If-Match precondition failed because the resource does not exist.",
+                traceId,
+                new[]
+                {
+                    "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match.",
+                }
+            ),
+            _ => ForETagMisMatch(
+                "The item has been modified by another user.",
+                traceId,
+                new[]
+                {
+                    "The resource item's etag value does not match what was specified in the 'If-Match' request header indicating that it has been modified by another client since it was last retrieved.",
+                }
+            ),
+        };
+
     public static JsonNode ForNotFound(string detail, TraceId traceId) =>
         CreateBaseJsonObject(
             detail,

--- a/src/dms/core/EdFi.DataManagementService.Core/Utilities/EtagValue.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Utilities/EtagValue.cs
@@ -20,10 +20,10 @@ public static class EtagValue
     public const char Separator = '-';
 
     /// <summary>
-    /// Splits an opaque etag value "{contentVersion}-{variantKey}" into its two parts. ContentVersion
-    /// is digits-only and variantKey characters are [a-z0-9_.], so the first '-' is the unambiguous
-    /// boundary. Returns <see langword="false"/> (and empty out-params) when either part is empty or
-    /// no separator is present. Callers that also need the header quote/weak-tag handling use
+    /// Splits an opaque etag value "{contentVersion}-{variantKey}" into its two parts. The variantKey
+    /// portion is guaranteed not to contain <see cref="Separator"/>, so the last '-' is the unambiguous
+    /// boundary. Returns <see langword="false"/> (and empty out-params) when either part is empty or no
+    /// separator is present. Callers that also need the header quote/weak-tag handling use
     /// <see cref="TryParseHeaderValue"/> first.
     /// </summary>
     public static bool TryParse(string? etagValue, out string contentVersion, out string variantKey)
@@ -36,7 +36,7 @@ public static class EtagValue
             return false;
         }
 
-        var separator = etagValue.IndexOf(Separator, StringComparison.Ordinal);
+        var separator = etagValue.LastIndexOf(Separator, StringComparison.Ordinal);
         if (separator <= 0 || separator == etagValue.Length - 1)
         {
             return false;

--- a/src/dms/core/EdFi.DataManagementService.Core/Utilities/EtagValue.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Utilities/EtagValue.cs
@@ -16,6 +16,37 @@ public static class EtagValue
     public static string Compose(string contentVersion, string variantKey) =>
         $"{contentVersion}-{variantKey}";
 
+    /// <summary>Separator between the ContentVersion and variantKey portions of an etag value.</summary>
+    public const char Separator = '-';
+
+    /// <summary>
+    /// Splits an opaque etag value "{contentVersion}-{variantKey}" into its two parts. ContentVersion
+    /// is digits-only and variantKey characters are [a-z0-9_.], so the first '-' is the unambiguous
+    /// boundary. Returns <see langword="false"/> (and empty out-params) when either part is empty or
+    /// no separator is present. Callers that also need the header quote/weak-tag handling use
+    /// <see cref="TryParseHeaderValue"/> first.
+    /// </summary>
+    public static bool TryParse(string? etagValue, out string contentVersion, out string variantKey)
+    {
+        contentVersion = string.Empty;
+        variantKey = string.Empty;
+
+        if (string.IsNullOrEmpty(etagValue))
+        {
+            return false;
+        }
+
+        var separator = etagValue.IndexOf(Separator, StringComparison.Ordinal);
+        if (separator <= 0 || separator == etagValue.Length - 1)
+        {
+            return false;
+        }
+
+        contentVersion = etagValue[..separator];
+        variantKey = etagValue[(separator + 1)..];
+        return true;
+    }
+
     /// <summary>Quotes an opaque etag value for the ETag / If-Match HTTP header (strong, no W/).</summary>
     public static string ToHeaderValue(string etagValue) => $"\"{etagValue}\"";
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -235,3 +235,42 @@ Feature: ETag validations
                       ]
                   }
                   """
+        @e2e-ci-shard-1
+        Scenario: 12 Ensure that a quoted If-Match (as emitted) is accepted on PUT
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "111111",
+                      "birthDate": "2014-08-14",
+                      "firstName": "Russella",
+                      "lastSurname": "Mayers"
+                  }
+                  """
+             Then it should respond with 201 or 200
+              And the quoted ETag is in the response header
+             When a PUT if-match "{IfMatchQuoted}" request is made to "/ed-fi/students/{id}" with
+                  """
+                  {
+                      "id": "{id}",
+                      "studentUniqueId": "111111",
+                      "birthDate": "2014-08-14",
+                      "firstName": "Russella",
+                      "lastSurname": "Mayorga"
+                  }
+                  """
+             Then it should respond with 204
+        @e2e-ci-shard-1
+        Scenario: 13 Ensure that a quoted If-Match (as emitted) is accepted on DELETE
+             When a POST request is made to "/ed-fi/students" with
+                  """
+                  {
+                      "studentUniqueId": "111111",
+                      "birthDate": "2014-08-14",
+                      "firstName": "Russella",
+                      "lastSurname": "Mayers"
+                  }
+                  """
+             Then it should respond with 201 or 200
+              And the quoted ETag is in the response header
+             When a DELETE if-match "{IfMatchQuoted}" request is made to "/ed-fi/students/{id}"
+             Then it should respond with 204

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Resources/etag.feature
@@ -204,8 +204,34 @@ Feature: ETag validations
                   }
                   """
              Then it should respond with 412
+              And the response body is
+                  """
+                  {
+                      "detail": "The If-Match precondition failed because the resource does not exist.",
+                      "type": "urn:ed-fi:api:optimistic-lock-failed",
+                      "title": "Optimistic Lock Failed",
+                      "status": 412,
+                      "validationErrors": {},
+                      "errors": [
+                          "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match."
+                      ]
+                  }
+                  """
         @e2e-ci-shard-1
         Scenario: 11 Ensure that a wildcard If-Match on a DELETE to a non-existent resource returns 412
              # The id value is a non-existing resource
              When a DELETE if-match "*" request is made to "/ed-fi/students/00000000-0000-4000-a000-000000000000"
              Then it should respond with 412
+              And the response body is
+                  """
+                  {
+                      "detail": "The If-Match precondition failed because the resource does not exist.",
+                      "type": "urn:ed-fi:api:optimistic-lock-failed",
+                      "title": "Optimistic Lock Failed",
+                      "status": 412,
+                      "validationErrors": {},
+                      "errors": [
+                          "The 'If-Match' request header requires a current representation of the resource, but none exists. Do not retry with If-Match; create the resource first, or omit If-Match."
+                      ]
+                  }
+                  """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -48,6 +48,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         private string _id = string.Empty;
         private string _location = string.Empty;
         private string _etag = string.Empty;
+        private string _rawEtag = string.Empty;
         private string _lastModifiedDate = string.Empty;
         private string _dependentId = string.Empty;
         private string _referencedResourceId = string.Empty;
@@ -566,6 +567,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             _logger.log.Information($"PUT body: {body}");
 
             ifMatch = ifMatch.Replace("{IfMatch}", _etag);
+            ifMatch = ifMatch.Replace("{IfMatchQuoted}", _rawEtag);
             _apiResponse = await _playwrightContext.ApiRequestContext?.PutAsync(
                 url,
                 new()
@@ -884,6 +886,7 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             _logger.log.Information($"DELETE url: {url}");
 
             ifMatch = ifMatch.Replace("{IfMatch}", _etag);
+            ifMatch = ifMatch.Replace("{IfMatchQuoted}", _rawEtag);
             _apiResponse = await _playwrightContext.ApiRequestContext?.DeleteAsync(
                 url,
                 new() { Headers = GetHeadersWithIfMatch(ifMatch) }
@@ -1640,6 +1643,14 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
         {
             _etag = StripEtagQuotes(_apiResponse.Headers["etag"]);
             _etag.Should().NotBeNullOrEmpty();
+        }
+
+        [Then("the quoted ETag is in the response header")]
+        public void ThenTheQuotedEtagIsInTheResponseHeader()
+        {
+            _rawEtag = _apiResponse.Headers["etag"];
+            _rawEtag.Should().NotBeNullOrEmpty();
+            _rawEtag.Should().StartWith("\"").And.EndWith("\""); // RFC 7232 §2.3 quoted strong validator
         }
 
         // The ETag response header is served as a quoted strong validator (RFC 7232 §2.3). Strip the


### PR DESCRIPTION
## Summary

Addresses nine findings from the PR #1091 review, layered as four sequenced, single-concern efforts on top of `etag-content-version`. (The GET-by-id-missing-etag finding is tracked separately as DMS-1266.)

**Refactor — contract consolidation (findings 5, 4, 9)**
- Typed wire-format grammar for the served etag: `EtagValue.TryParse` + `VariantKey.Components`/`FromComponents`/`TryParseComponents` (finding 5).
- Two focused services, `IServedEtagComposer` and `IIfMatchEvaluator`, replace duplicated etag construction/comparison across all five compose sites and the comparison sites (finding 4). Pure refactor — byte-identical output.
- Added a precondition-checker test guarding schema-epoch mismatch (finding 9).

**Functionality fixes (findings 2, 3)**
- Descriptor served `_etag` is now profile-sensitive (descriptors are profile-projected); `If-Match` stays profile-insensitive per the 2026-07-04 ADR amendment (compares only `ContentVersion` + `schemaEpoch`) (finding 2).
- `ETagPreconditionFailureReason { Concurrency, TargetDoesNotExist }` threaded to distinct 412 bodies. The concurrency body is kept **byte-identical** to legacy; a new, clearer body is returned when the target does not exist (finding 3).

**Test coverage (findings 8, 10)**
- E2E proves the RFC 7232 **quoted** `If-Match` round-trips verbatim on PUT and DELETE (scenarios 12/13) (finding 8).
- PostgreSQL + SQL Server integration fixtures prove profiled/unprofiled **DELETE** etag parity: a profiled-GET etag is accepted by an unprofiled DELETE; a stale profiled etag yields a 412; and the profiled etag is asserted to genuinely change on a hidden-field bump (finding 10).

**Cleanup (findings 11, 12)**
- Corrected stale "legacy content-hash fallback" XML docs on `RelationalReadMaterializer` — `ComposeEtag` throws when the etag inputs are absent; there is no fallback (finding 11).
- Debug-level structured logging at the three `If-Match` decision sites (precondition checker, write-execution resolver, descriptor write handler): single evaluation per path, the client `If-Match` value sanitized via `LoggingSanitizer`, all `IsEnabled(LogLevel.Debug)`-guarded (finding 12).

## Test Plan

- [x] Backend unit suite: 1890/1890 pass
- [x] PostgreSQL If-Match/profile integration: 17/17 pass
- [x] SQL Server If-Match/profile integration: 32/32 pass
- [x] E2E project builds clean (Reqnroll codegen) — **scenarios 12/13 to be exercised in CI** (require a running API + database stack)
- [x] Solution builds with 0 warnings / 0 errors (warnings-as-errors)

## Notes for reviewers

- **Client-visible API change:** a new 412 response body is returned when an `If-Match` targets a non-existent resource (distinct from the byte-identical-to-legacy concurrency body). Worth a deliberate human review of the wording.
- **Known follow-up:** the three finding-12 debug logs do not yet carry a TraceId/correlation id — their request contracts don't provide one; threading one is left as a scoped follow-up.

This work was developed with AI assistance (Claude Code); all changes were reviewed and a human remains accountable for the merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)