### PR TITLE
[DMS-1287] Exempt CMS /health from multi-tenant tenant resolution

### DIFF
--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/TenantResolutionMiddlewareTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Middleware/TenantResolutionMiddlewareTests.cs
@@ -467,4 +467,126 @@ internal class TenantResolutionMiddlewareTests
             A.CallTo(() => _tenantRepository.GetTenantByName(A<string>.Ignored)).MustNotHaveHappened();
         }
     }
+
+    [TestFixture("/health")]
+    [TestFixture("/HEALTH")]
+    [TestFixture("/health/")]
+    public class Given_MultiTenancy_Is_Enabled_And_A_Health_Path(string path)
+    {
+        private RequestDelegate _next = null!;
+        private IOptions<AppSettings> _appSettings = null!;
+        private ITenantContextProvider _tenantContextProvider = null!;
+        private ITenantRepository _tenantRepository = null!;
+        private ILogger<TenantResolutionMiddleware> _logger = null!;
+        private DefaultHttpContext _httpContext = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _next = A.Fake<RequestDelegate>();
+            _tenantContextProvider = new TenantContextProvider();
+            _tenantRepository = A.Fake<ITenantRepository>();
+            _logger = A.Fake<ILogger<TenantResolutionMiddleware>>();
+            _appSettings = Options.Create(
+                new AppSettings
+                {
+                    MultiTenancy = true,
+                    Datastore = "postgresql",
+                    IdentityProvider = "self-contained",
+                    SpecificationVersion = "v3",
+                }
+            );
+
+            var middleware = new TenantResolutionMiddleware(_next);
+            _httpContext = new DefaultHttpContext();
+            _httpContext.Request.Path = path;
+            _httpContext.Response.Body = new MemoryStream();
+            // No Tenant header
+
+            await middleware.Invoke(
+                _httpContext,
+                _appSettings,
+                _tenantContextProvider,
+                _tenantRepository,
+                _logger
+            );
+        }
+
+        [Test]
+        public void It_calls_next()
+        {
+            A.CallTo(() => _next(_httpContext)).MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public void It_does_not_look_up_tenant()
+        {
+            A.CallTo(() => _tenantRepository.GetTenantByName(A<string>.Ignored)).MustNotHaveHappened();
+        }
+
+        [Test]
+        public void It_leaves_tenant_context_not_multitenant()
+        {
+            _tenantContextProvider.Context.Should().BeOfType<TenantContext.NotMultitenant>();
+        }
+    }
+
+    [TestFixture("/healthcheck")]
+    [TestFixture("/healthy")]
+    [TestFixture("/health/foo")]
+    [TestFixture("/v3/health")]
+    [TestFixture("/health//")]
+    public class Given_MultiTenancy_Is_Enabled_And_A_Health_Lookalike_Path(string path)
+    {
+        private RequestDelegate _next = null!;
+        private IOptions<AppSettings> _appSettings = null!;
+        private ITenantContextProvider _tenantContextProvider = null!;
+        private ITenantRepository _tenantRepository = null!;
+        private ILogger<TenantResolutionMiddleware> _logger = null!;
+        private DefaultHttpContext _httpContext = null!;
+
+        [SetUp]
+        public async Task Setup()
+        {
+            _next = A.Fake<RequestDelegate>();
+            _tenantContextProvider = new TenantContextProvider();
+            _tenantRepository = A.Fake<ITenantRepository>();
+            _logger = A.Fake<ILogger<TenantResolutionMiddleware>>();
+            _appSettings = Options.Create(
+                new AppSettings
+                {
+                    MultiTenancy = true,
+                    Datastore = "postgresql",
+                    IdentityProvider = "self-contained",
+                    SpecificationVersion = "v3",
+                }
+            );
+
+            var middleware = new TenantResolutionMiddleware(_next);
+            _httpContext = new DefaultHttpContext();
+            _httpContext.Request.Path = path;
+            _httpContext.Response.Body = new MemoryStream();
+            // No Tenant header
+
+            await middleware.Invoke(
+                _httpContext,
+                _appSettings,
+                _tenantContextProvider,
+                _tenantRepository,
+                _logger
+            );
+        }
+
+        [Test]
+        public void It_returns_400()
+        {
+            _httpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        }
+
+        [Test]
+        public void It_does_not_call_next()
+        {
+            A.CallTo(() => _next(_httpContext)).MustNotHaveHappened();
+        }
+    }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/HealthModuleTests.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit/Modules/HealthModuleTests.cs
@@ -3,11 +3,15 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using EdFi.DmsConfigurationService.Frontend.AspNetCore.Configuration;
 using FluentAssertions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace EdFi.DmsConfigurationService.Frontend.AspNetCore.Tests.Unit.Modules;
@@ -32,5 +36,122 @@ public class HealthTests
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         DateTime.TryParse(content, CultureInfo.InvariantCulture, out DateTime dt).Should().Be(true);
+    }
+}
+
+/// <summary>
+/// Shared setup for full-pipeline health tests with CMS multi-tenancy enabled. Both the application
+/// configuration (read by endpoint mapping) and IOptions&lt;AppSettings&gt; (read by
+/// TenantResolutionMiddleware) must set MultiTenancy for the middleware to enforce tenant resolution.
+/// </summary>
+public abstract class MultiTenantPipelineTestBase
+{
+    protected static WebApplicationFactory<Program> CreateMultiTenantFactory(string? pathBase = null)
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+
+            builder.ConfigureAppConfiguration(
+                (_, config) =>
+                {
+                    var settings = new Dictionary<string, string?> { ["AppSettings:MultiTenancy"] = "true" };
+                    if (pathBase is not null)
+                    {
+                        settings["AppSettings:PathBase"] = pathBase;
+                    }
+                    config.AddInMemoryCollection(settings);
+                }
+            );
+
+            builder.ConfigureServices(
+                (_, services) => services.Configure<AppSettings>(s => s.MultiTenancy = true)
+            );
+        });
+    }
+}
+
+[TestFixture]
+public class Given_MultiTenancy_And_A_Health_Request : MultiTenantPipelineTestBase
+{
+    private HttpStatusCode _statusCode;
+    private string _body = null!;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var factory = CreateMultiTenantFactory();
+        using var client = factory.CreateClient();
+
+        // No Tenant header
+        var response = await client.GetAsync("/health");
+        _statusCode = response.StatusCode;
+        _body = await response.Content.ReadAsStringAsync();
+    }
+
+    [Test]
+    public void It_returns_200()
+    {
+        _statusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public void It_returns_a_timestamp_body()
+    {
+        DateTime.TryParse(_body, CultureInfo.InvariantCulture, out _).Should().BeTrue();
+    }
+}
+
+[TestFixture]
+public class Given_MultiTenancy_With_PathBase_And_A_Health_Request : MultiTenantPipelineTestBase
+{
+    private HttpStatusCode _statusCode;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var factory = CreateMultiTenantFactory(pathBase: "mt-config");
+        using var client = factory.CreateClient();
+
+        // No Tenant header
+        var response = await client.GetAsync("/mt-config/health");
+        _statusCode = response.StatusCode;
+    }
+
+    [Test]
+    public void It_returns_200()
+    {
+        _statusCode.Should().Be(HttpStatusCode.OK);
+    }
+}
+
+[TestFixture]
+public class Given_MultiTenancy_And_A_Protected_Request_Without_Tenant_Header : MultiTenantPipelineTestBase
+{
+    private HttpStatusCode _statusCode;
+    private string _body = null!;
+
+    [SetUp]
+    public async Task Setup()
+    {
+        await using var factory = CreateMultiTenantFactory();
+        using var client = factory.CreateClient();
+
+        // No Tenant header
+        var response = await client.GetAsync("/v3/vendors");
+        _statusCode = response.StatusCode;
+        _body = await response.Content.ReadAsStringAsync();
+    }
+
+    [Test]
+    public void It_returns_400()
+    {
+        _statusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public void It_returns_the_tenant_required_message()
+    {
+        _body.Should().Contain("The 'Tenant' header is required when multi-tenancy is enabled");
     }
 }

--- a/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Middleware/TenantResolutionMiddleware.cs
+++ b/src/config/frontend/EdFi.DmsConfigurationService.Frontend.AspNetCore/Middleware/TenantResolutionMiddleware.cs
@@ -30,11 +30,14 @@ public class TenantResolutionMiddleware(RequestDelegate next)
             return;
         }
 
+        // Allow /health endpoint without tenant header (health probes must be tenant-agnostic).
+        //   Matched exactly (not by segment prefix) so lookalike paths keep requiring a valid tenant.
         // Allow /connect endpoints without tenant header (for system administrator authentication)
         // Allow /v3/tenants endpoints without tenant header (for tenant management before tenants exist)
         // Allow /.well-known endpoints without tenant header (standard OIDC discovery endpoints)
         if (
-            context.Request.Path.StartsWithSegments("/connect", StringComparison.OrdinalIgnoreCase)
+            IsHealthPath(context.Request.Path)
+            || context.Request.Path.StartsWithSegments("/connect", StringComparison.OrdinalIgnoreCase)
             || context.Request.Path.StartsWithSegments("/v3/tenants", StringComparison.OrdinalIgnoreCase)
             || context.Request.Path.StartsWithSegments("/.well-known", StringComparison.OrdinalIgnoreCase)
         )
@@ -119,6 +122,17 @@ public class TenantResolutionMiddleware(RequestDelegate next)
             new { error = "Bad Request", message = "Failed to validate tenant" }
         );
     }
+
+    /// <summary>
+    /// Determines whether the request targets the health endpoint, which must be reachable without a
+    /// tenant header so health probes remain tenant-agnostic. Matches only "/health" and "/health/"
+    /// (case-insensitive), leaving lookalike paths such as "/health/foo" or "/healthcheck" subject to
+    /// tenant enforcement. Path base is already stripped by UsePathBase, so "/mt-config/health" arrives
+    /// here as "/health".
+    /// </summary>
+    private static bool IsHealthPath(PathString path) =>
+        path.Equals("/health", StringComparison.OrdinalIgnoreCase)
+        || path.Equals("/health/", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Sanitizes a string for safe logging by allowing only safe characters.


### PR DESCRIPTION
## Summary

Fixes DMS-1287. When CMS multi-tenancy is enabled, `TenantResolutionMiddleware` processed `GET /health` (including under a configured path base such as `/mt-config/health`) and returned **HTTP 400** for a missing `Tenant` header, breaking tenant-agnostic health probes.

This PR exempts the health endpoint from tenant resolution while preserving tenant enforcement for every other endpoint.

## Change

- `TenantResolutionMiddleware` now exempts the health endpoint alongside the existing `/connect`, `/v3/tenants`, and `/.well-known` exemptions.
- The health path is matched **exactly** via a new `IsHealthPath` helper — only `/health` and `/health/` (case-insensitive) — rather than by segment prefix, so lookalike paths such as `/health/foo` or `/healthcheck` continue to require a valid tenant.
- `UsePathBase` runs before this middleware, so `/mt-config/health` arrives as `/health`; no path-base handling is needed.
- Like the other exemptions, the health branch calls `_next` without populating tenant context, keeping the response tenant-agnostic; `ITenantRepository` is never consulted.
- The exemption is inside the multi-tenant branch (after the `MultiTenancy` early-return), so single-tenant behavior is unchanged. Existing exemptions are untouched.

## Acceptance criteria

- [x] **AC1** — Multi-tenant `/health` (including a configured path base) succeeds without a `Tenant` header when healthy.
- [x] **AC2** — Response is tenant-agnostic; no tenant-specific data (context stays `NotMultitenant`, `ITenantRepository` never called, only a timestamp returned).
- [x] **AC3** — Existing unhealthy/non-success behavior intact; the exemption forwards downstream via `_next` (e.g. `ReportInvalidConfigurationMiddleware` returning 500), and no dependency-health subsystem is introduced.
- [x] **AC4** — Non-health endpoints continue enforcing tenant context.
- [x] **AC5** — Automated pipeline/integration coverage proves both the exemption and continued enforcement.
- [x] **AC6** — Single-tenant health behavior unchanged.
- [ ] **AC7 — HANDOFF (not in this PR).** Removal of the exact-400 Azure-VM readiness workaround belongs to the DMS-1196 rollout (PR #1106) after a fixed CMS image is consumed. The workaround assets (`eng/azure-vm/`) are not present on this branch, so it cannot be completed here; tracked as a DMS-1196 follow-up.

## Tests

- **Middleware unit tests** (`TenantResolutionMiddlewareTests`): two parameterized `Given_` fixtures — allowed `/health`, `/HEALTH`, `/health/` each call `next`, never look up the tenant, and leave the context `NotMultitenant`; rejected `/healthcheck`, `/healthy`, `/health/foo`, `/v3/health`, `/health//` return 400 and never call `next`.
- **Full-pipeline tests** (`HealthModuleTests`, `WebApplicationFactory`): multi-tenant `/health` (no header) → 200 with a timestamp body; `AppSettings:PathBase=mt-config` `/mt-config/health` (no header) → 200; `/v3/vendors` (no header) → 400 with the tenant-required message (continued enforcement). The existing single-tenant `HealthTests.TestPingEndpoint` is unchanged.
- Full CMS frontend unit project: **488/488 passing**. CSharpier applied to all changed C# files.
