### PR TITLE
[DMS-1280] Require CMS authorization on claims management endpoints

### DIFF
--- a/docs/CLAIMS-LOADING-GUIDE.md
+++ b/docs/CLAIMS-LOADING-GUIDE.md
@@ -397,6 +397,15 @@ This flag enables:
 - Potential elevation of privileges
 - Bypass of intended authorization controls
 
+### Endpoint Authentication
+
+The `/management/*` claims endpoints require a valid CMS bearer token in addition to the flag above:
+
+- `POST /management/upload-claims` and `POST /management/reload-claims` require an admin scope.
+- `GET /management/current-claims` requires a read-only or admin scope.
+
+Requests without a valid token return `401` regardless of the flag, and a valid token with an insufficient scope returns `403`. The `Authorization: Bearer $TOKEN` header shown in the examples above is enforced.
+
 ## Troubleshooting
 
 ### Common Configuration Issues

--- a/docs/CLAIMS-LOADING-GUIDE.md
+++ b/docs/CLAIMS-LOADING-GUIDE.md
@@ -399,12 +399,20 @@ This flag enables:
 
 ### Endpoint Authentication
 
-The `/management/*` claims endpoints require a valid CMS bearer token in addition to the flag above:
+Every `/management/*` claims endpoint requires a valid CMS bearer token that satisfies **both** of the following, in addition to the dangerous flag above:
 
-- `POST /management/upload-claims` and `POST /management/reload-claims` require an admin scope.
-- `GET /management/current-claims` requires a read-only or admin scope.
+1. **The configuration-service role** — enforced by `SecurityConstants.ServicePolicy`. The token must carry the configured configuration-service role (the same role every other CMS management endpoint requires); a token for a different role is rejected even when its scope would otherwise be sufficient.
+2. **The endpoint-appropriate scope:**
+   - `POST /management/upload-claims` and `POST /management/reload-claims` require the **admin** scope.
+   - `GET /management/current-claims` requires the **read-only or admin** scope.
 
-Requests without a valid token return `401` regardless of the flag, and a valid token with an insufficient scope returns `403`. The `Authorization: Bearer $TOKEN` header shown in the examples above is enforced.
+Status behavior:
+
+- Missing or invalid bearer token → `401`.
+- Authenticated token that lacks the required configuration-service role or scope → `403`.
+- Fully authorized request while dynamic claims loading is disabled → `404`.
+
+The `Authorization: Bearer $TOKEN` header shown in the examples above is enforced.
 
 ## Troubleshooting
 

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 using EdFi.DmsConfigurationService.Backend.Claims;
 using EdFi.DmsConfigurationService.DataModel;
@@ -35,6 +36,9 @@ public abstract class ClaimsManagementModuleTests
     // A role the TestAuthHandler principal never carries; used to prove ServicePolicy is enforced.
     protected const string RoleTheTokenDoesNotHave = "unassigned-configuration-service-role";
 
+    // A syntactically invalid (non-JWT) bearer value that the production JWT handler rejects.
+    protected const string InvalidBearerToken = "not-a-valid-jwt";
+
     private readonly IClaimsUploadService _claimsUploadService = A.Fake<IClaimsUploadService>();
     private readonly IClaimsProvider _claimsProvider = A.Fake<IClaimsProvider>();
 
@@ -58,6 +62,20 @@ public abstract class ClaimsManagementModuleTests
             requiredServiceRole: null
         );
         Client = _factory.CreateClient();
+    }
+
+    protected void ArrangeClientWithInvalidBearerToken(bool dangerousFlagEnabled)
+    {
+        _factory = CreateFactory(
+            addTestAuthentication: false,
+            dangerousFlagEnabled,
+            requiredServiceRole: null
+        );
+        Client = _factory.CreateClient();
+        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+            "Bearer",
+            InvalidBearerToken
+        );
     }
 
     protected void ArrangeAuthenticatedClient(
@@ -161,6 +179,71 @@ public abstract class ClaimsManagementModuleTests
     {
         [SetUp]
         public void Setup() => ArrangeUnauthenticatedClient(dangerousFlagEnabled: false);
+
+        [Test]
+        public async Task It_should_reject_reload_claims_with_401()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_upload_claims_with_401()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_current_claims_with_401()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+    }
+
+    /// <summary>
+    /// A malformed (non-JWT) bearer token is rejected by the production JWT handler with 401
+    /// before the dangerous-flag check, even when the flag is enabled.
+    /// </summary>
+    [TestFixture]
+    public class Given_an_invalid_bearer_token_and_the_dangerous_flag_is_enabled : ClaimsManagementModuleTests
+    {
+        [SetUp]
+        public void Setup() => ArrangeClientWithInvalidBearerToken(dangerousFlagEnabled: true);
+
+        [Test]
+        public async Task It_should_reject_reload_claims_with_401()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_upload_claims_with_401()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_current_claims_with_401()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+    }
+
+    /// <summary>
+    /// A malformed (non-JWT) bearer token is rejected by the production JWT handler with 401
+    /// before the dangerous-flag check, even when the flag is disabled.
+    /// </summary>
+    [TestFixture]
+    public class Given_an_invalid_bearer_token_and_the_dangerous_flag_is_disabled
+        : ClaimsManagementModuleTests
+    {
+        [SetUp]
+        public void Setup() => ArrangeClientWithInvalidBearerToken(dangerousFlagEnabled: false);
 
         [Test]
         public async Task It_should_reject_reload_claims_with_401()

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text;
+using EdFi.DmsConfigurationService.Backend.Claims;
+using EdFi.DmsConfigurationService.DataModel;
+using EdFi.DmsConfigurationService.DataModel.Model.Authorization;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure.Authorization;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Infrastructure;
+using FakeItEasy;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
+
+/// <summary>
+/// Verifies that the /management/* claims endpoints require CMS bearer authorization
+/// (ServicePolicy + an AuthorizationScopePolicies scope) in addition to the existing
+/// DangerouslyEnableUnrestrictedClaimsLoading flag check.
+/// </summary>
+[TestFixture]
+public class ClaimsManagementModuleTests
+{
+    private const string ReloadClaimsRoute = "/management/reload-claims";
+    private const string UploadClaimsRoute = "/management/upload-claims";
+    private const string CurrentClaimsRoute = "/management/current-claims";
+
+    private readonly IClaimsUploadService _claimsUploadService = A.Fake<IClaimsUploadService>();
+    private readonly IClaimsProvider _claimsProvider = A.Fake<IClaimsProvider>();
+    private readonly List<WebApplicationFactory<Program>> _factories = [];
+
+    [TearDown]
+    public void TearDown()
+    {
+        foreach (var factory in _factories)
+        {
+            factory.Dispose();
+        }
+
+        _factories.Clear();
+    }
+
+    private WebApplicationFactory<Program> CreateFactory(
+        bool addTestAuthentication,
+        bool dangerousFlagEnabled
+    )
+    {
+        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureServices(
+                (ctx, collection) =>
+                {
+                    if (addTestAuthentication)
+                    {
+                        // Mimic the production authentication/authorization setup so that
+                        // ServicePolicy and the scope policies are evaluated for each request.
+                        collection.AddTestAuthentication();
+
+                        var identitySettings = ctx
+                            .Configuration.GetSection("IdentitySettings")
+                            .Get<IdentitySettings>()!;
+                        collection.AddAuthorization(options =>
+                        {
+                            options.AddPolicy(
+                                SecurityConstants.ServicePolicy,
+                                policy =>
+                                    policy.RequireClaim(
+                                        identitySettings.RoleClaimType,
+                                        identitySettings.ConfigServiceRole
+                                    )
+                            );
+                            AuthorizationScopePolicies.Add(options);
+                        });
+
+                        collection.AddTransient(_ => _claimsUploadService);
+                        collection.AddTransient(_ => _claimsProvider);
+                    }
+
+                    // Force the dangerous flag so the handler's inner gate is deterministic.
+                    collection.Configure<ClaimsOptions>(options =>
+                        options.DangerouslyEnableUnrestrictedClaimsLoading = dangerousFlagEnabled
+                    );
+                }
+            );
+        });
+
+        _factories.Add(factory);
+        return factory;
+    }
+
+    private HttpClient CreateUnauthenticatedClient(bool dangerousFlagEnabled) =>
+        CreateFactory(addTestAuthentication: false, dangerousFlagEnabled).CreateClient();
+
+    private HttpClient CreateAuthenticatedClient(string scope, bool dangerousFlagEnabled)
+    {
+        var client = CreateFactory(addTestAuthentication: true, dangerousFlagEnabled).CreateClient();
+        client.DefaultRequestHeaders.Add("X-Test-Scope", scope);
+        return client;
+    }
+
+    private static StringContent EmptyJsonBody() => new("{}", Encoding.UTF8, "application/json");
+
+    // Authentication is evaluated before the dangerous-flag check, so a request without a token
+    // returns 401 whether the flag is enabled or disabled.
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Reload_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    {
+        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+
+        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Upload_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    {
+        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+
+        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task Current_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    {
+        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+
+        var response = await client.GetAsync(CurrentClaimsRoute);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // A valid CMS token with an insufficient scope (read-only) cannot call the write endpoints.
+
+    [Test]
+    public async Task Reload_claims_with_a_read_only_token_returns_403()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.ReadOnlyScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Upload_claims_with_a_read_only_token_returns_403()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.ReadOnlyScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // A read-only token is authorized for the read endpoint (not 403); with the flag disabled
+    // the handler still returns 404.
+
+    [Test]
+    public async Task Current_claims_with_a_read_only_token_is_authorized_and_returns_404_when_flag_disabled()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.ReadOnlyScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.GetAsync(CurrentClaimsRoute);
+
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    // A full-access token is authorized; with the flag disabled every endpoint still returns 404.
+
+    [Test]
+    public async Task Reload_claims_with_a_full_access_token_returns_404_when_flag_disabled()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.AdminScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Upload_claims_with_a_full_access_token_returns_404_when_flag_disabled()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.AdminScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task Current_claims_with_a_full_access_token_returns_404_when_flag_disabled()
+    {
+        using var client = CreateAuthenticatedClient(
+            AuthorizationScopes.AdminScope.Name,
+            dangerousFlagEnabled: false
+        );
+
+        var response = await client.GetAsync(CurrentClaimsRoute);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/ClaimsManagementModuleTests.cs
@@ -23,37 +23,61 @@ namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
 
 /// <summary>
 /// Verifies that the /management/* claims endpoints require CMS bearer authorization
-/// (ServicePolicy + an AuthorizationScopePolicies scope) in addition to the existing
-/// DangerouslyEnableUnrestrictedClaimsLoading flag check.
+/// (SecurityConstants.ServicePolicy plus an AuthorizationScopePolicies scope) in addition to
+/// the existing DangerouslyEnableUnrestrictedClaimsLoading flag check.
 /// </summary>
-[TestFixture]
-public class ClaimsManagementModuleTests
+public abstract class ClaimsManagementModuleTests
 {
-    private const string ReloadClaimsRoute = "/management/reload-claims";
-    private const string UploadClaimsRoute = "/management/upload-claims";
-    private const string CurrentClaimsRoute = "/management/current-claims";
+    protected const string ReloadClaimsRoute = "/management/reload-claims";
+    protected const string UploadClaimsRoute = "/management/upload-claims";
+    protected const string CurrentClaimsRoute = "/management/current-claims";
+
+    // A role the TestAuthHandler principal never carries; used to prove ServicePolicy is enforced.
+    protected const string RoleTheTokenDoesNotHave = "unassigned-configuration-service-role";
 
     private readonly IClaimsUploadService _claimsUploadService = A.Fake<IClaimsUploadService>();
     private readonly IClaimsProvider _claimsProvider = A.Fake<IClaimsProvider>();
-    private readonly List<WebApplicationFactory<Program>> _factories = [];
+
+    private WebApplicationFactory<Program> _factory = null!;
+    protected HttpClient Client = null!;
 
     [TearDown]
-    public void TearDown()
+    public void DisposeClientAndFactory()
     {
-        foreach (var factory in _factories)
-        {
-            factory.Dispose();
-        }
+        Client?.Dispose();
+        _factory?.Dispose();
+    }
 
-        _factories.Clear();
+    protected static StringContent EmptyJsonBody() => new("{}", Encoding.UTF8, "application/json");
+
+    protected void ArrangeUnauthenticatedClient(bool dangerousFlagEnabled)
+    {
+        _factory = CreateFactory(
+            addTestAuthentication: false,
+            dangerousFlagEnabled,
+            requiredServiceRole: null
+        );
+        Client = _factory.CreateClient();
+    }
+
+    protected void ArrangeAuthenticatedClient(
+        string scope,
+        bool dangerousFlagEnabled,
+        string? requiredServiceRole = null
+    )
+    {
+        _factory = CreateFactory(addTestAuthentication: true, dangerousFlagEnabled, requiredServiceRole);
+        Client = _factory.CreateClient();
+        Client.DefaultRequestHeaders.Add("X-Test-Scope", scope);
     }
 
     private WebApplicationFactory<Program> CreateFactory(
         bool addTestAuthentication,
-        bool dangerousFlagEnabled
+        bool dangerousFlagEnabled,
+        string? requiredServiceRole
     )
     {
-        var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
             builder.UseEnvironment("Test");
             builder.ConfigureServices(
@@ -70,12 +94,14 @@ public class ClaimsManagementModuleTests
                             .Get<IdentitySettings>()!;
                         collection.AddAuthorization(options =>
                         {
+                            // requiredServiceRole lets a test require a role the principal lacks,
+                            // proving the route enforces ServicePolicy (patterned after ActionModuleTests).
                             options.AddPolicy(
                                 SecurityConstants.ServicePolicy,
                                 policy =>
                                     policy.RequireClaim(
                                         identitySettings.RoleClaimType,
-                                        identitySettings.ConfigServiceRole
+                                        requiredServiceRole ?? identitySettings.ConfigServiceRole
                                     )
                             );
                             AuthorizationScopePolicies.Add(options);
@@ -92,142 +118,198 @@ public class ClaimsManagementModuleTests
                 }
             );
         });
-
-        _factories.Add(factory);
-        return factory;
     }
 
-    private HttpClient CreateUnauthenticatedClient(bool dangerousFlagEnabled) =>
-        CreateFactory(addTestAuthentication: false, dangerousFlagEnabled).CreateClient();
-
-    private HttpClient CreateAuthenticatedClient(string scope, bool dangerousFlagEnabled)
+    /// <summary>
+    /// Authentication is evaluated before the dangerous-flag check, so a request without a token
+    /// returns 401 even when the flag is enabled.
+    /// </summary>
+    [TestFixture]
+    public class Given_no_bearer_token_and_the_dangerous_flag_is_enabled : ClaimsManagementModuleTests
     {
-        var client = CreateFactory(addTestAuthentication: true, dangerousFlagEnabled).CreateClient();
-        client.DefaultRequestHeaders.Add("X-Test-Scope", scope);
-        return client;
+        [SetUp]
+        public void Setup() => ArrangeUnauthenticatedClient(dangerousFlagEnabled: true);
+
+        [Test]
+        public async Task It_should_reject_reload_claims_with_401()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_upload_claims_with_401()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_current_claims_with_401()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
     }
 
-    private static StringContent EmptyJsonBody() => new("{}", Encoding.UTF8, "application/json");
-
-    // Authentication is evaluated before the dangerous-flag check, so a request without a token
-    // returns 401 whether the flag is enabled or disabled.
-
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task Reload_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    /// <summary>
+    /// Authentication is evaluated before the dangerous-flag check, so a request without a token
+    /// returns 401 even when the flag is disabled.
+    /// </summary>
+    [TestFixture]
+    public class Given_no_bearer_token_and_the_dangerous_flag_is_disabled : ClaimsManagementModuleTests
     {
-        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+        [SetUp]
+        public void Setup() => ArrangeUnauthenticatedClient(dangerousFlagEnabled: false);
 
-        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+        [Test]
+        public async Task It_should_reject_reload_claims_with_401()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        [Test]
+        public async Task It_should_reject_upload_claims_with_401()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+
+        [Test]
+        public async Task It_should_reject_current_claims_with_401()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task Upload_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    /// <summary>
+    /// A read-only token lacks the admin scope required by the write endpoints (403) but is
+    /// accepted by the read endpoint's ReadOnlyOrAdmin policy.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_read_only_token : ClaimsManagementModuleTests
     {
-        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(AuthorizationScopes.ReadOnlyScope.Name, dangerousFlagEnabled: false);
 
-        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+        [Test]
+        public async Task It_should_reject_reload_claims_with_403()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        [Test]
+        public async Task It_should_reject_upload_claims_with_403()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Test]
+        public async Task It_should_authorize_current_claims_and_return_404_when_flag_disabled()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
     }
 
-    [TestCase(true)]
-    [TestCase(false)]
-    public async Task Current_claims_without_a_token_returns_401(bool dangerousFlagEnabled)
+    /// <summary>
+    /// A fully authorized request still returns 404 while the dangerous flag is disabled, proving
+    /// authorization does not bypass the flag gate.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_full_access_token_and_the_dangerous_flag_is_disabled : ClaimsManagementModuleTests
     {
-        using var client = CreateUnauthenticatedClient(dangerousFlagEnabled);
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(AuthorizationScopes.AdminScope.Name, dangerousFlagEnabled: false);
 
-        var response = await client.GetAsync(CurrentClaimsRoute);
+        [Test]
+        public async Task It_should_return_404_for_reload_claims()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
 
-        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        [Test]
+        public async Task It_should_return_404_for_upload_claims()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Test]
+        public async Task It_should_return_404_for_current_claims()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
     }
 
-    // A valid CMS token with an insufficient scope (read-only) cannot call the write endpoints.
-
-    [Test]
-    public async Task Reload_claims_with_a_read_only_token_returns_403()
+    /// <summary>
+    /// An authenticated principal that carries an allowed scope but fails the configuration-service
+    /// role requirement must be rejected with 403 on every endpoint, proving each route enforces
+    /// ServicePolicy. The dangerous flag is disabled so a route missing ServicePolicy would instead
+    /// reach the handler and return 404, which the 403 assertion distinguishes.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_token_without_the_configuration_service_role : ClaimsManagementModuleTests
     {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.ReadOnlyScope.Name,
-            dangerousFlagEnabled: false
-        );
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(
+                AuthorizationScopes.AdminScope.Name,
+                dangerousFlagEnabled: false,
+                requiredServiceRole: RoleTheTokenDoesNotHave
+            );
 
-        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+        [Test]
+        public async Task It_should_reject_reload_claims_with_403()
+        {
+            var response = await Client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
 
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        [Test]
+        public async Task It_should_reject_upload_claims_with_403()
+        {
+            var response = await Client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
+
+        [Test]
+        public async Task It_should_reject_current_claims_with_403()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
     }
 
-    [Test]
-    public async Task Upload_claims_with_a_read_only_token_returns_403()
+    /// <summary>
+    /// The read endpoint uses MapSecuredGet (ReadOnlyOrAdmin), not the broader MapLimitedAccess
+    /// policy, so a valid token whose only scope is the auth-metadata read-only scope must be
+    /// rejected with 403.
+    /// </summary>
+    [TestFixture]
+    public class Given_a_token_with_an_unsupported_scope_for_the_read_endpoint : ClaimsManagementModuleTests
     {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.ReadOnlyScope.Name,
-            dangerousFlagEnabled: false
-        );
+        [SetUp]
+        public void Setup() =>
+            ArrangeAuthenticatedClient(
+                AuthorizationScopes.AuthMetadataReadOnlyAccessScope.Name,
+                dangerousFlagEnabled: false
+            );
 
-        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
-
-        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
-    }
-
-    // A read-only token is authorized for the read endpoint (not 403); with the flag disabled
-    // the handler still returns 404.
-
-    [Test]
-    public async Task Current_claims_with_a_read_only_token_is_authorized_and_returns_404_when_flag_disabled()
-    {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.ReadOnlyScope.Name,
-            dangerousFlagEnabled: false
-        );
-
-        var response = await client.GetAsync(CurrentClaimsRoute);
-
-        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-    }
-
-    // A full-access token is authorized; with the flag disabled every endpoint still returns 404.
-
-    [Test]
-    public async Task Reload_claims_with_a_full_access_token_returns_404_when_flag_disabled()
-    {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.AdminScope.Name,
-            dangerousFlagEnabled: false
-        );
-
-        var response = await client.PostAsync(ReloadClaimsRoute, EmptyJsonBody());
-
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-    }
-
-    [Test]
-    public async Task Upload_claims_with_a_full_access_token_returns_404_when_flag_disabled()
-    {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.AdminScope.Name,
-            dangerousFlagEnabled: false
-        );
-
-        var response = await client.PostAsync(UploadClaimsRoute, EmptyJsonBody());
-
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
-    }
-
-    [Test]
-    public async Task Current_claims_with_a_full_access_token_returns_404_when_flag_disabled()
-    {
-        using var client = CreateAuthenticatedClient(
-            AuthorizationScopes.AdminScope.Name,
-            dangerousFlagEnabled: false
-        );
-
-        var response = await client.GetAsync(CurrentClaimsRoute);
-
-        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        [Test]
+        public async Task It_should_reject_current_claims_with_403()
+        {
+            var response = await Client.GetAsync(CurrentClaimsRoute);
+            response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+        }
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Modules/ClaimsManagementModule.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using EdFi.DmsConfigurationService.Backend.Claims;
 using EdFi.DmsConfigurationService.Backend.Claims.Models;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Infrastructure.Authorization;
 using Microsoft.Extensions.Options;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Modules;
@@ -22,13 +23,13 @@ public class ClaimsManagementModule : IEndpointModule
 
         // Reload Claims endpoint
         managementEndpoints
-            .MapPost("/reload-claims", ReloadClaims)
+            .MapSecuredPost("/reload-claims", ReloadClaims)
             .WithName("ReloadClaims")
             .WithSummary("Reloads the Claims from the configured source");
 
         // Upload Claims endpoint
         managementEndpoints
-            .MapPost("/upload-claims", UploadClaims)
+            .MapSecuredPost("/upload-claims", UploadClaims)
             .WithName("UploadClaims")
             .WithSummary("Uploads Claims from request body")
             .Accepts<UploadClaimsRequest>("application/json")
@@ -39,7 +40,7 @@ public class ClaimsManagementModule : IEndpointModule
 
         // Get Current Claims endpoint
         managementEndpoints
-            .MapGet("/current-claims", GetCurrentClaims)
+            .MapSecuredGet("/current-claims", GetCurrentClaims)
             .WithName("GetCurrentClaims")
             .WithSummary("Retrieves the currently loaded claims in their original format")
             .Produces<JsonNode>(200)

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
@@ -76,10 +76,15 @@ Tests invalid claims upload:
 - Sends malformed claims
 - Verifies 400 response with validation errors
 
-### Scenario 6: Security
-Verifies the endpoints enforce security in two layers:
-- A valid CMS bearer token is required (`ServicePolicy` plus an admin scope for `upload-claims` and `reload-claims`, or a read-only-or-admin scope for `current-claims`). Requests without a valid token return 401 regardless of the flag below, and a valid token with an insufficient scope returns 403.
-- Dynamic claims loading must be enabled (`DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING=true`); otherwise an authorized request returns 404.
+## Authorization Coverage
+
+This feature's `Background` obtains a **full-access** CMS token (`Given valid credentials` / `And token received`) and sends it on every request, so scenarios 01–05 exercise only the **authenticated happy path** (including the 400 validation case in scenario 05). The feature does **not** contain a negative-authorization scenario.
+
+The negative authorization behavior of the `/management/*` claims endpoints is covered by the focused in-process unit tests in `ClaimsManagementModuleTests` (project `EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit`), not by this E2E feature:
+
+- **401** — a request without a bearer token, with the dangerous flag both enabled and disabled.
+- **403** — a valid token that is not authorized: a read-only scope on the write endpoints, an unsupported scope on the read endpoint, or a principal lacking the configuration-service role.
+- **404** — an authorized request while `DangerouslyEnableUnrestrictedClaimsLoading` is disabled.
 
 ## Troubleshooting
 

--- a/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
+++ b/src/config/tests/EdFi.DmsConfigurationService.Tests.E2E/Features/ClaimsManagement.README.md
@@ -77,7 +77,9 @@ Tests invalid claims upload:
 - Verifies 400 response with validation errors
 
 ### Scenario 6: Security
-Verifies endpoints require dynamic claims loading to be enabled
+Verifies the endpoints enforce security in two layers:
+- A valid CMS bearer token is required (`ServicePolicy` plus an admin scope for `upload-claims` and `reload-claims`, or a read-only-or-admin scope for `current-claims`). Requests without a valid token return 401 regardless of the flag below, and a valid token with an insufficient scope returns 403.
+- Dynamic claims loading must be enabled (`DMS_CONFIG_DANGEROUSLY_ENABLE_UNRESTRICTED_CLAIMS_LOADING=true`); otherwise an authorized request returns 404.
 
 ## Troubleshooting
 

--- a/src/dms/tests/RestClient/cms-dms-claimset-sync-demo.http
+++ b/src/dms/tests/RestClient/cms-dms-claimset-sync-demo.http
@@ -76,6 +76,7 @@ grant_type=client_credentials
 ### 1. Get current claims from CMS management endpoint
 # @name currentClaimsBefore
 GET http://localhost:{{configPort}}/config/management/current-claims
+Authorization: bearer {{configToken}}
 
 
 ### 2. View current claimsets in DMS
@@ -94,6 +95,7 @@ GET http://localhost:{{dmsPort}}/management/view-claimsets
 # - Uses NoFurtherAuthorizationRequired for simplicity
 # @name uploadMinimalClaims
 POST http://localhost:{{configPort}}/config/management/upload-claims
+Authorization: bearer {{configToken}}
 Content-Type: application/json
 
 {
@@ -192,6 +194,7 @@ Content-Type: application/json
 ### 1. Get current claims from CMS after upload
 # @name currentClaimsAfterUpload
 GET http://localhost:{{configPort}}/config/management/current-claims
+Authorization: bearer {{configToken}}
 
 
 ### 2. Verify minimal claimset in CMS
@@ -226,6 +229,7 @@ GET http://localhost:{{dmsPort}}/management/view-claimsets
 ### 1. Reload original claims in CMS from file system
 # @name cmsReloadOriginal
 POST http://localhost:{{configPort}}/config/management/reload-claims
+Authorization: bearer {{configToken}}
 
 
 ###
@@ -234,6 +238,7 @@ POST http://localhost:{{configPort}}/config/management/reload-claims
 ### 2. Verify CMS restored to original state
 # @name cmsTestClaimsetRestored
 GET http://localhost:{{configPort}}/config/management/current-claims
+Authorization: bearer {{configToken}}
 
 
 ### 3. Sync DMS with restored CMS state


### PR DESCRIPTION
## Summary

DMS-1280 — the three claims management endpoints in `ClaimsManagementModule` were the only CMS frontend routes that did not call `RequireAuthorization`. They were gated solely by the `DangerouslyEnableUnrestrictedClaimsLoading` flag, so with that flag enabled they were reachable with **no bearer token** — anyone with network access could read (`GET /management/current-claims`) or replace (`POST /management/upload-claims`, `POST /management/reload-claims`) the entire authorization model.

This routes all three through the existing `MapSecuredPost` / `MapSecuredGet` helpers so they require `SecurityConstants.ServicePolicy` plus the same scope policies the sibling modules already use:

- `POST /management/reload-claims` → `ServicePolicy` + `AdminScopePolicy`
- `POST /management/upload-claims` → `ServicePolicy` + `AdminScopePolicy`
- `GET /management/current-claims` → `ServicePolicy` + `ReadOnlyOrAdminScopePolicy`

The `DangerouslyEnableUnrestrictedClaimsLoading` check is preserved as an inner gate; successful behavior and response contracts are unchanged when authentication, scope, and the flag all permit access.

## Behavior

| Condition | Result |
|---|---|
| Missing / invalid token | **401**, whether the flag is on or off (auth evaluated before the flag) |
| Valid token but not authorized (insufficient scope, unsupported scope, or wrong service role) | **403** |
| Valid token, sufficient scope, flag disabled | **404** (unchanged) |
| Valid token, sufficient scope, flag enabled | existing 200 / 400 / 500 contract, unchanged |

## Tests

- Focused frontend unit tests (`ClaimsManagementModuleTests`, `Given_*`/`It_*` fixtures) cover: a missing token **and** a malformed (non-JWT) bearer token → 401 for each endpoint under both flag states (the invalid-token case runs through the production JWT handler and was also confirmed against the real CMS stack in Docker); read-only → 403 on the writes and authorized on the read; an allowed scope with the wrong service role → 403 on all three (proving `ServicePolicy` is enforced — mutation-checked); an unsupported scope (`AuthMetadataReadOnlyAccess`) → 403 on the read (proving `MapSecuredGet`, not the broader `MapLimitedAccess`); and an authorized request → 404 when the flag is disabled.
- Existing CMS E2E `ClaimsManagement.feature` continues to cover the authenticated happy path (flag enabled, full-access token) and was not modified — its background already acquires a token; its README now distinguishes that happy-path coverage from the unit tests' negative-authorization coverage.

## Non-goals

No refactoring, no route/response/DTO changes, no renaming of the dangerous flag, no new OpenAPI `Produces(401/403)` annotations (matching sibling secured endpoints), and no unrelated documentation fixes.

## Changes (all included in this PR)

- Route `reload-claims`, `upload-claims`, and `current-claims` through `MapSecuredPost` / `MapSecuredGet`, and add focused `ClaimsManagementModuleTests` (including missing/invalid-token, `ServicePolicy`, and scope negative coverage).
- Document the authentication requirements in `docs/CLAIMS-LOADING-GUIDE.md` (both the `ServicePolicy` configuration-service role and the endpoint scope, plus 401/403/404 behavior), and correct the CMS `ClaimsManagement.README.md` to distinguish the E2E happy-path from the unit tests' negative-authorization coverage.
- Add the already-created `configToken` bearer header to the CMS management requests in `cms-dms-claimset-sync-demo.http`.

## Validation

- Frontend unit tests (`ClaimsManagementModuleTests`) pass; CI runs the full CMS unit + E2E suites.
- Verified locally against a config image built from this branch (dangerous flag enabled, self-contained IdP): the CMS `ClaimsManagement.feature` E2E passes, and direct checks confirm 401 for a missing or malformed (non-JWT) bearer token, 403 for a read-only token on the writes, and 200 for authorized requests.

## Related

- Public API 8.0 documentation revert (removes the "unauthenticated / no bearer token" statement and restores the `Authorization: Bearer` headers): [Ed-Fi-Alliance-OSS/ed-fi-alliance-oss.github.io#551](https://github.com/Ed-Fi-Alliance-OSS/ed-fi-alliance-oss.github.io/pull/551)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
