### PR TITLE
[DMS-1289] Add MSSQL coverage to the scheduled database-template and API/SDK smoke matrix

### DIFF
--- a/.github/workflows/build-minimal-template.yml
+++ b/.github/workflows/build-minimal-template.yml
@@ -308,7 +308,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: Bulkload-logs
+          name: Bulkload-logs-${{ inputs.package_name }}
           path: ${{ github.workspace }}/eng/DatabaseTemplates/.packages/**/logfile.txt
           retention-days: 10
 
@@ -329,7 +329,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: Docker-Logs
+          name: Docker-Logs-${{ inputs.package_name }}
           path: ${{ github.workspace }}/logs
           retention-days: 10
 

--- a/.github/workflows/build-populated-template.yml
+++ b/.github/workflows/build-populated-template.yml
@@ -328,7 +328,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: Bulkload-logs
+          name: Bulkload-logs-${{ inputs.package_name }}
           path: ${{ github.workspace }}/eng/DatabaseTemplates/.packages/**/logfile.txt
           retention-days: 10
 
@@ -349,7 +349,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: Docker-Logs
+          name: Docker-Logs-${{ inputs.package_name }}
           path: ${{ github.workspace }}/logs
           retention-days: 10
 
@@ -586,7 +586,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "❌ Scheduled Populated Template build failed\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Workflow:* ${{ github.workflow }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "❌ Scheduled Populated Template build failed\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*Package:* ${{ inputs.package_name }}\n*Workflow:* ${{ github.workflow }}\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/build-populated-template.yml
+++ b/.github/workflows/build-populated-template.yml
@@ -190,7 +190,11 @@ jobs:
         run: |
           Import-Module ../Dms-Management.psm1 -Force
           Import-Module ./env-utility.psm1 -Force
-          $envValues = ReadValuesFromEnvFile "${{ inputs.environment_file }}"
+          # The SQL Server container was started from the composed engine env file (base +
+          # .env.mssql overlay), so credentials must be read from that same composed file,
+          # not the base file.
+          $effectiveEnvironmentFile = Resolve-DatabaseEngineEnvironmentFile -DatabaseEngine "${{ inputs.database_engine }}" -BaseEnvironmentFile "${{ inputs.environment_file }}" -DockerComposeRoot (Resolve-Path ".").Path
+          $envValues = ReadValuesFromEnvFile $effectiveEnvironmentFile
           $postgresUser = Get-EnvValue -EnvValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
           $postgresCredential = ConvertTo-PostgresCredential -UserName $postgresUser -Secret $envValues.POSTGRES_PASSWORD
 

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -203,7 +203,9 @@ jobs:
             "eng/docker-compose/tests/DataStoreConnectionString.Tests.ps1",
             "eng/docker-compose/tests/AzureVmDeployment.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",
-            "eng/smoke_test/tests/SmokeTest.Tests.ps1"
+            "eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1",
+            "eng/smoke_test/tests/SmokeTest.Tests.ps1",
+            "eng/DatabaseTemplates/tests/Smoke-LegSelection.Tests.ps1"
           )
           $result = Invoke-Pester -Path $paths -Output Detailed -PassThru
           if ($result.FailedCount -gt 0) {

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -13,18 +13,35 @@ on:
     paths: # Only run on PRs that change relevant files
       - 'src/Directory.Packages.props'
       - '**/OpenApiDocument.cs'
+      # Every pattern below is kept identical to the path map owned by
+      # eng/DatabaseTemplates/Select-SmokeTestLegs.ps1, which classifies each changed path into the
+      # specific engine/Data Standard legs it can affect (a Pester drift guard keeps this list and
+      # that map in sync). A PR run executes only the legs Select-SmokeTestLegs.ps1 selects for the
+      # files that changed; scheduled and workflow_dispatch runs always execute the full
+      # PostgreSQL/MSSQL x DS 5.2/6.1 matrix regardless of these paths.
+      #
       # SDK generation + smoke tooling this workflow exercises, so changes to them
       # are covered by PR validation instead of only the cron run (DMS-912).
       - '.github/workflows/scheduled-smoke-test.yml'
       - 'build-sdk.ps1'
       - 'eng/smoke_test/**'
       - 'eng/sdkGen/**'
-      # The populated-template build this workflow consumes per Data Standard version: its reusable
-      # workflow, the per-version smoke template env files, and the template build/restore/filtering
-      # logic (incl. the DS 6.1 educator-prep filter + tolerance). Listed so a change to the DS 6.1
-      # (or 5.2) smoke path is validated on PRs instead of only the cron run (DMS-1136).
+      # The populated-template build this workflow consumes per Data Standard version and database
+      # engine: its reusable workflow, the per-version smoke template env files, the engine compose
+      # files and shared local-stack infra, and the template build/restore/filtering logic (incl.
+      # the DS 6.1 educator-prep filter + tolerance). Listed so a change to any engine/DS leg is
+      # validated on PRs instead of only the cron run (DMS-1136).
       - '.github/workflows/build-populated-template.yml'
-      - 'eng/docker-compose/.env.smoke*'
+      - 'eng/docker-compose/mssql.yml'
+      - 'eng/docker-compose/.env.mssql'
+      - 'eng/docker-compose/postgresql.yml'
+      - 'eng/docker-compose/.env.smoke'
+      - 'eng/docker-compose/.env.smoke.ds61'
+      - 'eng/docker-compose/start-local-dms.ps1'
+      - 'eng/docker-compose/local-dms.yml'
+      - 'eng/docker-compose/local-config.yml'
+      - 'eng/docker-compose/env-utility.psm1'
+      - 'eng/Dms-Management.psm1'
       - 'eng/DatabaseTemplates/**'
 
 permissions:
@@ -37,26 +54,53 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Computes the engine x Data Standard matrix legs this run should execute: the full four-leg
+  # matrix on schedule/workflow_dispatch runs, or only the legs safely affected by the PR's changed
+  # files. The leg definitions and the changed-path-to-leg mapping both live in
+  # eng/DatabaseTemplates/Select-SmokeTestLegs.ps1, which is the single source of truth the
+  # downstream jobs below consume via ${{ needs.select-legs.outputs.include }}.
+  select-legs:
+    name: Select Smoke Legs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      include: ${{ steps.select.outputs.include }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Select smoke test legs
+        id: select
+        shell: pwsh
+        run: |
+          $changedFiles = @()
+          if ($env:GITHUB_EVENT_NAME -eq "pull_request") {
+            # fetch-depth 0 fetches all branches, so origin/<base> exists; on PR events HEAD is the
+            # merge commit, so this diff is exactly the PR's changes vs the base tip.
+            $changedFiles = @(git diff --name-only "$(git merge-base HEAD "origin/$env:GITHUB_BASE_REF")" HEAD)
+          }
+
+          $include = ./eng/DatabaseTemplates/Select-SmokeTestLegs.ps1 -EventName $env:GITHUB_EVENT_NAME -ChangedFiles $changedFiles
+          Write-Host "Selected smoke test legs: $include"
+          "include=$include" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
   build-populated-template:
-    name: Build Populated Template ${{ matrix.standard_version }}
-    # One leg per supported Ed-Fi Data Standard version (kept in sync with the smoke-test
-    # matrix below). To add or drop a version, edit both `include` blocks; see
-    # docs/DATA-STANDARD-VERSIONS.md. DS 5.2 is the default.
+    name: Build Populated Template ${{ matrix.database_engine }} ${{ matrix.standard_version }}
+    needs: select-legs
+    # One leg per supported database engine x Ed-Fi Data Standard version combination. The legs are
+    # defined once in eng/DatabaseTemplates/Select-SmokeTestLegs.ps1 (see
+    # docs/DATA-STANDARD-VERSIONS.md); this matrix simply builds whatever select-legs selected.
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - standard_version: "5.2.0"
-            package_name: "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"
-            provenance_file: "populated.template.intoto.jsonl"
-            environment_file: "./.env.smoke"
-          - standard_version: "6.1.0"
-            package_name: "EdFi.Api.Smoke.Template.PostgreSql.6.1.0"
-            provenance_file: "populated.template.6.1.0.intoto.jsonl"
-            environment_file: "./.env.smoke.ds61"
+        include: ${{ fromJSON(needs.select-legs.outputs.include) }}
     uses: ./.github/workflows/build-populated-template.yml
     with:
       standard_version: ${{ matrix.standard_version }}
+      database_engine: ${{ matrix.database_engine }}
       package_name: ${{ matrix.package_name }}
       manifest_file: "_manifest/spdx_2.2/manifest.spdx.json"
       provenance_file: ${{ matrix.provenance_file }}
@@ -172,29 +216,21 @@ jobs:
           cache-to: type=gha,mode=max,scope=smoke-config-image
 
   smoke-test:
-    name: Smoke Tests ${{ matrix.standard_version }}
-    needs: [build-populated-template, build-ci-docker-images]
+    name: Smoke Tests ${{ matrix.database_engine }} ${{ matrix.standard_version }}
+    needs: [select-legs, build-populated-template, build-ci-docker-images]
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       packages: read
-    # Each leg smoke-tests the template built for the same version. Keep this matrix in sync
-    # with the build-populated-template matrix above.
+    # One leg per supported database engine x Ed-Fi Data Standard version combination. The legs
+    # are defined once in eng/DatabaseTemplates/Select-SmokeTestLegs.ps1 (see
+    # docs/DATA-STANDARD-VERSIONS.md); this matrix simply smoke-tests whatever select-legs
+    # selected, the same source the build-populated-template matrix above consumes.
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - standard_version: "5.2.0"
-            package_name: "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"
-            environment_file: "./.env.smoke"
-            # The published ODS SDK sweep uses EdFi.Suite3.OdsApi.TestSdk.Standard.5.2.0,
-            # which is DS 5.2-specific, so it only runs on the 5.2 leg.
-            run_ods_sdk_tests: true
-          - standard_version: "6.1.0"
-            package_name: "EdFi.Api.Smoke.Template.PostgreSql.6.1.0"
-            environment_file: "./.env.smoke.ds61"
-            run_ods_sdk_tests: false
+        include: ${{ fromJSON(needs.select-legs.outputs.include) }}
 
     env:
       DMS_DOCKER_IMAGE: ${{ needs.build-ci-docker-images.outputs.dms_compose_image }}
@@ -295,7 +331,7 @@ jobs:
       - name: Start DMS with Core, TPDM, Sample, and Homograph (SmokeTest)
         run: |
           $env:LOG_LEVEL="Warning"
-          ./start-local-dms.ps1 -EnvironmentFile "${{ matrix.environment_file }}" -EnableConfig
+          ./start-local-dms.ps1 -EnvironmentFile "${{ matrix.environment_file }}" -EnableConfig -DatabaseEngine "${{ matrix.database_engine }}"
         working-directory: eng/docker-compose/
 
       - name: Wait for the Configuration Service to be ready
@@ -320,7 +356,10 @@ jobs:
       - name: Restore the Populated Template artifact into the smoke database
         run: |
           Import-Module ./Template-Management.psm1 -Force
-          Restore-TemplatePackage -PackageDirectory "${{ github.workspace }}/template-package" -DatabaseName $env:SMOKE_DATABASE_NAME
+          Import-Module ../docker-compose/env-utility.psm1 -Force
+          $envValues = ReadValuesFromEnvFile (Join-Path "../docker-compose" "${{ matrix.environment_file }}")
+          $mssqlPassword = Get-EnvValue -EnvValues $envValues -Name "MSSQL_SA_PASSWORD" -DefaultValue "abcdefgh1!"
+          Restore-TemplatePackage -PackageDirectory "${{ github.workspace }}/template-package" -DatabaseName $env:SMOKE_DATABASE_NAME -DatabaseEngine "${{ matrix.database_engine }}" -MssqlPassword $mssqlPassword
         working-directory: eng/DatabaseTemplates/
 
       # DMS fails fatally at startup when the Configuration Service has no data stores.
@@ -335,9 +374,21 @@ jobs:
           $envValues = ReadValuesFromEnvFile "${{ matrix.environment_file }}"
           $postgresUser = Get-EnvValue -EnvValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
           $postgresCredential = ConvertTo-PostgresCredential -UserName $postgresUser -Secret $envValues.POSTGRES_PASSWORD
+
+          # Add-DataStore always requires a PostgresCredential; for mssql it goes unused
+          # because -ConnectionString is supplied verbatim below. On the mssql leg the
+          # Configuration Service also runs on SQL Server (shared-database topology; no
+          # PostgreSQL container exists), so the credential is a required-parameter placeholder
+          # there, built from env values that are present in the smoke env file either way.
+          $dataStoreConnectionString = ""
+          if ("${{ matrix.database_engine }}" -eq "mssql") {
+            $mssqlPassword = Get-EnvValue -EnvValues $envValues -Name "MSSQL_SA_PASSWORD" -DefaultValue "abcdefgh1!"
+            $dataStoreConnectionString = New-DataStoreConnectionString -DatabaseEngine "mssql" -DbHost "dms-mssql" -Port 1433 -Username "sa" -Password $mssqlPassword -DatabaseName $env:SMOKE_DATABASE_NAME
+          }
+
           Add-CmsClient -CmsUrl "http://localhost:8081" -ClientId "data-store-admin" -ClientSecret "ValidClientSecret1234567890!Abcd" -DisplayName "Data Store Setup Administrator"
           $configToken = Get-CmsToken -CmsUrl "http://localhost:8081" -ClientId "data-store-admin" -ClientSecret "ValidClientSecret1234567890!Abcd"
-          $dataStoreId = Add-DataStore -CmsUrl "http://localhost:8081" -AccessToken $configToken -PostgresCredential $postgresCredential -PostgresDbName $env:SMOKE_DATABASE_NAME -Name "Smoke Test Data Store" -DataStoreType "SmokeTest"
+          $dataStoreId = Add-DataStore -CmsUrl "http://localhost:8081" -AccessToken $configToken -PostgresCredential $postgresCredential -PostgresDbName $env:SMOKE_DATABASE_NAME -ConnectionString $dataStoreConnectionString -Name "Smoke Test Data Store" -DataStoreType "SmokeTest"
           if (-not $dataStoreId) {
             throw "Failed to register the smoke test data store."
           }
@@ -432,7 +483,8 @@ jobs:
         working-directory: eng/smoke_test/
 
       # The ODS SDK sweep uses the published EdFi.Suite3.OdsApi.TestSdk.Standard.5.2.0 (DS 5.2),
-      # so it only runs on the DS 5.2 leg. DS 6.1 is still covered by the API + DMS SDK tests above.
+      # so it only runs on the DS 5.2 legs of both engines. DS 6.1 is still covered by the
+      # API + DMS SDK tests above.
       - name: Run NonDestructive ODS SDK Tests
         if: ${{ matrix.run_ods_sdk_tests }}
         run: |
@@ -462,7 +514,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
         with:
-          name: Smoke-Tests-Docker-Logs
+          name: Smoke-Tests-Docker-Logs-${{ matrix.database_engine }}-${{ matrix.standard_version }}
           path: ${{ github.workspace }}/logs
           retention-days: 10
 
@@ -484,7 +536,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "✅ *Scheduled Smoke Tests - SUCCESS*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*DMS Backend:* Single backend path\n*DS 5.2:* Core + TPDM + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK, ODS NonDestructive/Destructive SDK\n*DS 6.1:* Core (TPDM in-core) + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK (ODS SDK skipped, DS-5.2-specific)\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "✅ *Scheduled Smoke Tests - SUCCESS*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*DMS Backends:* PostgreSQL and MSSQL (each on DS 5.2 and 6.1)\n*DS 5.2:* Core + TPDM + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK, and ODS NonDestructive/Destructive SDK on both engines\n*DS 6.1:* Core (TPDM in-core) + Sample + Homograph; DMS NonDestructive API/SDK and DMS Destructive SDK on both engines (ODS SDK skipped, DS-5.2-specific)\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]
@@ -504,7 +556,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "❌ *Scheduled Smoke Tests - FAILURE*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*DMS Backend:* Single backend path\n*DS 5.2:* Core + TPDM + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK, ODS NonDestructive/Destructive SDK\n*DS 6.1:* Core (TPDM in-core) + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK (ODS SDK skipped, DS-5.2-specific)\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    "text": "❌ *Scheduled Smoke Tests - FAILURE*\n*Repository:* ${{ github.repository }}\n*Branch:* ${{ github.ref }}\n*DMS Backends:* PostgreSQL and MSSQL (each on DS 5.2 and 6.1)\n*DS 5.2:* Core + TPDM + Sample + Homograph; DMS NonDestructive API/SDK, DMS Destructive SDK, and ODS NonDestructive/Destructive SDK on both engines\n*DS 6.1:* Core (TPDM in-core) + Sample + Homograph; DMS NonDestructive API/SDK and DMS Destructive SDK on both engines (ODS SDK skipped, DS-5.2-specific)\n*Log URL:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/scheduled-smoke-test.yml
+++ b/.github/workflows/scheduled-smoke-test.yml
@@ -357,7 +357,13 @@ jobs:
         run: |
           Import-Module ./Template-Management.psm1 -Force
           Import-Module ../docker-compose/env-utility.psm1 -Force
-          $envValues = ReadValuesFromEnvFile (Join-Path "../docker-compose" "${{ matrix.environment_file }}")
+          # The SQL Server container was started from the composed engine env file (base +
+          # .env.mssql overlay), so credentials must be read from that same composed file,
+          # not the base file.
+          $dockerComposeRoot = (Resolve-Path "../docker-compose").Path
+          $baseEnvironmentFile = Join-Path $dockerComposeRoot "${{ matrix.environment_file }}"
+          $effectiveEnvironmentFile = Resolve-DatabaseEngineEnvironmentFile -DatabaseEngine "${{ matrix.database_engine }}" -BaseEnvironmentFile $baseEnvironmentFile -DockerComposeRoot $dockerComposeRoot
+          $envValues = ReadValuesFromEnvFile $effectiveEnvironmentFile
           $mssqlPassword = Get-EnvValue -EnvValues $envValues -Name "MSSQL_SA_PASSWORD" -DefaultValue "abcdefgh1!"
           Restore-TemplatePackage -PackageDirectory "${{ github.workspace }}/template-package" -DatabaseName $env:SMOKE_DATABASE_NAME -DatabaseEngine "${{ matrix.database_engine }}" -MssqlPassword $mssqlPassword
         working-directory: eng/DatabaseTemplates/
@@ -371,7 +377,11 @@ jobs:
         run: |
           Import-Module ../Dms-Management.psm1 -Force
           Import-Module ./env-utility.psm1 -Force
-          $envValues = ReadValuesFromEnvFile "${{ matrix.environment_file }}"
+          # The SQL Server container was started from the composed engine env file (base +
+          # .env.mssql overlay), so credentials must be read from that same composed file,
+          # not the base file.
+          $effectiveEnvironmentFile = Resolve-DatabaseEngineEnvironmentFile -DatabaseEngine "${{ matrix.database_engine }}" -BaseEnvironmentFile "${{ matrix.environment_file }}" -DockerComposeRoot (Resolve-Path ".").Path
+          $envValues = ReadValuesFromEnvFile $effectiveEnvironmentFile
           $postgresUser = Get-EnvValue -EnvValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
           $postgresCredential = ConvertTo-PostgresCredential -UserName $postgresUser -Secret $envValues.POSTGRES_PASSWORD
 

--- a/docs/DATA-STANDARD-VERSIONS.md
+++ b/docs/DATA-STANDARD-VERSIONS.md
@@ -106,21 +106,33 @@ Workflows that build per-version artifacts select the version through a per-work
 
 - **Populated template** (`EdFi.Api.Populated.Template.PostgreSQL.yml`) and the
   **scheduled smoke test** (`scheduled-smoke-test.yml`) delegate to the reusable
-  `build-populated-template.yml`. Each matrix leg runs the whole
-  build → SBOM → provenance pipeline as one unit (so per-version outputs stay
-  correlated), and the per-version package name, provenance file, and template env
-  file are read from the matrix `include` entry; **adding a version is adding one
-  `include` entry** (plus the schema artifacts and a template env file for that version).
+  `build-populated-template.yml`.
+  Each matrix leg runs the whole build → SBOM → provenance pipeline as one unit (so
+  per-version outputs stay correlated), and the per-version package name, provenance
+  file, and template env file are read from the matrix leg.
+  For the populated template workflow, that leg is a `standard_version` matrix
+  `include` entry, and **adding a version there is adding one `include` entry**
+  (plus the schema artifacts and a template env file for that version).
   - The **populated template** product workflow (tag/release/`workflow_dispatch`) builds
     both `5.2.0` and `6.1.0`. The `6.1.0` leg is validated by dispatch
     (`publish_package` defaults off) before any release; the reusable workflow's
     `environment_file` allowlist gates which env files may be used.
-  - The **scheduled smoke test** (which also runs on PRs touching its paths) runs both a
-    `5.2.0` and a `6.1.0` leg (the `6.1.0` populated build is validated end-to-end). The
-    ODS-published-SDK sweep stays `5.2.0`-only — it consumes the DS-5.2-specific
-    `EdFi.Suite3.OdsApi.TestSdk.Standard.5.2.0` package — and is gated by a `run_ods_sdk_tests`
-    matrix flag; the `6.1.0` leg's API surface is instead covered by the NonDestructive API tests
-    and the DMS-generated SDK.
+  - The **scheduled smoke test** (which also runs on PRs touching its paths) does not
+    read a static `include` list.
+    A `select-legs` job computes its matrix from the leg table inside
+    `eng/DatabaseTemplates/Select-SmokeTestLegs.ps1`, which is the single place the
+    smoke legs are defined.
+    Each Data Standard version carries two legs there, one per database engine
+    (postgresql and mssql), so the workflow runs four legs total: PostgreSQL/5.2.0,
+    PostgreSQL/6.1.0, MSSQL/5.2.0, and MSSQL/6.1.0 (the `6.1.0` legs' populated builds
+    are validated end-to-end on both engines).
+    Scheduled and `workflow_dispatch` runs always execute the full four-leg matrix;
+    PR runs execute only the legs a changed file can safely affect, falling back to
+    the full matrix when a change is unmapped or the changed-file list is empty.
+    The ODS-published-SDK sweep stays `5.2.0`-only on both engines - it consumes the
+    DS-5.2-specific `EdFi.Suite3.OdsApi.TestSdk.Standard.5.2.0` package - and is gated
+    by a `run_ods_sdk_tests` matrix flag; the `6.1.0` legs' API surface is instead
+    covered by the NonDestructive API tests and the DMS-generated SDK.
 
   > The template surface is intentionally reduced versus the local dev surface
   > (Core + TPDM + Sample + Homograph in `.env.ds<NN>`): DS 5.2 is Core + TPDM
@@ -213,14 +225,19 @@ Adding a version is the same set of small edits regardless of which version:
 4. **Security metadata.** Add `Claims/Standards/ds<NN>/Claims.json` (authored from the
    ODS API SecurityMetadata XML export via the `eng/CmsHierarchy` tool). No csproj
    change is needed — the embedded-resource glob picks it up.
-5. **CI.** Add an `include` entry to the `standard_version` matrix in each per-version lane —
+5. **CI.** Add an `include` entry to the `standard_version` matrix in each per-version lane -
    `EdFi.Api.Populated.Template.PostgreSQL.yml`, `EdFi.Api.Minimal.Template.PostgreSQL.yml`, and
-   the SDK callers `Pkg EdFi.Api.Sdk.yml` / `Pkg EdFi.Api.TestSdk.yml` (and, once validated,
-   `scheduled-smoke-test.yml`). Add the version's standalone template env file (its product schema
-   surface — Core + TPDM for 5.2, Core only for 6.1), referenced by the template entries, and allow
-   that env file in `build-populated-template.yml`'s `environment_file` allowlist. The SDK legs need
-   no template env file — they start DMS via the `.env.ds<NN>` overlay (a non-default version requires
-   a `data_standard_version` value in the leg so the overlay is applied).
+   the SDK callers `Pkg EdFi.Api.Sdk.yml` / `Pkg EdFi.Api.TestSdk.yml`.
+   Add the version's standalone template env file (its product schema surface - Core +
+   TPDM for 5.2, Core only for 6.1), referenced by the template entries, and allow that
+   env file in `build-populated-template.yml`'s `environment_file` allowlist.
+   The SDK legs need no template env file - they start DMS via the `.env.ds<NN>` overlay
+   (a non-default version requires a `data_standard_version` value in the leg so the
+   overlay is applied).
+   Once validated, add the version to the scheduled smoke test too: the leg table inside
+   `eng/DatabaseTemplates/Select-SmokeTestLegs.ps1` is the single place the smoke legs are
+   defined, and each Data Standard version carries two legs there, one for postgresql and
+   one for mssql, so adding a version means adding both engine legs to that table.
 6. **Version-coupled E2E.** Author the version's `@StandardVersion-<NN>` scenario variants for the
    version-coupled features (`XSDMetadata.feature`, `DiscoveryAPI.feature`) — captured from a running
    stack of that version, not hand-written — and add a per-PR lane that runs them with
@@ -234,7 +251,10 @@ ones.
 
 ## Dropping a Data Standard version
 
-Reverse of the above — remove that version's `Claims/Standards/ds<NN>/` folder, its
+Reverse of the above - remove that version's `Claims/Standards/ds<NN>/` folder, its
 `.env.ds<NN>` overlay, its `Directory.Packages.props` entries, its template env file,
-and its matrix `include` entry. Ensure the default version (5.2, unless the default is
-being changed) still exists.
+and its matrix `include` entry in each per-version lane.
+For the scheduled smoke test, remove the version's two legs (postgresql and mssql)
+from the leg table inside `eng/DatabaseTemplates/Select-SmokeTestLegs.ps1` instead of
+an `include` entry.
+Ensure the default version (5.2, unless the default is being changed) still exists.

--- a/eng/DatabaseTemplates/Assert-TemplateWorkflowInputs.ps1
+++ b/eng/DatabaseTemplates/Assert-TemplateWorkflowInputs.ps1
@@ -141,9 +141,6 @@ $isSmoke = [bool]$environmentContract.IsSmoke
 if ($WorkflowKind -eq "Minimal" -and $isSmoke) {
     throw "The Minimal template workflow cannot use smoke environment_file '$EnvironmentFile'."
 }
-if ($isSmoke -and $DatabaseEngine -eq "mssql") {
-    throw "environment_file '$EnvironmentFile' is PostgreSQL-only and cannot be combined with database_engine 'mssql'."
-}
 if ($isSmoke -and $PublishPackage) {
     throw "environment_file '$EnvironmentFile' is smoke-only and must not be published; set publish_package to false."
 }
@@ -151,9 +148,10 @@ if ($RequirePopulatedData -and -not $VerifyRestore) {
     throw "require_populated_data requires verify_restore."
 }
 
-# The tracked product env is shared by Minimal and Populated builds and therefore carries the
-# Populated PostgreSQL restore identity. The MSSQL engine overlay rewrites only its engine token at
-# runtime; the requested output artifact kind/engine is validated independently below.
+# The tracked env files (Minimal/Populated templates and smoke) are shared across engines and
+# therefore always carry the PostgreSQL restore identity, whether or not the artifact is smoke.
+# The MSSQL engine overlay rewrites only its engine token at runtime; the requested output
+# artifact kind/engine is validated independently below.
 $environmentTemplateKind = if ($isSmoke) { "Smoke" } else { "Populated" }
 $expectedEnvironmentTemplatePackage = "EdFi.Api.$environmentTemplateKind.Template.PostgreSql.$StandardVersion"
 $configuredEnvironmentTemplatePackage = [string]$environmentValues["DATABASE_TEMPLATE_PACKAGE"]

--- a/eng/DatabaseTemplates/Select-SmokeTestLegs.ps1
+++ b/eng/DatabaseTemplates/Select-SmokeTestLegs.ps1
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    Computes which scheduled-smoke-test matrix legs a workflow run should execute.
+
+.DESCRIPTION
+    The scheduled smoke-test workflow builds and exercises four legs: the cross product of two
+    Data Standard versions (5.2.0, 6.1.0) and two database engines (postgresql, mssql). Running
+    every leg on every pull request is wasteful when a change can only affect a subset of them, so
+    this script classifies the PR's changed files against a path map and returns only the legs a
+    change could plausibly affect. Scheduled and manually dispatched runs are not narrowed; they
+    always run the full matrix.
+
+    Safety rules (the result is never empty and never under-selects):
+      - Any event other than "pull_request" (schedule, workflow_dispatch, etc.) returns all four
+        legs unconditionally.
+      - On "pull_request", every changed file is classified against the path map below; the
+        result is the union of the legs selected by any changed file, in the canonical leg order.
+      - A changed file that does not match any pattern, an empty/absent changed-file list, or a
+        pattern-match failure each fall back to selecting all four legs.
+
+    Path pattern glob semantics:
+      - A pattern with no wildcard is compared to each changed file ordinally (exact match); for
+        example "eng/docker-compose/.env.smoke" does not match "eng/docker-compose/.env.smoke.ds61".
+      - "*" matches zero or more characters within a single path segment; it never matches "/".
+      - "**" matches zero or more whole path segments, including zero. "eng/smoke_test/**" matches
+        every path nested beneath "eng/smoke_test/". "**/OpenApiDocument.cs" matches a nested file
+        such as "src/.../OpenApiDocument.cs" as well as a root-level "OpenApiDocument.cs" (the zero
+        segment case).
+    Patterns are converted to anchored regular expressions to implement these semantics.
+
+.PARAMETER EventName
+    The GitHub Actions event name (e.g. "pull_request", "schedule", "workflow_dispatch").
+
+.PARAMETER ChangedFiles
+    Repo-relative changed file paths. Only consulted when EventName is "pull_request".
+
+.PARAMETER ListPathPatterns
+    When set, emit every path pattern in the classification map, one per line, and exit without
+    emitting legs; EventName and ChangedFiles are not consulted and must not be supplied. This seam
+    is consumed by a workflow drift-guard test that asserts the workflow's own trigger paths and
+    this script's path map never go out of sync.
+#>
+[CmdletBinding(DefaultParameterSetName = "Select")]
+param(
+    [Parameter(Mandatory, ParameterSetName = "Select")]
+    [string]$EventName,
+
+    [Parameter(ParameterSetName = "Select")]
+    [string[]]$ChangedFiles = @(),
+
+    [Parameter(Mandatory, ParameterSetName = "List")]
+    [switch]$ListPathPatterns
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Canonical leg order. Every full-matrix selection and every union selection below preserves this
+# order, regardless of the order in which changed files or path-map entries are enumerated.
+$allLegs = @(
+    [ordered]@{
+        standard_version  = "5.2.0"
+        database_engine   = "postgresql"
+        package_name      = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"
+        provenance_file   = "populated.template.intoto.jsonl"
+        environment_file  = "./.env.smoke"
+        run_ods_sdk_tests = $true
+    }
+    [ordered]@{
+        standard_version  = "6.1.0"
+        database_engine   = "postgresql"
+        package_name      = "EdFi.Api.Smoke.Template.PostgreSql.6.1.0"
+        provenance_file   = "populated.template.6.1.0.intoto.jsonl"
+        environment_file  = "./.env.smoke.ds61"
+        run_ods_sdk_tests = $false
+    }
+    [ordered]@{
+        standard_version  = "5.2.0"
+        database_engine   = "mssql"
+        package_name      = "EdFi.Api.Smoke.Template.MsSql.5.2.0"
+        provenance_file   = "populated.template.mssql.intoto.jsonl"
+        environment_file  = "./.env.smoke"
+        run_ods_sdk_tests = $true
+    }
+    [ordered]@{
+        standard_version  = "6.1.0"
+        database_engine   = "mssql"
+        package_name      = "EdFi.Api.Smoke.Template.MsSql.6.1.0"
+        provenance_file   = "populated.template.mssql.6.1.0.intoto.jsonl"
+        environment_file  = "./.env.smoke.ds61"
+        run_ods_sdk_tests = $false
+    }
+)
+
+$legPostgres52 = 0
+$legPostgres61 = 1
+$legMssql52 = 2
+$legMssql61 = 3
+$allLegIndices = @($legPostgres52, $legPostgres61, $legMssql52, $legMssql61)
+
+# Pattern -> the indices (into $allLegs) that a matching changed file selects.
+$pathPatternMap = [ordered]@{
+    "eng/docker-compose/mssql.yml"                   = @($legMssql52, $legMssql61)
+    "eng/docker-compose/.env.mssql"                  = @($legMssql52, $legMssql61)
+    "eng/docker-compose/postgresql.yml"              = @($legPostgres52, $legPostgres61)
+    "eng/docker-compose/.env.smoke"                  = @($legPostgres52, $legMssql52)
+    "eng/docker-compose/.env.smoke.ds61"             = @($legPostgres61, $legMssql61)
+    ".github/workflows/scheduled-smoke-test.yml"     = $allLegIndices
+    ".github/workflows/build-populated-template.yml" = $allLegIndices
+    "build-sdk.ps1"                                  = $allLegIndices
+    "eng/smoke_test/**"                              = $allLegIndices
+    "eng/sdkGen/**"                                  = $allLegIndices
+    "eng/DatabaseTemplates/**"                       = $allLegIndices
+    "eng/docker-compose/start-local-dms.ps1"         = $allLegIndices
+    "eng/docker-compose/local-dms.yml"               = $allLegIndices
+    "eng/docker-compose/local-config.yml"            = $allLegIndices
+    "eng/docker-compose/env-utility.psm1"            = $allLegIndices
+    "eng/Dms-Management.psm1"                        = $allLegIndices
+    "src/Directory.Packages.props"                   = $allLegIndices
+    "**/OpenApiDocument.cs"                          = $allLegIndices
+}
+
+if ($ListPathPatterns) {
+    foreach ($pattern in $pathPatternMap.Keys) {
+        Write-Output $pattern
+    }
+    return
+}
+
+function ConvertTo-PathPatternRegex {
+    <#
+    Converts one path-glob pattern (see the script's comment-based help for the "*"/"**"
+    semantics) into a single anchored, ordinal regular expression string.
+    #>
+    param([Parameter(Mandatory)][string]$Pattern)
+
+    $doubleStarMarker = "{0}DBLSTAR{0}" -f [char]1
+    $singleStarMarker = "{0}SGLSTAR{0}" -f [char]1
+
+    $withMarkers = $Pattern.Replace("**", $doubleStarMarker).Replace("*", $singleStarMarker)
+    $escaped = [regex]::Escape($withMarkers)
+
+    $doubleStarPattern = [regex]::Escape($doubleStarMarker)
+    $singleStarPattern = [regex]::Escape($singleStarMarker)
+
+    # "/**/ " in the middle of a pattern matches zero or more whole path segments.
+    $escaped = $escaped -replace ('/' + $doubleStarPattern + '/'), '(?:.*/)?'
+    # A leading "**/ " also matches a root-level path (the zero-segment case).
+    $escaped = $escaped -replace ('^' + $doubleStarPattern + '/'), '(?:.*/)?'
+    # A trailing "/** " matches everything nested beneath the preceding segment.
+    $escaped = $escaped -replace ('/' + $doubleStarPattern + '$'), '(?:/.*)?'
+    # A "**" left standing alone (not adjacent to a slash) matches anything.
+    $escaped = $escaped -replace $doubleStarPattern, '.*'
+    # A single "*" matches within one path segment only.
+    $escaped = $escaped -replace $singleStarPattern, '[^/]*'
+
+    return '^' + $escaped + '$'
+}
+
+function Get-SelectedLegIndexSet {
+    param(
+        [Parameter(Mandatory)][string]$EventName,
+        [string[]]$ChangedFiles,
+        [System.Collections.Specialized.OrderedDictionary]$PathPatternMap,
+        [int[]]$AllLegIndices
+    )
+
+    if ($EventName -ne "pull_request") {
+        return $AllLegIndices
+    }
+
+    $files = @($ChangedFiles | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($files.Count -eq 0) {
+        return $AllLegIndices
+    }
+
+    $patternRegexes = [ordered]@{}
+    foreach ($pattern in $PathPatternMap.Keys) {
+        $patternRegexes[$pattern] = ConvertTo-PathPatternRegex -Pattern $pattern
+    }
+
+    $selected = New-Object 'bool[]' $AllLegIndices.Count
+
+    foreach ($file in $files) {
+        $matchedAny = $false
+        try {
+            foreach ($pattern in $PathPatternMap.Keys) {
+                if ($file -cmatch $patternRegexes[$pattern]) {
+                    $matchedAny = $true
+                    foreach ($index in $PathPatternMap[$pattern]) {
+                        $selected[$index] = $true
+                    }
+                }
+            }
+        }
+        catch {
+            # A pattern-match failure is treated the same as an unmapped file: fail safe to the
+            # full matrix rather than silently under-selecting.
+            return $AllLegIndices
+        }
+
+        if (-not $matchedAny) {
+            return $AllLegIndices
+        }
+    }
+
+    return @($AllLegIndices | Where-Object { $selected[$_] })
+}
+
+$selectedIndices = Get-SelectedLegIndexSet `
+    -EventName $EventName `
+    -ChangedFiles $ChangedFiles `
+    -PathPatternMap $pathPatternMap `
+    -AllLegIndices $allLegIndices
+
+$selectedLegs = @($selectedIndices | ForEach-Object { [PSCustomObject]$allLegs[$_] })
+
+Write-Output ($selectedLegs | ConvertTo-Json -Compress -AsArray)

--- a/eng/DatabaseTemplates/tests/Smoke-LegSelection.Tests.ps1
+++ b/eng/DatabaseTemplates/tests/Smoke-LegSelection.Tests.ps1
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+Describe "Select-SmokeTestLegs" {
+    BeforeAll {
+        $script:templatesRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+        $script:selector = Join-Path $script:templatesRoot "Select-SmokeTestLegs.ps1"
+
+        $script:allLegs = @(
+            [pscustomobject]@{
+                standard_version  = "5.2.0"
+                database_engine   = "postgresql"
+                package_name      = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"
+                provenance_file   = "populated.template.intoto.jsonl"
+                environment_file  = "./.env.smoke"
+                run_ods_sdk_tests = $true
+            }
+            [pscustomobject]@{
+                standard_version  = "6.1.0"
+                database_engine   = "postgresql"
+                package_name      = "EdFi.Api.Smoke.Template.PostgreSql.6.1.0"
+                provenance_file   = "populated.template.6.1.0.intoto.jsonl"
+                environment_file  = "./.env.smoke.ds61"
+                run_ods_sdk_tests = $false
+            }
+            [pscustomobject]@{
+                standard_version  = "5.2.0"
+                database_engine   = "mssql"
+                package_name      = "EdFi.Api.Smoke.Template.MsSql.5.2.0"
+                provenance_file   = "populated.template.mssql.intoto.jsonl"
+                environment_file  = "./.env.smoke"
+                run_ods_sdk_tests = $true
+            }
+            [pscustomobject]@{
+                standard_version  = "6.1.0"
+                database_engine   = "mssql"
+                package_name      = "EdFi.Api.Smoke.Template.MsSql.6.1.0"
+                provenance_file   = "populated.template.mssql.6.1.0.intoto.jsonl"
+                environment_file  = "./.env.smoke.ds61"
+                run_ods_sdk_tests = $false
+            }
+        )
+
+        function Invoke-Selector {
+            param(
+                [Parameter(Mandatory)][string]$EventName,
+                [string[]]$ChangedFiles = @()
+            )
+            $json = & $script:selector -EventName $EventName -ChangedFiles $ChangedFiles
+            return @(ConvertFrom-Json -InputObject $json)
+        }
+
+        function Assert-LegSet {
+            param(
+                [Parameter(Mandatory)]$Actual,
+                [Parameter(Mandatory)][int[]]$ExpectedIndices
+            )
+            $expected = @($ExpectedIndices | ForEach-Object { $script:allLegs[$_].package_name })
+            $actualNames = @($Actual | ForEach-Object { $_.package_name })
+            $actualNames.Count | Should -Be $expected.Count
+            @(Compare-Object -ReferenceObject $expected -DifferenceObject $actualNames -SyncWindow 0) |
+                Should -BeNullOrEmpty
+        }
+    }
+
+    It "returns the full matrix for a <EventName> event regardless of -ChangedFiles" -ForEach @(
+        @{ EventName = "schedule" }
+        @{ EventName = "workflow_dispatch" }
+    ) {
+        $legs = Invoke-Selector -EventName $EventName -ChangedFiles @("eng/docker-compose/mssql.yml")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 1, 2, 3)
+    }
+
+    It "selects only the two mssql legs for eng/docker-compose/mssql.yml" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @("eng/docker-compose/mssql.yml")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(2, 3)
+    }
+
+    It "selects only the two postgresql legs for eng/docker-compose/postgresql.yml" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @("eng/docker-compose/postgresql.yml")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 1)
+    }
+
+    It "selects the two 6.1 legs across engines for eng/docker-compose/.env.smoke.ds61" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @("eng/docker-compose/.env.smoke.ds61")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(1, 3)
+    }
+
+    It "selects all four legs for a shared path" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @("eng/smoke_test/modules/SmokeTest.psm1")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 1, 2, 3)
+    }
+
+    It "selects all four legs for an unmapped path" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @("README.md")
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 1, 2, 3)
+    }
+
+    It "selects all four legs for an empty changed-file list" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @()
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 1, 2, 3)
+    }
+
+    It "selects the union of legs for mixed changed files" {
+        $legs = Invoke-Selector -EventName "pull_request" -ChangedFiles @(
+            "eng/docker-compose/mssql.yml",
+            "eng/docker-compose/.env.smoke"
+        )
+        Assert-LegSet -Actual $legs -ExpectedIndices @(0, 2, 3)
+    }
+
+    It "emits every leg object with all six keys and correct values" {
+        $legs = Invoke-Selector -EventName "schedule"
+        $legs.Count | Should -Be 4
+
+        foreach ($leg in $legs) {
+            @($leg.PSObject.Properties.Name | Sort-Object) | Should -Be @(
+                "database_engine",
+                "environment_file",
+                "package_name",
+                "provenance_file",
+                "run_ods_sdk_tests",
+                "standard_version"
+            )
+        }
+
+        $postgres52 = $legs | Where-Object { $_.database_engine -eq "postgresql" -and $_.standard_version -eq "5.2.0" }
+        $postgres61 = $legs | Where-Object { $_.database_engine -eq "postgresql" -and $_.standard_version -eq "6.1.0" }
+        $mssql52 = $legs | Where-Object { $_.database_engine -eq "mssql" -and $_.standard_version -eq "5.2.0" }
+        $mssql61 = $legs | Where-Object { $_.database_engine -eq "mssql" -and $_.standard_version -eq "6.1.0" }
+
+        $postgres52.package_name | Should -Be "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"
+        $postgres52.provenance_file | Should -Be "populated.template.intoto.jsonl"
+        $postgres52.environment_file | Should -Be "./.env.smoke"
+        $postgres52.run_ods_sdk_tests | Should -BeTrue
+
+        $postgres61.package_name | Should -Be "EdFi.Api.Smoke.Template.PostgreSql.6.1.0"
+        $postgres61.provenance_file | Should -Be "populated.template.6.1.0.intoto.jsonl"
+        $postgres61.environment_file | Should -Be "./.env.smoke.ds61"
+        $postgres61.run_ods_sdk_tests | Should -BeFalse
+
+        $mssql52.package_name | Should -Be "EdFi.Api.Smoke.Template.MsSql.5.2.0"
+        $mssql52.provenance_file | Should -Be "populated.template.mssql.intoto.jsonl"
+        $mssql52.environment_file | Should -Be "./.env.smoke"
+        $mssql52.run_ods_sdk_tests | Should -BeTrue
+
+        $mssql61.package_name | Should -Be "EdFi.Api.Smoke.Template.MsSql.6.1.0"
+        $mssql61.provenance_file | Should -Be "populated.template.mssql.6.1.0.intoto.jsonl"
+        $mssql61.environment_file | Should -Be "./.env.smoke.ds61"
+        $mssql61.run_ods_sdk_tests | Should -BeFalse
+    }
+
+    It "keeps the workflow trigger paths and the leg-selection path map identical" {
+        $workflowPath = [System.IO.Path]::GetFullPath(
+            (Join-Path $script:templatesRoot "../../.github/workflows/scheduled-smoke-test.yml")
+        )
+        $workflowContent = Get-Content -LiteralPath $workflowPath -Raw
+
+        # The pull_request block is the last child key under the top-level "on:" mapping in this
+        # workflow, so its body runs up to the next line that starts at column 0 - i.e. the next
+        # key that is a sibling of "on:" itself (here, "permissions:").
+        $pullRequestBlock = [regex]::Match(
+            $workflowContent,
+            '(?ms)^  pull_request:\r?\n(?<body>.*?)(?=^\S)'
+        ).Groups["body"].Value
+        $pullRequestBlock | Should -Not -BeNullOrEmpty -Because "the pull_request: block must be found before its paths can be compared"
+
+        # Each "paths:" list entry is a single- or double-quoted scalar; match either quote style
+        # so a future re-quoting of the list does not silently zero out this guard.
+        $workflowPaths = @(
+            [regex]::Matches($pullRequestBlock, '(?m)^\s*-\s+([''"])(?<path>[^''"]+)\1\s*$') |
+                ForEach-Object { $_.Groups["path"].Value }
+        )
+        $workflowPaths | Should -Not -BeNullOrEmpty -Because "an empty capture means the extraction regex has silently rotted rather than the paths block being genuinely empty"
+
+        $scriptPatterns = @(& $script:selector -ListPathPatterns)
+
+        @(Compare-Object -ReferenceObject $workflowPaths -DifferenceObject $scriptPatterns) |
+            Should -BeNullOrEmpty -Because "a path that can trigger scheduled-smoke-test.yml on a pull request must be classifiable by Select-SmokeTestLegs.ps1's path map, and every pattern in that map must correspond to a real workflow trigger path"
+    }
+}

--- a/eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1
+++ b/eng/DatabaseTemplates/tests/Template-WorkflowInputs.Tests.ps1
@@ -100,9 +100,11 @@ Describe "Assert-TemplateWorkflowInputs" {
         { & $script:validator @parameters } | Should -Not -Throw
     }
 
-    It "accepts the two non-publishing PostgreSQL smoke tuples" -ForEach @(
-        @{ StandardVersion = "5.2.0"; EnvironmentFile = "./.env.smoke"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0" }
-        @{ StandardVersion = "6.1.0"; EnvironmentFile = "./.env.smoke.ds61"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.6.1.0" }
+    It "accepts the four non-publishing smoke tuples" -ForEach @(
+        @{ DatabaseEngine = "postgresql"; StandardVersion = "5.2.0"; EnvironmentFile = "./.env.smoke"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0" }
+        @{ DatabaseEngine = "postgresql"; StandardVersion = "6.1.0"; EnvironmentFile = "./.env.smoke.ds61"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.6.1.0" }
+        @{ DatabaseEngine = "mssql"; StandardVersion = "5.2.0"; EnvironmentFile = "./.env.smoke"; PackageName = "EdFi.Api.Smoke.Template.MsSql.5.2.0" }
+        @{ DatabaseEngine = "mssql"; StandardVersion = "6.1.0"; EnvironmentFile = "./.env.smoke.ds61"; PackageName = "EdFi.Api.Smoke.Template.MsSql.6.1.0" }
     ) {
         {
             & $script:validator `
@@ -110,7 +112,7 @@ Describe "Assert-TemplateWorkflowInputs" {
                 -StandardVersion $StandardVersion `
                 -PackageName $PackageName `
                 -EnvironmentFile $EnvironmentFile `
-                -DatabaseEngine "postgresql" `
+                -DatabaseEngine $DatabaseEngine `
                 -PublishPackage $false `
                 -VerifyRestore $true `
                 -RequirePopulatedData $true `
@@ -199,16 +201,17 @@ Describe "Assert-TemplateWorkflowInputs" {
         } | Should -Throw "*DATABASE_TEMPLATE_PACKAGE*must be*6.1.0*"
     }
 
-    It "rejects MSSQL smoke, publishing smoke, and Minimal smoke combinations" -ForEach @(
-        @{ WorkflowKind = "Populated"; DatabaseEngine = "mssql"; PublishPackage = $false; Expected = "*PostgreSQL-only*" }
-        @{ WorkflowKind = "Populated"; DatabaseEngine = "postgresql"; PublishPackage = $true; Expected = "*must not be published*" }
-        @{ WorkflowKind = "Minimal"; DatabaseEngine = "postgresql"; PublishPackage = $false; Expected = "*Minimal template workflow cannot use smoke*" }
+    It "rejects publishing smoke, Minimal smoke, and mismatched MSSQL smoke package combinations" -ForEach @(
+        @{ WorkflowKind = "Populated"; DatabaseEngine = "postgresql"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"; PublishPackage = $true; Expected = "*must not be published*" }
+        @{ WorkflowKind = "Minimal"; DatabaseEngine = "postgresql"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"; PublishPackage = $false; Expected = "*Minimal template workflow cannot use smoke*" }
+        @{ WorkflowKind = "Populated"; DatabaseEngine = "mssql"; PackageName = "EdFi.Api.Smoke.Template.PostgreSql.5.2.0"; PublishPackage = $false; Expected = "*require package_name*" }
+        @{ WorkflowKind = "Populated"; DatabaseEngine = "mssql"; PackageName = "EdFi.Api.Smoke.Template.MsSql.5.2.0"; PublishPackage = $true; Expected = "*must not be published*" }
     ) {
         {
             & $script:validator `
                 -WorkflowKind $WorkflowKind `
                 -StandardVersion "5.2.0" `
-                -PackageName "EdFi.Api.Smoke.Template.PostgreSql.5.2.0" `
+                -PackageName $PackageName `
                 -EnvironmentFile "./.env.smoke" `
                 -DatabaseEngine $DatabaseEngine `
                 -PublishPackage $PublishPackage `


### PR DESCRIPTION
## Summary
Extends the scheduled smoke workflow from two PostgreSQL legs to a four-leg database-engine x Data Standard matrix (PostgreSQL/MSSQL x DS 5.2/6.1).
Each leg builds an engine-native smoke template in the same run, restores it (`.sql` for PostgreSQL, `.bak` for MSSQL), starts DMS through the selected `-DatabaseEngine` path, registers the restored database with an engine-correct connection string, and runs the existing API/SDK smoke coverage.

## Changes
- `scheduled-smoke-test.yml`: new `select-legs` job computes the matrix consumed by both the template-build and smoke jobs; engine-aware start/restore/registration steps; per-leg failure-artifact names (also fixes a latent upload-artifact v4 name collision between failing legs); engine-aware Slack notifications.
- New `eng/DatabaseTemplates/Select-SmokeTestLegs.ps1`: single source of truth for the four legs and the PR changed-path classification - full matrix on schedule/dispatch, only safely affected legs on PRs, safe-default to all legs for shared/unmapped changes.
- `Assert-TemplateWorkflowInputs.ps1`: correlated MSSQL smoke tuples are now accepted; the existing engine-token derivation requires `EdFi.Api.Smoke.Template.MsSql.<version>` package names.
- Trigger paths expanded to the engine/infra files the smoke flow executes, and kept identical to the script's path map by a Pester drift-guard test.
- CI Pester lane now runs `Template-WorkflowInputs.Tests.ps1` (pre-existing gap: it was registered in no CI lane) plus the new `Smoke-LegSelection.Tests.ps1`.
- `docs/DATA-STANDARD-VERSIONS.md` points at the script's leg table as the single place to add or drop a version (each version now carries a postgresql and an mssql leg).

## Testing
- Full CI Pester lane run locally in exact CI order: 750 tests, 749 passed, 1 expected self-skip, 0 failed.
- New leg-selection suite: 11 tests, including the drift guard (negative-tested: removing a path entry makes it fail).
- `actionlint` clean on both modified workflows; PSScriptAnalyzer clean on all changed scripts.
- All four smoke tuples validated against the real compose root via `Assert-TemplateWorkflowInputs.ps1`.
- Not yet exercised: a real four-leg workflow run; recommend a `workflow_dispatch` run after merge or from the branch.

## Notes for Reviewers
- MSSQL smoke legs reuse `.env.smoke` / `.env.smoke.ds61` through the runtime engine overlay, mirroring how `EdFi.Api.Populated.Template.MsSql.yml` reuses `.env.template`; `DATABASE_TEMPLATE_PACKAGE` intentionally keeps its PostgreSql identity (the artifact engine is validated independently via `package_name`).
- Leg selection never narrows scheduled or dispatched runs, and any shared, ambiguous, or unmapped change widens to all four legs.
- Known pre-existing issue left out of scope: `build-populated-template.yml`'s fixed-name failure artifacts (`Bulkload-logs`, `Docker-Logs`) can collide when multiple build legs fail in one run; it is shared with the template caller workflows and is a candidate follow-up ticket.
