### PR TITLE
[DMS-873] Organize MSSQL gap closure designs

### DIFF
--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -1,0 +1,60 @@
+---
+jira: DMS-873
+jira_url: https://edfi.atlassian.net/browse/DMS-873
+---
+
+# Spike: Inventory MSSQL Implementation and Parity Gaps
+
+## Outcome
+
+DMS has a functioning SQL Server backend. The remaining work is a bounded set of parity, validation,
+deployment, and lifecycle gaps rather than a new backend implementation.
+
+`DMS-1125` is the canonical Jira epic for this gap-closing work. `DMS-872` is the legacy epic under which the
+spike and several follow-up stories were originally organized. Non-Done work owned by the legacy epic should
+move to `DMS-1125`; this repository structure records the target ownership before Jira cleanup is applied.
+
+## Gap Inventory
+
+| Ticket | Gap | Design ownership |
+| --- | --- | --- |
+| `DMS-1270` | Optional separate CMS database topology is not consistent across local PostgreSQL and MSSQL workflows | [`01-local-database-topology-parity.md`](01-local-database-topology-parity.md) |
+| `DMS-1271` | Bootstrap cannot materialize a datastore from a published database-template package before CMS and DMS startup | [`02-database-template-restore-workflow.md`](02-database-template-restore-workflow.md) |
+| `DMS-1279` | Local/CI MSSQL remains on SQL Server 2022 and generated document storage does not use the SQL Server 2025 native `json` type | [`03-sql-server-2025-and-native-json.md`](03-sql-server-2025-and-native-json.md) |
+| `DMS-1284` | The Docker-stack DMS E2E path is PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
+| `DMS-1285` | Several critical relational write-path correctness and resilience scenarios lack real-MSSQL execution | [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md) |
+| `DMS-1286` | NamespaceBased CRUD authorization lacks broad real-MSSQL provider integration coverage | [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md) |
+
+## Related Work That Keeps Existing Ownership
+
+| Ticket | Ownership decision |
+| --- | --- |
+| `DMS-1019` | Keep under operational guardrails; it owns cross-engine performance measurement. |
+| `DMS-1023` | Keep under test migration; it owns shared fixtures, canonical scenario names, and parity assertions. |
+| `DMS-1065` | Keep under authorization follow-up; it owns measured follow-on performance optimization. |
+| `DMS-1127` | Keep under update-tracking follow-up; it validates native-cascade stamping and journaling behavior. |
+| `DMS-1255` | Keep under bootstrap ownership; it supplies template packages, the shared local-database default, and the `-DbOnly` prerequisite. |
+
+Links between these tickets and `DMS-873` remain useful for provenance, but a Jira relation does not imply
+that the related ticket must move into `DMS-1125`.
+
+## Sequencing
+
+1. Finish the `DMS-1255` template and `-DbOnly` prerequisite.
+2. Close local topology and template-restore workflow gaps (`DMS-1270`, `DMS-1271`).
+3. Upgrade the MSSQL runtime and make a deliberate native-JSON adoption decision (`DMS-1279`).
+4. Establish the MSSQL Docker E2E lane (`DMS-1284`).
+5. Close provider-backed write and NamespaceBased authorization matrices (`DMS-1285`, `DMS-1286`), using
+   E2E for representative public-boundary confidence rather than duplicating every integration scenario.
+
+Items may overlap when their prerequisites are satisfied, but each ticket must retain its documented test
+boundary and non-goals.
+
+## Spike Exit Criteria
+
+- Every identified non-Done gap has one owning Jira ticket and one discoverable design document.
+- `DMS-1125` is the target epic for MSSQL gap-closing work that has no more specific active epic.
+- Cross-epic dependencies and exclusions are explicit.
+- Jira parent changes, status changes, and description updates are performed only after human approval.
+- Follow-up tickets contain enough acceptance criteria to distinguish environment failures from product
+  failures and to prevent PostgreSQL regressions.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -3,16 +3,18 @@ jira: DMS-873
 jira_url: https://edfi.atlassian.net/browse/DMS-873
 ---
 
-# Spike: Inventory MSSQL Implementation and Parity Gaps
+# Inventory MSSQL Implementation and Parity Gaps
 
 ## Outcome
 
-DMS has a functioning SQL Server backend. The remaining work is a bounded set of parity, validation,
-deployment, and lifecycle gaps rather than a new backend implementation.
+DMS and CMS both support PostgreSQL and SQL Server. The remaining work is a bounded set of MSSQL parity,
+validation, deployment, and lifecycle gaps rather than a new backend implementation. This spike inventories
+those gaps and records their owning tickets, dependencies, and scope boundaries.
 
-`DMS-1125` is the canonical Jira epic for this gap-closing work. `DMS-872` is the legacy epic under which the
-spike and several follow-up stories were originally organized. Non-Done work owned by the legacy epic should
-move to `DMS-1125`; this repository structure records the target ownership before Jira cleanup is applied.
+`DMS-1125` is the canonical Jira epic for MSSQL gap-closing work that does not have a more specific active home.
+All seven work items originally listed in this design—`DMS-873`, `DMS-1270`, `DMS-1271`, `DMS-1279`,
+`DMS-1284`, `DMS-1285`, and `DMS-1286`—are already children of `DMS-1125`. The parent cleanup is complete;
+no reparenting remains pending for those items.
 
 ## Gap Inventory
 
@@ -24,6 +26,20 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | `DMS-1284` | The standard DMS and Instance Management Docker E2E paths are PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
 | `DMS-1285` | Several critical relational write-path correctness and resilience scenarios lack real-MSSQL execution | [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md) |
 | `DMS-1286` | NamespaceBased CRUD authorization lacks broad real-MSSQL provider integration coverage | [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md) |
+| `DMS-1289` | Scheduled smoke tests do not exercise the complete MSSQL template build, restore, registration, and API/SDK smoke path | [Detailed Jira scope and acceptance criteria](https://edfi.atlassian.net/browse/DMS-1289) |
+
+`DMS-1289` belongs in this inventory because scheduled release-confidence coverage is distinct from the Docker
+E2E boundary in `DMS-1284` and the provider-integration matrices in `DMS-1285` and `DMS-1286`.
+
+Each implementation item retains its own acceptance criteria and non-goals. `DMS-873` owns only this inventory
+and its scope boundaries; it does not re-own implementation assigned to the follow-up tickets.
+
+## Delivered Prerequisite
+
+`DMS-1255` is complete. It delivered the baseline MSSQL database-template packages, shared local-database
+default, `-DbOnly` startup slice, and engine-aware template build/restore foundations consumed by later work.
+Treat it as a delivered prerequisite and provenance link for `DMS-1270`, `DMS-1271`, `DMS-1279`, and
+`DMS-1289`, not as an active blocker.
 
 ## Related Work That Keeps Existing Ownership
 
@@ -33,46 +49,49 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | `DMS-1023` | Keep under test migration; it owns shared fixtures, canonical scenario names, and parity assertions. |
 | `DMS-1065` | Keep under authorization follow-up; it owns measured follow-on performance optimization. |
 | `DMS-1127` | Keep under update-tracking follow-up; it validates native-cascade stamping and journaling behavior. |
-| `DMS-1255` | Keep under bootstrap ownership; it supplies baseline template packages, the shared local-database default, and the `-DbOnly` prerequisite. `DMS-1271` owns the narrow restore-manifest extension. |
 | `DMS-1258` | Keep under its existing SQL Server foreign-key-pruning ownership and normative [`sql-server-pruning.md`](../../design-docs/sql-server-pruning.md) design. It must close the pending implementation gap but is not re-owned by this spike. |
 
-Links between these tickets and `DMS-873` remain useful for provenance, but a Jira relation does not imply
-that the related ticket must move into `DMS-1125`.
+Links between these tickets and `DMS-873` remain useful for provenance but do not transfer implementation
+ownership.
 
-## Blocking Relationships
+## Active Dependencies
 
 | Blocker | Blocked ticket | Reason |
 | --- | --- | --- |
-| `DMS-1255` | `DMS-1270` | The separate-topology option extends the shared local-database default delivered by `DMS-1255`. |
-| `DMS-1255` | `DMS-1271` | Template restore requires the published packages and `-DbOnly` startup slice delivered by `DMS-1255`. |
-| `DMS-1255` | `DMS-1279` | The runtime upgrade must prove forward restore of the SQL Server 2022 template packages delivered by `DMS-1255`. |
+| `DMS-1258` | `DMS-1127` | Native-cascade update-tracking validation requires the finalized SQL Server foreign-key-pruning behavior. |
 | `DMS-1270` | `DMS-1271` | Restore cannot close its shared/separate topology acceptance matrix until the separate-CMS contract exists. |
 | `DMS-1023` | `DMS-1285` | The write-path matrix consumes the canonical scenario catalog, fixtures, and assertion contract from `DMS-1023`. |
-| `DMS-1258` | `DMS-1127` | Native-cascade update-tracking validation requires the finalized SQL Server foreign-key-pruning behavior. |
 
-These are completion blockers, not a requirement to serialize all implementation work. `DMS-1284` and
-`DMS-1286` have no open hard blocker in this inventory. `DMS-1258` and `DMS-1127` retain their existing epic
-ownership while remaining on the MSSQL parity-closure path.
+These are completion dependencies, not a requirement to serialize all implementation work. `DMS-1284`,
+`DMS-1286`, and `DMS-1289` have no open hard blocker in this inventory. `DMS-1258` and `DMS-1127` retain their
+existing epic ownership while remaining on the MSSQL parity-closure path.
 
 ## Sequencing
 
-1. Finish the `DMS-1255` template and `-DbOnly` prerequisite. Continue `DMS-1258` under its existing pruning
-   ownership in parallel; MSSQL parity cannot be declared closed while that implementation remains pending.
-2. Close local topology and template-restore workflow gaps (`DMS-1270`, `DMS-1271`).
+1. Continue `DMS-1258` under its existing pruning ownership; complete `DMS-1127` after the finalized pruning
+   behavior is available.
+2. Close local topology and template-restore workflow gaps (`DMS-1270`, `DMS-1271`) using the foundation
+   delivered by `DMS-1255`.
 3. Upgrade the MSSQL runtime and make a deliberate native-JSON adopt/defer decision (`DMS-1279`); deferral does
    not block the runtime upgrade.
 4. Establish MSSQL lanes for both the standard DMS and Instance Management Docker E2E suites (`DMS-1284`).
 5. Close provider-backed write and NamespaceBased authorization matrices (`DMS-1285`, `DMS-1286`), using
    E2E for representative public-boundary confidence rather than duplicating every integration scenario.
+6. Add the full MSSQL scheduled smoke matrix (`DMS-1289`) using the template and engine-selection foundations
+   delivered by `DMS-1255`.
 
 Items may overlap when their prerequisites are satisfied, but each ticket must retain its documented test
 boundary and non-goals.
 
-## Spike Exit Criteria
+## Scope Guardrails and Exit Criteria
 
-- Every identified non-Done gap has one owning Jira ticket and one discoverable design document.
-- `DMS-1125` is the target epic for MSSQL gap-closing work that has no more specific active epic.
-- Cross-epic dependencies and exclusions are explicit.
-- Jira parent changes, status changes, and description updates are performed only after human approval.
-- Follow-up tickets contain enough acceptance criteria to distinguish environment failures from product
-  failures and to prevent PostgreSQL regressions.
+- Do not describe this work as adding SQL Server support; both DMS and CMS already support SQL Server.
+- Preserve PostgreSQL behavior unless a shared defect requires an intentional cross-engine change.
+- Validate provider-specific claims against a real SQL Server; SQL-shape tests alone are not sufficient for
+  provider behavior.
+- Keep CMS and DMS persistence responsibilities separate while allowing bootstrap and topology work to
+  coordinate both services.
+- Keep performance measurement and speculative optimization in their existing owning tickets.
+- Every identified non-Done gap has one owning Jira ticket, explicit dependencies and exclusions, and enough
+  acceptance criteria to distinguish environment failures from product failures. Detailed implementation scope
+  is discoverable through either the linked repository design or the owning Jira ticket.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -12,9 +12,9 @@ validation, deployment, and lifecycle gaps rather than a new backend implementat
 those gaps and records their owning tickets, dependencies, and scope boundaries.
 
 `DMS-1125` is the canonical Jira epic for MSSQL gap-closing work that does not have a more specific active home.
-All seven work items originally listed in this design—`DMS-873`, `DMS-1270`, `DMS-1271`, `DMS-1279`,
-`DMS-1284`, `DMS-1285`, and `DMS-1286`—are already children of `DMS-1125`. The parent cleanup is complete;
-no reparenting remains pending for those items.
+All eight inventoried work items—`DMS-873`, `DMS-1270`, `DMS-1271`, `DMS-1279`, `DMS-1284`, `DMS-1285`,
+`DMS-1286`, and `DMS-1289`—are children of `DMS-1125`. The parent cleanup is complete; no reparenting remains
+pending for those items.
 
 ## Gap Inventory
 
@@ -26,7 +26,7 @@ no reparenting remains pending for those items.
 | `DMS-1284` | The standard DMS and Instance Management Docker E2E paths are PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
 | `DMS-1285` | Several critical relational write-path correctness and resilience scenarios lack real-MSSQL execution | [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md) |
 | `DMS-1286` | NamespaceBased CRUD authorization lacks broad real-MSSQL provider integration coverage | [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md) |
-| `DMS-1289` | Scheduled smoke tests do not exercise the complete MSSQL template build, restore, registration, and API/SDK smoke path | [Detailed Jira scope and acceptance criteria](https://edfi.atlassian.net/browse/DMS-1289) |
+| `DMS-1289` | Scheduled smoke tests do not exercise the complete MSSQL template build, restore, registration, and API/SDK smoke path | [`07-mssql-scheduled-smoke.md`](07-mssql-scheduled-smoke.md) |
 
 `DMS-1289` belongs in this inventory because scheduled release-confidence coverage is distinct from the Docker
 E2E boundary in `DMS-1284` and the provider-integration matrices in `DMS-1285` and `DMS-1286`.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -21,7 +21,7 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | `DMS-1270` | Optional separate CMS database topology is not consistent across local PostgreSQL and MSSQL workflows | [`01-local-database-topology-parity.md`](01-local-database-topology-parity.md) |
 | `DMS-1271` | Bootstrap cannot materialize a datastore from a published database-template package before CMS and DMS startup | [`02-database-template-restore-workflow.md`](02-database-template-restore-workflow.md) |
 | `DMS-1279` | Local/CI MSSQL remains on SQL Server 2022, and the optional document-cache column needs a gated adopt/defer decision for SQL Server 2025 native `json` | [`03-sql-server-2025-and-native-json.md`](03-sql-server-2025-and-native-json.md) |
-| `DMS-1284` | The Docker-stack DMS E2E path is PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
+| `DMS-1284` | The standard DMS and Instance Management Docker E2E paths are PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
 | `DMS-1285` | Several critical relational write-path correctness and resilience scenarios lack real-MSSQL execution | [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md) |
 | `DMS-1286` | NamespaceBased CRUD authorization lacks broad real-MSSQL provider integration coverage | [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md) |
 
@@ -34,17 +34,19 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | `DMS-1065` | Keep under authorization follow-up; it owns measured follow-on performance optimization. |
 | `DMS-1127` | Keep under update-tracking follow-up; it validates native-cascade stamping and journaling behavior. |
 | `DMS-1255` | Keep under bootstrap ownership; it supplies baseline template packages, the shared local-database default, and the `-DbOnly` prerequisite. `DMS-1271` owns the narrow restore-manifest extension. |
+| `DMS-1258` | Keep under its existing SQL Server foreign-key-pruning ownership and normative [`sql-server-pruning.md`](../../design-docs/sql-server-pruning.md) design. It must close the pending implementation gap but is not re-owned by this spike. |
 
 Links between these tickets and `DMS-873` remain useful for provenance, but a Jira relation does not imply
 that the related ticket must move into `DMS-1125`.
 
 ## Sequencing
 
-1. Finish the `DMS-1255` template and `-DbOnly` prerequisite.
+1. Finish the `DMS-1255` template and `-DbOnly` prerequisite. Continue `DMS-1258` under its existing pruning
+   ownership in parallel; MSSQL parity cannot be declared closed while that implementation remains pending.
 2. Close local topology and template-restore workflow gaps (`DMS-1270`, `DMS-1271`).
 3. Upgrade the MSSQL runtime and make a deliberate native-JSON adopt/defer decision (`DMS-1279`); deferral does
    not block the runtime upgrade.
-4. Establish the MSSQL Docker E2E lane (`DMS-1284`).
+4. Establish MSSQL lanes for both the standard DMS and Instance Management Docker E2E suites (`DMS-1284`).
 5. Close provider-backed write and NamespaceBased authorization matrices (`DMS-1285`, `DMS-1286`), using
    E2E for representative public-boundary confidence rather than duplicating every integration scenario.
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -20,7 +20,7 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | --- | --- | --- |
 | `DMS-1270` | Optional separate CMS database topology is not consistent across local PostgreSQL and MSSQL workflows | [`01-local-database-topology-parity.md`](01-local-database-topology-parity.md) |
 | `DMS-1271` | Bootstrap cannot materialize a datastore from a published database-template package before CMS and DMS startup | [`02-database-template-restore-workflow.md`](02-database-template-restore-workflow.md) |
-| `DMS-1279` | Local/CI MSSQL remains on SQL Server 2022 and generated document storage does not use the SQL Server 2025 native `json` type | [`03-sql-server-2025-and-native-json.md`](03-sql-server-2025-and-native-json.md) |
+| `DMS-1279` | Local/CI MSSQL remains on SQL Server 2022, and the optional document-cache column needs a gated adopt/defer decision for SQL Server 2025 native `json` | [`03-sql-server-2025-and-native-json.md`](03-sql-server-2025-and-native-json.md) |
 | `DMS-1284` | The Docker-stack DMS E2E path is PostgreSQL-specific | [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md) |
 | `DMS-1285` | Several critical relational write-path correctness and resilience scenarios lack real-MSSQL execution | [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md) |
 | `DMS-1286` | NamespaceBased CRUD authorization lacks broad real-MSSQL provider integration coverage | [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md) |
@@ -33,7 +33,7 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 | `DMS-1023` | Keep under test migration; it owns shared fixtures, canonical scenario names, and parity assertions. |
 | `DMS-1065` | Keep under authorization follow-up; it owns measured follow-on performance optimization. |
 | `DMS-1127` | Keep under update-tracking follow-up; it validates native-cascade stamping and journaling behavior. |
-| `DMS-1255` | Keep under bootstrap ownership; it supplies template packages, the shared local-database default, and the `-DbOnly` prerequisite. |
+| `DMS-1255` | Keep under bootstrap ownership; it supplies baseline template packages, the shared local-database default, and the `-DbOnly` prerequisite. `DMS-1271` owns the narrow restore-manifest extension. |
 
 Links between these tickets and `DMS-873` remain useful for provenance, but a Jira relation does not imply
 that the related ticket must move into `DMS-1125`.
@@ -42,7 +42,8 @@ that the related ticket must move into `DMS-1125`.
 
 1. Finish the `DMS-1255` template and `-DbOnly` prerequisite.
 2. Close local topology and template-restore workflow gaps (`DMS-1270`, `DMS-1271`).
-3. Upgrade the MSSQL runtime and make a deliberate native-JSON adoption decision (`DMS-1279`).
+3. Upgrade the MSSQL runtime and make a deliberate native-JSON adopt/defer decision (`DMS-1279`); deferral does
+   not block the runtime upgrade.
 4. Establish the MSSQL Docker E2E lane (`DMS-1284`).
 5. Close provider-backed write and NamespaceBased authorization matrices (`DMS-1285`, `DMS-1286`), using
    E2E for representative public-boundary confidence rather than duplicating every integration scenario.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md
@@ -39,6 +39,21 @@ move to `DMS-1125`; this repository structure records the target ownership befor
 Links between these tickets and `DMS-873` remain useful for provenance, but a Jira relation does not imply
 that the related ticket must move into `DMS-1125`.
 
+## Blocking Relationships
+
+| Blocker | Blocked ticket | Reason |
+| --- | --- | --- |
+| `DMS-1255` | `DMS-1270` | The separate-topology option extends the shared local-database default delivered by `DMS-1255`. |
+| `DMS-1255` | `DMS-1271` | Template restore requires the published packages and `-DbOnly` startup slice delivered by `DMS-1255`. |
+| `DMS-1255` | `DMS-1279` | The runtime upgrade must prove forward restore of the SQL Server 2022 template packages delivered by `DMS-1255`. |
+| `DMS-1270` | `DMS-1271` | Restore cannot close its shared/separate topology acceptance matrix until the separate-CMS contract exists. |
+| `DMS-1023` | `DMS-1285` | The write-path matrix consumes the canonical scenario catalog, fixtures, and assertion contract from `DMS-1023`. |
+| `DMS-1258` | `DMS-1127` | Native-cascade update-tracking validation requires the finalized SQL Server foreign-key-pruning behavior. |
+
+These are completion blockers, not a requirement to serialize all implementation work. `DMS-1284` and
+`DMS-1286` have no open hard blocker in this inventory. `DMS-1258` and `DMS-1127` retain their existing epic
+ownership while remaining on the MSSQL parity-closure path.
+
 ## Sequencing
 
 1. Finish the `DMS-1255` template and `-DbOnly` prerequisite. Continue `DMS-1258` under its existing pruning

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
@@ -1,0 +1,69 @@
+---
+jira: DMS-1270
+jira_url: https://edfi.atlassian.net/browse/DMS-1270
+---
+
+# Story: Align Local Database Topology Across Engines with an Optional Separate CMS Database
+
+## Description
+
+Provide one consistent local topology contract for PostgreSQL and MSSQL. The default remains the shared
+database delivered by `DMS-1255`; operators may explicitly select a production-like topology in which CMS
+uses a dedicated configuration database and DMS instances use separate datastore databases.
+
+The topology choice must flow through the local start scripts, published-image start scripts, bootstrap
+wrappers, and `build-dms.ps1 StartEnvironment`. It must not be inferred from the selected database engine.
+
+## Topology Contract
+
+| Mode | CMS database | DMS datastore | Required behavior |
+| --- | --- | --- | --- |
+| Shared (default) | Selected local database | Same physical database | Preserve the `DMS-1255` default for PostgreSQL and MSSQL. |
+| Separate | Dedicated configuration database | Selected DMS datastore database | Create and initialize CMS independently; never redirect DMS schema or template restore into the CMS database. |
+
+Expose the separate mode through `-SeparateConfigDatabase`. Use one effective configuration-database name
+as the interpolation seam for both engines rather than embedding engine-specific names throughout the
+scripts. The switch and effective name must be forwarded consistently by every wrapper and entry point.
+
+## Database Creation
+
+- MSSQL keeps its guarded CMS-database creation behavior in the OpenIddict initialization path.
+- PostgreSQL gains equivalent guarded creation for the separate CMS database.
+- The PostgreSQL container initialization path must also create the separate CMS database when Keycloak mode
+  bypasses the OpenIddict setup path.
+- Document that PostgreSQL container-init changes require a fresh database volume; initialization scripts do
+  not rerun against an existing volume.
+- Creation must be idempotent and must fail with a clear diagnostic when an existing database cannot be used.
+
+## Coordination with Template Restore
+
+[`DMS-1271`](02-database-template-restore-workflow.md) owns template restore. In shared mode, restore occurs
+before CMS initialization, after which CMS creates its schema in the restored database. In separate mode,
+restore targets only the DMS datastore and never the CMS database.
+
+## Acceptance Criteria
+
+- `-SeparateConfigDatabase` is available on local/published start scripts, bootstrap wrappers, and
+  `build-dms.ps1 StartEnvironment` with consistent forwarding and validation.
+- Omitting the switch preserves the shared-database default on both engines.
+- Selecting the switch points CMS at a dedicated configuration database without changing the DMS datastore
+  selection.
+- PostgreSQL and MSSQL can create a missing dedicated CMS database through every supported identity-provider
+  path.
+- All four engine-by-topology cells start successfully, and CMS/DMS schemas land in the intended databases.
+- Pester coverage verifies forwarding, defaults, mutual exclusions, and target database selection.
+- README and environment-file documentation explain both modes and the PostgreSQL fresh-volume requirement.
+
+## Non-Goals
+
+- Changing the shared local default delivered by `DMS-1255`.
+- Designing production multi-tenant routing or a new CMS datastore model.
+- Restoring database-template packages; `DMS-1271` owns restore sequencing and execution.
+- Combining CMS and DMS persistence implementations.
+
+## Design References
+
+- [`../16-bootstrap/EPIC.md`](../16-bootstrap/EPIC.md)
+- [`../../design-docs/bootstrap/bootstrap-design.md`](../../design-docs/bootstrap/bootstrap-design.md)
+- [`../../design-docs/bootstrap/command-boundaries.md`](../../design-docs/bootstrap/command-boundaries.md)
+- [`02-database-template-restore-workflow.md`](02-database-template-restore-workflow.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
@@ -27,12 +27,15 @@ scripts. The switch and effective name must be forwarded consistently by every w
 
 ## Database Creation
 
-- MSSQL keeps its guarded CMS-database creation behavior in the OpenIddict initialization path.
-- PostgreSQL gains equivalent guarded creation for the separate CMS database.
-- The PostgreSQL container initialization path must also create the separate CMS database when Keycloak mode
-  bypasses the OpenIddict setup path.
-- Document that PostgreSQL container-init changes require a fresh database volume; initialization scripts do
-  not rerun against an existing volume.
+- CMS keeps engine-neutral ownership of database creation during its normal startup deployment. The existing
+  PostgreSQL and MSSQL `EnsureDatabase` paths create a missing dedicated configuration database when Keycloak
+  mode starts CMS without running the OpenIddict initialization script first.
+- Self-contained identity is the exception because `setup-openiddict.ps1 -InitDb` runs before CMS startup and
+  must connect to the CMS database to create its key store. MSSQL keeps its guarded pre-CMS creation behavior,
+  and PostgreSQL gains the equivalent guarded creation for the selected dedicated configuration database.
+- Do not add a PostgreSQL container-entrypoint initialization script for Keycloak. It would duplicate the CMS
+  deployment path and would work only on a fresh volume, while CMS startup must remain idempotent on both fresh
+  and existing volumes.
 - Creation must be idempotent and must fail with a clear diagnostic when an existing database cannot be used.
 
 ## Coordination with Template Restore
@@ -49,10 +52,12 @@ restore targets only the DMS datastore and never the CMS database.
 - Selecting the switch points CMS at a dedicated configuration database without changing the DMS datastore
   selection.
 - PostgreSQL and MSSQL can create a missing dedicated CMS database through every supported identity-provider
-  path.
+  path: CMS deployment owns the Keycloak path, while guarded OpenIddict initialization owns the pre-CMS
+  self-contained path.
 - All four engine-by-topology cells start successfully, and CMS/DMS schemas land in the intended databases.
-- Pester coverage verifies forwarding, defaults, mutual exclusions, and target database selection.
-- README and environment-file documentation explain both modes and the PostgreSQL fresh-volume requirement.
+- Pester coverage verifies forwarding, defaults, mutual exclusions, target database selection, and the
+  identity-provider-specific creation owner without introducing a duplicate container-init path.
+- README and environment-file documentation explain both modes and their database-creation paths.
 
 ## Non-Goals
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
@@ -16,7 +16,8 @@ wrappers, and `build-dms.ps1 StartEnvironment`. It must not be inferred from the
 
 ## Dependencies
 
-- Blocked by `DMS-1255`, which delivers the shared local-database default that this story extends.
+- Prerequisite delivered by `DMS-1255`: the shared local-database default that this story extends is already
+  available. Retain the Jira link for provenance; it does not describe remaining work for this story.
 - Blocks `DMS-1271`, whose restore acceptance matrix requires the shared and separate topology contracts.
 
 ## Topology Contract
@@ -26,9 +27,12 @@ wrappers, and `build-dms.ps1 StartEnvironment`. It must not be inferred from the
 | Shared (default) | Selected local database | Same physical database | Preserve the `DMS-1255` default for PostgreSQL and MSSQL. |
 | Separate | Dedicated configuration database | Selected DMS datastore database | Create and initialize CMS independently; never redirect DMS schema or template restore into the CMS database. |
 
-Expose the separate mode through `-SeparateConfigDatabase`. Use one effective configuration-database name
-as the interpolation seam for both engines rather than embedding engine-specific names throughout the
-scripts. The switch and effective name must be forwarded consistently by every wrapper and entry point.
+Expose the separate mode through `-SeparateConfigDatabase`. `DMS_CONFIG_DATABASE_NAME` is the definitive
+configuration-database-name contract for both engines and must be interpolated into both engines'
+`DMS_CONFIG_DATABASE_CONNECTION_STRING`. Without the switch, it resolves to the selected DMS datastore
+database (`POSTGRES_DB_NAME` or `MSSQL_DB_NAME`). With the switch, it resolves to the dedicated
+`edfi_configurationservice` database. Every wrapper and entry point must forward the switch and preserve this
+effective name; caller-authored connection strings must agree with it or fail with a clear diagnostic.
 
 ## Database Creation
 
@@ -38,7 +42,7 @@ scripts. The switch and effective name must be forwarded consistently by every w
 - Self-contained identity is the exception because `setup-openiddict.ps1 -InitDb` runs before CMS startup and
   must connect to the CMS database to create its key store. MSSQL keeps its guarded pre-CMS creation behavior,
   and PostgreSQL gains the equivalent guarded creation for the selected dedicated configuration database.
-- Do not add a PostgreSQL container-entrypoint initialization script for Keycloak. It would duplicate the CMS
+- Do not add configuration-database creation to `postgresql-init.sh` for Keycloak. It would duplicate the CMS
   deployment path and would work only on a fresh volume, while CMS startup must remain idempotent on both fresh
   and existing volumes.
 - Creation must be idempotent and must fail with a clear diagnostic when an existing database cannot be used.
@@ -47,21 +51,25 @@ scripts. The switch and effective name must be forwarded consistently by every w
 
 [`DMS-1271`](02-database-template-restore-workflow.md) owns template restore. In shared mode, restore occurs
 before CMS initialization, after which CMS creates its schema in the restored database. In separate mode,
-restore targets only the DMS datastore and never the CMS database.
+restore targets only the DMS datastore and never the CMS database. Retain `DMS-1270` and `DMS-1271` as
+separate stories: this story owns topology selection, propagation, database creation, and the four-cell
+bootstrap matrix; `DMS-1271` owns package validation, restore sequencing, and restore target safety.
 
 ## Acceptance Criteria
 
 - `-SeparateConfigDatabase` is available on local/published start scripts, bootstrap wrappers, and
   `build-dms.ps1 StartEnvironment` with consistent forwarding and validation.
-- Omitting the switch preserves the shared-database default on both engines.
-- Selecting the switch points CMS at a dedicated configuration database without changing the DMS datastore
-  selection.
+- Omitting the switch sets `DMS_CONFIG_DATABASE_NAME` to the selected DMS datastore database and preserves the
+  shared-database default on both engines.
+- Selecting the switch sets `DMS_CONFIG_DATABASE_NAME` to `edfi_configurationservice` and points CMS at that
+  dedicated database without changing the DMS datastore selection.
 - PostgreSQL and MSSQL can create a missing dedicated CMS database through every supported identity-provider
   path: CMS deployment owns the Keycloak path, while guarded OpenIddict initialization owns the pre-CMS
   self-contained path.
 - All four engine-by-topology cells start successfully, and CMS/DMS schemas land in the intended databases.
 - Pester coverage verifies forwarding, defaults, mutual exclusions, target database selection, and the
-  identity-provider-specific creation owner without introducing a duplicate container-init path.
+  identity-provider-specific creation owner without adding configuration-database creation to
+  `postgresql-init.sh`.
 - README and environment-file documentation explain both modes and their database-creation paths.
 
 ## Non-Goals

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md
@@ -14,6 +14,11 @@ uses a dedicated configuration database and DMS instances use separate datastore
 The topology choice must flow through the local start scripts, published-image start scripts, bootstrap
 wrappers, and `build-dms.ps1 StartEnvironment`. It must not be inferred from the selected database engine.
 
+## Dependencies
+
+- Blocked by `DMS-1255`, which delivers the shared local-database default that this story extends.
+- Blocks `DMS-1271`, whose restore acceptance matrix requires the shared and separate topology contracts.
+
 ## Topology Contract
 
 | Mode | CMS database | DMS datastore | Required behavior |

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -23,9 +23,9 @@ contains DMS datastore state only; a database template is never a CMS or identit
 
 ## Dependencies
 
-- Blocked by `DMS-1255` for the published template packages and `-DbOnly` startup slice.
-- Blocked by `DMS-1270` for the separate-CMS topology contract required by target-safety and topology-matrix
-  acceptance coverage.
+- Delivered prerequisite: `DMS-1255` supplies the published template packages and `-DbOnly` startup slice.
+- Active completion blocker: `DMS-1270` supplies the separate-CMS topology contract required by target-safety
+  and topology-matrix acceptance coverage.
 
 ## Restore Sequence
 
@@ -43,21 +43,27 @@ The wrapper performs the following sequence in restore mode:
    core/extension project inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping
    version, engine, and any engine-defined physical-schema version must match exactly. On mismatch, remove the
    candidate and leave the active workspace and selected database untouched.
-4. Prove that the entire selected DMS stack is stopped before replacing or reusing active restore workspace
-   state. A failed or indeterminate stop proof leaves the active workspace and target untouched.
-5. If the active workspace is absent or differs from the verified candidate, replace the complete
-   `.bootstrap` tree with the candidate. If it already matches, discard the candidate and reuse the complete
-   active tree. Never rewrite only a schema or manifest subtree.
-6. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
-7. Revalidate target safety against the live engine catalog. Restore the artifact into a generated scratch
-   database, validate its effective schema and DMS-only catalog contents, remove the scratch database, and only
-   then replace the explicitly selected physical DMS datastore database.
-8. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
-9. Run `configure-local-data-store.ps1` for the restored datastore.
-10. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
+4. Prove that the entire selected DMS stack is stopped before starting database preflight. A failed or
+   indeterminate stop proof leaves the active workspace and target untouched.
+5. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
+6. Revalidate target safety against the live engine catalog. Restore the artifact into a generated scratch
+   database, validate its effective schema and DMS-only catalog contents, and remove the scratch database.
+   Package, candidate-workspace, stop-proof, target-safety, or scratch-validation failure ends preflight,
+   removes transient state, and leaves both the active workspace and selected database unchanged.
+7. Stop the database-only slice and again prove that the complete selected stack is stopped. The verified
+   candidate and scratch result do not authorize workspace replacement while any stack service is running.
+8. Begin the commit stage. If the active workspace is absent or differs from the verified candidate, replace
+   the complete `.bootstrap` tree with the candidate. If it already matches, discard the candidate and reuse
+   the complete active tree. Never rewrite only a schema or manifest subtree.
+9. Run `start-*-dms.ps1 -DbOnly` again. Immediately before any destructive target operation, repeat the
+   reserved-name, separate-CMS, running-service, and live-catalog validation, then replace the explicitly
+   selected physical DMS datastore database from the same hash-verified artifact validated in scratch.
+10. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
+11. Run `configure-local-data-store.ps1` for the restored datastore.
+12. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
    schema and seed data.
-11. Run `start-*-dms.ps1 -DmsOnly`.
-12. Run supplemental API seed only when an explicit, compatible option requests it.
+13. Run `start-*-dms.ps1 -DmsOnly`.
+14. Run supplemental API seed only when an explicit, compatible option requests it.
 
 The wrapper owns when restore happens. An engine-dispatched restore module owns how the package is restored.
 
@@ -92,6 +98,8 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   canonical inventory, compares it with the manifest, verifies `dms.EffectiveSchema` against both the manifest
   and candidate bootstrap manifest, and enforces the DMS-only exclusions before touching the target. Feed and
   `-PackageDirectory` packages use identical producer/consumer checks; local origin is not a trust bypass.
+- Any failure through scratch validation is a preflight failure: transient candidate and scratch state is
+  removed, while the active `.bootstrap` tree and selected physical database remain unchanged.
 - A legacy package without the external manifest is not eligible for target replacement. If legacy-package
   compatibility is later required, it must use a safe scratch restore followed by `dms.EffectiveSchema`
   validation before any destructive operation against the selected datastore.
@@ -102,11 +110,12 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   plus SQL Server `master`, `model`, `msdb`, and `tempdb`. Apply this denylist during parameter validation and
   again against the live catalog before scratch creation, `DROP`, or `RESTORE`; generic identifier validation
   is not a substitute for reserved-name validation.
-- Fail before workspace replacement unless the complete selected stack is proven stopped; checking only
-  whether CMS or DMS points at the eventual restore target is insufficient because either service may still
-  have `.bootstrap` content bind-mounted.
+- Fail before workspace replacement unless the complete selected stack is proven stopped after scratch
+  validation; checking only whether CMS or DMS points at the eventual restore target is insufficient because
+  either service may still have `.bootstrap` content bind-mounted.
 - Fail before target restore if CMS or DMS is running against the target. Failure to prove either safety
-  condition leaves the existing workspace and database untouched.
+  condition during preflight leaves the existing workspace and database untouched; the same checks run again
+  immediately before target replacement so a post-commit race cannot authorize database mutation.
 - In shared-database mode, restore only a package proven to have the `DmsDatastoreOnly` content profile, and do
   so in the `-DbOnly` window before CMS creates a fresh schema and clients. No CMS or identity record from the
   package may survive into the initialized environment.
@@ -124,8 +133,8 @@ state form one handoff and may still be bind-mounted.
 
 - Bootstrap exposes an explicit restore option separate from `-LoadSeedData`.
 - Restore validates the external manifest and artifact hash, safely prepares the complete workspace, then
-  follows `-DbOnly -> scratch validation -> target restore -> -InfraOnly -> configure -> -DmsOnly`; it skips
-  schema provisioning only for restored targets.
+  follows `-DbOnly -> scratch validation -> stop proof -> complete workspace replacement -> -DbOnly -> target
+  restore -> -InfraOnly -> configure -> -DmsOnly`; it skips schema provisioning only for restored targets.
 - Before Docker startup or active-workspace replacement, restore proves that the package's Data Standard,
   core/extension inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping version, and
   any engine-defined physical-schema version match the authoritative candidate workspace.
@@ -135,16 +144,18 @@ state form one handoff and may still be bind-mounted.
 - Producers reject shared or contaminated sources. Consumers scratch-restore and reject packages containing
   `dmscs`, CMS/OpenIddict state, unexpected principals, or objects outside the manifest's DMS-only inventory
   before replacing the target, including packages supplied through `-PackageDirectory`.
-- Package resolution or external-manifest validation failures occur before Docker startup and leave the
-  workspace and target untouched. Target-selection or restore failures stop before CMS/DMS startup.
+- Package resolution or external-manifest validation failures occur before Docker startup. Every preflight
+  failure through scratch validation leaves the active workspace and selected target untouched. Target
+  selection or restore failures stop before CMS/DMS startup.
 - Existing non-restore bootstrap behavior is unchanged.
 - A mismatched or incomplete workspace is replaced only after the complete stack is proven stopped; the whole
   `.bootstrap` tree is removed and schema, claims, and seed handoff state are regenerated together.
 - Tests cover wrapper sequencing, candidate/package hash and project-inventory mismatches, reserved database
   names for both engines, local-package resolution, engine-specific scratch and target command construction,
   manifest/artifact validation before Docker activity, DMS-only producer and consumer gates, scratch cleanup,
-  failed stop proof, full-workspace replacement, bind-mount safety, shared/separate topology behavior, default
-  targeting, repeated single-target operation, and the distinction between restore and API seed delivery.
+  failed stop proof, the database-only preflight stop/restart boundary, full-workspace replacement, bind-mount
+  safety, shared/separate topology behavior, default targeting, repeated single-target operation, and the
+  distinction between restore and API seed delivery.
 - Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
   versions, including different extension selections, effective-schema validation, contaminated-package
   rejection before target replacement, and served data.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -16,10 +16,12 @@ a package artifact.
 
 `DMS-1255` supplies the baseline template packages and the `-DbOnly` startup phase used by this story. This
 story owns the narrow producer-and-consumer extension that adds a machine-readable restore manifest outside
-the database artifact. The shared template tooling captures the live metadata immediately before backup,
-creates and hashes the database artifact, then packages the completed manifest beside the `.sql` or `.bak`;
-general package publication remains under `DMS-1255` ownership. This extension also proves that the package
-contains DMS datastore state only; a database template is never a CMS or identity-state backup.
+the database artifact and authenticates the completed package as trusted executable input. The shared
+template tooling captures the live metadata immediately before backup, creates and hashes the database
+artifact, packages the completed manifest beside the `.sql` or `.bak`, and signs or attests the exact package
+bytes for an approved producer identity; general package publication remains under `DMS-1255` ownership. This
+extension also proves that the package contains DMS datastore state only; a database template is never a CMS
+or identity-state backup.
 
 ## Dependencies
 
@@ -31,10 +33,11 @@ contains DMS datastore state only; a database template is never a CMS or identit
 
 The wrapper performs the following sequence in restore mode:
 
-1. Resolve the database-template package and validate its package identity, restore manifest, artifact hash,
-   engine, Data Standard version, template kind, DMS-only content profile, and internally consistent
-   effective-schema metadata. Normalize and validate the selected target name, including the reserved-database
-   denylist and the separate-CMS exclusion, before creating any workspace state.
+1. Resolve the database-template package, authenticate the exact `.nupkg` bytes against an approved producer
+   identity, and validate its package identity, restore manifest, artifact hash, engine, Data Standard version,
+   template kind, DMS-only content profile, and internally consistent effective-schema metadata. Normalize and
+   validate the selected target name, including the reserved-database denylist and the separate-CMS exclusion,
+   before extracting a restore artifact, creating workspace state, or starting Docker.
 2. Materialize the requested schema, claims, and seed handoff into a new candidate workspace that is not the
    active `.bootstrap` tree and is never bind-mounted. Invoke the authoritative preparation phases so
    `prepare-dms-schema.ps1`, rather than the wrapper, computes the expected `EffectiveSchemaHash` and records
@@ -84,13 +87,16 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   removes the generated database on success or failure. Tests must prove that a target absent before preflight
   remains absent after every preflight failure. MSSQL preflight similarly connects through an administrative
   database and does not create the target.
-- PostgreSQL resolves the package's SQL artifact, replays it into the scratch database, validates it, then
-  drops/recreates the selected datastore database and replays the same hash-verified SQL into the target.
-- MSSQL resolves the package's `.bak`, validates logical file metadata, and performs `RESTORE ... WITH MOVE`
-  into the scratch database. After validation, it restores the same hash-verified backup into the selected
-  datastore with target-specific `MOVE` paths and `REPLACE`.
+- PostgreSQL extracts the SQL artifact from the authenticated, privately staged package, replays it into the
+  scratch database, validates it, then drops/recreates the selected datastore database and replays the same
+  immutable, hash-verified SQL bytes into the target.
+- MSSQL extracts the `.bak` from the authenticated, privately staged package, validates logical file metadata,
+  and performs `RESTORE ... WITH MOVE` into the scratch database. After validation, it restores the same
+  immutable, hash-verified backup bytes into the selected datastore with target-specific `MOVE` paths and
+  `REPLACE`.
 - Feed resolution and an explicit `-PackageDirectory` path are both supported so the workflow can be tested
-  before or without publication to the configured feed.
+  before or without publication to the configured feed. Both paths use the same package-authentication gate;
+  prepublication packages must be signed or attested by a configured development trust anchor.
 - The external restore manifest contains the package id/version, engine, Data Standard version, template kind,
   selected core/extension project inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational
   mapping version, engine version, database compatibility level, physical `DocumentJson` column type, any
@@ -99,22 +105,49 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   SHA-256.
 - Immediately before backup, the producer reads schema fields from `dms.EffectiveSchema` and provider fields
   from the live catalog. It fails unless the source is a dedicated DMS datastore database whose canonical
-  inventory contains only the `dms` schema, effective-schema-derived resource schemas, and explicitly
-  documented engine support objects. In particular, `dmscs`, Configuration Service/OpenIddict tables, copied
-  clients or keys, and unexpected database principals are forbidden. This gate also applies to direct local
-  use of the shared template helper, whose default database name may otherwise identify the shared local
-  database.
-- The consumer rejects a missing, malformed, mismatched, or hash-invalid manifest before starting the database
-  service or changing the active workspace. After `-DbOnly`, it independently derives the scratch database's
-  canonical inventory, compares it with the manifest, verifies `dms.EffectiveSchema` against both the manifest
-  and candidate bootstrap manifest, and enforces the DMS-only exclusions before touching the target. Feed and
-  `-PackageDirectory` packages use identical producer/consumer checks; local origin is not a trust bypass.
+  inventory contains only the exact DMS-owned objects derived from the authoritative DDL and selected project
+  inventory: the `dms` schema, effective-schema-derived resource schemas, the generated `auth` companion schema
+  when present, the generated `tracked_changes_<project>` companion schemas for the selected projects, and an
+  explicit provider-specific support-object allowlist. Similar-looking schema names and objects not present in
+  the authoritative inventory are not implicitly allowed. In particular, `dmscs`, Configuration
+  Service/OpenIddict tables, copied clients or keys, and unexpected database principals are forbidden. This
+  gate also applies to direct local use of the shared template helper, whose default database name may otherwise
+  identify the shared local database.
+- The consumer rejects an unauthenticated package or a missing, malformed, mismatched, or hash-invalid manifest
+  before extracting the restore artifact, starting the database service, or changing the active workspace.
+  After `-DbOnly`, it independently derives the scratch database's canonical inventory, compares it with the
+  manifest, verifies `dms.EffectiveSchema` against both the manifest and candidate bootstrap manifest, and
+  enforces the DMS-only exclusions before touching the target. Feed and `-PackageDirectory` packages use
+  identical producer/consumer checks; local origin is not a trust bypass.
 - Any failure through scratch validation is a preflight failure: transient candidate, preflight-database, and
   scratch state is removed, while the active `.bootstrap` tree and selected physical database remain
   unchanged. A target that did not exist before preflight remains absent.
 - A legacy package without the external manifest is not eligible for target replacement. If legacy-package
   compatibility is later required, it must use a safe scratch restore followed by `dms.EffectiveSchema`
   validation before any destructive operation against the selected datastore.
+
+## Package Trust Boundary
+
+Database-template packages are executable deployment inputs. PostgreSQL restore executes package-supplied SQL
+through `psql`, so a manifest and artifact hash stored beside that SQL provide internal consistency but not
+producer authenticity. Catalog validation after scratch replay cannot undo commands that affected another
+database, created a server principal, or escaped through a client meta-command.
+
+- Before extracting a database artifact or starting Docker, authenticate the exact `.nupkg` bytes with either a
+  verifiable NuGet author/repository signature or a provenance attestation that cryptographically binds the
+  package SHA-256, package id/version, and approved producer identity. Trust anchors and allowed producer
+  identities come from repository/operator configuration outside the package being verified.
+- Feed and `-PackageDirectory` resolution use the same trust policy. Restore mode has no unsigned-package
+  bypass. A local prepublication workflow uses an explicitly configured development signer or attestor rather
+  than treating filesystem origin as trust.
+- After authentication, copy the package into a private restore workspace, extract exactly one declared
+  artifact, verify its manifest hash, and prevent replacement of the staged package or artifact. Scratch and
+  target restore consume those same immutable bytes so validation cannot be separated from execution by a file
+  replacement race.
+- Artifact and inventory hashes remain required for deterministic identity and corruption detection, but they
+  never substitute for package authentication.
+- Authentication, trust-policy, package-staging, or immutability failure occurs before Docker startup and leaves
+  the active workspace and every database untouched.
 
 ## Topology and Target Safety
 
@@ -144,34 +177,41 @@ state form one handoff and may still be bind-mounted.
 ## Acceptance Criteria
 
 - Bootstrap exposes an explicit restore option separate from `-LoadSeedData`.
-- Restore validates the external manifest and artifact hash, safely prepares the complete workspace, then
-  follows `-DbOnly -> scratch validation -> stop proof -> complete workspace replacement -> -DbOnly -> target
-  restore -> -InfraOnly -> configure -> -DmsOnly`; it skips schema provisioning only for restored targets.
+- Restore authenticates the exact package bytes, validates the external manifest and artifact hash, safely
+  prepares the complete workspace, then follows `-DbOnly -> scratch validation -> stop proof -> complete
+  workspace replacement -> -DbOnly -> target restore -> -InfraOnly -> configure -> -DmsOnly`; it skips schema
+  provisioning only for restored targets.
 - Before Docker startup or active-workspace replacement, restore proves that the package's Data Standard,
   core/extension inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping version, and
   any engine-defined physical-schema version match the authoritative candidate workspace.
 - PostgreSQL SQL replay and MSSQL backup restore both materialize Minimal and Populated packages correctly.
 - Target validation rejects every reserved PostgreSQL/SQL Server database and prevents an MSSQL restore from
   replacing a separate CMS database before any workspace or database mutation.
-- Producers reject shared or contaminated sources. Consumers scratch-restore and reject packages containing
-  `dmscs`, CMS/OpenIddict state, unexpected principals, or objects outside the manifest's DMS-only inventory
-  before replacing the target, including packages supplied through `-PackageDirectory`.
-- Package resolution or external-manifest validation failures occur before Docker startup. Every preflight
-  failure through scratch validation leaves the active workspace and selected target untouched, including on
-  a fresh PostgreSQL volume where the selected target did not exist. Target selection or restore failures stop
-  before CMS/DMS startup.
+- Producers reject shared or contaminated sources while accepting the authoritative DMS-owned `auth` and
+  `tracked_changes_<project>` companion schemas. Consumers scratch-restore and reject packages containing
+  `dmscs`, CMS/OpenIddict state, unexpected principals, lookalike companion schemas, or objects outside the
+  manifest's exact DMS-only inventory before replacing the target, including packages supplied through
+  `-PackageDirectory`.
+- Package authentication, resolution, staging, or external-manifest validation failures occur before Docker
+  startup. Every preflight failure through scratch validation leaves the active workspace and selected target
+  untouched, including on a fresh PostgreSQL volume where the selected target did not exist. Target selection
+  or restore failures stop before CMS/DMS startup.
 - Existing non-restore bootstrap behavior is unchanged.
 - A mismatched or incomplete workspace is replaced only after the complete stack is proven stopped; the whole
   `.bootstrap` tree is removed and schema, claims, and seed handoff state are regenerated together.
-- Tests cover wrapper sequencing, candidate/package hash and project-inventory mismatches, reserved database
-  names for both engines, local-package resolution, engine-specific scratch and target command construction,
-  manifest/artifact validation before Docker activity, DMS-only producer and consumer gates, scratch cleanup,
-  generated preflight-database cleanup, fresh-volume PostgreSQL target-absence preservation, failed stop proof,
-  the database-only preflight stop/restart boundary, full-workspace replacement, bind-mount safety,
-  shared/separate topology behavior, default targeting, repeated single-target operation, and the distinction
-  between restore and API seed delivery.
+- Tests cover wrapper sequencing, candidate/package hash and project-inventory mismatches, valid trusted feed
+  and `-PackageDirectory` packages, unsigned and untrusted signers/attestors, package tampering after signing,
+  immutable staging for scratch/target reuse, reserved database names for both engines, local-package
+  resolution, engine-specific scratch and target command construction, package authentication plus
+  manifest/artifact validation before Docker activity, acceptance of authoritative `auth` and
+  `tracked_changes_<project>` objects, rejection of lookalike/unexpected objects, DMS-only producer and consumer
+  gates, scratch cleanup, generated preflight-database cleanup, fresh-volume PostgreSQL target-absence
+  preservation, failed stop proof, the database-only preflight stop/restart boundary, full-workspace replacement,
+  bind-mount safety, shared/separate topology behavior, default targeting, repeated single-target operation,
+  and the distinction between restore and API seed delivery.
 - Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
-  versions, including different extension selections, effective-schema validation, contaminated-package
+  versions, including different extension selections, package-authentication failure before replay, companion
+  `auth`/`tracked_changes_<project>` inventory validation, effective-schema validation, contaminated-package
   rejection before target replacement, and served data.
 
 ## Non-Goals

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -45,11 +45,16 @@ The wrapper performs the following sequence in restore mode:
    candidate and leave the active workspace and selected database untouched.
 4. Prove that the entire selected DMS stack is stopped before starting database preflight. A failed or
    indeterminate stop proof leaves the active workspace and target untouched.
-5. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
+5. Run `start-*-dms.ps1 -DbOnly` with an engine-dispatched restore-preflight override that starts only the
+   database service and waits for readiness without creating or selecting the requested target. PostgreSQL
+   must replace `POSTGRES_DB_NAME` with a generated, non-target preflight database for this first startup so
+   `postgresql-init.sh` cannot create the selected target when it initializes a fresh volume. MSSQL uses its
+   administrative database without materializing the target.
 6. Revalidate target safety against the live engine catalog. Restore the artifact into a generated scratch
    database, validate its effective schema and DMS-only catalog contents, and remove the scratch database.
    Package, candidate-workspace, stop-proof, target-safety, or scratch-validation failure ends preflight,
-   removes transient state, and leaves both the active workspace and selected database unchanged.
+   removes the candidate, scratch database, and generated preflight database, and leaves both the active
+   workspace and selected database unchanged, including preserving an absent target as absent.
 7. Stop the database-only slice and again prove that the complete selected stack is stopped. The verified
    candidate and scratch result do not authorize workspace replacement while any stack service is running.
 8. Begin the commit stage. If the active workspace is absent or differs from the verified candidate, replace
@@ -73,6 +78,12 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   scratch name uses a safe product prefix plus an unpredictable suffix, passes the same reserved-name checks,
   and is removed on success or failure. Selected-target replacement cannot begin until scratch validation
   succeeds.
+- The PostgreSQL restore-preflight start must not expose the selected target as `POSTGRES_DB_NAME` because
+  `postgresql-init.sh` creates that database while initializing a fresh volume. It uses a generated preflight
+  database instead, connects through an administrative database for catalog and cleanup operations, and
+  removes the generated database on success or failure. Tests must prove that a target absent before preflight
+  remains absent after every preflight failure. MSSQL preflight similarly connects through an administrative
+  database and does not create the target.
 - PostgreSQL resolves the package's SQL artifact, replays it into the scratch database, validates it, then
   drops/recreates the selected datastore database and replays the same hash-verified SQL into the target.
 - MSSQL resolves the package's `.bak`, validates logical file metadata, and performs `RESTORE ... WITH MOVE`
@@ -98,8 +109,9 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   canonical inventory, compares it with the manifest, verifies `dms.EffectiveSchema` against both the manifest
   and candidate bootstrap manifest, and enforces the DMS-only exclusions before touching the target. Feed and
   `-PackageDirectory` packages use identical producer/consumer checks; local origin is not a trust bypass.
-- Any failure through scratch validation is a preflight failure: transient candidate and scratch state is
-  removed, while the active `.bootstrap` tree and selected physical database remain unchanged.
+- Any failure through scratch validation is a preflight failure: transient candidate, preflight-database, and
+  scratch state is removed, while the active `.bootstrap` tree and selected physical database remain
+  unchanged. A target that did not exist before preflight remains absent.
 - A legacy package without the external manifest is not eligible for target replacement. If legacy-package
   compatibility is later required, it must use a safe scratch restore followed by `dms.EffectiveSchema`
   validation before any destructive operation against the selected datastore.
@@ -145,17 +157,19 @@ state form one handoff and may still be bind-mounted.
   `dmscs`, CMS/OpenIddict state, unexpected principals, or objects outside the manifest's DMS-only inventory
   before replacing the target, including packages supplied through `-PackageDirectory`.
 - Package resolution or external-manifest validation failures occur before Docker startup. Every preflight
-  failure through scratch validation leaves the active workspace and selected target untouched. Target
-  selection or restore failures stop before CMS/DMS startup.
+  failure through scratch validation leaves the active workspace and selected target untouched, including on
+  a fresh PostgreSQL volume where the selected target did not exist. Target selection or restore failures stop
+  before CMS/DMS startup.
 - Existing non-restore bootstrap behavior is unchanged.
 - A mismatched or incomplete workspace is replaced only after the complete stack is proven stopped; the whole
   `.bootstrap` tree is removed and schema, claims, and seed handoff state are regenerated together.
 - Tests cover wrapper sequencing, candidate/package hash and project-inventory mismatches, reserved database
   names for both engines, local-package resolution, engine-specific scratch and target command construction,
   manifest/artifact validation before Docker activity, DMS-only producer and consumer gates, scratch cleanup,
-  failed stop proof, the database-only preflight stop/restart boundary, full-workspace replacement, bind-mount
-  safety, shared/separate topology behavior, default targeting, repeated single-target operation, and the
-  distinction between restore and API seed delivery.
+  generated preflight-database cleanup, fresh-volume PostgreSQL target-absence preservation, failed stop proof,
+  the database-only preflight stop/restart boundary, full-workspace replacement, bind-mount safety,
+  shared/separate topology behavior, default targeting, repeated single-target operation, and the distinction
+  between restore and API seed delivery.
 - Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
   versions, including different extension selections, effective-schema validation, contaminated-package
   rejection before target replacement, and served data.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -14,22 +14,33 @@ Template restore is distinct from API seed delivery. Do not overload `-LoadSeedD
 BulkLoadClient delivery through the running API, while restore replaces or recreates a physical database from
 a package artifact.
 
-`DMS-1255` supplies the template packages and the `-DbOnly` startup phase used by this story.
+`DMS-1255` supplies the baseline template packages and the `-DbOnly` startup phase used by this story. This
+story owns the narrow producer-and-consumer extension that adds a machine-readable restore manifest outside
+the database artifact. The shared template tooling captures the live metadata immediately before backup,
+creates and hashes the database artifact, then packages the completed manifest beside the `.sql` or `.bak`;
+general package publication remains under `DMS-1255` ownership.
 
 ## Restore Sequence
 
 The wrapper performs the following sequence in restore mode:
 
-1. Stage the schema and claims workspace.
-2. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
-3. Resolve and validate the database-template package.
-4. Restore one explicitly selected physical DMS datastore database.
-5. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
-6. Run `configure-local-data-store.ps1` for the restored datastore.
-7. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
+1. Resolve the database-template package and validate its package identity, restore manifest, artifact hash,
+   engine, Data Standard version, template kind, and effective-schema metadata before Docker startup or any
+   destructive database work.
+2. Prove that the entire selected DMS stack is stopped before creating, replacing, or reusing restore
+   workspace state. A failed or indeterminate stop proof leaves the existing workspace and target untouched.
+3. Compare the requested schema set with the staged workspace. If the workspace is absent, stage schema,
+   claims, and seed handoff state. If it is mismatched or incomplete, remove the whole `.bootstrap` tree and
+   regenerate schema, claims, and seed handoff state together. Never rewrite only a schema or manifest subtree.
+4. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
+5. Revalidate target safety now that the database is reachable, then restore one explicitly selected physical
+   DMS datastore database.
+6. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
+7. Run `configure-local-data-store.ps1` for the restored datastore.
+8. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
    schema and seed data.
-8. Run `start-*-dms.ps1 -DmsOnly`.
-9. Run supplemental API seed only when an explicit, compatible option requests it.
+9. Run `start-*-dms.ps1 -DmsOnly`.
+10. Run supplemental API seed only when an explicit, compatible option requests it.
 
 The wrapper owns when restore happens. An engine-dispatched restore module owns how the package is restored.
 
@@ -41,12 +52,23 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   REPLACE` into the selected datastore database.
 - Feed resolution and an explicit `-PackageDirectory` path are both supported so the workflow can be tested
   before or without publication to the configured feed.
-- Package identity, engine, Data Standard version, template kind, and effective-schema metadata are validated
-  before destructive database work begins.
+- The external restore manifest contains the package id/version, engine, Data Standard version, template kind,
+  `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping version, engine version, database
+  compatibility level, physical `DocumentJson` column type, artifact filename, and artifact SHA-256. The
+  package producer reads the schema fields from `dms.EffectiveSchema` and the provider-specific fields from the
+  live database catalog immediately before creating the backup. The consumer rejects a missing, malformed,
+  mismatched, or hash-invalid manifest before starting the database service or touching the selected target.
+- A legacy package without the external manifest is not eligible for target replacement. If legacy-package
+  compatibility is later required, it must use a safe scratch restore followed by `dms.EffectiveSchema`
+  validation before any destructive operation against the selected datastore.
 
 ## Topology and Target Safety
 
-- Fail before restore if CMS or DMS is already running against the target.
+- Fail before workspace replacement unless the complete selected stack is proven stopped; checking only
+  whether CMS or DMS points at the eventual restore target is insufficient because either service may still
+  have `.bootstrap` content bind-mounted.
+- Fail before target restore if CMS or DMS is running against the target. Failure to prove either safety
+  condition leaves the existing workspace and database untouched.
 - In shared-database mode, restore the shared database only in the `-DbOnly` window, before CMS creates its
   schema and clients.
 - In separate-database mode, restore only the selected DMS datastore; never replace the CMS database.
@@ -54,23 +76,27 @@ The wrapper owns when restore happens. An engine-dispatched restore module owns 
   restored by explicit repeated invocations, followed by datastore registration/configuration.
 - Empty schema databases continue to use `provision-dms-schema.ps1`; template-backed databases use restore.
 
-If schema staging changes the Data Standard or extension set, invalidate the dependent claims and seed
-manifest sections before the claims-ready gate. Reusing stale claims/seed state across schema sets is not
-permitted.
+If the requested Data Standard or extension set differs from staged state, remove and regenerate the complete
+workspace only after the stop proof above. Partial manifest invalidation or subtree replacement is not
+permitted because schema, claims, and seed state form one handoff and may still be bind-mounted.
 
 ## Acceptance Criteria
 
 - Bootstrap exposes an explicit restore option separate from `-LoadSeedData`.
-- Restore follows `-DbOnly -> restore -> -InfraOnly -> configure -> -DmsOnly` and skips schema provisioning
-  only for restored targets.
+- Restore validates the external manifest and artifact hash, safely prepares the complete workspace, then
+  follows `-DbOnly -> restore -> -InfraOnly -> configure -> -DmsOnly`; it skips schema provisioning only for
+  restored targets.
 - PostgreSQL SQL replay and MSSQL backup restore both materialize Minimal and Populated packages correctly.
 - Target validation prevents an MSSQL restore from replacing a separate CMS database.
-- Package resolution, metadata validation, target selection, or restore failures stop before CMS/DMS startup.
+- Package resolution or external-manifest validation failures occur before Docker startup and leave the
+  workspace and target untouched. Target-selection or restore failures stop before CMS/DMS startup.
 - Existing non-restore bootstrap behavior is unchanged.
-- Changing the staged schema set invalidates dependent claims/seed manifest state.
+- A mismatched or incomplete workspace is replaced only after the complete stack is proven stopped; the whole
+  `.bootstrap` tree is removed and schema, claims, and seed handoff state are regenerated together.
 - Tests cover wrapper sequencing, parameter validation, local-package resolution, engine-specific command
-  construction, shared/separate topology behavior, default targeting, repeated single-target operation, and
-  the distinction between restore and API seed delivery.
+  construction, manifest/artifact validation before Docker activity, failed stop proof, full-workspace
+  replacement, bind-mount safety, shared/separate topology behavior, default targeting, repeated single-target
+  operation, and the distinction between restore and API seed delivery.
 - Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
   versions, including effective-schema validation and served data.
 
@@ -79,7 +105,8 @@ permitted.
 - A persisted multi-database restore control plane or resumable workflow.
 - Restoring multiple physical databases implicitly from CMS routing state.
 - Replacing API-based supplemental seed delivery.
-- Publishing template packages; `DMS-1255` owns package production.
+- General package publication workflow ownership; `DMS-1255` retains that ownership while this story adds only
+  the restore-manifest producer/consumer contract required for safe restore.
 
 ## Design References
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -21,6 +21,12 @@ creates and hashes the database artifact, then packages the completed manifest b
 general package publication remains under `DMS-1255` ownership. This extension also proves that the package
 contains DMS datastore state only; a database template is never a CMS or identity-state backup.
 
+## Dependencies
+
+- Blocked by `DMS-1255` for the published template packages and `-DbOnly` startup slice.
+- Blocked by `DMS-1270` for the separate-CMS topology contract required by target-safety and topology-matrix
+  acceptance coverage.
+
 ## Restore Sequence
 
 The wrapper performs the following sequence in restore mode:

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -1,0 +1,88 @@
+---
+jira: DMS-1271
+jira_url: https://edfi.atlassian.net/browse/DMS-1271
+---
+
+# Story: Add a Database-Template Restore Branch to Bootstrap
+
+## Description
+
+Add an explicit bootstrap path that materializes a DMS datastore from a published database-template package
+before CMS, identity, schema provisioning, or DMS startup touches the environment.
+
+Template restore is distinct from API seed delivery. Do not overload `-LoadSeedData`: that switch means
+BulkLoadClient delivery through the running API, while restore replaces or recreates a physical database from
+a package artifact.
+
+`DMS-1255` supplies the template packages and the `-DbOnly` startup phase used by this story.
+
+## Restore Sequence
+
+The wrapper performs the following sequence in restore mode:
+
+1. Stage the schema and claims workspace.
+2. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
+3. Resolve and validate the database-template package.
+4. Restore one explicitly selected physical DMS datastore database.
+5. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
+6. Run `configure-local-data-store.ps1` for the restored datastore.
+7. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
+   schema and seed data.
+8. Run `start-*-dms.ps1 -DmsOnly`.
+9. Run supplemental API seed only when an explicit, compatible option requests it.
+
+The wrapper owns when restore happens. An engine-dispatched restore module owns how the package is restored.
+
+## Engine-Specific Restore
+
+- PostgreSQL resolves the package's SQL artifact, drops/recreates the selected datastore database, and replays
+  the SQL into the new database.
+- MSSQL resolves the package's `.bak`, validates logical file metadata, and performs `RESTORE ... WITH MOVE,
+  REPLACE` into the selected datastore database.
+- Feed resolution and an explicit `-PackageDirectory` path are both supported so the workflow can be tested
+  before or without publication to the configured feed.
+- Package identity, engine, Data Standard version, template kind, and effective-schema metadata are validated
+  before destructive database work begins.
+
+## Topology and Target Safety
+
+- Fail before restore if CMS or DMS is already running against the target.
+- In shared-database mode, restore the shared database only in the `-DbOnly` window, before CMS creates its
+  schema and clients.
+- In separate-database mode, restore only the selected DMS datastore; never replace the CMS database.
+- One invocation restores one physical database. Additional school-year, district, or tenant datastores are
+  restored by explicit repeated invocations, followed by datastore registration/configuration.
+- Empty schema databases continue to use `provision-dms-schema.ps1`; template-backed databases use restore.
+
+If schema staging changes the Data Standard or extension set, invalidate the dependent claims and seed
+manifest sections before the claims-ready gate. Reusing stale claims/seed state across schema sets is not
+permitted.
+
+## Acceptance Criteria
+
+- Bootstrap exposes an explicit restore option separate from `-LoadSeedData`.
+- Restore follows `-DbOnly -> restore -> -InfraOnly -> configure -> -DmsOnly` and skips schema provisioning
+  only for restored targets.
+- PostgreSQL SQL replay and MSSQL backup restore both materialize Minimal and Populated packages correctly.
+- Target validation prevents an MSSQL restore from replacing a separate CMS database.
+- Package resolution, metadata validation, target selection, or restore failures stop before CMS/DMS startup.
+- Existing non-restore bootstrap behavior is unchanged.
+- Changing the staged schema set invalidates dependent claims/seed manifest state.
+- Tests cover wrapper sequencing, parameter validation, local-package resolution, engine-specific command
+  construction, shared/separate topology behavior, default targeting, repeated single-target operation, and
+  the distinction between restore and API seed delivery.
+- Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
+  versions, including effective-schema validation and served data.
+
+## Non-Goals
+
+- A persisted multi-database restore control plane or resumable workflow.
+- Restoring multiple physical databases implicitly from CMS routing state.
+- Replacing API-based supplemental seed delivery.
+- Publishing template packages; `DMS-1255` owns package production.
+
+## Design References
+
+- [`01-local-database-topology-parity.md`](01-local-database-topology-parity.md)
+- [`../../design-docs/bootstrap/bootstrap-design.md`](../../design-docs/bootstrap/bootstrap-design.md)
+- [`../../design-docs/bootstrap/command-boundaries.md`](../../design-docs/bootstrap/command-boundaries.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md
@@ -18,87 +18,130 @@ a package artifact.
 story owns the narrow producer-and-consumer extension that adds a machine-readable restore manifest outside
 the database artifact. The shared template tooling captures the live metadata immediately before backup,
 creates and hashes the database artifact, then packages the completed manifest beside the `.sql` or `.bak`;
-general package publication remains under `DMS-1255` ownership.
+general package publication remains under `DMS-1255` ownership. This extension also proves that the package
+contains DMS datastore state only; a database template is never a CMS or identity-state backup.
 
 ## Restore Sequence
 
 The wrapper performs the following sequence in restore mode:
 
 1. Resolve the database-template package and validate its package identity, restore manifest, artifact hash,
-   engine, Data Standard version, template kind, and effective-schema metadata before Docker startup or any
-   destructive database work.
-2. Prove that the entire selected DMS stack is stopped before creating, replacing, or reusing restore
-   workspace state. A failed or indeterminate stop proof leaves the existing workspace and target untouched.
-3. Compare the requested schema set with the staged workspace. If the workspace is absent, stage schema,
-   claims, and seed handoff state. If it is mismatched or incomplete, remove the whole `.bootstrap` tree and
-   regenerate schema, claims, and seed handoff state together. Never rewrite only a schema or manifest subtree.
-4. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
-5. Revalidate target safety now that the database is reachable, then restore one explicitly selected physical
-   DMS datastore database.
-6. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
-7. Run `configure-local-data-store.ps1` for the restored datastore.
-8. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
+   engine, Data Standard version, template kind, DMS-only content profile, and internally consistent
+   effective-schema metadata. Normalize and validate the selected target name, including the reserved-database
+   denylist and the separate-CMS exclusion, before creating any workspace state.
+2. Materialize the requested schema, claims, and seed handoff into a new candidate workspace that is not the
+   active `.bootstrap` tree and is never bind-mounted. Invoke the authoritative preparation phases so
+   `prepare-dms-schema.ps1`, rather than the wrapper, computes the expected `EffectiveSchemaHash` and records
+   any engine-defined physical-schema version in the candidate manifest.
+3. Compare the package manifest with the candidate bootstrap manifest. The Data Standard version, selected
+   core/extension project inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping
+   version, engine, and any engine-defined physical-schema version must match exactly. On mismatch, remove the
+   candidate and leave the active workspace and selected database untouched.
+4. Prove that the entire selected DMS stack is stopped before replacing or reusing active restore workspace
+   state. A failed or indeterminate stop proof leaves the active workspace and target untouched.
+5. If the active workspace is absent or differs from the verified candidate, replace the complete
+   `.bootstrap` tree with the candidate. If it already matches, discard the candidate and reuse the complete
+   active tree. Never rewrite only a schema or manifest subtree.
+6. Run `start-*-dms.ps1 -DbOnly` to start only the selected database service and wait for readiness.
+7. Revalidate target safety against the live engine catalog. Restore the artifact into a generated scratch
+   database, validate its effective schema and DMS-only catalog contents, remove the scratch database, and only
+   then replace the explicitly selected physical DMS datastore database.
+8. Run `start-*-dms.ps1 -InfraOnly` to initialize identity and CMS.
+9. Run `configure-local-data-store.ps1` for the restored datastore.
+10. Skip `provision-dms-schema.ps1` for that datastore because the template already contains the generated
    schema and seed data.
-9. Run `start-*-dms.ps1 -DmsOnly`.
-10. Run supplemental API seed only when an explicit, compatible option requests it.
+11. Run `start-*-dms.ps1 -DmsOnly`.
+12. Run supplemental API seed only when an explicit, compatible option requests it.
 
 The wrapper owns when restore happens. An engine-dispatched restore module owns how the package is restored.
 
 ## Engine-Specific Restore
 
-- PostgreSQL resolves the package's SQL artifact, drops/recreates the selected datastore database, and replays
-  the SQL into the new database.
-- MSSQL resolves the package's `.bak`, validates logical file metadata, and performs `RESTORE ... WITH MOVE,
-  REPLACE` into the selected datastore database.
+- Both engines first materialize the package into a generated, non-user-selectable scratch database. The
+  scratch name uses a safe product prefix plus an unpredictable suffix, passes the same reserved-name checks,
+  and is removed on success or failure. Selected-target replacement cannot begin until scratch validation
+  succeeds.
+- PostgreSQL resolves the package's SQL artifact, replays it into the scratch database, validates it, then
+  drops/recreates the selected datastore database and replays the same hash-verified SQL into the target.
+- MSSQL resolves the package's `.bak`, validates logical file metadata, and performs `RESTORE ... WITH MOVE`
+  into the scratch database. After validation, it restores the same hash-verified backup into the selected
+  datastore with target-specific `MOVE` paths and `REPLACE`.
 - Feed resolution and an explicit `-PackageDirectory` path are both supported so the workflow can be tested
   before or without publication to the configured feed.
 - The external restore manifest contains the package id/version, engine, Data Standard version, template kind,
-  `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping version, engine version, database
-  compatibility level, physical `DocumentJson` column type, artifact filename, and artifact SHA-256. The
-  package producer reads the schema fields from `dms.EffectiveSchema` and the provider-specific fields from the
-  live database catalog immediately before creating the backup. The consumer rejects a missing, malformed,
-  mismatched, or hash-invalid manifest before starting the database service or touching the selected target.
+  selected core/extension project inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational
+  mapping version, engine version, database compatibility level, physical `DocumentJson` column type, any
+  engine-defined physical-schema version such as `MssqlPhysicalSchemaVersion`, the fixed `DmsDatastoreOnly`
+  content profile, a canonical schema/object inventory and its SHA-256, artifact filename, and artifact
+  SHA-256.
+- Immediately before backup, the producer reads schema fields from `dms.EffectiveSchema` and provider fields
+  from the live catalog. It fails unless the source is a dedicated DMS datastore database whose canonical
+  inventory contains only the `dms` schema, effective-schema-derived resource schemas, and explicitly
+  documented engine support objects. In particular, `dmscs`, Configuration Service/OpenIddict tables, copied
+  clients or keys, and unexpected database principals are forbidden. This gate also applies to direct local
+  use of the shared template helper, whose default database name may otherwise identify the shared local
+  database.
+- The consumer rejects a missing, malformed, mismatched, or hash-invalid manifest before starting the database
+  service or changing the active workspace. After `-DbOnly`, it independently derives the scratch database's
+  canonical inventory, compares it with the manifest, verifies `dms.EffectiveSchema` against both the manifest
+  and candidate bootstrap manifest, and enforces the DMS-only exclusions before touching the target. Feed and
+  `-PackageDirectory` packages use identical producer/consumer checks; local origin is not a trust bypass.
 - A legacy package without the external manifest is not eligible for target replacement. If legacy-package
   compatibility is later required, it must use a safe scratch restore followed by `dms.EffectiveSchema`
   validation before any destructive operation against the selected datastore.
 
 ## Topology and Target Safety
 
+- Normalize database names case-insensitively and reject PostgreSQL `postgres`, `template0`, and `template1`,
+  plus SQL Server `master`, `model`, `msdb`, and `tempdb`. Apply this denylist during parameter validation and
+  again against the live catalog before scratch creation, `DROP`, or `RESTORE`; generic identifier validation
+  is not a substitute for reserved-name validation.
 - Fail before workspace replacement unless the complete selected stack is proven stopped; checking only
   whether CMS or DMS points at the eventual restore target is insufficient because either service may still
   have `.bootstrap` content bind-mounted.
 - Fail before target restore if CMS or DMS is running against the target. Failure to prove either safety
   condition leaves the existing workspace and database untouched.
-- In shared-database mode, restore the shared database only in the `-DbOnly` window, before CMS creates its
-  schema and clients.
+- In shared-database mode, restore only a package proven to have the `DmsDatastoreOnly` content profile, and do
+  so in the `-DbOnly` window before CMS creates a fresh schema and clients. No CMS or identity record from the
+  package may survive into the initialized environment.
 - In separate-database mode, restore only the selected DMS datastore; never replace the CMS database.
 - One invocation restores one physical database. Additional school-year, district, or tenant datastores are
   restored by explicit repeated invocations, followed by datastore registration/configuration.
 - Empty schema databases continue to use `provision-dms-schema.ps1`; template-backed databases use restore.
 
-If the requested Data Standard or extension set differs from staged state, remove and regenerate the complete
-workspace only after the stop proof above. Partial manifest invalidation or subtree replacement is not
-permitted because schema, claims, and seed state form one handoff and may still be bind-mounted.
+If the requested Data Standard or extension set differs from active staged state, prepare and validate a
+complete candidate first, then replace the complete workspace only after the package cross-check and stop proof
+above. Partial manifest invalidation or subtree replacement is not permitted because schema, claims, and seed
+state form one handoff and may still be bind-mounted.
 
 ## Acceptance Criteria
 
 - Bootstrap exposes an explicit restore option separate from `-LoadSeedData`.
 - Restore validates the external manifest and artifact hash, safely prepares the complete workspace, then
-  follows `-DbOnly -> restore -> -InfraOnly -> configure -> -DmsOnly`; it skips schema provisioning only for
-  restored targets.
+  follows `-DbOnly -> scratch validation -> target restore -> -InfraOnly -> configure -> -DmsOnly`; it skips
+  schema provisioning only for restored targets.
+- Before Docker startup or active-workspace replacement, restore proves that the package's Data Standard,
+  core/extension inventory, `ApiSchemaFormatVersion`, `EffectiveSchemaHash`, relational mapping version, and
+  any engine-defined physical-schema version match the authoritative candidate workspace.
 - PostgreSQL SQL replay and MSSQL backup restore both materialize Minimal and Populated packages correctly.
-- Target validation prevents an MSSQL restore from replacing a separate CMS database.
+- Target validation rejects every reserved PostgreSQL/SQL Server database and prevents an MSSQL restore from
+  replacing a separate CMS database before any workspace or database mutation.
+- Producers reject shared or contaminated sources. Consumers scratch-restore and reject packages containing
+  `dmscs`, CMS/OpenIddict state, unexpected principals, or objects outside the manifest's DMS-only inventory
+  before replacing the target, including packages supplied through `-PackageDirectory`.
 - Package resolution or external-manifest validation failures occur before Docker startup and leave the
   workspace and target untouched. Target-selection or restore failures stop before CMS/DMS startup.
 - Existing non-restore bootstrap behavior is unchanged.
 - A mismatched or incomplete workspace is replaced only after the complete stack is proven stopped; the whole
   `.bootstrap` tree is removed and schema, claims, and seed handoff state are regenerated together.
-- Tests cover wrapper sequencing, parameter validation, local-package resolution, engine-specific command
-  construction, manifest/artifact validation before Docker activity, failed stop proof, full-workspace
-  replacement, bind-mount safety, shared/separate topology behavior, default targeting, repeated single-target
-  operation, and the distinction between restore and API seed delivery.
+- Tests cover wrapper sequencing, candidate/package hash and project-inventory mismatches, reserved database
+  names for both engines, local-package resolution, engine-specific scratch and target command construction,
+  manifest/artifact validation before Docker activity, DMS-only producer and consumer gates, scratch cleanup,
+  failed stop proof, full-workspace replacement, bind-mount safety, shared/separate topology behavior, default
+  targeting, repeated single-target operation, and the distinction between restore and API seed delivery.
 - Live validation covers PostgreSQL and MSSQL with Minimal and Populated templates and supported Data Standard
-  versions, including effective-schema validation and served data.
+  versions, including different extension selections, effective-schema validation, contaminated-package
+  rejection before target replacement, and served data.
 
 ## Non-Goals
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
@@ -45,14 +45,38 @@ Before enabling native storage:
    - without a production `DocumentCache` path, validate generated DDL and direct `DocumentCache` provider
      round trips; or
    - explicitly add the cache projector/read path to an owning ticket before requiring DMS CRUD/query coverage.
-4. Change `MssqlDialect.JsonColumnType`, regenerate provisioned-schema goldens and relational-model manifests,
-   and update the authoritative data-model DDL. Replace the current string-based
+4. Establish and bump the MSSQL physical-schema identity described below, change
+   `MssqlDialect.JsonColumnType`, regenerate provisioned-schema goldens and relational-model manifests, and
+   update the authoritative data-model DDL. Replace the current string-based
    `LEFT(LTRIM(DocumentJson), 1)` object check, because native `json` does not allow implicit string conversion;
    use a native-compatible root-object constraint such as `ISJSON(DocumentJson, OBJECT) = 1` and cover it.
 5. In direct real-SQL-Server integration tests, verify table creation, object-only validation, explicit and
    inferred provider parameter binding, insert/select round trips, `OPENJSON`, `JSON_VALUE`, supported bulk
    operations, schema inspection, and result materialization against the native column.
 6. Rebuild and republish MSSQL database-template packages after the generated schema changes.
+
+### Artifact and Schema Identity
+
+`EffectiveSchemaHash` and `RelationalMappingVersion` remain the shared logical mapping identity. Do not bump
+the global relational mapping version for this provider-only optional-cache storage change: doing so would
+change PostgreSQL fingerprints and generated seed DDL even though PostgreSQL mapping and storage are
+unchanged.
+
+Instead, generated MSSQL artifacts have a DMS-owned `MssqlPhysicalSchemaVersion`:
+
+- The `nvarchar(max)` baseline is version `v1`; native `json` adoption introduces `v2`.
+- MSSQL DDL records the version in a SQL Server-only singleton `dms.MssqlPhysicalSchema` metadata table. A
+  legacy database without the table is recognized as `v1` only when catalog inspection also finds the legacy
+  `nvarchar(max)` shape; absence can never imply the native baseline.
+- MSSQL DDL artifact identity and determinism use `(ApiSchema set, mssql, RelationalMappingVersion,
+  MssqlPhysicalSchemaVersion)`. Update the authoritative DDL-generation contract and diagnostic manifests to
+  include that final component. PostgreSQL keeps its existing identity tuple and byte-for-byte DDL.
+- The database-template restore manifest from `DMS-1271` records `MssqlPhysicalSchemaVersion` beside the
+  physical `DocumentJson` type. Package production, scratch restore, SchemaTools verification, and any future
+  cache startup path require the version marker and live catalog type to agree.
+- This physical version does not key ordinary mapping packs while `DocumentCache` has no production read/write
+  path. If such a path is introduced, its owning design must either add the version to the relevant compiled
+  artifact key or prove that the existing physical-type startup gate is the only required discriminator.
 
 ### Existing Database Transition
 
@@ -62,9 +86,10 @@ uses mandatory reprovisioning rather than an in-place migration:
 
 - Phase 1 continues to support existing SQL Server 2022-created databases with `nvarchar(max)` unchanged.
 - An environment or template may claim the native-JSON baseline only after it is recreated from newly
-  generated DDL or a newly published template package.
+  generated `v2` DDL or a newly published `v2` template package.
 - Schema/template verification must inspect the actual SQL Server column type and reject an `nvarchar(max)`
-  `DocumentJson` when native JSON is expected, with drop/reprovision guidance.
+  `DocumentJson` when native JSON is expected. It must also reject a missing or mismatched
+  `MssqlPhysicalSchemaVersion`, with drop/reprovision guidance.
 - Do not enable a future cache writer, reader, or `SqlDbType.Json` binding path without a startup compatibility
   gate that verifies the physical type. `EffectiveSchemaHash` alone is insufficient for this provider-specific
   storage decision.
@@ -81,8 +106,8 @@ the mechanism that enables native JSON.
 - Validate the forward path from SQL Server 2022-built backups to the 2025 runtime before republishing.
 - Once packages are built against SQL Server 2025/native JSON, document that they are not expected to restore
   to SQL Server 2022.
-- Image, compatibility-level, generated-schema, and package metadata must identify the supported baseline
-  consistently.
+- Image, compatibility-level, generated-schema, MSSQL physical-schema version, and package metadata must
+  identify the supported baseline consistently.
 
 ## Acceptance Criteria
 
@@ -101,14 +126,18 @@ the mechanism that enables native JSON.
 These criteria apply only when the decision is adopt:
 
 - Generated DDL, authoritative data-model DDL, goldens, manifests, and newly built template packages use native
-  `json` consistently, including a native-compatible object-only constraint.
+  `json` and `MssqlPhysicalSchemaVersion=v2` consistently, including a native-compatible object-only
+  constraint.
+- SQL Server `v1` and `v2` outputs have distinct physical artifact identities. PostgreSQL
+  `EffectiveSchemaHash`, mapping identity, generated DDL, goldens, and runtime behavior remain byte-for-byte
+  unchanged by the adoption commit.
 - Real-SQL-Server integration tests exercise direct `DocumentCache` DDL and provider round trips for parameter
   binding, object validation, insert/select, JSON functions, supported bulk operations, schema inspection, and
   result materialization. DMS CRUD/query coverage is required only if a production cache path is explicitly
   added to scope.
 - Existing databases are not silently treated as converted: native-baseline validation rejects
-  `nvarchar(max)` with reprovisioning guidance, and any future runtime cache path has a physical-type startup
-  gate.
+  `nvarchar(max)` or missing/mismatched MSSQL physical-version metadata with reprovisioning guidance, and any
+  future runtime cache path has a physical-type startup gate.
 - Newly rebuilt Minimal and Populated MSSQL templates pass physical-type and served-data verification.
 
 ## Non-Goals

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
@@ -11,7 +11,9 @@ Move the supported local and CI MSSQL runtime from SQL Server 2022 to SQL Server
 evaluate changing generated `DocumentJson` columns from `nvarchar(max)` to SQL Server's native `json` type.
 
 The runtime upgrade and storage-format change are separate delivery phases. A successful runtime upgrade must
-not be blocked by a decision to defer the native-JSON transition.
+not be blocked by a decision to defer the native-JSON transition. Phase 1 is required. Phase 2 ends with a
+recorded adopt/defer decision; its implementation criteria apply only when the release-status gate chooses
+adoption. A defer decision keeps `nvarchar(max)` and links a follow-up without preventing Phase 1 completion.
 
 ## Phase 1: SQL Server 2025 Runtime
 
@@ -25,7 +27,11 @@ not be blocked by a decision to defer the native-JSON transition.
 ## Phase 2: Native `json` Storage
 
 The native `json` type is a physical storage decision behind `ISqlDialect.JsonColumnType`. Shared document
-semantics and PostgreSQL `jsonb` behavior do not change.
+semantics and PostgreSQL `jsonb` behavior do not change. Today that dialect property is used only by the
+optional `dms.DocumentCache.DocumentJson` DDL; DMS has no production cache projector or cache-backed read path.
+Ordinary resource CRUD, query, batching, and reconstitution therefore cannot prove native-JSON parameter or
+result behavior, and this story must not claim that coverage unless it also receives explicit ownership of a
+production `DocumentCache` path.
 
 Before enabling native storage:
 
@@ -35,11 +41,35 @@ Before enabling native storage:
 2. Validate the pinned `Microsoft.Data.SqlClient` version and the .NET 10 parameter-binding path. Prefer
    `SqlDbType.Json`/the provider's supported JSON surface when explicit typing is required; retain CLR `string`
    only where provider inference is intentional and covered by integration tests.
-3. Change `MssqlDialect.JsonColumnType`, regenerate provisioned-schema goldens and relational-model manifests,
-   and audit every read/write/bulk path for `nvarchar(max)` assumptions.
-4. Verify `OPENJSON`, `JSON_VALUE`, triggers, views, bulk operations, schema comparison, and reconstitution against
-   native columns.
-5. Rebuild and republish MSSQL database-template packages after the generated schema changes.
+3. Choose the executable validation boundary:
+   - without a production `DocumentCache` path, validate generated DDL and direct `DocumentCache` provider
+     round trips; or
+   - explicitly add the cache projector/read path to an owning ticket before requiring DMS CRUD/query coverage.
+4. Change `MssqlDialect.JsonColumnType`, regenerate provisioned-schema goldens and relational-model manifests,
+   and update the authoritative data-model DDL. Replace the current string-based
+   `LEFT(LTRIM(DocumentJson), 1)` object check, because native `json` does not allow implicit string conversion;
+   use a native-compatible root-object constraint such as `ISJSON(DocumentJson, OBJECT) = 1` and cover it.
+5. In direct real-SQL-Server integration tests, verify table creation, object-only validation, explicit and
+   inferred provider parameter binding, insert/select round trips, `OPENJSON`, `JSON_VALUE`, supported bulk
+   operations, schema inspection, and result materialization against the native column.
+6. Rebuild and republish MSSQL database-template packages after the generated schema changes.
+
+### Existing Database Transition
+
+SchemaTools provisioning is create-only and does not migrate an existing `nvarchar(max)` column. Runtime
+`dms.EffectiveSchema` validation also does not inspect physical column types. Native-JSON adoption therefore
+uses mandatory reprovisioning rather than an in-place migration:
+
+- Phase 1 continues to support existing SQL Server 2022-created databases with `nvarchar(max)` unchanged.
+- An environment or template may claim the native-JSON baseline only after it is recreated from newly
+  generated DDL or a newly published template package.
+- Schema/template verification must inspect the actual SQL Server column type and reject an `nvarchar(max)`
+  `DocumentJson` when native JSON is expected, with drop/reprovision guidance.
+- Do not enable a future cache writer, reader, or `SqlDbType.Json` binding path without a startup compatibility
+  gate that verifies the physical type. `EffectiveSchemaHash` alone is insufficient for this provider-specific
+  storage decision.
+- Document that there is no in-place data-preserving conversion in this story. A future production migration
+  requires its own design and tests.
 
 SQL Server 2025 uses compatibility level 170 as its default/recommended release baseline. Microsoft documents
 the native `json` type as available at all database compatibility levels, so level 170 is not a prerequisite
@@ -56,21 +86,38 @@ the mechanism that enables native JSON.
 
 ## Acceptance Criteria
 
+### Required Runtime Upgrade And Decision
+
 - All local, CI, CMS, and template workflow image pins use the selected SQL Server 2025 image.
 - Existing MSSQL lanes pass on SQL Server 2025 before generated JSON storage changes.
 - Published SQL Server 2022-built templates restore and serve data on the 2025 runtime.
-- Native JSON is enabled only after the release-status gate is satisfied and provider behavior is proven.
-- Generated DDL, goldens, manifests, and template packages consistently use the selected document-column type.
-- Provider integration tests cover create, read, update, query, bulk/batch, and reconstitution paths with native
-  JSON parameters and results.
+- The release-status and provider-capability decision is recorded as adopt or defer. A defer result keeps
+  `nvarchar(max)`, records the reason, and links follow-up work without blocking Phase 1 completion.
 - PostgreSQL behavior and generated DDL remain unchanged.
 - Documentation states the backup compatibility boundary and the reason for compatibility level 170.
+
+### Conditional Native-JSON Adoption
+
+These criteria apply only when the decision is adopt:
+
+- Generated DDL, authoritative data-model DDL, goldens, manifests, and newly built template packages use native
+  `json` consistently, including a native-compatible object-only constraint.
+- Real-SQL-Server integration tests exercise direct `DocumentCache` DDL and provider round trips for parameter
+  binding, object validation, insert/select, JSON functions, supported bulk operations, schema inspection, and
+  result materialization. DMS CRUD/query coverage is required only if a production cache path is explicitly
+  added to scope.
+- Existing databases are not silently treated as converted: native-baseline validation rejects
+  `nvarchar(max)` with reprovisioning guidance, and any future runtime cache path has a physical-type startup
+  gate.
+- Newly rebuilt Minimal and Populated MSSQL templates pass physical-type and served-data verification.
 
 ## Non-Goals
 
 - Changing the public JSON document contract.
 - Introducing JSON-specific indexes without measured query requirements.
 - Treating a preview feature as mandatory without explicit project acceptance.
+- Implementing the optional `DocumentCache` projector/read path unless separately assigned to this ticket.
+- Providing an in-place, data-preserving `nvarchar(max)`-to-`json` migration.
 - Supporting restore of SQL Server 2025-built backups on SQL Server 2022.
 
 ## Design References

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
@@ -17,8 +17,9 @@ adoption. A defer decision keeps `nvarchar(max)` and links a follow-up without p
 
 ## Dependencies
 
-- Blocked by `DMS-1255` for the SQL Server 2022 template packages and image-coupling contract used by the
-  forward-restore compatibility gate.
+- Delivered prerequisite: `DMS-1255` supplies the SQL Server 2022 template packages and image-coupling contract
+  used by the forward-restore compatibility gate. Retain the Jira relationship for provenance rather than as
+  an active blocker.
 - Native-JSON adoption coordinates with the `DMS-1271` restore-manifest contract, but `DMS-1271` does not block
   the required runtime upgrade or a recorded defer decision.
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
@@ -1,0 +1,82 @@
+---
+jira: DMS-1279
+jira_url: https://edfi.atlassian.net/browse/DMS-1279
+---
+
+# Story: Adopt SQL Server 2025 and Evaluate Native JSON Document Storage
+
+## Description
+
+Move the supported local and CI MSSQL runtime from SQL Server 2022 to SQL Server 2025, then deliberately
+evaluate changing generated `DocumentJson` columns from `nvarchar(max)` to SQL Server's native `json` type.
+
+The runtime upgrade and storage-format change are separate delivery phases. A successful runtime upgrade must
+not be blocked by a decision to defer the native-JSON transition.
+
+## Phase 1: SQL Server 2025 Runtime
+
+- Update every authoritative image pin used by local compose, DMS CI, CMS CI, and template-build workflows.
+- Keep workflow comments and package documentation aligned with the actual image used to build MSSQL backup
+  packages.
+- Verify container readiness and in-container `sqlcmd` tooling before changing generated DDL.
+- Prove SQL Server 2022-built template backups restore on the SQL Server 2025 runtime.
+- Run the existing MSSQL backend, API integration, SchemaTools, CMS, and template build/verify lanes unchanged.
+
+## Phase 2: Native `json` Storage
+
+The native `json` type is a physical storage decision behind `ISqlDialect.JsonColumnType`. Shared document
+semantics and PostgreSQL `jsonb` behavior do not change.
+
+Before enabling native storage:
+
+1. Verify the native `json` type's current SQL Server 2025 release status. Microsoft currently documents it as
+   preview for boxed SQL Server 2025. Adopt it only after it is generally available or the project explicitly
+   accepts a preview database format for the supported MSSQL tier.
+2. Validate the pinned `Microsoft.Data.SqlClient` version and the .NET 10 parameter-binding path. Prefer
+   `SqlDbType.Json`/the provider's supported JSON surface when explicit typing is required; retain CLR `string`
+   only where provider inference is intentional and covered by integration tests.
+3. Change `MssqlDialect.JsonColumnType`, regenerate provisioned-schema goldens and relational-model manifests,
+   and audit every read/write/bulk path for `nvarchar(max)` assumptions.
+4. Verify `OPENJSON`, `JSON_VALUE`, triggers, views, bulk operations, schema comparison, and reconstitution against
+   native columns.
+5. Rebuild and republish MSSQL database-template packages after the generated schema changes.
+
+SQL Server 2025 uses compatibility level 170 as its default/recommended release baseline. Microsoft documents
+the native `json` type as available at all database compatibility levels, so level 170 is not a prerequisite
+for the type. Set or verify level 170 for a consistent supported-runtime baseline, and do not describe it as
+the mechanism that enables native JSON.
+
+## Backup Compatibility
+
+- Validate the forward path from SQL Server 2022-built backups to the 2025 runtime before republishing.
+- Once packages are built against SQL Server 2025/native JSON, document that they are not expected to restore
+  to SQL Server 2022.
+- Image, compatibility-level, generated-schema, and package metadata must identify the supported baseline
+  consistently.
+
+## Acceptance Criteria
+
+- All local, CI, CMS, and template workflow image pins use the selected SQL Server 2025 image.
+- Existing MSSQL lanes pass on SQL Server 2025 before generated JSON storage changes.
+- Published SQL Server 2022-built templates restore and serve data on the 2025 runtime.
+- Native JSON is enabled only after the release-status gate is satisfied and provider behavior is proven.
+- Generated DDL, goldens, manifests, and template packages consistently use the selected document-column type.
+- Provider integration tests cover create, read, update, query, bulk/batch, and reconstitution paths with native
+  JSON parameters and results.
+- PostgreSQL behavior and generated DDL remain unchanged.
+- Documentation states the backup compatibility boundary and the reason for compatibility level 170.
+
+## Non-Goals
+
+- Changing the public JSON document contract.
+- Introducing JSON-specific indexes without measured query requirements.
+- Treating a preview feature as mandatory without explicit project acceptance.
+- Supporting restore of SQL Server 2025-built backups on SQL Server 2022.
+
+## Design References
+
+- [`../../design-docs/data-model.md`](../../design-docs/data-model.md)
+- [`../../design-docs/ddl-generation.md`](../../design-docs/ddl-generation.md)
+- [Microsoft: JSON data type](https://learn.microsoft.com/en-us/sql/t-sql/data-types/json-data-type?view=sql-server-ver17)
+- [Microsoft: JSON data type support in SqlClient](https://learn.microsoft.com/en-us/sql/connect/ado-net/sql/json-data-sql-server?view=sql-server-ver17)
+- [Microsoft: ALTER DATABASE compatibility level](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-database-transact-sql-compatibility-level?view=sql-server-ver17)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md
@@ -15,6 +15,13 @@ not be blocked by a decision to defer the native-JSON transition. Phase 1 is req
 recorded adopt/defer decision; its implementation criteria apply only when the release-status gate chooses
 adoption. A defer decision keeps `nvarchar(max)` and links a follow-up without preventing Phase 1 completion.
 
+## Dependencies
+
+- Blocked by `DMS-1255` for the SQL Server 2022 template packages and image-coupling contract used by the
+  forward-restore compatibility gate.
+- Native-JSON adoption coordinates with the `DMS-1271` restore-manifest contract, but `DMS-1271` does not block
+  the required runtime upgrade or a recorded defer decision.
+
 ## Phase 1: SQL Server 2025 Runtime
 
 - Update every authoritative image pin used by local compose, DMS CI, CMS CI, and template-build workflows.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
@@ -3,27 +3,35 @@ jira: DMS-1284
 jira_url: https://edfi.atlassian.net/browse/DMS-1284
 ---
 
-# Story: Run the DMS Docker E2E Suite Against MSSQL
+# Story: Run the DMS and Instance Management Docker E2E Suites Against MSSQL
 
 ## Description
 
-Make the containerized DMS E2E path engine-aware so the supported MSSQL deployment is exercised through the
-same public HTTP and Docker-stack boundary used for PostgreSQL.
+Make both containerized DMS E2E entry points engine-aware so the supported MSSQL deployment is exercised
+through the same public HTTP and Docker-stack boundaries used for PostgreSQL. This includes the standard
+`build-dms.ps1 E2ETest` suite and the separate multi-datastore route-context suite invoked through
+`build-dms.ps1 InstanceE2ETest`.
 
 Provider-backed backend and in-process API integration tests do not cover compose wiring, CMS datastore
 registration, generated-schema provisioning, container health, or public HTTP behavior. This story closes
-that boundary without creating a second MSSQL-specific E2E product.
+those boundaries without creating MSSQL-specific copies of either E2E product.
 
 ## Design
 
 - Add an explicit `-DatabaseEngine postgresql|mssql` selection to `build-dms.ps1 E2ETest` and the local E2E
   setup path. PostgreSQL remains the default.
+- Add the same selection to `build-dms.ps1 InstanceE2ETest` and its setup/teardown path. Replace compile-time
+  PostgreSQL connection strings and feature-data assumptions with engine-selected route-context connection
+  strings for all three provisioned instance databases.
 - Reuse the local MSSQL stack delivered by `DMS-1238` rather than introducing an independent compose topology.
 - Dispatch database provisioning, connection-string construction, data reset, readiness, diagnostics, and
   teardown by engine.
 - Provision generated MSSQL DDL, including `dms.EffectiveSchema`, before DMS starts.
 - Configure CMS registration, the DMS container, and the test process with the same selected database name and
   engine. Custom database names must not fall back to PostgreSQL defaults.
+- For Instance Management E2E, provision all three district/school-year databases with generated MSSQL DDL,
+  register MSSQL connection strings for every route context, restart DMS after registration as the existing
+  suite requires, and verify that routing keeps requests isolated by district and school year.
 - Remove Npgsql and PostgreSQL SQL assumptions from the MSSQL path while preserving the PostgreSQL path.
 - Treat an unavailable or unhealthy SQL Server as a failed test environment, not an ignored test result.
 
@@ -40,6 +48,7 @@ provider-integration case:
 | Change tracking | Conditional requests, change versions, deletes, and key changes |
 | Schema variation | Extensions and supported Data Standard versions |
 | Identity | Self-contained and Keycloak identity-provider modes |
+| Instance routing | Three MSSQL datastores, district/school-year route contexts, routing isolation, and not-found behavior for unregistered contexts |
 
 Split the matrix between required pull-request shards and scheduled broader coverage when runtime demands it,
 but keep the complete supported matrix documented and runnable locally.
@@ -48,15 +57,19 @@ but keep the complete supported matrix documented and runnable locally.
 
 - `build-dms.ps1 E2ETest -DatabaseEngine mssql` performs teardown/setup, provisions an MSSQL E2E database,
   starts CMS and DMS against it, and runs the requested filter.
+- `build-dms.ps1 InstanceE2ETest -DatabaseEngine mssql` provisions the three route-context MSSQL databases,
+  registers engine-correct connection strings, restarts DMS after registration, and runs the existing
+  Instance Management shards without PostgreSQL containers, providers, or SQL.
 - Engine-specific connection and reset helpers execute no PostgreSQL provider or SQL code on the MSSQL path.
-- The full suite is locally invokable against MSSQL; unsupported scenarios are explicit and justified rather
-  than silently skipped.
+- Both full suites are locally invokable against MSSQL; unsupported scenarios are explicit and justified
+  rather than silently skipped.
 - Required CI shards cover the documented representative matrix and fail on infrastructure or scenario errors.
 - MSSQL container, DMS, and CMS logs plus TRX/timing artifacts follow existing failure-upload conventions.
-- Script-level tests cover engine selection, argument forwarding, database-name propagation, and cleanup safety.
+- Script-level tests cover engine selection, argument forwarding, database-name propagation, three-database
+  Instance Management provisioning/registration, and cleanup safety.
 - Existing PostgreSQL commands and CI lanes behave unchanged when the engine is omitted or set to `postgresql`.
-- E2E documentation includes local commands, environment variables, direct-test requirements, and
-  troubleshooting.
+- Standard and Instance Management E2E documentation includes local commands, environment variables,
+  direct-test requirements, and troubleshooting for both engines.
 
 ## Non-Goals
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
@@ -1,0 +1,73 @@
+---
+jira: DMS-1284
+jira_url: https://edfi.atlassian.net/browse/DMS-1284
+---
+
+# Story: Run the DMS Docker E2E Suite Against MSSQL
+
+## Description
+
+Make the containerized DMS E2E path engine-aware so the supported MSSQL deployment is exercised through the
+same public HTTP and Docker-stack boundary used for PostgreSQL.
+
+Provider-backed backend and in-process API integration tests do not cover compose wiring, CMS datastore
+registration, generated-schema provisioning, container health, or public HTTP behavior. This story closes
+that boundary without creating a second MSSQL-specific E2E product.
+
+## Design
+
+- Add an explicit `-DatabaseEngine postgresql|mssql` selection to `build-dms.ps1 E2ETest` and the local E2E
+  setup path. PostgreSQL remains the default.
+- Reuse the local MSSQL stack delivered by `DMS-1238` rather than introducing an independent compose topology.
+- Dispatch database provisioning, connection-string construction, data reset, readiness, diagnostics, and
+  teardown by engine.
+- Provision generated MSSQL DDL, including `dms.EffectiveSchema`, before DMS starts.
+- Configure CMS registration, the DMS container, and the test process with the same selected database name and
+  engine. Custom database names must not fall back to PostgreSQL defaults.
+- Remove Npgsql and PostgreSQL SQL assumptions from the MSSQL path while preserving the PostgreSQL path.
+- Treat an unavailable or unhealthy SQL Server as a failed test environment, not an ignored test result.
+
+## E2E Scenario Matrix
+
+The required MSSQL signal covers representative public-boundary scenarios rather than duplicating every
+provider-integration case:
+
+| Area | Representative coverage |
+| --- | --- |
+| Resources | Create/read/update/delete, query, paging, and total count |
+| Descriptors and profiles | Descriptor CRUD plus representative read/write profile behavior |
+| Authorization | Relationship and NamespaceBased allow/deny behavior with real token and claim-set wiring |
+| Change tracking | Conditional requests, change versions, deletes, and key changes |
+| Schema variation | Extensions and supported Data Standard versions |
+| Identity | Self-contained and Keycloak identity-provider modes |
+
+Split the matrix between required pull-request shards and scheduled broader coverage when runtime demands it,
+but keep the complete supported matrix documented and runnable locally.
+
+## Acceptance Criteria
+
+- `build-dms.ps1 E2ETest -DatabaseEngine mssql` performs teardown/setup, provisions an MSSQL E2E database,
+  starts CMS and DMS against it, and runs the requested filter.
+- Engine-specific connection and reset helpers execute no PostgreSQL provider or SQL code on the MSSQL path.
+- The full suite is locally invokable against MSSQL; unsupported scenarios are explicit and justified rather
+  than silently skipped.
+- Required CI shards cover the documented representative matrix and fail on infrastructure or scenario errors.
+- MSSQL container, DMS, and CMS logs plus TRX/timing artifacts follow existing failure-upload conventions.
+- Script-level tests cover engine selection, argument forwarding, database-name propagation, and cleanup safety.
+- Existing PostgreSQL commands and CI lanes behave unchanged when the engine is omitted or set to `postgresql`.
+- E2E documentation includes local commands, environment variables, direct-test requirements, and
+  troubleshooting.
+
+## Non-Goals
+
+- Implementing backend defects found by the E2E suite; file or link those defects separately.
+- Database-template production or restore (`DMS-1255`, `DMS-1271`).
+- Foreign-key pruning.
+- Duplicating the full provider-integration matrices from `DMS-1285` or `DMS-1286`.
+
+## Design References
+
+- [`../13-test-migration/EPIC.md`](../13-test-migration/EPIC.md)
+- [`../13-test-migration/02-parity-and-fixtures.md`](../13-test-migration/02-parity-and-fixtures.md)
+- [`05-mssql-write-path-coverage.md`](05-mssql-write-path-coverage.md)
+- [`06-mssql-namespace-authorization-coverage.md`](06-mssql-namespace-authorization-coverage.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md
@@ -34,21 +34,23 @@ those boundaries without creating MSSQL-specific copies of either E2E product.
   suite requires, and verify that routing keeps requests isolated by district and school year.
 - Remove Npgsql and PostgreSQL SQL assumptions from the MSSQL path while preserving the PostgreSQL path.
 - Treat an unavailable or unhealthy SQL Server as a failed test environment, not an ignored test result.
+- Keep this work separate from `DMS-1289`: this story owns the standard DMS and Instance Management Docker
+  E2E suites, while `DMS-1289` owns the existing scheduled database-template restore and API/SDK smoke
+  workflow.
 
 ## E2E Scenario Matrix
 
 The required MSSQL signal covers representative public-boundary scenarios rather than duplicating every
 provider-integration case:
 
-| Area | Representative coverage |
-| --- | --- |
-| Resources | Create/read/update/delete, query, paging, and total count |
-| Descriptors and profiles | Descriptor CRUD plus representative read/write profile behavior |
-| Authorization | Relationship and NamespaceBased allow/deny behavior with real token and claim-set wiring |
-| Change tracking | Conditional requests, change versions, deletes, and key changes |
-| Schema variation | Extensions and supported Data Standard versions |
-| Identity | Self-contained and Keycloak identity-provider modes |
-| Instance routing | Three MSSQL datastores, district/school-year route contexts, routing isolation, and not-found behavior for unregistered contexts |
+- Resources: create/read/update/delete, query, paging, and total count.
+- Descriptors and profiles: descriptor CRUD plus representative read/write profile behavior.
+- Authorization: Relationship and NamespaceBased allow/deny behavior with real token and claim-set wiring.
+- Change tracking: conditional requests, change versions, deletes, and key changes.
+- Schema variation: extensions and supported Data Standard versions.
+- Identity: self-contained and Keycloak identity-provider modes.
+- Instance routing: three MSSQL datastores, district/school-year route contexts, routing isolation, and
+  not-found behavior for unregistered contexts.
 
 Split the matrix between required pull-request shards and scheduled broader coverage when runtime demands it,
 but keep the complete supported matrix documented and runnable locally.
@@ -61,20 +63,28 @@ but keep the complete supported matrix documented and runnable locally.
   registers engine-correct connection strings, restarts DMS after registration, and runs the existing
   Instance Management shards without PostgreSQL containers, providers, or SQL.
 - Engine-specific connection and reset helpers execute no PostgreSQL provider or SQL code on the MSSQL path.
-- Both full suites are locally invokable against MSSQL; unsupported scenarios are explicit and justified
-  rather than silently skipped.
-- Required CI shards cover the documented representative matrix and fail on infrastructure or scenario errors.
-- MSSQL container, DMS, and CMS logs plus TRX/timing artifacts follow existing failure-upload conventions.
+- Instance Management scenarios verify district and school-year isolation across all three registered
+  datastores and the existing not-found behavior for unregistered route contexts.
+- Local execution supports both full suites, filters/shards, custom database settings, and repeat runs against
+  MSSQL; unsupported scenarios are explicit and justified rather than silently skipped.
+- Required CI lanes run documented MSSQL shards for both suites, cover the representative standard-DMS matrix
+  plus Instance Management routing behavior, and fail on infrastructure or scenario errors.
+- Diagnostics for both suites collect sanitized SQL Server, DMS, and CMS logs plus setup/provisioning output,
+  TRX results, and timing artifacts using existing failure-upload conventions.
+- Cleanup for both suites runs on success and failure, removes their MSSQL test resources using the existing
+  safety conventions, and does not remove unrelated containers, volumes, or databases.
 - Script-level tests cover engine selection, argument forwarding, database-name propagation, three-database
   Instance Management provisioning/registration, and cleanup safety.
 - Existing PostgreSQL commands and CI lanes behave unchanged when the engine is omitted or set to `postgresql`.
-- Standard and Instance Management E2E documentation includes local commands, environment variables,
-  direct-test requirements, and troubleshooting for both engines.
+- Standard and Instance Management E2E documentation includes local and CI commands, required environment
+  variables, direct-test requirements, diagnostics, cleanup, and troubleshooting for both engines.
 
 ## Non-Goals
 
 - Implementing backend defects found by the E2E suite; file or link those defects separately.
 - Database-template production or restore (`DMS-1255`, `DMS-1271`).
+- Changes to the existing scheduled API/SDK smoke workflow; `DMS-1289` owns its MSSQL template build, restore,
+  registration, and smoke-test matrix.
 - Foreign-key pruning.
 - Duplicating the full provider-integration matrices from `DMS-1285` or `DMS-1286`.
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md
@@ -1,0 +1,72 @@
+---
+jira: DMS-1285
+jira_url: https://edfi.atlassian.net/browse/DMS-1285
+---
+
+# Story: Close MSSQL Relational Write-Path Correctness and Resilience Coverage Gaps
+
+## Description
+
+Run the critical relational write-path correctness and resilience scenarios against real SQL Server through
+the production MSSQL repository, generated DDL, command executor, and write-session boundaries.
+
+Parity is behavioral. The story does not require identical PostgreSQL and MSSQL test filenames or fixture
+counts. Begin with a reviewed inventory that maps each PostgreSQL-only scenario to existing equivalent MSSQL
+coverage, new coverage, or a justified non-applicable dialect difference.
+
+## Required Scenario Families
+
+| Scenario family | Required assertions |
+| --- | --- |
+| Baseline create | Root, nested collection, extension, and extension-child rows are complete and reconstitute correctly. |
+| Changed PUT | Omitted inlined values clear correctly; omitted collection and extension state is deleted. |
+| Collection reorder | Stable `CollectionItemId` values are reused and sibling ordinals remain unique and contiguous. |
+| Guarded no-op and races | Unchanged writes do not rewrite rowsets or bump content version; stale and commit-window races preserve committed state and retry semantics. |
+| Multi-batch collections | Large create/update/delete operations stay within SQL Server command/parameter limits and never leave partial state. |
+| POST-as-update | Ordinary update, immutable-identity rejection, and concurrent-create conversion to update behave consistently. |
+| Rollback after early writes | Injected failures roll back document, root, child, extension, identity, and tracking changes atomically. |
+
+## Design
+
+- Reuse the shared fixture vocabulary and assertions owned by
+  [`DMS-1023`](../13-test-migration/02-parity-and-fixtures.md) where practical.
+- Provider-specific setup is allowed when it reaches the same production boundary and preserves equivalent
+  externally visible and authoritative-storage assertions.
+- Cover content-version and last-modified behavior in addition to relational row shape.
+- Exercise batching at sizes that force multiple reservations, inserts, updates, or deletes under SQL Server
+  parameter pressure.
+- A bounded MSSQL defect exposed by the matrix may be fixed in this story. A materially separate defect may be
+  split into a linked blocker, but its scenario remains incomplete while the blocker is open.
+- Assign all required MSSQL scenarios to configured CI shards that fail when SQL Server is unavailable or
+  misconfigured.
+
+## Acceptance Criteria
+
+- A reviewed inventory maps every PostgreSQL-only core write scenario to MSSQL coverage or a documented,
+  justified non-applicable result.
+- Real-SQL-Server integration tests cover every required scenario family above.
+- Equivalent scenarios assert response behavior, document/root/child/extension state, stable collection
+  identity, ordinals, update tracking, concurrency outcomes, and rollback.
+- Batching persists or deletes the full requested set without exceeding compiled-command/provider limits or
+  leaving partial state.
+- Rejected immutable identity changes and injected failures leave all authoritative tables unchanged.
+- Intentional provider differences are explicit and tested; assertions are not weakened merely for MSSQL.
+- PostgreSQL relational write tests continue to pass unchanged.
+- No required scenario remains PostgreSQL-only when the story closes unless a linked blocking defect remains
+  open and this story also remains open.
+
+## Non-Goals
+
+- Identical test-file counts between providers.
+- Throughput, latency, or lock-wait targets; `DMS-1019` owns benchmarking.
+- Speculative optimizations; `DMS-1065` owns measured follow-up optimization.
+- The Docker-stack MSSQL runner; `DMS-1284` owns that boundary.
+- Foreign-key pruning.
+
+## Design References
+
+- [`../07-relational-write-path/03-persist-and-batch.md`](../07-relational-write-path/03-persist-and-batch.md)
+- [`../07-relational-write-path/03b-profile-aware-persist-executor.md`](../07-relational-write-path/03b-profile-aware-persist-executor.md)
+- [`../13-test-migration/01-backend-integration-tests.md`](../13-test-migration/01-backend-integration-tests.md)
+- [`../13-test-migration/02-parity-and-fixtures.md`](../13-test-migration/02-parity-and-fixtures.md)
+- [`../../design-docs/transactions-and-concurrency.md`](../../design-docs/transactions-and-concurrency.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md
@@ -14,6 +14,11 @@ Parity is behavioral. The story does not require identical PostgreSQL and MSSQL 
 counts. Begin with a reviewed inventory that maps each PostgreSQL-only scenario to existing equivalent MSSQL
 coverage, new coverage, or a justified non-applicable dialect difference.
 
+## Dependencies
+
+- Blocked by `DMS-1023`, which establishes the canonical scenario catalog, fixtures, and assertion contract
+  consumed by this provider-coverage story.
+
 ## Required Scenario Families
 
 | Scenario family | Required assertions |

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md
@@ -1,0 +1,75 @@
+---
+jira: DMS-1286
+jira_url: https://edfi.atlassian.net/browse/DMS-1286
+---
+
+# Story: Add Real-MSSQL Integration Coverage for NamespaceBased CRUD Authorization
+
+## Description
+
+Exercise the existing NamespaceBased authorization implementation through the production MSSQL backend and a
+real SQL Server. Shared compiler and unit coverage is not sufficient to certify provider exception decoding,
+authorization/mutation ordering, SQL Server parameter limits, and rollback safety.
+
+`DMS-1057` remains the owner of NamespaceBased semantics. This story validates the MSSQL provider boundary and
+fixes only defects required to preserve that existing contract.
+
+## Coverage Matrix
+
+| Operation | Required MSSQL behavior |
+| --- | --- |
+| GET-many | Include matching namespaces; exclude non-matching, null, and empty values before paging and `totalCount`. |
+| GET-by-id | Deny mismatches and uninitialized stored namespaces before hydration or document exposure. |
+| POST create | Authorize the proposed namespace and write no document, descriptor, or resource rows on denial. |
+| PUT / POST-as-update | Authorize stored values before proposed values and before precondition/mutation handling; preserve all rows on denial. |
+| DELETE | Authorize the stored namespace before deletion and preserve all rows on denial. |
+| Descriptors | Apply the same proposed/stored NamespaceBased contract for supported descriptor operations. |
+| Mixed strategies | Compose NamespaceBased as an AND condition around the relationship-strategy OR group. |
+
+## Provider Failure Contract
+
+- Exercise actual `SqlException` failures produced by the generated MSSQL authorization path.
+- Decode valid `AUTH1 - ns1|...` payloads into the established typed namespace mismatch, stored-uninitialized,
+  proposed-missing, or stale-target outcomes.
+- Malformed or unmappable payloads fail closed through the established 500 Security Configuration Error
+  ProblemDetails response. Do not expose raw provider text or SQL details.
+- Add a provider-specific extractor only if real-engine tests demonstrate that generic `SqlException.Message`
+  parsing is insufficient or unstable.
+
+## Parameter Limits
+
+Use the established NamespaceBased SQL Server contract from `DMS-1057`: supported prefix counts execute with
+parameterized predicates, while an over-limit request fails deterministically before partial authorization or
+mutation. Do not introduce a namespace-prefix TVP as part of this coverage story.
+
+## Acceptance Criteria
+
+- Real-SQL-Server integration tests cover matching success and mismatch denial for GET-many, GET-by-id, POST,
+  PUT, POST-as-update, and DELETE.
+- Ordinary resources and descriptors are represented for the operation families they support.
+- Authorization filtering precedes paging and `totalCount`; single-record denial precedes hydration.
+- Stored authorization precedes proposed authorization and precondition/mutation work for update operations.
+- Every denied write leaves `dms.Document`, descriptor, root, child, extension, identity, and tracking state
+  unchanged.
+- Mixed NamespaceBased/relationship authorization uses the established AND/OR composition.
+- Valid MSSQL `AUTH1` payloads map to typed failures; malformed payloads return sanitized security-configuration
+  failures.
+- Supported prefix counts run successfully, and over-limit requests fail before issuing a partial write.
+- Required tests run in configured MSSQL CI and fail on an unavailable or misconfigured SQL Server.
+- Existing PostgreSQL NamespaceBased tests continue to pass unchanged.
+
+## Non-Goals
+
+- Reimplementing NamespaceBased authorization.
+- Building the MSSQL Docker E2E runner or duplicating its public-boundary scenario matrix (`DMS-1284`).
+- ReadChanges NamespaceBased authorization.
+- Ownership-based or custom view-based authorization.
+- Authorization performance optimization (`DMS-1065`).
+- Changing public ProblemDetails text except to correct a demonstrated MSSQL parity defect.
+
+## Design References
+
+- [`../../design-docs/auth.md`](../../design-docs/auth.md)
+- [`../14-authorization/08-namespace-auth-strategy.md`](../14-authorization/08-namespace-auth-strategy.md)
+- [`../14-authorization/20-configuration-problem-details.md`](../14-authorization/20-configuration-problem-details.md)
+- [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md
@@ -22,7 +22,7 @@ fixes only defects required to preserve that existing contract.
 | GET-by-id | Deny mismatches and uninitialized stored namespaces before hydration or document exposure. |
 | POST create | Authorize the proposed namespace and write no document, descriptor, or resource rows on denial. |
 | PUT / POST-as-update | Authorize stored values before proposed values and before precondition/mutation handling; preserve all rows on denial. |
-| DELETE | Authorize the stored namespace before deletion and preserve all rows on denial. |
+| DELETE | Authorize the stored namespace before `If-Match` evaluation or deletion and preserve all rows on denial. |
 | Descriptors | Apply the same proposed/stored NamespaceBased contract for supported descriptor operations. |
 | Mixed strategies | Compose NamespaceBased as an AND condition around the relationship-strategy OR group. |
 
@@ -48,7 +48,11 @@ mutation. Do not introduce a namespace-prefix TVP as part of this coverage story
   PUT, POST-as-update, and DELETE.
 - Ordinary resources and descriptors are represented for the operation families they support.
 - Authorization filtering precedes paging and `totalCount`; single-record denial precedes hydration.
-- Stored authorization precedes proposed authorization and precondition/mutation work for update operations.
+- Stored authorization precedes proposed authorization and precondition/mutation work for update operations;
+  stored DELETE authorization precedes `If-Match` evaluation and deletion.
+- For both ordinary resources and descriptors, an existing DELETE target for which NamespaceBased
+  authorization and `If-Match` would both fail returns 403 rather than 412. After authorization succeeds, the
+  normal `If-Match` result is preserved. Collision tests cover both orderings against real SQL Server.
 - Every denied write leaves `dms.Document`, descriptor, root, child, extension, identity, and tracking state
   unchanged.
 - Mixed NamespaceBased/relationship authorization uses the established AND/OR composition.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/07-mssql-scheduled-smoke.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/07-mssql-scheduled-smoke.md
@@ -1,0 +1,90 @@
+---
+jira: DMS-1289
+jira_url: https://edfi.atlassian.net/browse/DMS-1289
+---
+
+# Story: Add MSSQL Coverage to Scheduled Smoke Tests
+
+## Description
+
+`DMS-1255` added MSSQL parity to the Minimal and Populated database-template build workflows, including native
+`.bak` creation and restore verification. The scheduled smoke workflow still builds and exercises only
+PostgreSQL smoke templates for Data Standard 5.2 and 6.1.
+
+Add MSSQL to the existing scheduled smoke workflow while retaining PostgreSQL coverage. Exercise the complete
+engine-native path: build a smoke template, restore it, start DMS, register the restored database, and run the
+API and SDK smoke tests.
+
+## Dependencies
+
+- Delivered prerequisite: `DMS-1255` supplies the MSSQL template build, backup/restore, and local
+  engine-selection foundations. Retain the Jira relationship for provenance rather than as an active blocker.
+- Keep this work separate from `DMS-1284`, which owns the standard DMS and Instance Management Docker E2E
+  suites rather than the scheduled template and API/SDK smoke workflow.
+
+## Design
+
+- Extend `.github/workflows/scheduled-smoke-test.yml` with a database-engine dimension.
+- Cover PostgreSQL and MSSQL for Data Standard 5.2 and 6.1.
+- Build an engine-native smoke template for each selected leg and consume that artifact in the matching smoke
+  job.
+- Keep smoke packages workflow-local with `publish_package: false`.
+- Allow correlated MSSQL smoke inputs in `Assert-TemplateWorkflowInputs.ps1` while retaining engine, package,
+  environment-file, Data Standard, restore, and non-publishing validation.
+- Start DMS through the selected `-DatabaseEngine` path.
+- Restore PostgreSQL `.sql` and MSSQL `.bak` artifacts through the engine-aware template restore helper.
+- Register the restored smoke database with an engine-correct connection string.
+- Run the existing applicable smoke coverage on both engines:
+  - NonDestructive API tests.
+  - NonDestructive DMS SDK tests.
+  - Destructive DMS SDK tests.
+  - ODS SDK tests remain limited to Data Standard 5.2 because the consumed ODS SDK is Data Standard
+    5.2-specific.
+- Preserve strict failure behavior: do not ignore MSSQL failures or convert a nonzero smoke-test result into
+  success.
+- Include engine and Data Standard in job, artifact, log, and summary names.
+- Update result notifications to report PostgreSQL and MSSQL rather than a single backend path.
+
+## Pull-Request Filtering
+
+- Keep the workflow path-filtered so unrelated pull requests do not run the smoke pipeline.
+- Include shared smoke/template files and MSSQL-specific environment, Compose, start, build, and restore paths
+  that can affect this flow.
+- On pull requests, run only the engine/Data Standard legs affected by the change when that can be determined
+  safely.
+- Shared or ambiguous changes run both engines rather than risking a coverage gap.
+- Scheduled and `workflow_dispatch` runs always execute the full PostgreSQL/MSSQL and Data Standard 5.2/6.1
+  matrix.
+
+## Acceptance Criteria
+
+- Scheduled and manual runs execute four smoke legs: PostgreSQL 5.2, PostgreSQL 6.1, MSSQL 5.2, and MSSQL 6.1.
+- Every leg restores the engine-native smoke artifact built in the same workflow run.
+- Smoke artifacts are not published to Azure Artifacts.
+- MSSQL registration uses a SQL Server connection string targeting the restored smoke database; PostgreSQL
+  behavior remains unchanged.
+- Health checks, credential creation, SDK generation, NonDestructive API tests, NonDestructive DMS SDK tests,
+  and Destructive DMS SDK tests pass on both engines.
+- ODS SDK smoke tests run only on the Data Standard 5.2 legs for both engines.
+- Any unexpected smoke-test failure fails its matrix leg.
+- Pull requests outside the relevant path set do not trigger the workflow.
+- Relevant pull requests run the safely affected legs; shared or ambiguous changes run both engines.
+- Scheduled and manual runs are never reduced by pull-request filtering logic.
+- Validation tests cover valid MSSQL smoke tuples, invalid engine/package/version combinations, and rejection
+  of publishing smoke packages.
+- Failure logs and summaries identify engine and Data Standard without exposing credentials or
+  connection-string secrets.
+- Existing PostgreSQL smoke coverage remains passing.
+
+## Non-Goals
+
+- Publishing smoke-template packages.
+- Replacing or rewriting the smoke-test console.
+- Adding prerelease-specific execution.
+- Broadly suppressing backend-specific failures.
+
+## Design References
+
+- [`../16-bootstrap/EPIC.md`](../16-bootstrap/EPIC.md)
+- [`02-database-template-restore-workflow.md`](02-database-template-restore-workflow.md)
+- [`04-mssql-docker-e2e.md`](04-mssql-docker-e2e.md)

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -26,7 +26,7 @@ cross-cutting local and CI workflows that do not have another active home.
   bootstrap workflow
 - `DMS-1279` — `03-sql-server-2025-and-native-json.md` — Adopt the SQL Server 2025 runtime and evaluate the
   native `json` storage transition
-- `DMS-1284` — `04-mssql-docker-e2e.md` — Run the DMS Docker E2E suite against MSSQL
+- `DMS-1284` — `04-mssql-docker-e2e.md` — Run the DMS and Instance Management Docker E2E suites against MSSQL
 - `DMS-1285` — `05-mssql-write-path-coverage.md` — Close relational write-path correctness and resilience
   coverage gaps
 - `DMS-1286` — `06-mssql-namespace-authorization-coverage.md` — Add real-MSSQL integration coverage for
@@ -38,17 +38,22 @@ cross-cutting local and CI workflows that do not have another active home.
   to a follow-up story.
 - `DMS-1255` supplies the database-template packages and `-DbOnly` startup slice required by `DMS-1270`,
   `DMS-1271`, and `DMS-1279`. It remains tracked under its existing bootstrap ownership.
+- `DMS-1258` retains implementation ownership for the SQL Server foreign-key-pruning design. It may proceed in
+  parallel with workflow work, but the MSSQL gap inventory cannot be considered closed while it remains
+  pending.
 - `DMS-1270` and `DMS-1271` meet at one topology seam: restore always targets a DMS datastore. In shared mode,
-  restore occurs before CMS initialization touches that database; in separate mode, restore must not target
-  the CMS database. `DMS-1271` also owns the narrow package-producer extension and consumer validation for an
-  external restore manifest; general template publication remains with `DMS-1255`.
+  a scratch-validated DMS-only package is restored before CMS initialization touches that database; in
+  separate mode, restore must not target the CMS database. `DMS-1271` also owns the narrow package-producer
+  extension and consumer validation for an external restore manifest; general template publication remains
+  with `DMS-1255`.
 - `DMS-1279` separates the required SQL Server 2025 runtime upgrade from a conditional native `json` storage
   change. A recorded defer decision does not block the runtime upgrade. Adoption applies to the optional
   `DocumentCache` column, uses direct provider coverage unless a production cache path is separately assigned,
-  and requires reprovisioned databases/templates plus physical-type validation rather than an implicit
-  migration.
-- `DMS-1284` owns the public HTTP and Docker-stack boundary. Backend defects found there should be linked to
-  their owning implementation or provider-integration story rather than absorbed into the E2E harness.
+  and requires a distinct MSSQL physical-schema version, reprovisioned databases/templates, and catalog-type
+  validation rather than an implicit migration or a PostgreSQL-affecting relational mapping-version bump.
+- `DMS-1284` owns the public HTTP and Docker-stack boundary for both the standard DMS E2E suite and the separate
+  multi-datastore Instance Management E2E suite. Backend defects found there should be linked to their owning
+  implementation or provider-integration story rather than absorbed into the E2E harness.
 - `DMS-1285` reuses the shared fixtures and scenario names owned by `DMS-1023`; it owns real-MSSQL write-path
   execution for the remaining uncovered scenarios.
 - `DMS-1286` owns the real-MSSQL NamespaceBased provider boundary. `DMS-1284` owns representative public E2E
@@ -62,6 +67,8 @@ cross-cutting local and CI workflows that do not have another active home.
 - `DMS-1127` — SQL Server native-cascade update-tracking validation, governed by
   [`sql-server-pruning.md`](../../design-docs/sql-server-pruning.md) and
   [`update-tracking.md`](../../design-docs/update-tracking.md)
+- `DMS-1258` — SQL Server foreign-key-pruning implementation governed by
+  [`sql-server-pruning.md`](../../design-docs/sql-server-pruning.md)
 
 ## Scope Guardrails
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -40,9 +40,13 @@ cross-cutting local and CI workflows that do not have another active home.
   `DMS-1271`, and `DMS-1279`. It remains tracked under its existing bootstrap ownership.
 - `DMS-1270` and `DMS-1271` meet at one topology seam: restore always targets a DMS datastore. In shared mode,
   restore occurs before CMS initialization touches that database; in separate mode, restore must not target
-  the CMS database.
-- `DMS-1279` separates the SQL Server 2025 runtime upgrade from the native `json` storage change. Runtime and
-  template compatibility must be established before changing generated schema.
+  the CMS database. `DMS-1271` also owns the narrow package-producer extension and consumer validation for an
+  external restore manifest; general template publication remains with `DMS-1255`.
+- `DMS-1279` separates the required SQL Server 2025 runtime upgrade from a conditional native `json` storage
+  change. A recorded defer decision does not block the runtime upgrade. Adoption applies to the optional
+  `DocumentCache` column, uses direct provider coverage unless a production cache path is separately assigned,
+  and requires reprovisioned databases/templates plus physical-type validation rather than an implicit
+  migration.
 - `DMS-1284` owns the public HTTP and Docker-stack boundary. Backend defects found there should be linked to
   their owning implementation or provider-integration story rather than absorbed into the E2E harness.
 - `DMS-1285` reuses the shared fixtures and scenario names owned by `DMS-1023`; it owns real-MSSQL write-path

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -31,15 +31,17 @@ cross-cutting local and CI workflows that do not have another active home.
   coverage gaps
 - `DMS-1286` — `06-mssql-namespace-authorization-coverage.md` — Add real-MSSQL integration coverage for
   NamespaceBased CRUD authorization
+- `DMS-1289` — `07-mssql-scheduled-smoke.md` — Add MSSQL coverage to the scheduled database-template and
+  API/SDK smoke matrix
 
 ## Cross-Work-Item Dependencies
 
 - `DMS-873` owns the gap inventory and scope boundaries. It does not re-own implementation already assigned
   to a follow-up story.
-- `DMS-1255` delivered the shared local-database default prerequisite for `DMS-1270`; its Jira link remains for
-  provenance rather than representing outstanding `DMS-1270` work. It also supplies the database-template
-  packages and `-DbOnly` startup slice required by `DMS-1271` and `DMS-1279` and remains tracked under its
-  existing bootstrap ownership.
+- `DMS-1255` delivered the shared local-database default prerequisite for `DMS-1270`; its Jira links remain for
+  provenance rather than representing active blockers. It also supplies the database-template packages,
+  `-DbOnly` startup slice, and engine-aware build/restore foundations required by `DMS-1271`, `DMS-1279`, and
+  `DMS-1289`, and remains tracked under its existing bootstrap ownership.
 - `DMS-1258` retains implementation ownership for the SQL Server foreign-key-pruning design. It may proceed in
   parallel with workflow work and is the Jira blocker for `DMS-1127`; the MSSQL gap inventory cannot be
   considered closed while this implementation and its update-tracking validation remain pending.
@@ -60,6 +62,9 @@ cross-cutting local and CI workflows that do not have another active home.
   assertions. `DMS-1285` owns real-MSSQL execution for the remaining uncovered write-path scenarios.
 - `DMS-1286` owns the real-MSSQL NamespaceBased provider boundary. `DMS-1284` owns representative public E2E
   coverage and must not duplicate the full provider matrix.
+- `DMS-1289` owns the scheduled engine-native template build, restore, registration, and API/SDK smoke matrix.
+  It retains PostgreSQL coverage and is separate from the standard DMS and Instance Management Docker E2E
+  lanes owned by `DMS-1284`.
 
 ## Related Cross-Epic Work
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -36,16 +36,17 @@ cross-cutting local and CI workflows that do not have another active home.
 
 - `DMS-873` owns the gap inventory and scope boundaries. It does not re-own implementation already assigned
   to a follow-up story.
-- `DMS-1255` supplies the database-template packages and `-DbOnly` startup slice required by `DMS-1270`,
-  `DMS-1271`, and `DMS-1279`. It remains tracked under its existing bootstrap ownership.
+- `DMS-1255` is the Jira blocker for `DMS-1270`, `DMS-1271`, and `DMS-1279`. It supplies the shared local-
+  database default, database-template packages, and `-DbOnly` startup slice required by those stories and
+  remains tracked under its existing bootstrap ownership.
 - `DMS-1258` retains implementation ownership for the SQL Server foreign-key-pruning design. It may proceed in
-  parallel with workflow work, but the MSSQL gap inventory cannot be considered closed while it remains
-  pending.
-- `DMS-1270` and `DMS-1271` meet at one topology seam: restore always targets a DMS datastore. In shared mode,
-  a scratch-validated DMS-only package is restored before CMS initialization touches that database; in
-  separate mode, restore must not target the CMS database. `DMS-1271` also owns the narrow package-producer
-  extension and consumer validation for an external restore manifest; general template publication remains
-  with `DMS-1255`.
+  parallel with workflow work and is the Jira blocker for `DMS-1127`; the MSSQL gap inventory cannot be
+  considered closed while this implementation and its update-tracking validation remain pending.
+- `DMS-1270` is the Jira blocker for `DMS-1271`. The stories meet at one topology seam: restore always targets a
+  DMS datastore. In shared mode, a scratch-validated DMS-only package is restored before CMS initialization
+  touches that database; in separate mode, restore must not target the CMS database. `DMS-1271` also owns the
+  narrow package-producer extension and consumer validation for an external restore manifest; general template
+  publication remains with `DMS-1255`.
 - `DMS-1279` separates the required SQL Server 2025 runtime upgrade from a conditional native `json` storage
   change. A recorded defer decision does not block the runtime upgrade. Adoption applies to the optional
   `DocumentCache` column, uses direct provider coverage unless a production cache path is separately assigned,
@@ -54,8 +55,8 @@ cross-cutting local and CI workflows that do not have another active home.
 - `DMS-1284` owns the public HTTP and Docker-stack boundary for both the standard DMS E2E suite and the separate
   multi-datastore Instance Management E2E suite. Backend defects found there should be linked to their owning
   implementation or provider-integration story rather than absorbed into the E2E harness.
-- `DMS-1285` reuses the shared fixtures and scenario names owned by `DMS-1023`; it owns real-MSSQL write-path
-  execution for the remaining uncovered scenarios.
+- `DMS-1023` is the Jira blocker for `DMS-1285`; it supplies the canonical scenario catalog, fixtures, and
+  assertions. `DMS-1285` owns real-MSSQL execution for the remaining uncovered write-path scenarios.
 - `DMS-1286` owns the real-MSSQL NamespaceBased provider boundary. `DMS-1284` owns representative public E2E
   coverage and must not duplicate the full provider matrix.
 

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -36,9 +36,10 @@ cross-cutting local and CI workflows that do not have another active home.
 
 - `DMS-873` owns the gap inventory and scope boundaries. It does not re-own implementation already assigned
   to a follow-up story.
-- `DMS-1255` is the Jira blocker for `DMS-1270`, `DMS-1271`, and `DMS-1279`. It supplies the shared local-
-  database default, database-template packages, and `-DbOnly` startup slice required by those stories and
-  remains tracked under its existing bootstrap ownership.
+- `DMS-1255` delivered the shared local-database default prerequisite for `DMS-1270`; its Jira link remains for
+  provenance rather than representing outstanding `DMS-1270` work. It also supplies the database-template
+  packages and `-DbOnly` startup slice required by `DMS-1271` and `DMS-1279` and remains tracked under its
+  existing bootstrap ownership.
 - `DMS-1258` retains implementation ownership for the SQL Server foreign-key-pruning design. It may proceed in
   parallel with workflow work and is the Jira blocker for `DMS-1127`; the MSSQL gap inventory cannot be
   considered closed while this implementation and its update-tracking validation remain pending.

--- a/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
+++ b/reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md
@@ -1,0 +1,72 @@
+---
+jira: DMS-1125
+jira_url: https://edfi.atlassian.net/browse/DMS-1125
+---
+
+# Epic: Close MSSQL Implementation and Parity Gaps
+
+## Description
+
+DMS already supports PostgreSQL and SQL Server. This epic closes the remaining MSSQL deployment,
+runtime-validation, persistence-correctness, and operational-workflow gaps needed for equivalent release
+confidence across the two supported relational engines.
+
+This is a gap-closure epic, not a new backend implementation. Existing PostgreSQL behavior remains the
+regression baseline, and existing cross-engine designs remain authoritative for shared semantics. Work stays
+in its owning domain when a specialized epic already exists; this epic owns the MSSQL-specific gaps and the
+cross-cutting local and CI workflows that do not have another active home.
+
+## Work Items
+
+- `DMS-873` — `00-gap-analysis-and-follow-up-inventory.md` — Inventory remaining MSSQL gaps and organize
+  follow-up work
+- `DMS-1270` — `01-local-database-topology-parity.md` — Align local database topology across engines with an
+  optional separate CMS database
+- `DMS-1271` — `02-database-template-restore-workflow.md` — Add the database-template restore branch to the
+  bootstrap workflow
+- `DMS-1279` — `03-sql-server-2025-and-native-json.md` — Adopt the SQL Server 2025 runtime and evaluate the
+  native `json` storage transition
+- `DMS-1284` — `04-mssql-docker-e2e.md` — Run the DMS Docker E2E suite against MSSQL
+- `DMS-1285` — `05-mssql-write-path-coverage.md` — Close relational write-path correctness and resilience
+  coverage gaps
+- `DMS-1286` — `06-mssql-namespace-authorization-coverage.md` — Add real-MSSQL integration coverage for
+  NamespaceBased CRUD authorization
+
+## Cross-Work-Item Dependencies
+
+- `DMS-873` owns the gap inventory and scope boundaries. It does not re-own implementation already assigned
+  to a follow-up story.
+- `DMS-1255` supplies the database-template packages and `-DbOnly` startup slice required by `DMS-1270`,
+  `DMS-1271`, and `DMS-1279`. It remains tracked under its existing bootstrap ownership.
+- `DMS-1270` and `DMS-1271` meet at one topology seam: restore always targets a DMS datastore. In shared mode,
+  restore occurs before CMS initialization touches that database; in separate mode, restore must not target
+  the CMS database.
+- `DMS-1279` separates the SQL Server 2025 runtime upgrade from the native `json` storage change. Runtime and
+  template compatibility must be established before changing generated schema.
+- `DMS-1284` owns the public HTTP and Docker-stack boundary. Backend defects found there should be linked to
+  their owning implementation or provider-integration story rather than absorbed into the E2E harness.
+- `DMS-1285` reuses the shared fixtures and scenario names owned by `DMS-1023`; it owns real-MSSQL write-path
+  execution for the remaining uncovered scenarios.
+- `DMS-1286` owns the real-MSSQL NamespaceBased provider boundary. `DMS-1284` owns representative public E2E
+  coverage and must not duplicate the full provider matrix.
+
+## Related Cross-Epic Work
+
+- [`DMS-1019` — Benchmark Harness for Read/Write Hot Paths](../12-ops-guardrails/04-performance-benchmarks.md)
+- [`DMS-1023` — Cross-Engine Parity Tests and Shared Fixtures](../13-test-migration/02-parity-and-fixtures.md)
+- [`DMS-1065` — Further Performance Optimizations](../14-authorization/16-further-performance-optimizations.md)
+- `DMS-1127` — SQL Server native-cascade update-tracking validation, governed by
+  [`sql-server-pruning.md`](../../design-docs/sql-server-pruning.md) and
+  [`update-tracking.md`](../../design-docs/update-tracking.md)
+
+## Scope Guardrails
+
+- Do not describe this epic as adding SQL Server support. SQL Server is already a supported backend.
+- Preserve PostgreSQL behavior and tests unless a shared defect requires an intentional cross-engine change.
+- Run provider-specific claims against a real SQL Server; deterministic SQL-shape tests alone are not enough
+  for provider behavior, transactionality, exception decoding, or engine limits.
+- Keep CMS persistence changes in CMS-owned code and tests. Cross-service bootstrap and topology work may
+  coordinate CMS and DMS without merging their persistence responsibilities.
+- Treat dialect differences as explicit, documented contracts. Do not weaken externally visible behavior to
+  make an MSSQL test pass.
+- Keep performance measurement in `DMS-1019` and speculative optimization in `DMS-1065`.

--- a/reference/design/backend-redesign/epics/JIRA-INDEX.md
+++ b/reference/design/backend-redesign/epics/JIRA-INDEX.md
@@ -193,3 +193,4 @@ This index links design documents under `reference/design/backend-redesign/epics
   - `DMS-1284` — Run the DMS and Instance Management Docker E2E Suites Against MSSQL — `reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md`
   - `DMS-1285` — Close MSSQL Relational Write-Path Correctness and Resilience Coverage Gaps — `reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md`
   - `DMS-1286` — Add Real-MSSQL Integration Coverage for NamespaceBased CRUD Authorization — `reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md`
+  - `DMS-1289` — Add MSSQL Coverage to Scheduled Smoke Tests — `reference/design/backend-redesign/epics/17-mssql-gap-closure/07-mssql-scheduled-smoke.md`

--- a/reference/design/backend-redesign/epics/JIRA-INDEX.md
+++ b/reference/design/backend-redesign/epics/JIRA-INDEX.md
@@ -190,6 +190,6 @@ This index links design documents under `reference/design/backend-redesign/epics
   - `DMS-1270` — Align Local Database Topology Across Engines with an Optional Separate CMS Database — `reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md`
   - `DMS-1271` — Add a Database-Template Restore Branch to Bootstrap — `reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md`
   - `DMS-1279` — Adopt SQL Server 2025 and Evaluate Native JSON Document Storage — `reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md`
-  - `DMS-1284` — Run the DMS Docker E2E Suite Against MSSQL — `reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md`
+  - `DMS-1284` — Run the DMS and Instance Management Docker E2E Suites Against MSSQL — `reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md`
   - `DMS-1285` — Close MSSQL Relational Write-Path Correctness and Resilience Coverage Gaps — `reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md`
   - `DMS-1286` — Add Real-MSSQL Integration Coverage for NamespaceBased CRUD Authorization — `reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md`

--- a/reference/design/backend-redesign/epics/JIRA-INDEX.md
+++ b/reference/design/backend-redesign/epics/JIRA-INDEX.md
@@ -184,3 +184,12 @@ This index links design documents under `reference/design/backend-redesign/epics
   - `DMS-1154` — Replace DMS ApiSchema DLL Resource Loading — `reference/design/backend-redesign/epics/16-bootstrap/04-apischema-runtime-content-loading.md`
   - `DMS-1155` — MetaEd ApiSchema Asset Packaging — `reference/design/backend-redesign/epics/16-bootstrap/05-metaed-apischema-asset-packaging.md`
   - `DMS-1156` — Package-Backed Standard Schema Selection — `reference/design/backend-redesign/epics/16-bootstrap/06-package-backed-standard-schema-selection.md`
+
+- `DMS-1125` — Close MSSQL Implementation and Parity Gaps — `reference/design/backend-redesign/epics/17-mssql-gap-closure/EPIC.md`
+  - `DMS-873` — Inventory MSSQL Implementation and Parity Gaps — `reference/design/backend-redesign/epics/17-mssql-gap-closure/00-gap-analysis-and-follow-up-inventory.md`
+  - `DMS-1270` — Align Local Database Topology Across Engines with an Optional Separate CMS Database — `reference/design/backend-redesign/epics/17-mssql-gap-closure/01-local-database-topology-parity.md`
+  - `DMS-1271` — Add a Database-Template Restore Branch to Bootstrap — `reference/design/backend-redesign/epics/17-mssql-gap-closure/02-database-template-restore-workflow.md`
+  - `DMS-1279` — Adopt SQL Server 2025 and Evaluate Native JSON Document Storage — `reference/design/backend-redesign/epics/17-mssql-gap-closure/03-sql-server-2025-and-native-json.md`
+  - `DMS-1284` — Run the DMS Docker E2E Suite Against MSSQL — `reference/design/backend-redesign/epics/17-mssql-gap-closure/04-mssql-docker-e2e.md`
+  - `DMS-1285` — Close MSSQL Relational Write-Path Correctness and Resilience Coverage Gaps — `reference/design/backend-redesign/epics/17-mssql-gap-closure/05-mssql-write-path-coverage.md`
+  - `DMS-1286` — Add Real-MSSQL Integration Coverage for NamespaceBased CRUD Authorization — `reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md`


### PR DESCRIPTION
## Summary

- establish DMS-1125 as the repository's MSSQL gap-closure epic
- record the DMS-873 gap analysis and add Jira-keyed design documents for DMS-1270, DMS-1271, DMS-1279, DMS-1284, DMS-1285, and DMS-1286
- document cross-ticket ownership, dependencies, scope guardrails, and SQL Server 2025/native JSON adoption constraints
- add the epic and its work items to the backend-redesign Jira index

## Jira

- DMS-873
- DMS-1125

## Validation

- `git diff --cached --check`
- verified unique Jira frontmatter for every new document
- verified all relative Markdown links and Jira-index targets resolve
- no runtime tests run; documentation-only change