### PR TITLE
[DMS-1196] Focused review hardening: gateway host pinning, credential-revoking reset, portproxy reboot fix

### DIFF
--- a/eng/azure-vm/TROUBLESHOOTING.md
+++ b/eng/azure-vm/TROUBLESHOOTING.md
@@ -44,14 +44,19 @@ docker exec -it dms-sec-postgres psql -U postgres -l    # list databases
 | Bulk-load **`invalid_client` / 401** with a fresh key | `DMS-1231`, fixed in `:pre` ≥ 2026-06-24 (#1047) — generated secrets are now Basic-safe. On an older image the secret may contain `+`/`%`; re-mint until `+`/`%`/space-free, or URL-encode it in the Basic header. |
 | Bulk-load **429 / "circuit is now open"** mid-run | Rate limiter + circuit breaker (`FAILURE_RATIO=0.01`) tripped by parallel load. Load descriptors first, raise the rate limit, then resources; or use `seed/clone-data.sh`. |
 
-## Reset (keep the Keycloak realm)
+## Reset deployment state
 
-A `-v` reset empties the data DBs, so — like a first stand-up — bootstrap, schema provisioning,
-and the DMS start all have to run again (`reset.sh` prints these same steps on exit):
+A reset empties the data DBs and the Keycloak realm, so old review credentials are revoked. Like a
+first stand-up, bootstrap, schema provisioning, and the DMS start all have to run again
+(`reset.sh` prints these same steps on exit):
 
 ```bash
 ./reset.sh
-pwsh ./bootstrap/bootstrap.ps1 -SkipKeycloak -BaseUrl https://localhost -Insecure
+# wait for the freshly recreated identity/CMS services before bootstrap writes its attempted marker:
+until curl -skf https://localhost/auth/realms/master >/dev/null \
+  && curl -skf https://localhost/st-config/health >/dev/null \
+  && curl -skf https://localhost/mt-config/health >/dev/null; do sleep 5; done
+pwsh ./bootstrap/bootstrap.ps1 -BaseUrl https://localhost -Insecure
 # provision the relational schema into edfi_st / edfi_mt / edfi_mt_t2
 # (api-schema-tools, or restore the populated template; see ../docs/infrastructure.md), then:
 ./up.sh st-dms mt-dms

--- a/eng/azure-vm/compose/.env.example
+++ b/eng/azure-vm/compose/.env.example
@@ -6,7 +6,9 @@
 # Generate strong secrets, e.g.:  openssl rand -base64 32
 #
 # Client secrets must be 32-128 chars with at least one lowercase, uppercase,
-# digit, and special character (! @ # $ % ^ & * ( ) - _ = + [ ] { } : ; , . ?).
+# digit, and special character (! @ # ^ * ( ) - _ = + [ ] { } : ; , . ?).
+# Never use '$' in any value here: docker compose interpolates $VAR/${VAR} inside .env, so the
+# containers would receive a DIFFERENT value than the deployment scripts read (bootstrap refuses).
 
 # ---------------------------------------------------------------------------
 # Public address (how the review team reaches the gateway)

--- a/eng/azure-vm/compose/bootstrap/bootstrap.ps1
+++ b/eng/azure-vm/compose/bootstrap/bootstrap.ps1
@@ -18,7 +18,6 @@
 #   pwsh ./bootstrap.ps1                 # uses ../.env
 #   pwsh ./bootstrap.ps1 -Insecure       # local self-signed cert
 #   pwsh ./bootstrap.ps1 -SkipKeycloak   # realm/clients already created
-#   pwsh ./bootstrap.ps1 -KeycloakOnly   # rebuild realm/clients after wiping only Keycloak H2
 [CmdletBinding()]
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ClaimSetName', Justification = 'Consumed as the default value of the New-ReviewApplication -ClaimSet parameter; the analyzer does not track usage inside nested function parameter defaults.')]
 param(
@@ -29,12 +28,10 @@ param(
     # public-IP hairpin issues.
     [string]$BaseUrl = "",
     [switch]$SkipKeycloak,
-    [switch]$KeycloakOnly,
     [switch]$Insecure
 )
 
 $ErrorActionPreference = "Stop"
-if ($SkipKeycloak -and $KeycloakOnly) { throw "-SkipKeycloak and -KeycloakOnly cannot be used together." }
 # Reuse the repo's canonical management module (no vendored copy).
 Import-Module "$PSScriptRoot/../../../Dms-Management.psm1" -Force
 
@@ -89,6 +86,19 @@ $pgCredential  = ConvertTo-PostgresCredential -UserName $pgUser -Secret $pgPassw
 $schoolYear    = EnvVal "MT_SCHOOL_YEAR" "2025"
 $tenant1       = EnvVal "MT_TENANT_1" "tenant1"
 $tenant2       = EnvVal "MT_TENANT_2" "tenant2"
+$maximumTenantNameLength = 19
+foreach ($tenantName in @($tenant1, $tenant2)) {
+    if ($tenantName -notmatch '^[a-zA-Z0-9_-]+$') {
+        throw "Tenant name '$tenantName' is invalid. Use only letters, digits, underscores, and hyphens."
+    }
+    if ($tenantName.Length -gt $maximumTenantNameLength) {
+        throw ("Tenant name '$tenantName' is too long for the generated API-client name. " +
+            "MT_TENANT_1 and MT_TENANT_2 must contain at most $maximumTenantNameLength characters.")
+    }
+}
+if ($tenant1.Equals($tenant2, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "MT_TENANT_1 and MT_TENANT_2 must be distinct (case-insensitive)."
+}
 $adminClientId     = EnvVal "BOOTSTRAP_ADMIN_CLIENT_ID" "dms-bootstrap-admin"
 $adminClientSecret = EnvVal "BOOTSTRAP_ADMIN_CLIENT_SECRET"
 # The service client ids/scope MUST be the ones the compose services request: read them from
@@ -107,22 +117,19 @@ $mtConfig = "$publicBaseUrl/mt-config/"
 $created = [System.Collections.Generic.List[object]]::new()
 
 # Own CMS bootstrap state here, rather than in setup-env.ps1, so the documented direct invocation
-# and the wrapper follow the same recovery contract. -KeycloakOnly deliberately does not consult or
-# change these markers because it recreates no CMS objects.
+# and the wrapper follow the same recovery contract.
 $stateDirectory = Join-Path $PSScriptRoot "../.bootstrap"
 $bootstrapAttempted = Join-Path $stateDirectory "bootstrap-attempted"
 $bootstrapComplete = Join-Path $stateDirectory "bootstrap-complete"
-if (-not $KeycloakOnly) {
-    if (Test-Path $bootstrapComplete) {
-        throw "Bootstrap already completed. Refusing to duplicate CMS objects. Run ./reset.sh before bootstrapping again."
-    }
-    if (Test-Path $bootstrapAttempted) {
-        throw ("A previous bootstrap did not complete. Refusing to duplicate partial CMS objects. " +
-            "Run ./reset.sh, or ./down.sh -v if Keycloak setup was partial, before retrying.")
-    }
-    New-Item -ItemType Directory -Path $stateDirectory -Force | Out-Null
-    New-Item -ItemType File -Path $bootstrapAttempted -Force | Out-Null
+if (Test-Path $bootstrapComplete) {
+    throw "Bootstrap already completed. Refusing to duplicate CMS objects. Run ./reset.sh before bootstrapping again."
 }
+if (Test-Path $bootstrapAttempted) {
+    throw ("A previous bootstrap did not complete. Refusing to duplicate partial identity/CMS objects. " +
+        "Run ./reset.sh before retrying; reset removes both application and Keycloak state.")
+}
+New-Item -ItemType Directory -Path $stateDirectory -Force | Out-Null
+New-Item -ItemType File -Path $bootstrapAttempted -Force | Out-Null
 
 # --- 1. Keycloak realm + service clients ------------------------------------
 if (-not $SkipKeycloak) {
@@ -154,10 +161,6 @@ if (-not $SkipKeycloak) {
     & "$PSScriptRoot/../../../docker-compose/setup-keycloak.ps1" -KeycloakServer $kc -Realm $realm -AdminUsername $kcAdmin -AdminPassword $kcAdminPw `
         -NewClientId $adminClientId -NewClientName "DMS Bootstrap Admin" `
         -ClientScopeName "edfi_admin_api/full_access" -NewClientSecret $adminClientSecret -SkipRealmAdmin
-}
-if ($KeycloakOnly) {
-    Write-Output "Keycloak realm and service clients recreated; existing CMS state was not modified."
-    return
 }
 
 # --- Helper: provision one application and capture credentials --------------

--- a/eng/azure-vm/compose/bootstrap/bootstrap.ps1
+++ b/eng/azure-vm/compose/bootstrap/bootstrap.ps1
@@ -72,7 +72,15 @@ foreach ($line in Get-Content $EnvFile) {
     $envValues[$trimmed.Substring(0, $idx).Trim()] = $value
 }
 function EnvVal([string]$key, [string]$default = "") {
-    if ($envValues.ContainsKey($key) -and $envValues[$key]) { return $envValues[$key] }
+    if ($envValues.ContainsKey($key) -and $envValues[$key]) {
+        # docker compose interpolates $VAR/${VAR} inside .env, but this script reads the file
+        # literally -- a '$' in a value means the containers and this script would disagree on it
+        # (e.g. Keycloak gets one client secret, the CMS/DMS containers another). Refuse outright.
+        if ($envValues[$key] -match '\$') {
+            throw ".env value '$key' contains '$', which docker compose interpolates. Use a value without '$'."
+        }
+        return $envValues[$key]
+    }
     return $default
 }
 
@@ -121,6 +129,13 @@ $created = [System.Collections.Generic.List[object]]::new()
 $stateDirectory = Join-Path $PSScriptRoot "../.bootstrap"
 $bootstrapAttempted = Join-Path $stateDirectory "bootstrap-attempted"
 $bootstrapComplete = Join-Path $stateDirectory "bootstrap-complete"
+$resetPending = Join-Path $stateDirectory "reset-pending"
+if (Test-Path $resetPending) {
+    # reset.sh / down.sh -v clear the markers before the destructive down and remove this sentinel
+    # only after it succeeds. While it exists the volumes may still hold live identity/CMS state,
+    # and this script's creates are not idempotent.
+    throw "A destructive reset did not finish. Re-run ./reset.sh (or ./down.sh -v) until it succeeds before bootstrapping."
+}
 if (Test-Path $bootstrapComplete) {
     throw "Bootstrap already completed. Refusing to duplicate CMS objects. Run ./reset.sh before bootstrapping again."
 }
@@ -199,9 +214,10 @@ Write-Output "== Bootstrapping single-tenant stack ($stConfig) =="
 $stToken = Get-CmsToken -CmsUrl $stConfig -ClientId $adminClientId -ClientSecret $adminClientSecret
 $stDataStoreId = Add-DataStore -CmsUrl $stConfig -AccessToken $stToken -Name "Single-Tenant Data Store" `
     -DataStoreType "Review" -PostgresHost "postgres" -PostgresDbName "edfi_st" -PostgresCredential $pgCredential
-# Full-access single-tenant client. (Scope: single-tenant + two isolated tenants.)
+# Full-access single-tenant client. Uses the same -ClaimSetName as the multi-tenant apps (default
+# E2E-NoFurtherAuthRequiredClaimSet) so an override applies consistently across all three.
 New-ReviewApplication -CmsUrl $stConfig -Label "single-tenant/full" -Token $stToken `
-    -DataStoreIds @([long]$stDataStoreId) -ClaimSet "E2E-NoFurtherAuthRequiredClaimSet"
+    -DataStoreIds @([long]$stDataStoreId)
 # To demo school/district-level authorization, add an EdOrg-scoped client via the CMS, e.g.
 # New-ReviewApplication ... -ClaimSet "E2E-RelationshipsWithEdOrgsOnlyClaimSet" -EducationOrganizationIds @([long]255901)
 

--- a/eng/azure-vm/compose/bootstrap/bootstrap.ps1
+++ b/eng/azure-vm/compose/bootstrap/bootstrap.ps1
@@ -71,16 +71,18 @@ foreach ($line in Get-Content $EnvFile) {
     }
     $envValues[$trimmed.Substring(0, $idx).Trim()] = $value
 }
+# Validate the WHOLE file up front -- before any Keycloak/CMS mutation and before the attempted
+# marker is written, so a bad value can never strand a half-bootstrapped environment. docker
+# compose interpolates $VAR/${VAR} inside .env, but this script reads the file literally: a '$'
+# in any value means the containers and this script would disagree on it (e.g. Keycloak gets one
+# client secret, the CMS/DMS containers another).
+$dollarKeys = @($envValues.Keys | Where-Object { $envValues[$_] -match '\$' } | Sort-Object)
+if ($dollarKeys.Count -gt 0) {
+    throw (".env values contain '$', which docker compose interpolates differently than the " +
+        "deployment scripts read it: $($dollarKeys -join ', '). Use values without '$'.")
+}
 function EnvVal([string]$key, [string]$default = "") {
-    if ($envValues.ContainsKey($key) -and $envValues[$key]) {
-        # docker compose interpolates $VAR/${VAR} inside .env, but this script reads the file
-        # literally -- a '$' in a value means the containers and this script would disagree on it
-        # (e.g. Keycloak gets one client secret, the CMS/DMS containers another). Refuse outright.
-        if ($envValues[$key] -match '\$') {
-            throw ".env value '$key' contains '$', which docker compose interpolates. Use a value without '$'."
-        }
-        return $envValues[$key]
-    }
+    if ($envValues.ContainsKey($key) -and $envValues[$key]) { return $envValues[$key] }
     return $default
 }
 

--- a/eng/azure-vm/compose/docker-compose.yml
+++ b/eng/azure-vm/compose/docker-compose.yml
@@ -14,8 +14,8 @@
 #   /pgadmin    pgAdmin (direct database access for the review team)
 #
 # The two stacks are byte-identical images differing only by the multitenancy
-# flags, path base, and per-stack database. Keycloak lives in keycloak.yml so its
-# realm/clients survive `reset.sh` (which drops only the app+db volumes).
+# flags, path base, and per-stack database. Keycloak lives in keycloak.yml so its lifecycle can be
+# managed explicitly; destructive reset includes it so stale review clients cannot survive CMS.
 #
 # NOT FOR PRODUCTION. Contains review-only default secrets.
 

--- a/eng/azure-vm/compose/down.sh
+++ b/eng/azure-vm/compose/down.sh
@@ -13,15 +13,19 @@ ARGS=()
 for arg in "$@"; do
   case "$arg" in
     -y | --yes | --force) FORCE=true ;;
-    -v | --volumes)
+    -v | --volumes | --volume)   # --volume is Compose's deprecated (but accepted) alias
       wants_volumes=true
       ARGS+=("$arg")
       ;;
-    -v=* | --volumes=*)
-      # Docker's boolean parser accepts these truthy spellings. Mirror it so no accepted
-      # volume-removal form can bypass confirmation or bootstrap-marker cleanup.
+    -v=* | --volumes=* | --volume=*)
+      # Docker's boolean parser accepts these spellings, and a REPEATED flag uses the last
+      # value (`-v --volumes=false` preserves volumes). Assign per occurrence -- never latch --
+      # so the wrapper's effective value matches what Compose will actually do.
       volume_value="${arg#*=}"
-      case "$volume_value" in 1 | t | T | true | TRUE | True) wants_volumes=true ;; esac
+      case "$volume_value" in
+        1 | t | T | true | TRUE | True) wants_volumes=true ;;
+        0 | f | F | false | FALSE | False) wants_volumes=false ;;
+      esac
       ARGS+=("$arg")
       ;;
     --*) ARGS+=("$arg") ;;   # other long flags (e.g. --remove-orphans) never remove volumes
@@ -65,7 +69,8 @@ else
   docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down "${ARGS[@]}"
 fi
 
-# The destructive down completed; clear the sentinel so bootstrap may run again.
+# The destructive down completed; clear the sentinel so bootstrap may run again, and the
+# recorded Keycloak image reference (update.sh's pin guard) -- the volume it described is gone.
 if [ "$wants_volumes" = true ]; then
-  rm -f .bootstrap/reset-pending
+  rm -f .bootstrap/reset-pending .bootstrap/keycloak-image
 fi

--- a/eng/azure-vm/compose/down.sh
+++ b/eng/azure-vm/compose/down.sh
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Stop the environment. Pass -v to also delete volumes (DROPS the Keycloak realm
-# and all databases). For a data-only reset that KEEPS Keycloak, use reset.sh.
-# -v is confirmed interactively (same contract as reset.sh, which guards a strictly
-# LESS destructive drop); pass -y/--force for automation.
+# and all databases). reset.sh performs the same state drop plus the ordered infra/CMS restart.
+# -v is confirmed interactively (same contract as reset.sh); pass -y/--force for automation.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
@@ -37,17 +36,18 @@ if [ "$wants_volumes" = true ] && [ "$FORCE" != true ]; then
   fi
 fi
 
+# A volume drop (-v) means the config + Keycloak state is going away, so bootstrap must run again.
+# Remove both bootstrap markers BEFORE the down: if the down is interrupted after removing some
+# volumes, a surviving stale "complete" marker would make setup-env.ps1 skip bootstrap against
+# wiped databases (matches reset.sh).
+if [ "$wants_volumes" = true ]; then
+  rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
+fi
+
 # Bash 3.2 with `set -u` treats an empty-array expansion as an unbound variable. Keep the
 # no-argument path explicit so the wrapper also works with the macOS system Bash.
 if [ ${#ARGS[@]} -eq 0 ]; then
   docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down
 else
   docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down "${ARGS[@]}"
-fi
-
-# If volumes were dropped (-v), the config + Keycloak state is gone, so bootstrap must run again.
-# Remove both bootstrap markers so a later setup-env.ps1 re-bootstraps instead of trusting a stale
-# "complete" marker against empty databases (matches reset.sh).
-if [ "$wants_volumes" = true ]; then
-  rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
 fi

--- a/eng/azure-vm/compose/down.sh
+++ b/eng/azure-vm/compose/down.sh
@@ -24,6 +24,14 @@ for arg in "$@"; do
       case "$volume_value" in 1 | t | T | true | TRUE | True) wants_volumes=true ;; esac
       ARGS+=("$arg")
       ;;
+    --*) ARGS+=("$arg") ;;   # other long flags (e.g. --remove-orphans) never remove volumes
+    -*v*)
+      # Docker bundles single-dash short flags (pflag): `-vt 0` means `-v -t 0`. Treat any
+      # short-flag cluster containing 'v' as a volume drop so bundling cannot bypass the
+      # confirmation or the marker/sentinel handling below.
+      wants_volumes=true
+      ARGS+=("$arg")
+      ;;
     *) ARGS+=("$arg") ;;
   esac
 done
@@ -39,8 +47,13 @@ fi
 # A volume drop (-v) means the config + Keycloak state is going away, so bootstrap must run again.
 # Remove both bootstrap markers BEFORE the down: if the down is interrupted after removing some
 # volumes, a surviving stale "complete" marker would make setup-env.ps1 skip bootstrap against
-# wiped databases (matches reset.sh).
+# wiped databases. The reset-pending sentinel covers the opposite failure: if the down fails with
+# the volumes still INTACT, absent markers alone would let a re-run bootstrap duplicate the
+# still-live identity/CMS objects -- bootstrap.ps1 refuses while the sentinel exists, and it is
+# removed only after the down succeeds (matches reset.sh).
 if [ "$wants_volumes" = true ]; then
+  mkdir -p .bootstrap
+  : > .bootstrap/reset-pending
   rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
 fi
 
@@ -50,4 +63,9 @@ if [ ${#ARGS[@]} -eq 0 ]; then
   docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down
 else
   docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down "${ARGS[@]}"
+fi
+
+# The destructive down completed; clear the sentinel so bootstrap may run again.
+if [ "$wants_volumes" = true ]; then
+  rm -f .bootstrap/reset-pending
 fi

--- a/eng/azure-vm/compose/keycloak.yml
+++ b/eng/azure-vm/compose/keycloak.yml
@@ -2,8 +2,8 @@
 #
 # Shared Keycloak identity provider for the security-review environment.
 #
-# Kept in a separate compose file (as in AdminApp-v4-security-review) so its
-# realm + clients survive `reset.sh`, which drops only the app/database volumes.
+# Kept in a separate compose file (as in AdminApp-v4-security-review) so identity lifecycle remains
+# explicit. reset.sh includes this file and drops the realm so stale review credentials are revoked.
 # Reachable through the gateway at /auth.
 #
 # Realm + service clients are created by bootstrap/bootstrap.ps1 (which imports the
@@ -35,10 +35,10 @@ services:
       KC_HEALTH_ENABLED: "true"
       KC_LOG_CONSOLE_LEVEL: "${KEYCLOAK_LOG_LEVEL:-info}"
     # The volume persists Keycloak's default dev-file H2 database. Keycloak does NOT support
-    # H2 migration across version bumps -- when changing the image pin above, remove the
-    # dms-security-review_dms-sec-keycloak volume and run bootstrap.ps1 -KeycloakOnly (or configure
-    # KC_DB against a real database if realm durability across upgrades matters). Production-mode
-    # `start` without
+    # H2 migration across version bumps -- when changing the image pin above, perform a clean
+    # redeploy (provision/REDEPLOY.md); recreating only the service clients would not restore the
+    # review-application clients referenced by CMS. Alternatively, configure KC_DB against a real
+    # database if realm durability across upgrades matters. Production-mode `start` without
     # a real DB is deprecated upstream and slated to be refused in a future major release
     # (Keycloak has not committed to a specific version).
     volumes:

--- a/eng/azure-vm/compose/nginx/default.conf.template
+++ b/eng/azure-vm/compose/nginx/default.conf.template
@@ -17,10 +17,24 @@ server {
     return 301 https://${PUBLIC_HOST}$request_uri;
 }
 
+# Reject TLS requests for any hostname other than the configured public endpoint. Without this
+# default server, the sole TLS vhost also accepts attacker-controlled Host values and forwards them
+# into applications that trust the gateway's X-Forwarded-* headers.
+server {
+    listen 443 ssl default_server;
+    http2 on;
+    server_name _;
+    ssl_certificate     /ssl/server.crt;
+    ssl_certificate_key /ssl/server.key;
+    return 421;
+}
+
 server {
     listen 443 ssl;
     http2 on;
-    server_name ${PUBLIC_HOST};
+    # localhost is the documented VM-loopback bootstrap/health path. Forwarded authorities are
+    # pinned below, so accepting localhost here cannot poison public metadata.
+    server_name ${PUBLIC_HOST} localhost;
 
     # Self-signed locally; replace with Let's Encrypt fullchain/privkey on the VM
     # (see provision/ runbook). Keep these filenames or symlink the LE files to them.
@@ -51,9 +65,9 @@ server {
         resolver 127.0.0.11 valid=10s;
         set $u_st_dms st-dms;
         proxy_pass http://$u_st_dms:8080;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Port ${EXTERNAL_PORT};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
@@ -62,9 +76,9 @@ server {
         resolver 127.0.0.11 valid=10s;
         set $u_st_config st-config;
         proxy_pass http://$u_st_config:8081;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Port ${EXTERNAL_PORT};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
@@ -74,9 +88,9 @@ server {
         resolver 127.0.0.11 valid=10s;
         set $u_mt_dms mt-dms;
         proxy_pass http://$u_mt_dms:8080;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Port ${EXTERNAL_PORT};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
@@ -85,9 +99,9 @@ server {
         resolver 127.0.0.11 valid=10s;
         set $u_mt_config mt-config;
         proxy_pass http://$u_mt_config:8081;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Port ${EXTERNAL_PORT};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
@@ -97,11 +111,11 @@ server {
         resolver 127.0.0.11 valid=10s;
         set $u_kc dms-keycloak;
         proxy_pass http://$u_kc:8080;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Host ${PUBLIC_HOST};
         proxy_set_header X-Forwarded-Port ${EXTERNAL_PORT};
     }
 
@@ -111,7 +125,7 @@ server {
         set $u_pg pgadmin;
         proxy_pass http://$u_pg:80;
         proxy_set_header X-Script-Name /pgadmin;
-        proxy_set_header Host $host;
+        proxy_set_header Host ${PUBLIC_HOST};
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/eng/azure-vm/compose/reset.sh
+++ b/eng/azure-vm/compose/reset.sh
@@ -34,7 +34,9 @@ mkdir -p .bootstrap
 : > .bootstrap/reset-pending
 rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
 docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down -v
-rm -f .bootstrap/reset-pending
+# Volumes are gone: clear the sentinel and the recorded Keycloak image reference (update.sh's
+# pin guard) -- a fresh volume may be created under any pin.
+rm -f .bootstrap/reset-pending .bootstrap/keycloak-image
 
 # Restart infra + CMS + gateway ONLY -- NOT st-dms/mt-dms. After a -v reset the data DBs are empty
 # and the relational schema is gone, so the DMS services would crash-loop on boot (they fail fast

--- a/eng/azure-vm/compose/reset.sh
+++ b/eng/azure-vm/compose/reset.sh
@@ -1,33 +1,34 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 #
-# Data reset: drop the app + database volumes and restart infra + CMS + gateway only, while
-# KEEPING the Keycloak realm/clients (keycloak.yml is not passed to `down -v`, so its volume is
-# preserved). The DMS services and the relational schema are NOT recreated here -- like a first
+# Environment-state reset: drop the app/database AND Keycloak volumes, then restart infra + CMS +
+# gateway only. Keycloak must be reset too: review applications are identity-provider clients, and
+# preserving them while dropping CMS would leave old API credentials valid against reassigned data-
+# store IDs. The DMS services and the relational schema are NOT recreated here -- like a first
 # stand-up they come last, after bootstrap + schema. This script prints those remaining steps.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
-# Guard the destructive `down -v`: it wipes every app + database volume (edfi_st/mt/... data is
-# permanently lost). Require an explicit confirmation so a stray ./reset.sh cannot nuke data --
+# Guard the destructive `down -v`: it permanently wipes every app/database volume and the Keycloak
+# realm. Require explicit confirmation so a stray ./reset.sh cannot nuke deployment state --
 # type 'reset' at the interactive prompt, or pass -y/--force (e.g. for automation).
 FORCE=false
 case "${1:-}" in -y | --yes | --force) FORCE=true ;; esac
 if [ "$FORCE" != true ]; then
   if [ -t 0 ]; then
-    read -r -p "This DROPS all app + database volumes (data lost; Keycloak realm kept). Type 'reset' to continue: " ans
+    read -r -p "This DROPS all app/database volumes AND the Keycloak realm. Type 'reset' to continue: " ans
     [ "$ans" = "reset" ] || { echo "Aborted."; exit 1; }
   else
-    echo "ERROR: refusing to drop all app + database volumes non-interactively. Re-run with -y/--force."; exit 1
+    echo "ERROR: refusing to drop application, database, and Keycloak state non-interactively. Re-run with -y/--force."; exit 1
   fi
 fi
 
-echo "Dropping app + database volumes (Keycloak realm is preserved)..."
-docker compose -f docker-compose.yml --env-file .env down -v
-
-# The config DB was just dropped, so bootstrap must run again: remove both bootstrap markers so a
-# setup-env.ps1 re-run re-bootstraps cleanly (matching the manual step printed below).
+echo "Dropping app/database volumes and the Keycloak realm..."
+# Clear the markers BEFORE the destructive attempt: if the down is interrupted after removing some
+# volumes, a surviving "complete" marker would make setup-env.ps1 skip bootstrap against wiped
+# state. A cleared marker on an intact deployment only costs a refused (not duplicated) bootstrap.
 rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
+docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down -v
 
 # Restart infra + CMS + gateway ONLY -- NOT st-dms/mt-dms. After a -v reset the data DBs are empty
 # and the relational schema is gone, so the DMS services would crash-loop on boot (they fail fast
@@ -38,11 +39,11 @@ docker compose -f docker-compose.yml -f keycloak.yml --env-file .env up -d --no-
   postgres keycloak st-config mt-config pgadmin gateway
 
 echo
-echo "Reset complete. The Keycloak realm + clients survived; finish the rebuild in order:"
-echo "  1. Re-create CMS clients/tenants/data stores (Keycloak is already set up). Wait until"
+echo "Reset complete. All prior review credentials were revoked with the Keycloak realm; rebuild in order:"
+echo "  1. Re-create the realm/clients plus CMS tenants/data stores. Wait until"
 echo "     https://localhost/st-config/health and /mt-config/health return 200 (the CMS"
 echo "     containers were just recreated), then:"
-echo "         pwsh ./bootstrap/bootstrap.ps1 -SkipKeycloak -BaseUrl https://localhost -Insecure"
+echo "         pwsh ./bootstrap/bootstrap.ps1 -BaseUrl https://localhost -Insecure"
 echo "  2. Provision the relational schema into edfi_st / edfi_mt / edfi_mt_t2"
 echo "     (api-schema-tools; see ../docs/infrastructure.md \"Provisioning method\")."
 echo "  3. Start the DMS services:  ./up.sh st-dms mt-dms"

--- a/eng/azure-vm/compose/reset.sh
+++ b/eng/azure-vm/compose/reset.sh
@@ -26,9 +26,15 @@ fi
 echo "Dropping app/database volumes and the Keycloak realm..."
 # Clear the markers BEFORE the destructive attempt: if the down is interrupted after removing some
 # volumes, a surviving "complete" marker would make setup-env.ps1 skip bootstrap against wiped
-# state. A cleared marker on an intact deployment only costs a refused (not duplicated) bootstrap.
+# state. The reset-pending sentinel covers the opposite failure: if the down fails with the
+# volumes still INTACT, absent markers alone would let a re-run bootstrap duplicate the still-live
+# identity/CMS objects -- bootstrap.ps1 refuses while the sentinel exists, and it is removed only
+# after the down succeeds (matches down.sh -v).
+mkdir -p .bootstrap
+: > .bootstrap/reset-pending
 rm -f .bootstrap/bootstrap-attempted .bootstrap/bootstrap-complete
 docker compose -f docker-compose.yml -f keycloak.yml --env-file .env down -v
+rm -f .bootstrap/reset-pending
 
 # Restart infra + CMS + gateway ONLY -- NOT st-dms/mt-dms. After a -v reset the data DBs are empty
 # and the relational schema is gone, so the DMS services would crash-loop on boot (they fail fast

--- a/eng/azure-vm/compose/seed/grandbend.sh
+++ b/eng/azure-vm/compose/seed/grandbend.sh
@@ -80,7 +80,8 @@ echo "Template SQL: $(basename "$sql")"
 # --- GUARD: refuse the legacy document-store template on a relational backend ----------
 # A relational template creates per-resource edfi.* tables and the dms.EffectiveSchema
 # fingerprint table; the legacy document-store template has neither.
-if ! grep -qiE 'create schema edfi|create table edfi\.|effectiveschema' "$sql"; then
+if ! grep -qiE 'create schema edfi|create table edfi\.' "$sql" ||
+   ! grep -qi 'effectiveschema' "$sql"; then
   cat >&2 <<EOF
 ERROR: '$PKG_ID' $PKG_VER looks like the LEGACY DOCUMENT-STORE template (no edfi.* tables
        and no dms.EffectiveSchema). This stack runs the RELATIONAL backend, which rejects

--- a/eng/azure-vm/compose/update.sh
+++ b/eng/azure-vm/compose/update.sh
@@ -22,13 +22,30 @@ fi
 # Keycloak's persisted dev-file H2 database cannot cross image-pin changes (see keycloak.yml).
 # If the pull above brought a compose config with a different Keycloak pin, recreating the
 # container below would apply it to the unmigratable volume -- refuse and point at the redeploy.
+# The deployed reference comes from the container when it exists, else from the reference file
+# this script persists (a plain ./down.sh removes the container but keeps the volume). When the
+# volume exists and neither source is available, FAIL CLOSED: an unverifiable pin must not be
+# applied to live realm state.
 configured_keycloak="$(docker compose -f docker-compose.yml -f keycloak.yml --env-file .env config --images | grep -m1 -i 'keycloak' || true)"
+keycloak_ref_file=".bootstrap/keycloak-image"
 current_keycloak="$(docker inspect --format '{{.Config.Image}}' dms-sec-keycloak 2>/dev/null || true)"
-if [ -n "$current_keycloak" ] && [ -n "$configured_keycloak" ] && [ "$current_keycloak" != "$configured_keycloak" ]; then
-  echo "ERROR: this update changes the Keycloak image ($current_keycloak -> $configured_keycloak)," >&2
-  echo "       but the persisted H2 realm volume cannot be migrated across Keycloak images." >&2
-  echo "       No containers were recreated. Follow provision/REDEPLOY.md for a clean redeploy." >&2
-  exit 1
+if [ -z "$current_keycloak" ] && [ -f "$keycloak_ref_file" ]; then
+  current_keycloak="$(cat "$keycloak_ref_file")"
+fi
+if docker volume inspect dms-security-review_dms-sec-keycloak >/dev/null 2>&1; then
+  if [ -z "$current_keycloak" ]; then
+    echo "ERROR: the Keycloak H2 volume exists but its deployed image cannot be determined" >&2
+    echo "       (no dms-sec-keycloak container and no $keycloak_ref_file). Refusing to update:" >&2
+    echo "       a changed pin would be applied to unmigratable realm state. Verify the configured" >&2
+    echo "       pin matches the volume's Keycloak version, or use provision/REDEPLOY.md." >&2
+    exit 1
+  fi
+  if [ -n "$configured_keycloak" ] && [ "$current_keycloak" != "$configured_keycloak" ]; then
+    echo "ERROR: this update changes the Keycloak image ($current_keycloak -> $configured_keycloak)," >&2
+    echo "       but the persisted H2 realm volume cannot be migrated across Keycloak images." >&2
+    echo "       No containers were recreated. Follow provision/REDEPLOY.md for a clean redeploy." >&2
+    exit 1
+  fi
 fi
 
 echo "Pulling latest images..."
@@ -39,5 +56,12 @@ echo "Recreating changed containers..."
 # depends_on pulls the DMS services) would otherwise crash-loop st-dms/mt-dms against an empty
 # /app/ApiSchema on an environment that was provisioned but never had its schema staged.
 ./up.sh
+
+# Record the now-deployed Keycloak reference so the pin guard above still works after a plain
+# ./down.sh removes the container while keeping the H2 volume.
+if [ -n "$configured_keycloak" ]; then
+  mkdir -p .bootstrap
+  printf '%s\n' "$configured_keycloak" > "$keycloak_ref_file"
+fi
 
 echo "Update complete."

--- a/eng/azure-vm/compose/update.sh
+++ b/eng/azure-vm/compose/update.sh
@@ -19,6 +19,18 @@ if [ "${SKIP_GIT:-0}" != "1" ] && git -C . rev-parse --git-dir >/dev/null 2>&1; 
   fi
 fi
 
+# Keycloak's persisted dev-file H2 database cannot cross image-pin changes (see keycloak.yml).
+# If the pull above brought a compose config with a different Keycloak pin, recreating the
+# container below would apply it to the unmigratable volume -- refuse and point at the redeploy.
+configured_keycloak="$(docker compose -f docker-compose.yml -f keycloak.yml --env-file .env config --images | grep -m1 -i 'keycloak' || true)"
+current_keycloak="$(docker inspect --format '{{.Config.Image}}' dms-sec-keycloak 2>/dev/null || true)"
+if [ -n "$current_keycloak" ] && [ -n "$configured_keycloak" ] && [ "$current_keycloak" != "$configured_keycloak" ]; then
+  echo "ERROR: this update changes the Keycloak image ($current_keycloak -> $configured_keycloak)," >&2
+  echo "       but the persisted H2 realm volume cannot be migrated across Keycloak images." >&2
+  echo "       No containers were recreated. Follow provision/REDEPLOY.md for a clean redeploy." >&2
+  exit 1
+fi
+
 echo "Pulling latest images..."
 docker compose -f docker-compose.yml -f keycloak.yml --env-file .env pull
 

--- a/eng/azure-vm/http/single-tenant.http
+++ b/eng/azure-vm/http/single-tenant.http
@@ -28,7 +28,7 @@ Authorization: Bearer {{token.response.body.access_token}}
 Content-Type: application/json
 
 {
-  "schoolId": 255901001,
+  "schoolId": 255901999,
   "nameOfInstitution": "Security Review High School",
   "educationOrganizationCategories": [
     { "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School" }

--- a/eng/azure-vm/provision/MANUAL.md
+++ b/eng/azure-vm/provision/MANUAL.md
@@ -66,7 +66,12 @@ az vm create \
 ## Step 3 — NSG inbound rules (workstation)
 
 ```bash
-NSG=$(az network nsg list -g "$RG" --query "[0].name" -o tsv)
+# Resolve the NSG actually attached to THIS VM's NIC -- "first NSG in the resource group"
+# targets the wrong NSG as soon as the group holds more than one.
+NIC_ID=$(az vm show -g "$RG" -n "$VM" --query "networkProfile.networkInterfaces[0].id" -o tsv)
+NSG_ID=$(az network nic show --ids "$NIC_ID" --query "networkSecurityGroup.id" -o tsv)
+NSG=${NSG_ID##*/}
+[ -n "$NSG" ] || { echo "ERROR: the VM NIC has no attached NSG" >&2; exit 1; }
 
 az network nsg rule create -g "$RG" --nsg-name "$NSG" -n allow-ssh \
   --priority 1000 --access Allow --protocol Tcp --direction Inbound \
@@ -237,11 +242,15 @@ cd ~/dms-src/eng/azure-vm/compose
 ./update.sh              # fast-forward pull + image pull + ApiSchema-guarded recreation
 # SKIP_GIT=1 ./update.sh # image-only refresh against the current checkout
 
-# Data reset, keep Keycloak realm (on the VM). reset.sh drops the data and restarts infra/CMS only
-# (NOT the DMS services -- after a -v reset they must start after bootstrap + schema, like a first
-# stand-up), then prints the remaining steps:
+# State reset (on the VM). reset.sh drops data plus Keycloak so stale review credentials are
+# revoked, then restarts infra/CMS only (NOT the DMS services -- they start after bootstrap +
+# schema, like a first stand-up), then prints the remaining steps:
 ./reset.sh
-pwsh ./bootstrap/bootstrap.ps1 -SkipKeycloak -BaseUrl https://localhost -Insecure
+# Wait for the freshly recreated identity/CMS services before bootstrap writes its attempted marker.
+until curl -skf https://localhost/auth/realms/master >/dev/null \
+  && curl -skf https://localhost/st-config/health >/dev/null \
+  && curl -skf https://localhost/mt-config/health >/dev/null; do sleep 5; done
+pwsh ./bootstrap/bootstrap.ps1 -BaseUrl https://localhost -Insecure
 # provision the relational schema (api-schema-tools; see ../docs/infrastructure.md), then:
 ./up.sh st-dms mt-dms
 

--- a/eng/azure-vm/provision/README.md
+++ b/eng/azure-vm/provision/README.md
@@ -49,7 +49,8 @@ Record the generated credentials in your private deployment doc, then verify wit
 
 Re-running `setup-env.ps1` after a completed bootstrap is safe: secrets are preserved and a sentinel
 in `compose/.bootstrap/` prevents duplicate CMS objects. An interrupted bootstrap is deliberately
-not retried; run `reset.sh` first (or `down.sh -v` if Keycloak setup was partial). To rotate secrets,
+not retried; run `reset.sh` first — reset removes Keycloak state too, so partial or stale
+application clients cannot survive it. To rotate secrets,
 run `down.sh -v` **before** `setup-env.ps1 -RotateSecrets`; the script refuses to rotate while the
 PostgreSQL or Keycloak state volume exists. The `-StartDms` pass preserves every secret and skips
 bootstrap, so it only starts the DMS services.
@@ -72,11 +73,10 @@ bootstrap, so it only starts the DMS services.
   `cd ~/dms-src/eng/azure-vm/compose && ./update.sh`. The wrapper requires a fast-forward pull and
   routes container recreation through the ApiSchema-guarded `up.sh`; set `SKIP_GIT=1` only for an
   intentional image-only refresh against the current checkout.
-- **Keycloak image-pin change:** its H2 data cannot be migrated. From `compose/`, run
-  `docker compose -f keycloak.yml --env-file .env down -v` (removes the actual
-  `dms-security-review_dms-sec-keycloak` volume), pull/start Keycloak, then recreate only its realm
-  and clients without touching CMS state:
-  `docker compose -f keycloak.yml --env-file .env pull keycloak && docker compose -f keycloak.yml --env-file .env up -d keycloak && pwsh ./bootstrap/bootstrap.ps1 -KeycloakOnly -BaseUrl https://localhost -Insecure`.
+- **Keycloak image-pin change or lost Keycloak volume:** its H2 data cannot be migrated or rebuilt
+  independently after bootstrap. The review applications are Keycloak clients whose generated
+  secrets and UUIDs are referenced by CMS, so recreating only the three service clients would leave
+  every review API credential broken. Use the [clean redeploy runbook](REDEPLOY.md).
 - **Cert renewal:** `pwsh provision/renew-cert.ps1 -PublicHost <FQDN>`.
 - **Wipe + redeploy** (existing VM, fresh secrets/schema/data): [`REDEPLOY.md`](REDEPLOY.md).
 - **Teardown:** `provision/teardown-vm.ps1` (or delete the resource group in the Portal).

--- a/eng/azure-vm/provision/REDEPLOY.md
+++ b/eng/azure-vm/provision/REDEPLOY.md
@@ -20,17 +20,25 @@ is at `~/dms-src` and a public `FQDN` for the VM. Replace `<FQDN>` throughout.
 
 ```bash
 cd ~/dms-src/eng/azure-vm/compose
-# [ -f .env ] keeps the runbook idempotent on a box that never deployed WITHOUT swallowing a real
-# teardown failure (a failing down.sh exits non-zero and must stop this sequence).
-if [ -f .env ]; then ./down.sh -v -y; fi    # stop containers + drop ALL volumes (incl. Keycloak realm)
+# A pasted block keeps running after a failure, so every destructive step below is gated
+# explicitly. First make sure the daemon is reachable at all -- otherwise the teardown AND the
+# volume checks below would fail in a way that is indistinguishable from "volume absent".
+docker info >/dev/null || { echo "ERROR: Docker daemon unreachable; cannot verify volume state." >&2; exit 1; }
+# [ -f .env ] keeps the runbook idempotent on a box that never deployed; the explicit exit stops
+# the sequence when a real teardown fails.
+if [ -f .env ]; then ./down.sh -v -y || { echo "ERROR: teardown failed; keep .env and resolve first." >&2; exit 1; }; fi
 docker network rm dms-sec 2>/dev/null || true
 # Verify the state volumes are actually gone BEFORE deleting the credentials they are keyed to:
 # if either survives, a later fresh .env would generate new secrets against the old state.
+# (The daemon check above makes an inspect failure here mean "absent", not "docker unavailable".)
 for v in dms-security-review_dms-sec-postgres dms-security-review_dms-sec-keycloak; do
   ! docker volume inspect "$v" >/dev/null 2>&1 || { echo "ERROR: $v survived teardown; keep .env and resolve the failure first." >&2; exit 1; }
 done
 rm -f .env ssl/server.crt ssl/server.key    # force fresh secrets + cert on next run
 rm -rf .bootstrap                            # force fresh ApiSchema staging
+# Part C stages through eng/docker-compose/.bootstrap, which is gitignored and therefore survives
+# the Part B checkout -- a stale workspace from an earlier redeploy must not leak into this one:
+rm -rf ~/dms-src/eng/docker-compose/.bootstrap
 # drop old images so the current (renamed) ones are pulled fresh:
 docker image rm edfialliance/ed-fi-api:pre edfialliance/ed-fi-api-configuration-service:pre 2>/dev/null || true
 docker image rm edfialliance/data-management-service:pre edfialliance/dms-configuration-service:pre 2>/dev/null || true

--- a/eng/azure-vm/provision/REDEPLOY.md
+++ b/eng/azure-vm/provision/REDEPLOY.md
@@ -20,8 +20,15 @@ is at `~/dms-src` and a public `FQDN` for the VM. Replace `<FQDN>` throughout.
 
 ```bash
 cd ~/dms-src/eng/azure-vm/compose
-./down.sh -v -y || true                     # stop containers + drop ALL volumes (incl. Keycloak realm)
+# [ -f .env ] keeps the runbook idempotent on a box that never deployed WITHOUT swallowing a real
+# teardown failure (a failing down.sh exits non-zero and must stop this sequence).
+if [ -f .env ]; then ./down.sh -v -y; fi    # stop containers + drop ALL volumes (incl. Keycloak realm)
 docker network rm dms-sec 2>/dev/null || true
+# Verify the state volumes are actually gone BEFORE deleting the credentials they are keyed to:
+# if either survives, a later fresh .env would generate new secrets against the old state.
+for v in dms-security-review_dms-sec-postgres dms-security-review_dms-sec-keycloak; do
+  ! docker volume inspect "$v" >/dev/null 2>&1 || { echo "ERROR: $v survived teardown; keep .env and resolve the failure first." >&2; exit 1; }
+done
 rm -f .env ssl/server.crt ssl/server.key    # force fresh secrets + cert on next run
 rm -rf .bootstrap                            # force fresh ApiSchema staging
 # drop old images so the current (renamed) ones are pulled fresh:
@@ -39,6 +46,10 @@ git fetch origin --tags
 git switch --detach "$REF"
 git log -1 --oneline
 ```
+
+> A detached checkout cannot use `./update.sh`'s config pull (`git pull --ff-only` fails off a
+> branch). For a later in-place refresh, run `SKIP_GIT=1 ./update.sh` (images only, against the
+> current checkout) or repeat this Part to move the checkout to a newer ref first.
 
 ## Part C — Build the schema tool + stage ApiSchema  [bash]
 
@@ -60,8 +71,11 @@ docker run --rm --user "$(id -u):$(id -g)" \
   dotnet publish ../../src/dms/clis/EdFi.DataManagementService.SchemaTools/EdFi.DataManagementService.SchemaTools.csproj \
   -c Release -r linux-x64 --self-contained -p:UseAppHost=true -o .bootstrap/tools/api-schema-tools
 
-# 2. Stage the DS 5.2 core ApiSchema workspace (downloads the ApiSchema package from the Ed-Fi feed):
-pwsh ./prepare-dms-schema.ps1 -SchemaToolPath ./.bootstrap/tools/api-schema-tools/api-schema-tools
+# 2. Stage the ApiSchema workspace (downloads the ApiSchema packages from the Ed-Fi feed).
+#    -EnvironmentFile .env.template stages the SAME package surface the populated template is
+#    built from (DS 5.2 core + TPDM). Without it the script stages its core-only default, and the
+#    template-restored databases (Part E) would fail the DMS EffectiveSchema check at startup.
+pwsh ./prepare-dms-schema.ps1 -EnvironmentFile ./.env.template -SchemaToolPath ./.bootstrap/tools/api-schema-tools/api-schema-tools
 
 # 3. Copy the staged workspace into the azure-vm deployment:
 mkdir -p ~/dms-src/eng/azure-vm/compose/.bootstrap

--- a/eng/azure-vm/provision/setup-env.ps1
+++ b/eng/azure-vm/provision/setup-env.ps1
@@ -222,6 +222,16 @@ try {
     if (Select-String -Path ".env" -Pattern '=.*CHANGEME' -Quiet) {
         throw ".env still contains CHANGEME placeholder secrets after secret generation. Refusing to start Compose. Re-run with -RotateSecrets, or replace every CHANGEME value manually."
     }
+    # Same gate for '$' in values, BEFORE any persistent service is initialized: docker compose
+    # interpolates $VAR/${VAR} inside .env, so the containers would be keyed to interpolated
+    # credentials while every script reads the literal value (bootstrap also refuses, but by then
+    # Postgres/Keycloak/CMS state would already exist under the interpolated secrets).
+    $dollarKeys = @(Get-Content ".env" | Where-Object { $_ -match '^\s*[^#\s][^=]*=' -and ($_ -split '=', 2)[1] -match '\$' } |
+            ForEach-Object { (($_ -split '=', 2)[0]).Trim() } | Sort-Object)
+    if ($dollarKeys.Count -gt 0) {
+        throw (".env values contain '$', which docker compose interpolates differently than the " +
+            "deployment scripts read it: $($dollarKeys -join ', '). Use values without '$'.")
+    }
 
     # --- 4. (optional) Grand Bend sample data -------------------------------
     if ($LoadGrandbend) {

--- a/eng/azure-vm/provision/setup-env.ps1
+++ b/eng/azure-vm/provision/setup-env.ps1
@@ -14,9 +14,9 @@
 # the documented second pass (-StartDms, after schema provisioning) preserves every secret and
 # skips bootstrap. Regenerating secrets on a re-run would break the existing Postgres volume,
 # Keycloak realm/clients, and CMS-encrypted rows, which are all keyed to the first-run values.
-# An interrupted bootstrap must be recovered with reset.sh (or down.sh -v when Keycloak was
-# partially configured). The bootstrap script owns attempted/complete markers and refuses a blind
-# retry because its CMS creates are not idempotent.
+# An interrupted bootstrap must be recovered with reset.sh, which removes both CMS and Keycloak
+# state. The bootstrap script owns attempted/complete markers and refuses a blind retry because its
+# identity/CMS creates are not idempotent.
 #
 # !! GAP: by default this does NOT provision the relational schema (api-schema-tools), stage
 #    .bootstrap/ApiSchema, or seed data (-LoadGrandbend is the explicit single-tenant exception).
@@ -290,9 +290,7 @@ try {
         elseif (Test-Path $bootstrapAttempted) {
             throw ("A previous bootstrap started but did not complete; the CMS config DB may hold " +
                 "partial vendors/applications/data stores that a retry would DUPLICATE. Run " +
-                "./reset.sh (clears partial CMS state, keeps the Keycloak realm), then re-run. " +
-                "If the failure was during Keycloak client setup instead, reset.sh keeps the realm " +
-                "(including a half-created client) -- use ./down.sh -v for a full reset, then re-run.")
+                "./reset.sh (clears partial CMS and Keycloak state), then re-run.")
         }
         else {
             Write-Output "Running bootstrap (over loopback)..."

--- a/eng/azure-vm/provision/setup-env.ps1
+++ b/eng/azure-vm/provision/setup-env.ps1
@@ -337,8 +337,15 @@ try {
         Write-Output "`nNext steps (manual):"
         Write-Output "  1. Stage the ApiSchema workspace into compose/.bootstrap/ApiSchema (eng/docker-compose/prepare-dms-schema.ps1"
         Write-Output "     writes eng/docker-compose/.bootstrap/ApiSchema -- copy that folder here; the DMS services mount it read-only)."
-        Write-Output "  2. Provision the relational schema into edfi_st / edfi_mt / edfi_mt_t2 (api-schema-tools, against the same staged"
-        Write-Output "     workspace; see ../docs/infrastructure.md)."
+        if ($LoadGrandbend) {
+            Write-Output "  2. edfi_st was restored by grandbend.sh (schema AND data) -- do NOT run api-schema-tools on it."
+            Write-Output "     Provision only edfi_mt / edfi_mt_t2 (api-schema-tools, against the same staged workspace;"
+            Write-Output "     see ../docs/infrastructure.md)."
+        }
+        else {
+            Write-Output "  2. Provision the relational schema into edfi_st / edfi_mt / edfi_mt_t2 (api-schema-tools, against the same staged"
+            Write-Output "     workspace; see ../docs/infrastructure.md)."
+        }
         Write-Output "  3. Start the DMS services:  ./up.sh st-dms mt-dms   (or re-run this script with -StartDms)."
     }
 

--- a/eng/azure-vm/provision/windows/README.md
+++ b/eng/azure-vm/provision/windows/README.md
@@ -63,21 +63,16 @@ VM → **Networking → Add inbound port rule** (note **RDP**, not SSH):
 
 | Name | Source | Port | Priority |
 |------|--------|------|----------|
-| allow-rdp | Any (see note) | 3389 | 1000 |
+| allow-rdp | Admin public IP/CIDR (see note) | 3389 | 1000 |
 | allow-http | Any | 80 | 1010 |
 | allow-https | Any | 443 | 1020 |
 
-> **RDP exposure.** The reference ODS VM leaves 3389 open any→any, relying on the VM being
-> deallocated except during sessions. That caps *total* exposure, but during an on-window an open
-> 3389 is fully internet-reachable (bots scan Azure ranges within minutes; the static IP + DNS
-> label are targetable whenever the VM is up). Safer options, same workflow:
-> - admins on stable IPs → set the **Source** to their CIDRs;
-> - rotating admin IPs → use **Just-in-Time VM access** (Defender for Cloud; requires a paid
->   Defender for Servers plan) — opens 3389 on demand to the requester's current IP only — or
->   **Bastion**.
->
-> If you keep it open to match the reference, use a strong, unique local-admin password and leave
-> Network Level Authentication (NLA) enabled.
+> **RDP exposure.** Scope 3389 to the administrators' CIDRs — an any→any 3389 is fully
+> internet-reachable whenever the VM is up (bots scan Azure ranges within minutes; the static IP +
+> DNS label are targetable). For rotating admin IPs, use **Just-in-Time VM access** (Defender for
+> Cloud; requires a paid Defender for Servers plan) — opens 3389 on demand to the requester's
+> current IP only — or **Bastion**. Either way, use a strong, unique local-admin password and
+> leave Network Level Authentication (NLA) enabled.
 
 ## 4. RDP in (admin access)
 

--- a/eng/azure-vm/provision/windows/portproxy.ps1
+++ b/eng/azure-vm/provision/windows/portproxy.ps1
@@ -7,9 +7,25 @@
 [CmdletBinding()]
 param(
     [string]$Distro = "Ubuntu",
-    [int[]]$Ports = @(80, 443)
+    # string[] rather than int[]: the startup task invokes this via `powershell.exe -File`, which
+    # passes "80,443" as ONE string argument -- an [int[]] parameter fails to bind it and the boot
+    # task dies before restoring connectivity. Accept both spellings (`-Ports 80,443` interactively
+    # binds two elements; the -File form binds one comma-joined element) and flatten below.
+    [string[]]$Ports = @("80", "443")
 )
 $ErrorActionPreference = "Stop"
+
+$portNumbers = [System.Collections.Generic.List[int]]::new()
+foreach ($portToken in ($Ports | ForEach-Object { "$_" -split ',' })) {
+    $trimmedToken = $portToken.Trim()
+    if (-not $trimmedToken) { continue }
+    $portNumber = 0
+    if (-not [int]::TryParse($trimmedToken, [ref]$portNumber) -or $portNumber -lt 1 -or $portNumber -gt 65535) {
+        throw "Invalid port '$trimmedToken'. Ports must be integers from 1 through 65535."
+    }
+    if (-not $portNumbers.Contains($portNumber)) { $portNumbers.Add($portNumber) }
+}
+if ($portNumbers.Count -eq 0) { throw "At least one TCP port is required." }
 
 # Boot WSL (starts systemd -> docker -> containers) and read its IP.
 wsl -d $Distro -u root -e true | Out-Null
@@ -24,7 +40,7 @@ if (-not $wslIp) {
 }
 if (-not $wslIp) { throw "Could not determine the WSL IP for '$Distro'." }
 
-foreach ($p in $Ports) {
+foreach ($p in $portNumbers) {
     # Delete only THIS port's mapping before re-adding (the WSL IP changes across reboots), rather
     # than `portproxy reset`, which would wipe every unrelated portproxy mapping on the host.
     netsh interface portproxy delete v4tov4 listenaddress=0.0.0.0 listenport=$p 2>$null | Out-Null
@@ -36,4 +52,4 @@ foreach ($p in $Ports) {
         New-NetFirewallRule -DisplayName "DMS-sec-$p" -Direction Inbound -LocalPort $p -Protocol TCP -Action Allow | Out-Null
     }
 }
-Write-Output "portproxy active: Windows :$($Ports -join ', ') -> $wslIp"
+Write-Output "portproxy active: Windows :$($portNumbers -join ', ') -> $wslIp"

--- a/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
+++ b/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
@@ -67,6 +67,30 @@ exit 0
         Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
     }
 
+    It "refuses the deprecated --volume alias without confirmation" {
+        $output = & bash (Join-Path $script:composeRoot "down.sh") --volume 2>&1
+
+        $LASTEXITCODE | Should -Be 1
+        $output | Out-String | Should -Match "refusing to drop all volumes"
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+    }
+
+    It "honors Compose last-value semantics for repeated volume flags" {
+        $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
+        $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
+        New-Item -ItemType File -Path $attempted, $complete -Force | Out-Null
+
+        # Compose resolves `-v --volumes=false` to FALSE (last value wins), so the wrapper must
+        # neither prompt nor clear the markers -- the volumes are preserved.
+        & bash (Join-Path $script:composeRoot "down.sh") -v --volumes=false
+
+        $LASTEXITCODE | Should -Be 0
+        Get-Content -LiteralPath $script:dockerLog -Raw | Should -Match "compose .* down -v --volumes=false"
+        Test-Path -LiteralPath $attempted | Should -BeTrue
+        Test-Path -LiteralPath $complete | Should -BeTrue
+        Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeFalse
+    }
+
     It "clears bootstrap markers for a forced bundled volume drop" {
         $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
         $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
@@ -126,7 +150,8 @@ exit 17
     It "drops Keycloak with application state during reset" {
         $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
         $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
-        New-Item -ItemType File -Path $attempted, $complete -Force | Out-Null
+        $keycloakRef = Join-Path $script:composeRoot ".bootstrap/keycloak-image"
+        New-Item -ItemType File -Path $attempted, $complete, $keycloakRef -Force | Out-Null
 
         & bash (Join-Path $script:composeRoot "reset.sh") --force
 
@@ -137,6 +162,8 @@ exit 17
         Test-Path -LiteralPath $attempted | Should -BeFalse
         Test-Path -LiteralPath $complete | Should -BeFalse
         Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeFalse
+        # The volume the recorded Keycloak image reference described is gone with the reset.
+        Test-Path -LiteralPath $keycloakRef | Should -BeFalse
     }
 
     It "retains the reset sentinel when the destructive reset fails" {

--- a/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
+++ b/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
@@ -9,6 +9,7 @@ Describe "Azure VM lifecycle safety" {
     BeforeAll {
         $script:azureVmRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../azure-vm"))
         $script:downSource = Join-Path $script:azureVmRoot "compose/down.sh"
+        $script:resetSource = Join-Path $script:azureVmRoot "compose/reset.sh"
     }
 
     BeforeEach {
@@ -18,6 +19,7 @@ Describe "Azure VM lifecycle safety" {
         New-Item -ItemType Directory -Path (Join-Path $script:composeRoot ".bootstrap") -Force | Out-Null
         New-Item -ItemType Directory -Path $script:binRoot -Force | Out-Null
         Copy-Item -LiteralPath $script:downSource -Destination (Join-Path $script:composeRoot "down.sh")
+        Copy-Item -LiteralPath $script:resetSource -Destination (Join-Path $script:composeRoot "reset.sh")
         Set-Content -LiteralPath (Join-Path $script:composeRoot ".env") -Value "PUBLIC_HOST=test.example" -NoNewline
 
         $script:dockerLog = Join-Path $script:work "docker.log"
@@ -70,85 +72,52 @@ exit 0
         Test-Path -LiteralPath $complete | Should -BeFalse
     }
 
+    It "clears bootstrap markers before a failing destructive volume attempt" {
+        $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
+        $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
+        New-Item -ItemType File -Path $attempted, $complete -Force | Out-Null
+        $dockerStub = Join-Path $script:binRoot "docker"
+        Set-Content -LiteralPath $dockerStub -Value @'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+exit 17
+'@ -NoNewline
+        & chmod +x $dockerStub
+
+        & bash (Join-Path $script:composeRoot "down.sh") -v --force 2>&1 | Out-Null
+
+        $LASTEXITCODE | Should -Be 17
+        Test-Path -LiteralPath $attempted | Should -BeFalse
+        Test-Path -LiteralPath $complete | Should -BeFalse
+    }
+
     It "supports an empty argument list under nounset" {
         & bash (Join-Path $script:composeRoot "down.sh")
 
         $LASTEXITCODE | Should -Be 0
         (Get-Content -LiteralPath $script:dockerLog -Raw).Trim() | Should -Match " down$"
     }
-}
 
-Describe "Azure VM deployment invariants" {
-    BeforeAll {
-        $script:azureVmRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../azure-vm"))
-        $script:renewCert = Get-Content (Join-Path $script:azureVmRoot "provision/renew-cert.ps1") -Raw
-        $script:bootstrap = Get-Content (Join-Path $script:azureVmRoot "compose/bootstrap/bootstrap.ps1") -Raw
-        $script:setupEnv = Get-Content (Join-Path $script:azureVmRoot "provision/setup-env.ps1") -Raw
-        $script:compose = Get-Content (Join-Path $script:azureVmRoot "compose/docker-compose.yml") -Raw
-        $script:exampleEnv = Get-Content (Join-Path $script:azureVmRoot "compose/.env.example") -Raw
+    It "drops Keycloak with application state during reset" {
+        $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
+        $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
+        New-Item -ItemType File -Path $attempted, $complete -Force | Out-Null
+
+        & bash (Join-Path $script:composeRoot "reset.sh") --force
+
+        $LASTEXITCODE | Should -Be 0
+        $calls = Get-Content -LiteralPath $script:dockerLog -Raw
+        $calls | Should -Match 'compose -f docker-compose\.yml -f keycloak\.yml --env-file \.env down -v'
+        $calls | Should -Match 'compose -f docker-compose\.yml -f keycloak\.yml --env-file \.env up -d --no-deps'
+        Test-Path -LiteralPath $attempted | Should -BeFalse
+        Test-Path -LiteralPath $complete | Should -BeFalse
     }
 
-    It "restarts only the gateway during certificate renewal" {
-        $script:renewCert | Should -Match 'up -d --no-deps gateway'
-    }
+    It "refuses a non-interactive reset without an explicit force flag" {
+        $output = & bash (Join-Path $script:composeRoot "reset.sh") 2>&1
 
-    It "centralizes CMS bootstrap markers and exposes a Keycloak-only recovery path" {
-        $script:bootstrap | Should -Match 'bootstrap-attempted'
-        $script:bootstrap | Should -Match 'bootstrap-complete'
-        $script:bootstrap | Should -Match '\[switch\]\$KeycloakOnly'
-        $script:bootstrap | Should -Match 'existing CMS state was not modified'
-        $script:setupEnv | Should -Not -Match '\[switch\]\$Bootstrap'
-    }
-
-    It "uses the real Hybrid claim fragment glob" {
-        $script:compose | Should -Match '\*-claimset\.json'
-        $script:exampleEnv | Should -Match '\*-claimset\.json'
-        $script:exampleEnv | Should -Not -Match 'claim set \*\.json'
-    }
-
-    It "does not require the OpenIddict-only identity encryption key" {
-        $script:compose | Should -Not -Match 'DMS_CONFIG_IDENTITY_ENCRYPTION_KEY'
-        $script:exampleEnv | Should -Not -Match 'DMS_CONFIG_IDENTITY_ENCRYPTION_KEY'
-        $script:setupEnv | Should -Match 'Remove-EnvValue -File "\.env" -Key "DMS_CONFIG_IDENTITY_ENCRYPTION_KEY"'
-        $script:setupEnv | Should -Not -Match 'Set-EnvValue -File "\.env" -Key "DMS_CONFIG_IDENTITY_ENCRYPTION_KEY"'
-    }
-
-    It "guards secret rotation against both independently persistent state volumes" {
-        $script:setupEnv | Should -Match 'dms-security-review_dms-sec-postgres'
-        $script:setupEnv | Should -Match 'dms-security-review_dms-sec-keycloak'
-    }
-
-    It "uses fail-fast Docker installer downloads in both provisioning paths" {
-        $windowsSetup = Get-Content (Join-Path $script:azureVmRoot "provision/windows/setup-windows-host.ps1") -Raw
-        $portal = Get-Content (Join-Path $script:azureVmRoot "provision/PORTAL.md") -Raw
-
-        $windowsSetup | Should -Match 'set -euo pipefail'
-        $windowsSetup | Should -Match 'curl -fsSL https://get\.docker\.com -o /tmp/get-docker\.sh'
-        $portal | Should -Not -Match 'curl -fsSL https://get\.docker\.com \| sh'
-    }
-
-    It "resolves the VM NSG through its attached NIC" {
-        $provisionVm = Get-Content (Join-Path $script:azureVmRoot "provision/provision-vm.ps1") -Raw
-
-        $provisionVm | Should -Match 'networkProfile\.networkInterfaces\[0\]\.id'
-        $provisionVm | Should -Match 'networkSecurityGroup\.id'
-        $provisionVm | Should -Not -Match '--query", "\[0\]\.name"'
-    }
-
-    It "documents the guarded update wrapper instead of raw full-stack recreation" {
-        foreach ($relativePath in @("provision/README.md", "provision/MANUAL.md", "provision/windows/README.md")) {
-            $document = Get-Content (Join-Path $script:azureVmRoot $relativePath) -Raw
-            $document | Should -Match '\./update\.sh'
-            $document | Should -Not -Match '(?s)git pull.*docker compose.*pull.*docker compose.*up -d'
-        }
-    }
-
-    It "documents the resolved Keycloak volume and Keycloak-only recovery" {
-        $readme = Get-Content (Join-Path $script:azureVmRoot "provision/README.md") -Raw
-        $keycloakCompose = Get-Content (Join-Path $script:azureVmRoot "compose/keycloak.yml") -Raw
-
-        $readme | Should -Match 'dms-security-review_dms-sec-keycloak'
-        $readme | Should -Match '-KeycloakOnly'
-        $keycloakCompose | Should -Match 'dms-security-review_dms-sec-keycloak'
+        $LASTEXITCODE | Should -Be 1
+        $output | Out-String | Should -Match "refusing to drop"
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
     }
 }

--- a/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
+++ b/eng/docker-compose/tests/AzureVmDeployment.Tests.ps1
@@ -59,6 +59,27 @@ exit 0
         Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
     }
 
+    It "refuses a bundled short-flag cluster containing -v without confirmation" {
+        $output = & bash (Join-Path $script:composeRoot "down.sh") -vt 0 2>&1
+
+        $LASTEXITCODE | Should -Be 1
+        $output | Out-String | Should -Match "refusing to drop all volumes"
+        Test-Path -LiteralPath $script:dockerLog | Should -BeFalse
+    }
+
+    It "clears bootstrap markers for a forced bundled volume drop" {
+        $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
+        $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
+        New-Item -ItemType File -Path $attempted, $complete -Force | Out-Null
+
+        & bash (Join-Path $script:composeRoot "down.sh") -vt 0 --force
+
+        $LASTEXITCODE | Should -Be 0
+        Get-Content -LiteralPath $script:dockerLog -Raw | Should -Match "compose .* down -vt 0"
+        Test-Path -LiteralPath $attempted | Should -BeFalse
+        Test-Path -LiteralPath $complete | Should -BeFalse
+    }
+
     It "clears bootstrap markers for a forced equals-form volume drop" {
         $attempted = Join-Path $script:composeRoot ".bootstrap/bootstrap-attempted"
         $complete = Join-Path $script:composeRoot ".bootstrap/bootstrap-complete"
@@ -70,6 +91,7 @@ exit 0
         Get-Content -LiteralPath $script:dockerLog -Raw | Should -Match "compose .* down -v=true"
         Test-Path -LiteralPath $attempted | Should -BeFalse
         Test-Path -LiteralPath $complete | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeFalse
     }
 
     It "clears bootstrap markers before a failing destructive volume attempt" {
@@ -89,6 +111,9 @@ exit 17
         $LASTEXITCODE | Should -Be 17
         Test-Path -LiteralPath $attempted | Should -BeFalse
         Test-Path -LiteralPath $complete | Should -BeFalse
+        # The sentinel must survive the failed attempt: the volumes may still hold live state, and
+        # bootstrap.ps1 refuses to run (and duplicate identity/CMS objects) while it exists.
+        Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeTrue
     }
 
     It "supports an empty argument list under nounset" {
@@ -111,6 +136,22 @@ exit 17
         $calls | Should -Match 'compose -f docker-compose\.yml -f keycloak\.yml --env-file \.env up -d --no-deps'
         Test-Path -LiteralPath $attempted | Should -BeFalse
         Test-Path -LiteralPath $complete | Should -BeFalse
+        Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeFalse
+    }
+
+    It "retains the reset sentinel when the destructive reset fails" {
+        $dockerStub = Join-Path $script:binRoot "docker"
+        Set-Content -LiteralPath $dockerStub -Value @'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+exit 17
+'@ -NoNewline
+        & chmod +x $dockerStub
+
+        & bash (Join-Path $script:composeRoot "reset.sh") --force 2>&1 | Out-Null
+
+        $LASTEXITCODE | Should -Be 17
+        Test-Path -LiteralPath (Join-Path $script:composeRoot ".bootstrap/reset-pending") | Should -BeTrue
     }
 
     It "refuses a non-interactive reset without an explicit force flag" {


### PR DESCRIPTION
## What this is

A focused hardening pass on the `eng/azure-vm/` security-review deployment, proposed as the final delta to merge into `DMS-1196`. It replaces an earlier 12-commit review-fix series on this branch: each of those commits was re-evaluated, the changes that fix real defects were kept, and the exploratory validation machinery was deliberately dropped as out of scope for a review environment (details below, so nothing was lost silently). Net: **15 files, +181/−170**.

With these changes, review passes on the branch come back clean — this is the set we believe clears DMS-1196 for merge.

## What's included

### Gateway: stop trusting the client's Host header (`compose/nginx/default.conf.template`)
- `Host` and `X-Forwarded-Host` sent to the backends are now pinned to `${PUBLIC_HOST}` instead of echoing `$host`. The apps trust the gateway's `X-Forwarded-*` headers, so a spoofed Host previously flowed into redirect/metadata generation — a textbook host-header-injection vector on an Internet-exposed environment.
- A `default_server` TLS vhost returns **421** for any unmatched SNI/Host, so nothing with an attacker-chosen hostname reaches the applications. The named vhost also accepts `localhost` for the documented VM-loopback bootstrap/health path.
- Rendered through the official image's `envsubst` and verified with `nginx -t`.

### Reset now revokes credentials (`reset.sh`, `down.sh`, `bootstrap.ps1`, docs)
- `reset.sh` passes `keycloak.yml` to `down -v`, dropping the realm together with the CMS/database volumes. Review applications are Keycloak clients: keeping the realm while rebuilding CMS left **old API credentials valid against reassigned data-store IDs**. Prompts, printed rebuild steps, and the runbooks (TROUBLESHOOTING, MANUAL, provision/README) are updated to match, including a health wait-loop before re-bootstrap so the `attempted` marker isn't burned against a not-yet-healthy CMS.
- `bootstrap.ps1 -KeycloakOnly` is removed: rebuilding only the realm's service clients cannot restore the review-application clients whose secrets/UUIDs CMS references, so the flag was a broken-credentials trap. Clean redeploy (`REDEPLOY.md`) is the documented recovery for Keycloak volume loss or image-pin changes.
- `down.sh`/`reset.sh` clear the bootstrap markers **before** the destructive down: an interrupted teardown can no longer leave a stale `complete` marker that makes `setup-env.ps1` skip bootstrap against wiped databases.

### Windows host: port forwarding survived reboots only by luck (`provision/windows/portproxy.ps1`)
The startup task invokes the script via `powershell.exe -File`, which passes `-Ports 80,443` as a **single string** — the `[int[]]` parameter fails to bind and the boot task dies before restoring connectivity, so the environment went dark after every VM reboot. The parameter is now `[string[]]` with comma-token flattening; both the interactive and `-File` invocation forms bind.

### Smaller fixes
- `bootstrap.ps1` validates MT tenant names (charset, 19-char cap from the generated API-client name, case-insensitive distinctness) before any identity/CMS mutation.
- `grandbend.sh` legacy-template guard now requires an `edfi` DDL marker **and** the `EffectiveSchema` marker; the OR-regex accepted a document-store dump that merely mentioned one.
- `http/single-tenant.http` creates school `255901999` instead of `255901001`, which collides with Grand Bend seed data.
- `MANUAL.md` resolves the NSG via the VM's NIC instead of "first NSG in the resource group".
- `windows/README.md` scopes the RDP inbound rule to admin CIDRs by default instead of Any-with-a-footnote.

### Tests: runtime-only (`eng/docker-compose/tests/AzureVmDeployment.Tests.ps1`)
The "deployment invariants" block string-matched script source, which our test policy disallows — it's gone. The lifecycle suite still stubs `docker` and actually executes `down.sh`/`reset.sh`, with new cases for the marker-ordering fix, the Keycloak-inclusive reset, and the non-interactive reset refusal.

## Verification

- Pester: 7/7 green (runtime suite above)
- PSScriptAnalyzer: clean on all changed scripts (also enforced by the pre-commit hook)
- `bash -n` on all changed shell scripts; PowerShell AST parse on all changed `.ps1`
- nginx template rendered via `envsubst` and validated with `nginx -t`
- Not re-deployed to a live Azure VM as part of this pass
