### PR TITLE
[DMS-1269] Reduce GET-many hydration cost by removing redundant reference and descriptor source scans

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorStampingTriggerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorStampingTriggerTests.cs
@@ -174,12 +174,24 @@ public class Given_A_Provisioned_Mssql_Database_With_Descriptor_Stamping_Trigger
         return await _database.ExecuteScalarAsync<long>("SELECT [dms].[GetMaxChangeVersion]();");
     }
 
-    private async Task DelayForDistinctTimestampsAsync()
+    private async Task<DateTime> BackdateDocumentContentStampAsync(long documentId)
     {
-        // Server-side delay so the post-write ContentLastModifiedAt is strictly greater
-        // than the seed stamp, letting assertions use BeAfter instead of the weaker
-        // BeOnOrAfter (which cannot catch a stamp that never moved).
-        await _database.ExecuteNonQueryAsync("WAITFOR DELAY '00:00:00.050';");
+        // Moving the seed stamp deterministically into the past keeps the strict BeAfter
+        // assertions independent of server clock granularity: sysutcdatetime() can return an
+        // identical value for two reads milliseconds apart, but never one five minutes stale.
+        // Strictness is what catches a stamp the trigger never wrote, since such a stamp stays
+        // at the backdated value; BeOnOrAfter would accept it.
+        // No trigger exists on dms.Document, so this write neither stamps nor allocates a version.
+        await _database.ExecuteNonQueryAsync(
+            """
+            UPDATE [dms].[Document]
+            SET [ContentLastModifiedAt] = DATEADD(minute, -5, sysutcdatetime())
+            WHERE DocumentId = @documentId;
+            """,
+            new SqlParameter("@documentId", documentId)
+        );
+
+        return (await ReadDocumentStampAsync(documentId)).ContentLastModifiedAt;
     }
 
     private sealed record StampPair(StampValues Document, StampValues Mirror);
@@ -207,7 +219,7 @@ public class Given_A_Provisioned_Mssql_Database_With_Descriptor_Stamping_Trigger
     {
         var seed = await SeedAsync();
         var beforeMaxChangeVersion = await ReadMaxChangeVersionAsync();
-        await DelayForDistinctTimestampsAsync();
+        var seedContentLastModifiedAt = await BackdateDocumentContentStampAsync(seed.DocumentId);
 
         await _database.ExecuteNonQueryAsync(
             """
@@ -220,7 +232,7 @@ public class Given_A_Provisioned_Mssql_Database_With_Descriptor_Stamping_Trigger
         var afterMaxChangeVersion = await ReadMaxChangeVersionAsync();
         var afterDocument = await ReadDocumentStampAsync(seed.DocumentId);
         afterDocument.ContentVersion.Should().BeGreaterThan(seed.ContentVersion);
-        afterDocument.ContentLastModifiedAt.Should().BeAfter(seed.ContentLastModifiedAt);
+        afterDocument.ContentLastModifiedAt.Should().BeAfter(seedContentLastModifiedAt);
         (afterMaxChangeVersion - beforeMaxChangeVersion)
             .Should()
             .Be(1L, "a descriptor delete must allocate exactly one content stamp");
@@ -231,7 +243,7 @@ public class Given_A_Provisioned_Mssql_Database_With_Descriptor_Stamping_Trigger
     {
         var seed = await SeedAsync();
         var beforeMaxChangeVersion = await ReadMaxChangeVersionAsync();
-        await DelayForDistinctTimestampsAsync();
+        var seedContentLastModifiedAt = await BackdateDocumentContentStampAsync(seed.DocumentId);
 
         await _database.ExecuteNonQueryAsync(
             """
@@ -246,7 +258,7 @@ public class Given_A_Provisioned_Mssql_Database_With_Descriptor_Stamping_Trigger
         var after = await ReadStampPairAsync(seed.DocumentId);
         after.Mirror.Should().Be(after.Document);
         after.Document.ContentVersion.Should().BeGreaterThan(seed.ContentVersion);
-        after.Document.ContentLastModifiedAt.Should().BeAfter(seed.ContentLastModifiedAt);
+        after.Document.ContentLastModifiedAt.Should().BeAfter(seedContentLastModifiedAt);
         (afterMaxChangeVersion - beforeMaxChangeVersion)
             .Should()
             .Be(1L, "a single descriptor value change must allocate exactly one content stamp");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
@@ -21,6 +21,8 @@ namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
 /// document so both providers are held to the same expectations.
 /// </summary>
 [TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
 [Category(MssqlCiShards.Shard1)]
 public class Given_A_Mssql_Page_With_Multi_Column_And_Child_Document_References
 {
@@ -251,6 +253,8 @@ public class Given_A_Mssql_Page_With_Multi_Column_And_Child_Document_References
 /// failing or leaking references belonging to documents outside the page.
 /// </summary>
 [TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
 [Category(MssqlCiShards.Shard1)]
 public class Given_A_Mssql_Empty_Page_With_Document_References
 {
@@ -325,6 +329,8 @@ public class Given_A_Mssql_Empty_Page_With_Document_References
 /// result set and no lookup result set at all.
 /// </summary>
 [TestFixture]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
 [Category(MssqlCiShards.Shard1)]
 public class Given_A_Mssql_Descriptor_Only_Resource_Page
 {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Page-level document-reference lookup coverage against a real SQL Server database, mirroring
+/// <c>Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_References</c> document for
+/// document so both providers are held to the same expectations.
+/// </summary>
+[TestFixture]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Page_With_Multi_Column_And_Child_Document_References
+{
+    private const string TestSchema = "refpage";
+
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private ResourceReadPlan _plan = null!;
+    private HydratedPage _result = null!;
+    private IReadOnlyList<JsonNode> _reconstitutedPage = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("MSSQL connection string not configured.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        _connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var connection = new SqlConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.MssqlProvisionSql(TestSchema));
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.MssqlSeedSql(TestSchema));
+
+        _plan = HydrationTestHelper.BuildStudentSectionAssociationReadPlan(TestSchema, SqlDialect.Mssql);
+
+        await using var hydrationConnection = new SqlConnection(_connectionString);
+        await hydrationConnection.OpenAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            _plan,
+            MssqlDocumentReferenceLookupPageKeyset.ExcludingOffPageDocument(TestSchema),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+
+        _reconstitutedPage = DocumentReconstituter.ReconstitutePage(_plan, _result);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null)
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_hydrates_only_the_page_documents()
+    {
+        _result
+            .DocumentMetadata.Select(static row => row.DocumentId)
+            .Should()
+            .Equal(DocumentReferenceLookupPageFixture.PageDocumentIdsInOrder);
+    }
+
+    [Test]
+    public void It_returns_each_distinct_referenced_document_exactly_once_in_document_id_order()
+    {
+        _result.DocumentReferenceLookup.Should().NotBeNull();
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row => row.DocumentId)
+            .Should()
+            .Equal(
+                DocumentReferenceLookupPageFixture.ExpectedReferencedDocumentIdsInOrder,
+                "ids repeated across columns of one row, across rows, and across the root and child tables collapse to one row each"
+            );
+    }
+
+    [Test]
+    public void It_excludes_references_reachable_only_from_off_page_child_rows()
+    {
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row => row.DocumentId)
+            .Should()
+            .NotContain(
+                DocumentReferenceLookupPageFixture.OffPageProgram,
+                "the child branch scopes through the child's root-scope locator, not its own key"
+            );
+    }
+
+    [Test]
+    public void It_returns_the_document_uuid_and_resource_key_for_each_referenced_document()
+    {
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row =>
+                (row.DocumentId, row.DocumentUuid, row.ResourceKeyId)
+            )
+            .Should()
+            .Equal(
+                (
+                    DocumentReferenceLookupPageFixture.StudentA,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.StudentA),
+                    DocumentReferenceLookupPageFixture.StudentResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.StudentB,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.StudentB),
+                    DocumentReferenceLookupPageFixture.StudentResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.Section,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.Section),
+                    DocumentReferenceLookupPageFixture.SectionResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.DualCreditEdOrg,
+                    DocumentReferenceLookupPageFixture.UuidFor(
+                        DocumentReferenceLookupPageFixture.DualCreditEdOrg
+                    ),
+                    DocumentReferenceLookupPageFixture.EducationOrganizationResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.Program,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.Program),
+                    DocumentReferenceLookupPageFixture.ProgramResourceKeyId
+                )
+            );
+    }
+
+    [Test]
+    public void It_resolves_the_descriptor_uri_for_the_page()
+    {
+        _result
+            .DescriptorRowsInPlanOrder.Single()
+            .Rows.Select(static row => (row.DescriptorId, row.Uri))
+            .Should()
+            .Equal(
+                (
+                    DocumentReferenceLookupPageFixture.AttemptStatusDescriptorId,
+                    DocumentReferenceLookupPageFixture.AttemptStatusUri
+                )
+            );
+    }
+
+    [Test]
+    public void It_reconstitutes_one_document_per_page_row()
+    {
+        _reconstitutedPage
+            .Should()
+            .HaveCount(DocumentReferenceLookupPageFixture.PageDocumentIdsInOrder.Length);
+    }
+
+    [Test]
+    public void It_reconstitutes_a_fully_populated_document_with_every_reference_and_descriptor()
+    {
+        var document = _reconstitutedPage[0];
+
+        document["attemptStatusDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(DocumentReferenceLookupPageFixture.AttemptStatusUri);
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-701");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-X");
+        document["dualCreditEducationOrganizationReference"]!["educationOrganizationId"]!
+            .GetValue<long>()
+            .Should()
+            .Be(255901);
+
+        var programs = document["programs"]!.AsArray();
+        programs.Should().HaveCount(2);
+        programs[0]!["programReference"]!["programName"]!.GetValue<string>().Should().Be("Program P");
+        programs[1]!["programReference"]!["programName"]!
+            .GetValue<string>()
+            .Should()
+            .Be("Program Named Like Student");
+    }
+
+    [Test]
+    public void It_reconstitutes_a_document_whose_optional_reference_is_null_but_others_are_populated()
+    {
+        var document = _reconstitutedPage[1];
+
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-702");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-X");
+        document["dualCreditEducationOrganizationReference"]
+            .Should()
+            .BeNull("a null reference column must not produce a partial reference object");
+        document["attemptStatusDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_omits_every_reference_object_for_a_document_whose_references_are_all_null()
+    {
+        var document = _reconstitutedPage[2];
+
+        document["studentReference"].Should().BeNull();
+        document["sectionReference"].Should().BeNull();
+        document["dualCreditEducationOrganizationReference"].Should().BeNull();
+        document["attemptStatusDescriptor"].Should().BeNull();
+        document["programs"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_reconstitutes_a_document_that_repeats_one_referenced_document_across_columns()
+    {
+        var document = _reconstitutedPage[3];
+
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-730");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-DUP");
+        document["dualCreditEducationOrganizationReference"]!["educationOrganizationId"]!
+            .GetValue<long>()
+            .Should()
+            .Be(255902);
+    }
+
+    private static async Task ExecuteSql(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Confirms an empty page produces no document-reference lookup rows on SQL Server rather than
+/// failing or leaking references belonging to documents outside the page.
+/// </summary>
+[TestFixture]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Empty_Page_With_Document_References
+{
+    private const string TestSchema = "refpageempty";
+
+    private string _databaseName = null!;
+    private HydratedPage _result = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("MSSQL connection string not configured.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        var connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.MssqlProvisionSql(TestSchema));
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.MssqlSeedSql(TestSchema));
+
+        var plan = HydrationTestHelper.BuildStudentSectionAssociationReadPlan(TestSchema, SqlDialect.Mssql);
+
+        await using var hydrationConnection = new SqlConnection(connectionString);
+        await hydrationConnection.OpenAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            plan,
+            MssqlDocumentReferenceLookupPageKeyset.Empty(TestSchema),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null)
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_returns_no_documents()
+    {
+        _result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_returns_an_empty_document_reference_lookup_result_set()
+    {
+        _result.DocumentReferenceLookup.Should().NotBeNull();
+        _result.DocumentReferenceLookup!.Rows.Should().BeEmpty();
+    }
+
+    private static async Task ExecuteSql(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Confirms a resource carrying descriptor edges but no document references compiles without a
+/// document-reference lookup on SQL Server, so the hydration batch emits the descriptor projection
+/// result set and no lookup result set at all.
+/// </summary>
+[TestFixture]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Descriptor_Only_Resource_Page
+{
+    private const string TestSchema = "refpagedesc";
+    private const long GradeLevelDescriptorId = 810;
+    private const string GradeLevelUri = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+
+    private string _databaseName = null!;
+    private ResourceReadPlan _plan = null!;
+    private HydratedPage _result = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore("MSSQL connection string not configured.");
+        }
+
+        _databaseName = MssqlTestDatabaseHelper.GenerateUniqueDatabaseName();
+        MssqlTestDatabaseHelper.CreateDatabase(_databaseName);
+        var connectionString = MssqlTestDatabaseHelper.BuildConnectionString(_databaseName);
+
+        await using var connection = new SqlConnection(connectionString);
+        await connection.OpenAsync();
+
+        await ExecuteSql(
+            connection,
+            $"""
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{TestSchema}') EXEC('CREATE SCHEMA [{TestSchema}]');
+
+            CREATE TABLE dms.[Document] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DocumentUuid] uniqueidentifier NOT NULL,
+                [ResourceKeyId] smallint NOT NULL DEFAULT 0,
+                [ContentVersion] bigint NOT NULL DEFAULT 1,
+                [IdentityVersion] bigint NOT NULL DEFAULT 1,
+                [ContentLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [IdentityLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [CreatedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            CREATE TABLE dms.[Descriptor] (
+                [DocumentId] bigint PRIMARY KEY,
+                [Namespace] varchar(255) NOT NULL DEFAULT '',
+                [CodeValue] varchar(50) NOT NULL DEFAULT '',
+                [ShortDescription] varchar(75) NOT NULL DEFAULT '',
+                [Description] varchar(1024) NULL,
+                [EffectiveBeginDate] date NULL,
+                [EffectiveEndDate] date NULL,
+                [Discriminator] varchar(128) NOT NULL DEFAULT '',
+                [Uri] varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {TestSchema}.[DescriptorOnly] (
+                [DocumentId] bigint PRIMARY KEY,
+                [GradeLevelDescriptor_DescriptorId] bigint NULL
+            );
+            """
+        );
+
+        await ExecuteSql(
+            connection,
+            $"""
+            INSERT INTO dms.[Document] ([DocumentId], [DocumentUuid], [ResourceKeyId])
+            VALUES
+                (901, '00000000-0000-0000-0000-000000000901', 30),
+                (902, '00000000-0000-0000-0000-000000000902', 30);
+
+            INSERT INTO dms.[Descriptor] ([DocumentId], [Uri])
+            VALUES ({GradeLevelDescriptorId}, '{GradeLevelUri}');
+
+            INSERT INTO {TestSchema}.[DescriptorOnly] ([DocumentId], [GradeLevelDescriptor_DescriptorId])
+            VALUES (901, {GradeLevelDescriptorId}), (902, NULL);
+            """
+        );
+
+        _plan = HydrationTestHelper.BuildDescriptorOnlyReadPlan(TestSchema, SqlDialect.Mssql);
+
+        await using var hydrationConnection = new SqlConnection(connectionString);
+        await hydrationConnection.OpenAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            _plan,
+            MssqlDocumentReferenceLookupPageKeyset.AllDescriptorOnlyRows(TestSchema),
+            SqlDialect.Mssql,
+            CancellationToken.None
+        );
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        if (_databaseName is not null)
+        {
+            MssqlTestDatabaseHelper.DropDatabaseIfExists(_databaseName);
+        }
+    }
+
+    [Test]
+    public void It_compiles_no_document_reference_lookup_plan()
+    {
+        _plan.DocumentReferenceLookup.Should().BeNull();
+    }
+
+    [Test]
+    public void It_returns_no_document_reference_lookup_result_set()
+    {
+        _result.DocumentReferenceLookup.Should().BeNull();
+    }
+
+    [Test]
+    public void It_still_resolves_descriptor_uris_for_the_page()
+    {
+        _result.DocumentMetadata.Should().HaveCount(2);
+        _result
+            .DescriptorRowsInPlanOrder.Single()
+            .Rows.Select(static row => (row.DescriptorId, row.Uri))
+            .Should()
+            .Equal((GradeLevelDescriptorId, GradeLevelUri));
+    }
+
+    private static async Task ExecuteSql(SqlConnection connection, string sql)
+    {
+        await using var cmd = new SqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+internal static class MssqlDocumentReferenceLookupPageKeyset
+{
+    public static PageKeysetSpec ExcludingOffPageDocument(string schema) =>
+        Create(
+            $"""
+            SELECT [DocumentId] FROM {schema}.[StudentSectionAssociation]
+            WHERE [DocumentId] <> {DocumentReferenceLookupPageFixture.OffPageDocumentId}
+            ORDER BY [DocumentId]
+            OFFSET @offset ROWS FETCH NEXT @limit ROWS ONLY
+            """,
+            limit: 25L
+        );
+
+    public static PageKeysetSpec Empty(string schema) =>
+        Create(
+            $"""
+            SELECT [DocumentId] FROM {schema}.[StudentSectionAssociation]
+            ORDER BY [DocumentId]
+            OFFSET @offset ROWS FETCH NEXT @limit ROWS ONLY
+            """,
+            limit: 0L
+        );
+
+    public static PageKeysetSpec AllDescriptorOnlyRows(string schema) =>
+        Create(
+            $"""
+            SELECT [DocumentId] FROM {schema}.[DescriptorOnly]
+            ORDER BY [DocumentId]
+            OFFSET @offset ROWS FETCH NEXT @limit ROWS ONLY
+            """,
+            limit: 25L
+        );
+
+    private static PageKeysetSpec Create(string pageDocumentIdSql, long limit) =>
+        new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: pageDocumentIdSql,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                    new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?> { ["offset"] = 0L, ["limit"] = limit }
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDocumentReferenceLookupPageTests.cs
@@ -171,6 +171,12 @@ public class Given_A_Mssql_Page_With_Multi_Column_And_Child_Document_References
     }
 
     [Test]
+    public void It_reconstitutes_the_whole_page_exactly_with_no_link_objects()
+    {
+        DocumentReferenceLookupPageFixture.AssertNonLinkPageMatchesExactly(_reconstitutedPage);
+    }
+
+    [Test]
     public void It_reconstitutes_a_fully_populated_document_with_every_reference_and_descriptor()
     {
         var document = _reconstitutedPage[0];

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
@@ -1,0 +1,597 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.ApiSchema;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Page-level link-injection coverage: a query returning several documents must emit
+/// <c>link.rel</c>/<c>link.href</c> on every document's reference, resolved from the page-scoped
+/// document-reference lookup rather than from any single document's own read.
+/// </summary>
+/// <remarks>
+/// Runs against the real generated DS-5.2 DDL with a genuine <see cref="MappingSet"/>, so it
+/// exercises the production write and read pipeline end to end. The exact contents of the
+/// document-reference lookup for multi-column and child-collection sources are asserted separately
+/// by <c>Given_A_Mssql_Page_With_Multi_Column_And_Child_Document_References</c>; this fixture covers
+/// the link-emission half over a genuine page.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Page_Of_AcademicWeeks_With_Link_Injection
+{
+    private const string FixtureRelativePath = "src/dms/backend/Fixtures/authoritative/ds-5.2";
+    private const int MaximumPageSize = 500;
+
+    private static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+
+    private static readonly MssqlPageLinkInjectionSeed[] _seeds =
+    [
+        new(
+            SchoolId: 255911,
+            WeekIdentifier: "Page-Week-2025-08-15",
+            SchoolDocumentUuid: new DocumentUuid(Guid.Parse("aaaaaaaa-0000-0000-0000-000000000011")),
+            AcademicWeekDocumentUuid: new DocumentUuid(Guid.Parse("bbbbbbbb-0000-0000-0000-000000000012"))
+        ),
+        new(
+            SchoolId: 255912,
+            WeekIdentifier: "Page-Week-2025-08-22",
+            SchoolDocumentUuid: new DocumentUuid(Guid.Parse("aaaaaaaa-0000-0000-0000-000000000013")),
+            AcademicWeekDocumentUuid: new DocumentUuid(Guid.Parse("bbbbbbbb-0000-0000-0000-000000000014"))
+        ),
+    ];
+
+    private MssqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private IMssqlGeneratedDdlBaselineLease _databaseLease = null!;
+    private MssqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private ResourceInfo _schoolResourceInfo = null!;
+    private ResourceSchema _schoolResourceSchema = null!;
+    private ResourceInfo _academicWeekResourceInfo = null!;
+    private ResourceSchema _academicWeekResourceSchema = null!;
+    private QueryResult _queryResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            FixtureRelativePath,
+            strict: true
+        );
+        _mappingSet = _fixture.MappingSet;
+        _databaseLease = await MssqlBackendBaselineCache.AcquireLeaseAsync(
+            FixtureRelativePath,
+            strict: true,
+            _fixture.GeneratedDdl
+        );
+        _database = _databaseLease.Database;
+        _serviceProvider = CreateServiceProvider();
+
+        (ProjectSchema schoolProjectSchema, ResourceSchema schoolSchema) = GetResourceSchema(
+            _fixture.EffectiveSchemaSet,
+            "ed-fi",
+            "School"
+        );
+        _schoolResourceInfo = CreateResourceInfo(schoolProjectSchema, schoolSchema);
+        _schoolResourceSchema = schoolSchema;
+
+        (ProjectSchema academicWeekProjectSchema, ResourceSchema academicWeekSchema) = GetResourceSchema(
+            _fixture.EffectiveSchemaSet,
+            "ed-fi",
+            "AcademicWeek"
+        );
+        _academicWeekResourceInfo = CreateResourceInfo(academicWeekProjectSchema, academicWeekSchema);
+        _academicWeekResourceSchema = academicWeekSchema;
+
+        await SeedReferenceDataAsync();
+
+        foreach (MssqlPageLinkInjectionSeed seed in _seeds)
+        {
+            UpsertResult schoolResult = await UpsertSchoolAsync(seed);
+            schoolResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+            UpsertResult academicWeekResult = await UpsertAcademicWeekAsync(seed);
+            academicWeekResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        }
+
+        _queryResult = await QueryAcademicWeeksAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (_databaseLease is not null)
+        {
+            await _databaseLease.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_every_academic_week_in_the_page()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        success.EdfiDocs.Should().HaveCount(_seeds.Length);
+    }
+
+    [Test]
+    public void It_emits_link_rel_and_link_href_on_every_document_in_the_page()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        foreach (MssqlPageLinkInjectionSeed seed in _seeds)
+        {
+            JsonNode document = success.EdfiDocs.Single(candidate =>
+                string.Equals(
+                    candidate!["weekIdentifier"]!.GetValue<string>(),
+                    seed.WeekIdentifier,
+                    StringComparison.Ordinal
+                )
+            )!;
+
+            document["id"]!.GetValue<string>().Should().Be(seed.AcademicWeekDocumentUuid.Value.ToString("D"));
+
+            JsonNode schoolReference = document["schoolReference"]!;
+            schoolReference.Should().NotBeNull();
+            schoolReference["schoolId"]!.GetValue<long>().Should().Be(seed.SchoolId);
+
+            LinkInjectionAssertions.AssertLink(
+                schoolReference,
+                expectedRel: "School",
+                expectedProjectEndpointName: "ed-fi",
+                expectedEndpointName: "schools",
+                expectedDocumentUuid: seed.SchoolDocumentUuid.Value
+            );
+        }
+    }
+
+    [Test]
+    public void It_resolves_each_document_reference_to_its_own_referenced_document()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        string[] hrefsInWeekOrder =
+        [
+            .. success
+                .EdfiDocs.OrderBy(
+                    static document => document!["weekIdentifier"]!.GetValue<string>(),
+                    StringComparer.Ordinal
+                )
+                .Select(static document =>
+                    document!["schoolReference"]!["link"]!["href"]!.GetValue<string>()
+                ),
+        ];
+
+        hrefsInWeekOrder
+            .Should()
+            .Equal(
+                [
+                    .. _seeds
+                        .OrderBy(static seed => seed.WeekIdentifier, StringComparer.Ordinal)
+                        .Select(static seed =>
+                            $"/ed-fi/schools/{seed.SchoolDocumentUuid.Value.ToString("D")}"
+                        ),
+                ],
+                "a page-scoped lookup must not collapse distinct references onto one referenced document"
+            );
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddScoped<IDataStoreSelection, DataStoreSelection>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddMssqlReferenceResolver();
+
+        short schoolResourceKeyId = _mappingSet.ResourceKeyIdByResource[SchoolResource];
+        Dictionary<short, DocumentLinkSlugTriple> slugByResourceKeyId = new()
+        {
+            [schoolResourceKeyId] = new DocumentLinkSlugTriple(
+                ProjectEndpointName: "ed-fi",
+                EndpointName: "schools",
+                ResourceName: "School"
+            ),
+        };
+        services.Replace(
+            ServiceDescriptor.Singleton<IDocumentLinkSlugResolver>(
+                new DeterministicLinkSlugResolver(slugByResourceKeyId)
+            )
+        );
+        services.Configure<ResourceLinksOptions>(static options => options.Enabled = true);
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    private static (ProjectSchema ProjectSchema, ResourceSchema ResourceSchema) GetResourceSchema(
+        EffectiveSchemaSet effectiveSchemaSet,
+        string projectEndpointName,
+        string resourceName
+    )
+    {
+        EffectiveProjectSchema effectiveProjectSchema = effectiveSchemaSet.ProjectsInEndpointOrder.Single(
+            project =>
+                string.Equals(
+                    project.ProjectEndpointName,
+                    projectEndpointName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+        );
+
+        ProjectSchema projectSchema = new(effectiveProjectSchema.ProjectSchema, NullLogger.Instance);
+        JsonNode resourceSchemaNode =
+            projectSchema.FindResourceSchemaNodeByResourceName(new ResourceName(resourceName))
+            ?? projectSchema
+                .GetAllResourceSchemaNodes()
+                .SingleOrDefault(node =>
+                    string.Equals(
+                        node["resourceName"]?.GetValue<string>(),
+                        resourceName,
+                        StringComparison.Ordinal
+                    )
+                )
+            ?? throw new InvalidOperationException(
+                $"Could not find resource '{resourceName}' in project '{projectEndpointName}'."
+            );
+
+        return (projectSchema, new ResourceSchema(resourceSchemaNode));
+    }
+
+    private static ResourceInfo CreateResourceInfo(
+        ProjectSchema projectSchema,
+        ResourceSchema resourceSchema
+    ) =>
+        new(
+            ProjectName: projectSchema.ProjectName,
+            ResourceName: resourceSchema.ResourceName,
+            IsDescriptor: resourceSchema.IsDescriptor,
+            ResourceVersion: projectSchema.ResourceVersion,
+            AllowIdentityUpdates: resourceSchema.AllowIdentityUpdates
+        );
+
+    private async Task SeedReferenceDataAsync()
+    {
+        await SeedDescriptorAsync(
+            Guid.Parse("c1000001-0000-0000-0000-000000000001"),
+            "EducationOrganizationCategoryDescriptor",
+            "Ed-Fi:EducationOrganizationCategoryDescriptor",
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School",
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor",
+            "School",
+            "School"
+        );
+        await SeedDescriptorAsync(
+            Guid.Parse("c1000002-0000-0000-0000-000000000002"),
+            "GradeLevelDescriptor",
+            "Ed-Fi:GradeLevelDescriptor",
+            "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade",
+            "uri://ed-fi.org/GradeLevelDescriptor",
+            "Ninth grade",
+            "Ninth grade"
+        );
+    }
+
+    private async Task SeedDescriptorAsync(
+        Guid documentUuid,
+        string resourceName,
+        string discriminator,
+        string uri,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        short resourceKeyId = await GetResourceKeyIdAsync("Ed-Fi", resourceName);
+        long documentId = await InsertDescriptorAsync(
+            documentUuid,
+            resourceKeyId,
+            discriminator,
+            uri,
+            @namespace,
+            codeValue,
+            shortDescription
+        );
+
+        await InsertReferentialIdentityAsync(
+            CreateDescriptorReferentialId("Ed-Fi", resourceName, uri),
+            documentId,
+            resourceKeyId
+        );
+    }
+
+    private async Task<UpsertResult> UpsertSchoolAsync(MssqlPageLinkInjectionSeed seed)
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        JsonNode requestBody = CreateSchoolRequestBody(seed);
+        UpsertRequest request = new(
+            ResourceInfo: _schoolResourceInfo,
+            DocumentInfo: RelationalDocumentInfoTestHelper.CreateDocumentInfo(
+                requestBody,
+                _schoolResourceInfo,
+                _schoolResourceSchema,
+                _mappingSet
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-page-link-injection-seed-school"),
+            DocumentUuid: seed.SchoolDocumentUuid
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .UpsertDocument(request);
+    }
+
+    private async Task<UpsertResult> UpsertAcademicWeekAsync(MssqlPageLinkInjectionSeed seed)
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        JsonNode requestBody = CreateAcademicWeekRequestBody(seed);
+        UpsertRequest request = new(
+            ResourceInfo: _academicWeekResourceInfo,
+            DocumentInfo: RelationalDocumentInfoTestHelper.CreateDocumentInfo(
+                requestBody,
+                _academicWeekResourceInfo,
+                _academicWeekResourceSchema,
+                _mappingSet
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("mssql-page-link-injection-seed-academicweek"),
+            DocumentUuid: seed.AcademicWeekDocumentUuid
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .UpsertDocument(request);
+    }
+
+    private async Task<QueryResult> QueryAcademicWeeksAsync()
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        RelationalQueryRequest request = new(
+            ResourceInfo: _academicWeekResourceInfo,
+            AuthorizationContext: new RelationalAuthorizationContext([]),
+            MappingSet: _mappingSet,
+            QueryElements: [],
+            AuthorizationStrategyEvaluators: [],
+            PaginationParameters: new PaginationParameters(
+                Limit: 25,
+                Offset: 0,
+                TotalCount: false,
+                MaximumPageSize: MaximumPageSize
+            ),
+            TraceId: new TraceId("mssql-page-link-injection-query-academicweek")
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .QueryDocuments(request);
+    }
+
+    private static JsonNode CreateSchoolRequestBody(MssqlPageLinkInjectionSeed seed)
+    {
+        return JsonNode.Parse(
+            $$"""
+            {
+              "schoolId": {{seed.SchoolId}},
+              "nameOfInstitution": "Page Link Injection Test High School {{seed.SchoolId}}",
+              "educationOrganizationCategories": [
+                {
+                  "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"
+                }
+              ],
+              "gradeLevels": [
+                {
+                  "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
+                }
+              ]
+            }
+            """
+        )!;
+    }
+
+    private static JsonNode CreateAcademicWeekRequestBody(MssqlPageLinkInjectionSeed seed)
+    {
+        return JsonNode.Parse(
+            $$"""
+            {
+              "weekIdentifier": "{{seed.WeekIdentifier}}",
+              "schoolReference": { "schoolId": {{seed.SchoolId}} },
+              "beginDate": "2025-08-15",
+              "endDate": "2025-08-22",
+              "totalInstructionalDays": 5
+            }
+            """
+        )!;
+    }
+
+    private void SetSelectedInstance(IServiceProvider serviceProvider)
+    {
+        serviceProvider
+            .GetRequiredService<IDataStoreSelection>()
+            .SetSelectedDataStore(
+                new DataStore(
+                    Id: 1,
+                    DataStoreType: "test",
+                    Name: "MssqlPageLinkInjection",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+    }
+
+    private async Task<short> GetResourceKeyIdAsync(string projectName, string resourceName)
+    {
+        return await _database.ExecuteScalarAsync<short>(
+            """
+            SELECT [ResourceKeyId]
+            FROM [dms].[ResourceKey]
+            WHERE [ProjectName] = @projectName
+              AND [ResourceName] = @resourceName;
+            """,
+            new SqlParameter("@projectName", projectName),
+            new SqlParameter("@resourceName", resourceName)
+        );
+    }
+
+    private async Task<long> InsertDocumentAsync(Guid documentUuid, short resourceKeyId)
+    {
+        return await _database.ExecuteScalarAsync<long>(
+            """
+            DECLARE @Inserted TABLE ([DocumentId] bigint);
+            INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId])
+            OUTPUT inserted.[DocumentId] INTO @Inserted ([DocumentId])
+            VALUES (@documentUuid, @resourceKeyId);
+            SELECT TOP (1) [DocumentId] FROM @Inserted;
+            """,
+            new SqlParameter("@documentUuid", documentUuid),
+            new SqlParameter("@resourceKeyId", resourceKeyId)
+        );
+    }
+
+    private async Task<long> InsertDescriptorAsync(
+        Guid documentUuid,
+        short resourceKeyId,
+        string discriminator,
+        string uri,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        long documentId = await InsertDocumentAsync(documentUuid, resourceKeyId);
+
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO [dms].[Descriptor] (
+                [DocumentId],
+                [ResourceKeyId],
+                [Namespace],
+                [CodeValue],
+                [ShortDescription],
+                [Description],
+                [Discriminator],
+                [Uri]
+            )
+            VALUES (
+                @documentId,
+                @resourceKeyId,
+                @namespace,
+                @codeValue,
+                @shortDescription,
+                @description,
+                @discriminator,
+                @uri
+            );
+            """,
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@resourceKeyId", resourceKeyId),
+            new SqlParameter("@namespace", @namespace),
+            new SqlParameter("@codeValue", codeValue),
+            new SqlParameter("@shortDescription", shortDescription),
+            new SqlParameter("@description", shortDescription),
+            new SqlParameter("@discriminator", discriminator),
+            new SqlParameter("@uri", uri)
+        );
+
+        return documentId;
+    }
+
+    private async Task InsertReferentialIdentityAsync(
+        ReferentialId referentialId,
+        long documentId,
+        short resourceKeyId
+    )
+    {
+        await _database.ExecuteNonQueryAsync(
+            """
+            MERGE INTO [dms].[ReferentialIdentity] AS target
+            USING (SELECT @referentialId AS [ReferentialId]) AS source
+              ON target.[ReferentialId] = source.[ReferentialId]
+            WHEN NOT MATCHED THEN
+              INSERT ([ReferentialId], [DocumentId], [ResourceKeyId])
+              VALUES (@referentialId, @documentId, @resourceKeyId);
+            """,
+            new SqlParameter("@referentialId", referentialId.Value),
+            new SqlParameter("@documentId", documentId),
+            new SqlParameter("@resourceKeyId", resourceKeyId)
+        );
+    }
+
+    private static ReferentialId CreateDescriptorReferentialId(
+        string projectName,
+        string resourceName,
+        string descriptorUri
+    )
+    {
+        return ReferentialIdCalculator.ReferentialIdFrom(
+            new BaseResourceInfo(new ProjectName(projectName), new ResourceName(resourceName), true),
+            new DocumentIdentity([
+                new DocumentIdentityElement(
+                    DocumentIdentity.DescriptorIdentityJsonPath,
+                    descriptorUri.ToLowerInvariant()
+                ),
+            ])
+        );
+    }
+}
+
+/// <summary>
+/// One School plus the AcademicWeek that references it, seeded so the query under test returns a
+/// page of several documents whose references resolve to different referenced documents.
+/// </summary>
+internal sealed record MssqlPageLinkInjectionSeed(
+    long SchoolId,
+    string WeekIdentifier,
+    DocumentUuid SchoolDocumentUuid,
+    DocumentUuid AcademicWeekDocumentUuid
+);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
@@ -403,11 +403,13 @@ public class Given_A_Mssql_Page_Of_AcademicWeeks_With_Link_Injection
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-page-link-injection-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlPageLinkInjectionIntegrationTests.cs
@@ -221,7 +221,7 @@ public class Given_A_Mssql_Page_Of_AcademicWeeks_With_Link_Injection
         services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
         services.AddTestReadableProfileProjector();
         services.AddScoped<RelationalDocumentStoreRepository>();
-        services.AddMssqlReferenceResolver();
+        services.AddMssqlBackendIntegrationTestServices();
 
         short schoolResourceKeyId = _mappingSet.ResourceKeyIdByResource[SchoolResource];
         Dictionary<short, DocumentLinkSlugTriple> slugByResourceKeyId = new()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReferenceLookupPlanCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/DocumentReferenceLookupPlanCompilerTests.cs
@@ -73,12 +73,13 @@ public class Given_DocumentReferenceLookupPlanCompiler
         lookup.SourcesInOrder[0].FkColumn.Value.Should().Be("School_DocumentId");
     }
 
-    [TestCase(SqlDialect.Pgsql, "\"", "\"")]
-    [TestCase(SqlDialect.Mssql, "[", "]")]
-    public void It_should_dedup_two_bindings_on_the_same_child_table_with_distinct_fk_columns(
+    [TestCase(SqlDialect.Pgsql, "\"", "\"", "CROSS JOIN LATERAL")]
+    [TestCase(SqlDialect.Mssql, "[", "]", "CROSS APPLY")]
+    public void It_should_collapse_two_bindings_on_the_same_child_table_into_one_unpivoted_scan(
         SqlDialect dialect,
         string openQuote,
-        string closeQuote
+        string closeQuote,
+        string rowSetJoinKeyword
     )
     {
         var model = BuildModelWithTwoChildCollectionBindings();
@@ -87,19 +88,66 @@ public class Given_DocumentReferenceLookupPlanCompiler
         lookup.Should().NotBeNull();
         var sql = lookup!.SelectByKeysetSql;
 
-        // Two bindings → two UNION branches (no DISTINCT prefix), both joined via the same
-        // child-table root locator.
-        sql.Should().Contain("UNION");
-        sql.Should().NotContain("SELECT DISTINCT ");
+        // Two bindings on one table → one scan that expands both FK columns inline, so the
+        // keyset join is emitted once rather than once per reference column.
+        sql.Should().NotContain("UNION");
+        sql.Should().Contain("SELECT DISTINCT ");
+        sql.Should()
+            .Contain(
+                $"{rowSetJoinKeyword} (VALUES (t0.{openQuote}School_DocumentId{closeQuote}), "
+                    + $"(t0.{openQuote}Sponsor_DocumentId{closeQuote})) AS v0({openQuote}DocumentId{closeQuote})"
+            );
         sql.Should()
             .Contain($"t0.{openQuote}{StudentRootLocator}{closeQuote} = k.{openQuote}DocumentId{closeQuote}");
-        sql.Should()
-            .Contain($"t1.{openQuote}{StudentRootLocator}{closeQuote} = k.{openQuote}DocumentId{closeQuote}");
+        sql.Should().NotContain("t1.");
+
+        // The null predicate must apply to the expanded value, not to a single source column,
+        // so a row contributes only its non-null references instead of being dropped entirely.
+        sql.Should().Contain($"WHERE v0.{openQuote}DocumentId{closeQuote} IS NOT NULL");
 
         lookup
             .SourcesInOrder.Select(static source => source.FkColumn.Value)
             .Should()
             .Equal("School_DocumentId", "Sponsor_DocumentId");
+    }
+
+    [TestCase(SqlDialect.Pgsql, "\"", "\"", "CROSS JOIN LATERAL")]
+    [TestCase(SqlDialect.Mssql, "[", "]", "CROSS APPLY")]
+    public void It_should_emit_one_branch_per_source_table_and_unpivot_only_multi_column_tables(
+        SqlDialect dialect,
+        string openQuote,
+        string closeQuote,
+        string rowSetJoinKeyword
+    )
+    {
+        var model = BuildModelWithRootAndTwoChildCollectionBindings();
+        var lookup = CompileLookup(model, dialect);
+
+        lookup.Should().NotBeNull();
+        var sql = lookup!.SelectByKeysetSql;
+
+        // Two source tables → exactly one UNION. The root contributes a single FK column and
+        // keeps the plain projection; the child contributes two and is expanded inline.
+        sql.Split("UNION", StringSplitOptions.None).Should().HaveCount(2);
+        sql.Should()
+            .Contain(
+                $"SELECT t0.{openQuote}Sponsor_DocumentId{closeQuote} AS {openQuote}DocumentId{closeQuote}"
+            );
+        sql.Should()
+            .Contain(
+                $"{rowSetJoinKeyword} (VALUES (t1.{openQuote}School_DocumentId{closeQuote}), "
+                    + $"(t1.{openQuote}Sponsor_DocumentId{closeQuote})) AS v1({openQuote}DocumentId{closeQuote})"
+            );
+        sql.Should().NotContain("v0(");
+
+        lookup
+            .SourcesInOrder.Select(static source => (source.Table.Name, source.FkColumn.Value))
+            .Should()
+            .Equal(
+                ("Student", "Sponsor_DocumentId"),
+                ("StudentAddress", "School_DocumentId"),
+                ("StudentAddress", "Sponsor_DocumentId")
+            );
     }
 
     [Test]
@@ -298,6 +346,47 @@ public class Given_DocumentReferenceLookupPlanCompiler
         );
     }
 
+    private static RelationalResourceModel BuildModelWithRootAndTwoChildCollectionBindings()
+    {
+        var childBindingModel = BuildModelWithTwoChildCollectionBindings();
+        var addressTable = childBindingModel.TablesInDependencyOrder[1];
+        var rootSponsorPath = new JsonPathExpression(
+            "$.sponsorReference",
+            [new JsonPathSegment.Property("sponsorReference")]
+        );
+        var rootTable = BuildStudentRootTable(
+            extraDocumentFkColumns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Sponsor_DocumentId"),
+                    Kind: ColumnKind.DocumentFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: rootSponsorPath,
+                    TargetResource: _schoolResource
+                ),
+            ]
+        );
+
+        return childBindingModel with
+        {
+            Root = rootTable,
+            TablesInDependencyOrder = [rootTable, addressTable],
+            DocumentReferenceBindings =
+            [
+                new DocumentReferenceBinding(
+                    IsIdentityComponent: false,
+                    ReferenceObjectPath: rootSponsorPath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("Sponsor_DocumentId"),
+                    TargetResource: _schoolResource,
+                    IdentityBindings: []
+                ),
+                .. childBindingModel.DocumentReferenceBindings,
+            ],
+        };
+    }
+
     private static RelationalResourceModel BuildModelWithMissingFkColumnBinding()
     {
         var model = BuildModelWithCollectionTableBinding();
@@ -338,38 +427,45 @@ public class Given_DocumentReferenceLookupPlanCompiler
         };
     }
 
-    private static DbTableModel BuildStudentRootTable() =>
-        new(
+    private static DbTableModel BuildStudentRootTable() => BuildStudentRootTable([]);
+
+    private static DbTableModel BuildStudentRootTable(IReadOnlyList<DbColumnModel> extraDocumentFkColumns)
+    {
+        List<DbColumnModel> baseColumns =
+        [
+            new(
+                ColumnName: new DbColumnName("DocumentId"),
+                Kind: ColumnKind.ParentKeyPart,
+                ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                IsNullable: false,
+                SourceJsonPath: null,
+                TargetResource: null
+            ),
+            new(
+                ColumnName: new DbColumnName("StudentUniqueId"),
+                Kind: ColumnKind.Scalar,
+                ScalarType: new RelationalScalarType(ScalarKind.String),
+                IsNullable: false,
+                SourceJsonPath: new JsonPathExpression(
+                    "$.studentUniqueId",
+                    [new JsonPathSegment.Property("studentUniqueId")]
+                ),
+                TargetResource: null
+            ),
+        ];
+        baseColumns.AddRange(extraDocumentFkColumns);
+
+        return new DbTableModel(
             Table: new DbTableName(_edfiSchema, "Student"),
             JsonScope: _rootScope,
             Key: new TableKey(
                 ConstraintName: "PK_Student",
                 Columns: [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
             ),
-            Columns:
-            [
-                new DbColumnModel(
-                    ColumnName: new DbColumnName("DocumentId"),
-                    Kind: ColumnKind.ParentKeyPart,
-                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
-                    IsNullable: false,
-                    SourceJsonPath: null,
-                    TargetResource: null
-                ),
-                new DbColumnModel(
-                    ColumnName: new DbColumnName("StudentUniqueId"),
-                    Kind: ColumnKind.Scalar,
-                    ScalarType: new RelationalScalarType(ScalarKind.String),
-                    IsNullable: false,
-                    SourceJsonPath: new JsonPathExpression(
-                        "$.studentUniqueId",
-                        [new JsonPathSegment.Property("studentUniqueId")]
-                    ),
-                    TargetResource: null
-                ),
-            ],
+            Columns: baseColumns,
             Constraints: []
         );
+    }
 
     private static DbTableModel BuildStudentAddressTable(IReadOnlyList<DbColumnModel> extraDocumentFkColumns)
     {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/mappingset.manifest.json
@@ -3106,7 +3106,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "46d43c48e9bd79709c57e21eac11abc23a2c9b6b797d924063b9a49caa4082bf",
+                "select_by_keyset_sql_sha256": "0dda696acf72c8ba3a270651e8b4534d787816c196024a29101e4c11f51005ba",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -10496,7 +10496,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7b1e1b185873bb47d29ec54cba1f23b5edd99da34822ca0a9ba26928b0816e37",
+                "select_by_keyset_sql_sha256": "eb27e81398030a66595259297cf65842a2d70a64fac46dc0f765a5bf77e7e112",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -12139,7 +12139,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bc2cd5e2aada102da9d093b35739395c025c16bd4ef9401f9f05411f8cb2b7bf",
+                "select_by_keyset_sql_sha256": "9226b5947f9c81c988dc1199eac6eab757669d7b119eec456f2704856bcf88a5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -13753,7 +13753,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "faa1aad2f0e92c7f07250cf0ce1470b7a300be102ed9b152ab3aefcbd4a1bd01",
+                "select_by_keyset_sql_sha256": "8fa9edfa62a556166406b1dcebc52915f63a644d1b81bfe43bd02b7b684e4acb",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -14307,7 +14307,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "93de0f631ef6e9bc2dc7bc347b3cdc54606ec545aca28c33748f217f75ac969e",
+                "select_by_keyset_sql_sha256": "f38fd1ee844771d4474814fac1734815dc02723e317c93f927b134134adbcc3c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -16490,7 +16490,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ea34b8dcbf03730f77873fc9cee0428256db2934917799fc0758a103a2a4f2ab",
+                "select_by_keyset_sql_sha256": "52379816fc5a1319bf9bd4c499ee4f77807b88185caefdb3effc39611b646436",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -18181,7 +18181,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "615a0f450fca204b69e9f540dbb22ea115691e5d853795f5300e61a0ea7cd434",
+                "select_by_keyset_sql_sha256": "e0c9f8f99b438652e0951b87553a6d9a71c370412130dca78f760cd596562087",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -21174,7 +21174,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "4c3b582b29d1e87cd32085d7f4cdcea5b897aff2cfe534876476f747de0b2ab8",
+                "select_by_keyset_sql_sha256": "438b93867495a7f9de39853b193d4b49a93bb9ce7b973f5850dc91cbba81a6b9",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -22079,7 +22079,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33197c8664a235cfc6251c0467ca5b70c7027e539b1d20d46613c26dab7f71f8",
+                "select_by_keyset_sql_sha256": "620e147e80dddec4d97a346df63ebe62519442193739fcb446a7404fa49b486f",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -25325,7 +25325,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cde41b2ffed383d99bf56d220b2f7eb5b41c4b07491e7b5c2b8bf5838895ce1f",
+                "select_by_keyset_sql_sha256": "b48d241337c3708cad9ba3f6115d96aa5cac6f6ef5f3262b7b536247e340e3ee",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -26795,7 +26795,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0599bde9cde57ca56e7322a70215a420170c45e179a54bacbc188ffc7d85cb05",
+                "select_by_keyset_sql_sha256": "5e0c958d18337caa86a7bbd2440bb8813c9beaebb47c83dbc3e3df265c6df803",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -28834,7 +28834,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ff7e4a576b981a9ee16235fa67e71d40fda09b89db61cd48faa60c9cae4f856d",
+                "select_by_keyset_sql_sha256": "810b2263317b2684c2f51630b3d3e9ce2a73187c8d90c168c902790c9fe8d6f0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -30899,7 +30899,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7398607c60590b3fa78c5b3c502c825841f5c9cf4eaa0dcff3cc65d1d627b17c",
+                "select_by_keyset_sql_sha256": "b04075d273e2857561012b262448a634353fc68ffbe3060745d40b4e877ffcc7",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -32085,7 +32085,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1a9bc54bae72a43d77128fae43dd2196283b9f5a7304512721bc02be7fbd185b",
+                "select_by_keyset_sql_sha256": "57fd1cdd638b9efd8da90211747b978b2ee925c4324b7287279e8607862547f1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -33903,7 +33903,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8c239d88c2f18f6bf1c8e00c6f6677d09a876a10546ffcf6ce7b839f8a0a3b85",
+                "select_by_keyset_sql_sha256": "445f8ec47a7448ef5288e0ce0356467663ee482131ac29cbbe3e1c35d4d6cf95",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -34945,7 +34945,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b4766d488150ead5f389f55bc316f516ca74f6d4ec6ca37bf2857dce53dd7cc5",
+                "select_by_keyset_sql_sha256": "b0cb08b19c4adec2eaaca5f35c76fbf87c3f0cae23871e2ec1dd977782fa3743",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -36821,7 +36821,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2de6b4bccc16353529843cb19c4bbfb84a6e6be507e5ee29413a148b6809e0cc",
+                "select_by_keyset_sql_sha256": "25406fdff467fcf5998119e8610b08e7435a918ee189b48c10530d555df706df",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -39549,7 +39549,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5d18245eab5c581147cb742b030f77817a1bbf906b187f2364181ea1afc94a6",
+                "select_by_keyset_sql_sha256": "d479499fbca318b4aece6c218cdaa9c3ee2e9deec6f1012582e0e5d0c6e6da6d",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -40753,7 +40753,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2b09f30b0d17d7a1544fe4c635ddff7098cde668f10dd3a72033f2bd65ac03b1",
+                "select_by_keyset_sql_sha256": "c038b2b11de42ff022c09f1fb21f8aff11a684d3b2c08f278794849ac7a90f91",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -41989,7 +41989,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a944f4bde761239f5f25bce9e5f6fc0213a50954c8980c77e266e7f960639e50",
+                "select_by_keyset_sql_sha256": "414d738aa726d83e01ff985f513d12d324a3630d910aa9c0d8d1aea143c00f38",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -43166,7 +43166,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cf003de20bb83536b50d107bb08a09dcadfba2475573360a327a12acbd45712e",
+                "select_by_keyset_sql_sha256": "a16357df8e0d28f556ac6ed921e10a37c95132b3f0bf48850e57f171906b8f8b",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -47315,7 +47315,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "acf768f2b438ffacdb86ef57666ce7215cfedfbb8c1bc5f7f0665b97c6366acd",
+                "select_by_keyset_sql_sha256": "f02ff7c4b1b98846bcd0f040b1c4a1e598dffefb8b61281f13b6d803c32da372",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -50537,7 +50537,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "102526328b978fd644fde8b715e09f4f672f062b04ed0f32e8cd3d5c174ac34f",
+                "select_by_keyset_sql_sha256": "1e6c43ac8520cd549e42e18f07a2a4661f1e180056359f549631316aab2bc8f0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -51125,7 +51125,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d5359589399bc8d23ef09da07774f731cef588f15435cf4322c08fd23a863aef",
+                "select_by_keyset_sql_sha256": "0f32c6e34f33bcd722dc9193e1c0f29e172aa5bd9fd53d806f137336d19bcd4e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -52994,7 +52994,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a488e818262dc23031956ae5426e40cdaf2e379442b42e3f1d2c15c57b5e2a3",
+                "select_by_keyset_sql_sha256": "e06d9c6d14085adb8bab5497ab3ef45d158890a5ee65248d1a3f984b2701b478",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -55734,7 +55734,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7d8f216c224984a9047b365dff0bf629b489fb55fa44a7a57e05611064a42e5b",
+                "select_by_keyset_sql_sha256": "f7c72227c02f3b58db7f84aad0cf42567949eb220c3eeed128cb9e3d69243ad1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -57785,7 +57785,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ebfc7e2ce61b1f47321732a411b9e0b557d4cab18e966e9fcf4a42cc908aa8e2",
+                "select_by_keyset_sql_sha256": "7a923c908401c45bf34b471e1ff6f4549b3ec44219e68cff69e0aec92f1e6014",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -58591,7 +58591,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1984fd68c99f30774765cb0bb9008e279dc3420a1340208a5ef429f63f8864a9",
+                "select_by_keyset_sql_sha256": "aba70dd2120efae13da450769e2d658fbae278294ead55453c966280ad95b5a4",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -59208,7 +59208,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "929c6cc856a1826a23669d072f4297610048de4268c2b11c8e70fe98b013c1d5",
+                "select_by_keyset_sql_sha256": "24b8de6c0e3e9ca20f561a13112c2b310012015929a2450ba7096d70e08a2d93",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -62134,7 +62134,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bfa5552c025d3b41e8001c13e223e6d58a7650f6aa9de28c8c1c865b980654f5",
+                "select_by_keyset_sql_sha256": "6b26d061c38db405c9bb9517e5aeed9ea50e876ae051f9ee73e71c9f8ae88bd5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -65238,7 +65238,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f687fdd70d954791862419e9ecc69a0d31ece3948662926a3cf8295df2b39cbc",
+                "select_by_keyset_sql_sha256": "e407a406491a517dced52ed2b9efcca9d3635318f22e7406ff7edfe3e344c223",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -67278,7 +67278,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "07ff3b411b776a92e06a597e4ce928c6c03bc3594a1a4de35959d4c8293cedc1",
+                "select_by_keyset_sql_sha256": "829ddad67ee941cfabcbcfaec1e46f95709d3d9db3efc8731a3ddfa94a16f23e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -72665,7 +72665,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bf64144f0a9e09a18879c78c825778ded71569ca086f5952a1c2f9d6f7e9965d",
+                "select_by_keyset_sql_sha256": "2206f5f92cbcd9944162ef7c6860dc4d518c478ab690431b86e795154b429902",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -74573,7 +74573,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5803df217858638468682a7244366cb911879f31bfa380bc0d51db9cd9e66880",
+                "select_by_keyset_sql_sha256": "c872ff6054c3260fc0d1b10a52d3d97789b8ed16f2d268f4bb24919228604a1d",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -75369,7 +75369,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b36f37f47e93b210b0a28f2aae790cf5120ead460e19b0b63223a59f3fde1008",
+                "select_by_keyset_sql_sha256": "d872e5b00c1dc420c0c67457f6b1b6f9f216391c0e3a4fcf6e81c131b7953bfc",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -75843,7 +75843,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b522c1f500bf16c0dc06d8dfb25edc3169be071326e40916a51131e27d8658de",
+                "select_by_keyset_sql_sha256": "2385d53b88e655fd78279000503951a195ee2c9ad509e3683f62961ac9ce077c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -79485,7 +79485,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "86cc904a80db045baa50d0755f9314efd361c9e860db6f17ae55e309221427c2",
+                "select_by_keyset_sql_sha256": "b26a935fbf5d0907a3c8c0239df18c63c9782d159316bdaeb02312f0f366432f",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -80653,7 +80653,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "20b1721fca257c361f960e9732582d26d939031c8d4b91f2ca87ecd5816449b7",
+                "select_by_keyset_sql_sha256": "ed0c3cfeda5e9fbd37bedb32acb0e808cb0d8e1a42f5f5a72ea240d8c2227fe8",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -82591,7 +82591,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05a360d303bde3527da705d9b235cdd8ede2064b413fb0d5a6564c0aeefe1895",
+                "select_by_keyset_sql_sha256": "628afd53a9e4ac086be5894861a74b72ab62d864d1a3fca2c7fd81eccc7baf96",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -84526,7 +84526,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "606d11982f45706fada9cb52d5f375d103356b99f7a253442446daf0f960729f",
+                "select_by_keyset_sql_sha256": "a0f85019b8483acdc9201f728d07e9456effa21fa08da4c1374a6965593d2427",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -86056,7 +86056,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7413eadaebc60cf6f4fad9cdc9475972d587c32df5a3f4940187a17def5b71fd",
+                "select_by_keyset_sql_sha256": "dbca182c963078859ec7011b9fa3f4844ecd255cacba5fc51acd5f1a41cc3d79",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -87369,7 +87369,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a25c14fa54a6e688856a2c7abd9618f9dc17bcee815eb5a187e8feef2e93cd0",
+                "select_by_keyset_sql_sha256": "016f860e025f04fb2fc342902ab43215303ac2cb8c9942a37739a13fd8f24da0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -88990,7 +88990,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e3e3ed34bf4474cfa1dcfe0ee41525b7263c713a0084e5f7cfaf1449ec8e6955",
+                "select_by_keyset_sql_sha256": "7430aacc37b74e99bb346e758424ec5b1caa55242cdea4264e82fd35d4d70773",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -93510,7 +93510,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "eaddb3a8b3950b55b5f581ad02cc29a3bf8e607cfda72d21f094773e7776c2f8",
+                "select_by_keyset_sql_sha256": "2ab640d2b95614d9947a5e9190358d13ed3fb874c112464353850239c747f443",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -94631,7 +94631,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "169b6c7ae64105496ddfeda0a98f272ea34c05e922086ce6527152c2c94d0abd",
+                "select_by_keyset_sql_sha256": "c9d4a52d71af3057653bfbd276a7039ed22367a0bd4847a6039f5a835b4ed18e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -96095,7 +96095,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "83227a77dc0a5be8f8025c3666f410483b40b9b443bc17d5e3a3e40aef597fee",
+                "select_by_keyset_sql_sha256": "69b30e96f517ce6a3313fa4c70c97a475421c028634310b3766eb1bc1409d0d5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -96796,7 +96796,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0b3f99c4f435f36300f9f680fd64f24c242133fb51042ecb80baac254de27f30",
+                "select_by_keyset_sql_sha256": "ebd6f823e8cd54d4a871fe506f30f62bd16a0d4812b9eba64e8fa1e4e94abf1c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -97183,7 +97183,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3972719fe4375bafeefaeda2ce8838bb5e28e43af3e98dee22f9616ecb1ad02b",
+                "select_by_keyset_sql_sha256": "77342edd06bb60981fb69328d18737390be32d1232e774ed056b098b085c988e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -98083,7 +98083,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1d0da06c993ab8aa413cfbb09f474f423685f939640fc4675692bd2cec40a30d",
+                "select_by_keyset_sql_sha256": "7fd4aace8dce2b3f106bca72079643be3063346d05363ff6348ec796ee65aa3e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -98962,7 +98962,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "664ace47fc239d93b4bb070fd4dda09f0ad0d2b9bbd40b78215f26e98dba0f75",
+                "select_by_keyset_sql_sha256": "04ff6d0d9b4bc673f20de6f37fa64cba75e9415f0424cbc82fb1c75615d208bd",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -99814,7 +99814,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a9c6e1bca250fdab68aa6325f0f77a85fc7b3cbac07e3c44e52def1a467f1f1",
+                "select_by_keyset_sql_sha256": "4df4d1dce234b061049f6bf968c51a3e8d81aa1d1e15c3760f5b742e2f6079d8",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -100599,7 +100599,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "75aeed4c8c2db75a839cd442ab1d087637cd941190671f56183e63aef9fce361",
+                "select_by_keyset_sql_sha256": "4ff78e097eba6114cde885bd62897e5e499803c71244b722aa272b54d94a0ce6",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -101073,7 +101073,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "16938c26de3a1a4e4e7260e8c5c8a43825c33359359b95f0d025bec8cd964ef3",
+                "select_by_keyset_sql_sha256": "69e642940418747107c4dc79db67efd46135c8ae00a64de896421f584fd665da",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -102344,7 +102344,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e08b5a716b92cef659e20a19bda361007551006042262dc6215a79a60eaf87b0",
+                "select_by_keyset_sql_sha256": "92879425de21a98a1f2e591e5ee9c7ea282d67ee8249a0910079f081a8f9a2e7",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -103618,7 +103618,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6caa75ce9b3a4ac5a915b7fba625b8a44a438e93686e0cfff2487e44e9cea7e1",
+                "select_by_keyset_sql_sha256": "167c6f1b5df910d938171c6352ef2c543374c16cf5bb9e036042829be340fa64",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -104395,7 +104395,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05ed9dd9f13ac5c1f7d3ea8ed54a76cdf79e17ce9e6df2ead3b04ee0b7ce3172",
+                "select_by_keyset_sql_sha256": "64a3d060b63dff18dedf157a0476a2fceb0b23c244d6bb97ef2d5cb08fe2cbac",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -105119,7 +105119,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ca14bc865362ac84c91e30b9339fa8a2fe9e76eb079b3c0a8705c38dda7d934a",
+                "select_by_keyset_sql_sha256": "153a3cfbdeff38b78906821e3cf3c4d6d6f7b90dcb8f2bdcbe32573a6d1ab0f3",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -105768,7 +105768,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c0c9b7e9224ac4afa648c57f0acb915def5982a58ed6108d1c94547e64fd1d1f",
+                "select_by_keyset_sql_sha256": "7a82907fb046d8cdc6424af57955c364c726f57708fdc4ce6c916ad98289f6e1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -106561,7 +106561,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e9be71752e2d591f0c7a6e68706cbe1c012a0ab9b0795d1a48188d3a136f3af9",
+                "select_by_keyset_sql_sha256": "5017e68793a32c1145512a7b500fd4237e3818517fb1d93b5980fe7078da7d16",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -107301,7 +107301,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "02bf694239b7a60c50bb23c4c309b13af1f100f134ad7a2c4c6e4dc3e8db4152",
+                "select_by_keyset_sql_sha256": "bed43877000b159c654f46de10d2493a3ac32ea860175cab1d6de02ac49a0edc",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -108733,7 +108733,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "67e9bda399367d8d8964f6656c9e3935f589446215bb94b0af3394dbf0b4ba89",
+                "select_by_keyset_sql_sha256": "7846736f79a49fb7ac5c1bfb2a21ecda1b285806bd3e7b704e3c9dbc45e490af",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -109528,7 +109528,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "9358d1fab731a8219d326ad3c26a94ac65d3bd7d0060d10bd4c54f74cbe95792",
+                "select_by_keyset_sql_sha256": "4947825e5b13166ec7fed0501193abdb6786bfab89f5995ae5fe718012c9c305",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -110385,7 +110385,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5d5d919822433e82bbf91206f600f7a74c51b44066c51c5709203d9f0f3cba27",
+                "select_by_keyset_sql_sha256": "95f9e309c84b69a6c5b0401b79c349fec1beedcc4593bf101fdf92f16ecab216",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -110993,7 +110993,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "900795b62986f0f7295a5bad7523a813ebd1e2e49e3a12f9ba838148f7811635",
+                "select_by_keyset_sql_sha256": "f6fd62f99670604d7f508cc9bf394942ce3662946bec2a2abe548c78f64a05fd",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -120464,8 +120464,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f39360e27cd8ae3604263bbdb22cab2166012f7541b0159e8f1b59a50662b44f",
-                "select_by_single_document_sql_sha256": "a6adf4cc94244993f6cce3f66c0cba29972954c0bf90603c60872277d3f9993d",
+                "select_by_keyset_sql_sha256": "51f2478482de4aefbd58d5cec3e4a4b69fff672f89b386726aaeb5d163418274",
+                "select_by_single_document_sql_sha256": "061e5e4a07a55aa957aa064c35840082f77b921370b667a6be7e92abb2bf726f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -127854,8 +127854,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "17e8ef3129339d54eb0d49607c02e86ae3e8f4c688fc1440bda837875d9107b4",
-                "select_by_single_document_sql_sha256": "897706172ad3d8132e8e7786bc6f22258934eca80532316f1f003de757f77139",
+                "select_by_keyset_sql_sha256": "51fa3b414ae6a106807924ac8d4ce485113ffb99058eaf37c3513e87966603a7",
+                "select_by_single_document_sql_sha256": "baf677ac9eeddcd19ae6b42b86c02331bbcdf3ad3a6122c04b9bc3bd3a7e65ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -129497,8 +129497,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3f82bc02404955b59d6d383ec842371a61f5ddce0d3cc728b23f7ee1786d28ef",
-                "select_by_single_document_sql_sha256": "391fa1e423c91829981178c132d571486a163d7b44404eafd2bc5ab9ff8e8fff",
+                "select_by_keyset_sql_sha256": "243748542ee50d0cea4f99cf257bdcb413e3888e76c3e17dd0f6d9cea3b94d09",
+                "select_by_single_document_sql_sha256": "daf110933cb950cd3f20796d1c682b807053f42ef599f4b63244e138b763fe61",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -131111,8 +131111,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6a57305308773f8bd3abc382f0fbdeb5128dc0a16aaf39580f2efa4fae6a4ba1",
-                "select_by_single_document_sql_sha256": "293f19dfcd4bf3aa997cf07835c7c6d0badcdee7a3a2f7e50a899e73b4e6cab9",
+                "select_by_keyset_sql_sha256": "b3f5c167787e3e0826d2b45a35d58ed1a2e1d568ceffd111b7a03b4844da7829",
+                "select_by_single_document_sql_sha256": "321f939510d6dd1a472fc4eb08e37eef5bd8b5d7c599a70b5936b2c7df7b5dd0",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -131665,8 +131665,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fd1b1302ff15175576fc878fc4090e4a726da7baef5d043006cb1c2a141f984f",
-                "select_by_single_document_sql_sha256": "c77d4ab8ffea0d8bb9fbad96b232819d815ef2e3a757cb839ea2f44c6b0f3535",
+                "select_by_keyset_sql_sha256": "9113bacf3302224ffb890b71903b52ca374a1a8b5dc3758a99fb1f545e8e4ec8",
+                "select_by_single_document_sql_sha256": "b67683e6def69db8459428589a6e7d6d0f3056a5b9c916b8e41a1d179de312d1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -133848,8 +133848,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e576c13f70ffc7060fadb02c1ac85ad7bdc93923c60f248f706715b9d25667d7",
-                "select_by_single_document_sql_sha256": "23a500af182f578ac6429dcae16df9c4627976092132cf3be9a69bc470850c01",
+                "select_by_keyset_sql_sha256": "48f274ce2c741bc9d4f46760f54c85be966dd0fcfe68fa342d9c7a6f259bbbad",
+                "select_by_single_document_sql_sha256": "4adeb5808449e7fddca150f4848c0a9df4961bc6fb89ce39f5fc1c9733c26a5b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -135539,8 +135539,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ab59464dac840fe20120b98f11ab7a4f740f06a0b826ef76f5b6048961b40698",
-                "select_by_single_document_sql_sha256": "9a611932ebde7064b7cee648bb258c297c09fa2f4aa428c43f67ca9791ea3e83",
+                "select_by_keyset_sql_sha256": "7669597d42903d88b67d3626e406877a73d99e4bf94fd3978736b1ff3b9f20ce",
+                "select_by_single_document_sql_sha256": "ae5e95b6007177697e9952d0335b61e980ab007f6c9434df8bbde9e118fec632",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -138532,8 +138532,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6f3a37ca8c808cefaa61cd897b65aa18710093af74930a55bc82fcd3d8c1375b",
-                "select_by_single_document_sql_sha256": "7cbc1dd7ff123cb83f7db8a226201fb1598bed11a33748cf10046bf81d2bbad2",
+                "select_by_keyset_sql_sha256": "e44d3aaf281d296069372e56b7bcb2b9256eaae75fd2ab44cad14425596ec614",
+                "select_by_single_document_sql_sha256": "1d32d3decb67d897327d43aafd0f2dcd3e6450283654ce2548951e615f515114",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139437,8 +139437,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "4654c6f46919da92cc5c43aeba63ff6d5b42a71c50e59802df91c9e45403c963",
-                "select_by_single_document_sql_sha256": "5aaa655f39db805b93ac72fe2973deb6fb351479a66e63dbdb2f6ee9ed8270d5",
+                "select_by_keyset_sql_sha256": "fdf6ad1d9a8ca642444568311d08a3a76a46b93fff9b6b895cf45860b12805e1",
+                "select_by_single_document_sql_sha256": "c2af2c1fdfb594a6677e4c3d63ff3545724ea96856b3876fdea7f54541898e5f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -142683,8 +142683,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33e58c9554ff95d9dca7251e0662b6ab601228f810d40bd4e68751584040c441",
-                "select_by_single_document_sql_sha256": "bcabf740b8151c8e1b788e6923796493632387f824522e73ee48743f5d688adc",
+                "select_by_keyset_sql_sha256": "93e995147ffeebb599b7c7eba34d09ac2d99ccc5cbfe2331ba6968f186a307d6",
+                "select_by_single_document_sql_sha256": "c87cff1f978b33858f0aa3b51765a43c6734325c700cc650a2604890390163f5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -144153,8 +144153,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "63f9fc6b9f8ceec5de78b520ca0d99c5333f10cc03808aa565f7d8124e2e590e",
-                "select_by_single_document_sql_sha256": "9c51d1806735a5698dea2cbcb107285b3e9d34bccd4ed6683c276e1c181a82a7",
+                "select_by_keyset_sql_sha256": "312c48c3eb3bb85ed69430b94e9e765dfc7b6e7d5f13b569827149e7aa854bd5",
+                "select_by_single_document_sql_sha256": "41da8595a7516b485b5cc3c74aaddd86a43f6f22dd76e53e658107b69216ca38",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -146192,8 +146192,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "dd216b84d6c239253c405e162690e7b2020b64bbe592b9c29535fa5328d75932",
-                "select_by_single_document_sql_sha256": "6da9eef1e8eaaca5760eccec0017571c536cee151d64fa2e0740bdb616dfdc2b",
+                "select_by_keyset_sql_sha256": "b68aa07dcab202642f27fef361952d780f765e90416e9c48fd3de913e9135c5a",
+                "select_by_single_document_sql_sha256": "11cce6fa41604d938e7d5303f5125a45ed677ab9f406509579752512bf60da60",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148257,8 +148257,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ac936c4c15c2a841607648ba4bff107d2a3f1c82ac2727026ef9066ea34c3487",
-                "select_by_single_document_sql_sha256": "fb62880678fe134ec036429012796b4e06b8fe809a41bfc4436304c5f4e19a58",
+                "select_by_keyset_sql_sha256": "3510f8eb93b6357fff8ff83b05ce598c00a6e054609400b7441248e4753214d0",
+                "select_by_single_document_sql_sha256": "e572734b8178d10ec60caca1bd1f4cdd3d516ac836805de32823ce56e7c75b7e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -149443,8 +149443,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d73f6edd1f02983c122f4edf24f5c017f7a2cedf0137237ed5cfd916dac0b72c",
-                "select_by_single_document_sql_sha256": "9b53c26542917dd0df74b087622f96526e3bda0c89dcb399d474fb0d530626d4",
+                "select_by_keyset_sql_sha256": "a471dadc1c3eb8ab8b6564b298b293692b96945bd0207e1a7bf574106cfcef33",
+                "select_by_single_document_sql_sha256": "74c44a4d2ee676569c031d02cad16bd6661cd7291beb8504effa510713dda32b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -151261,8 +151261,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e44c81078b7b1b25e36d2ef300014faf3641c43148d4454e5dd15800d5af1d7e",
-                "select_by_single_document_sql_sha256": "ef946fa16c0bad24f1091427d9284f44bc05ca7505042baf66d6319ed9807a74",
+                "select_by_keyset_sql_sha256": "664725560b89f8b1e63eed9175a12eadbf5cc09c9bc5760946054a0bfb28a0e3",
+                "select_by_single_document_sql_sha256": "57f8a72c07898ae81246b46b1be6dbfe3095a361c646446aa0e907ac26fda524",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -152303,8 +152303,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8cf4087f2b7c1bb3dd3bba2106ff4bcb7eeaa924503db637d207e107eab5a4c4",
-                "select_by_single_document_sql_sha256": "6f94802ac3d835e728fb03fa90822dd6abfb7cde6fd8f44a50f5f3eccd56843c",
+                "select_by_keyset_sql_sha256": "753c860c0e3d156a49fac2946afa8efe74e1f22a8ad45f145d93dc490e8bd70a",
+                "select_by_single_document_sql_sha256": "84dcafb0ad50e6dd2599ad34cfe14024f0b7f29cebd7d5191a3fde7a50c9437c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -154179,8 +154179,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f92687cbde4d61e50b1aba5bfb3dba6d313c71e298c084d54f737ad9dbc914df",
-                "select_by_single_document_sql_sha256": "215d351e0d6784306d3d44a9a65e9d6c26b487ec92a92ce5eab97224adfb8ef6",
+                "select_by_keyset_sql_sha256": "3e455fd811873be6e097b0d85eaa40d08f35d949e91aced687f23d58283b9467",
+                "select_by_single_document_sql_sha256": "f5e4b8c605e4a0595e0313a741106447de087f3c64a51a6a5f55d50b6c5eb269",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -156907,8 +156907,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2f741dcf9308c6fc345e7527c2149c1ecba72af3338a747e9bb9258a5ef7dd20",
-                "select_by_single_document_sql_sha256": "c2479cd91c75fbeb913f72fba5a8ef58c2b6b7c1688bd9207740f99be22c056f",
+                "select_by_keyset_sql_sha256": "6630f960929014baab86e0f3d533a001104e7e206095accdca6d221c04e2acf3",
+                "select_by_single_document_sql_sha256": "a77120ae9183c948558e6d929fa37814643f067bd2ee09c148f6e1db76efcab5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -158111,8 +158111,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d463b52e017b62a2be7a968be93c970354fd5bb4839275fd4b47bcefff31718e",
-                "select_by_single_document_sql_sha256": "aa41dabec5237d310ac6b6e00b8c2d03ec1922233b084f3c19facd3195b6e23d",
+                "select_by_keyset_sql_sha256": "22fb11cc51f27835c48e5bb7539961955dec3c1e3a4986784fcee313cd38a698",
+                "select_by_single_document_sql_sha256": "00a755604cfe5077cf60c7eff936cd7bf1299cccfeabc56350dec2199554475e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -159347,8 +159347,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bbd7ec63f6bb8aa1fe49cc76e7713e037fe8622bd62ee93c3c424c3a40c5f815",
-                "select_by_single_document_sql_sha256": "fdf1991bb8c3061e3911895d91aa5759852ea343c4864ae29f461fb865f59598",
+                "select_by_keyset_sql_sha256": "a795b7834e963d2d073acc48db716de4ae636c166506bf38dc6da0ec74b4aa0a",
+                "select_by_single_document_sql_sha256": "cf46398551eb2f34fd154f98f1567cfdb2d2a17e61a285e1ba9cd8953376bf10",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -160524,8 +160524,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a36c0e1d5c19accc38ee4a7cd7abbb08d0d8b97bba3c7554457a5c3f8ac0dd74",
-                "select_by_single_document_sql_sha256": "6b7bf3082c1c6abd451b9a8de329917a7532c0d58c3ef8cdcd3c5ded64d7d500",
+                "select_by_keyset_sql_sha256": "35adcdc9ef468b83ffc71afd41ebbe7902c2330eabc999334823b8a50dc0dea4",
+                "select_by_single_document_sql_sha256": "5133f05377209e9f7ef642b6310afc7550579c494cb09f526a642e5ba34d5ea9",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -164673,8 +164673,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e06c766dc4d2e83f186b1b55b22900598b3ec71d1cb50047179f87db336fc9e4",
-                "select_by_single_document_sql_sha256": "3dd9d236009b8fcbf1db8ac7db3d5201daf6db36714cecc8bf818c2b6b4a3511",
+                "select_by_keyset_sql_sha256": "51f6723ecac2f0c61f3eed460cd1e3e8e5ff8f78a9fba0c19f6a8189bef06034",
+                "select_by_single_document_sql_sha256": "61fbabd94fc8b70f5f6381138dc12800bae831a0cfa5693330411fc16cbba234",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -167895,8 +167895,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3b2db7d19d86d90c11d2b1bf192994ecd9b593f1b9e76772915e3edd45194e78",
-                "select_by_single_document_sql_sha256": "562e010257e88241970df76d2ca9b7c606dcf89a3357ece0f18c6c600495d8f0",
+                "select_by_keyset_sql_sha256": "1701a0b9be3ea108e96f81c781c432ea5611fa9ba7e6d24d1e1ba4c407fd21b3",
+                "select_by_single_document_sql_sha256": "a4d922b56b48e61a73ee5657606136029be91d3771fd7ecde397a2514daa116b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -168483,8 +168483,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "080bad20ddcc9e62739fd7b8fc739b470f0d6e41b1b3e3ecf152b973ba58592d",
-                "select_by_single_document_sql_sha256": "c077302b7de4f06213b25adbf86bdccc9bff5f8cb208fef82fe765b4fb31c1c6",
+                "select_by_keyset_sql_sha256": "82db74cd3278ec8f9cfe258f64102328263c776f35adc107a3ede86c1cf520dc",
+                "select_by_single_document_sql_sha256": "f352acedfe64b982c3251ab746d1fce4b5a3c29c6cc1a54a6776b21ff68403da",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -170352,8 +170352,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "831c96a0f3a4bca781ec9079068ff13020bcab848960d8427720fd58146c7b61",
-                "select_by_single_document_sql_sha256": "4feb68e84c774a956796b3f4a5ea98eea661a0d385b717418a398070cac5be70",
+                "select_by_keyset_sql_sha256": "3ab7d71e11227c695e93d73fd60622a43e75c36429bd4b0ef4cd8fecd6cea8c6",
+                "select_by_single_document_sql_sha256": "92e845d95ef6019a0b223f53e2118a8375fe5abc84885feba5378dd98eeffa7b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -173092,8 +173092,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ee0f6090b5e2780295487aeab72c7522fa12b436604449796b5871d0a69957ea",
-                "select_by_single_document_sql_sha256": "4238cbbf90e8d8b35cc54c911440a1b76b130337f0fea492d1208d50fa39e99f",
+                "select_by_keyset_sql_sha256": "f73f2c18df0720d1280f43c3fd0c0bc96ba8faccc3239d7c84766a90af55617e",
+                "select_by_single_document_sql_sha256": "ca121129ca86647a2caed26e19ca739b2edc943a3869d0aad66f6a1e9b9122f4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -175143,8 +175143,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "eeb63d622b2a225557cb953150d4974a46e3463951405be638caa68a30031886",
-                "select_by_single_document_sql_sha256": "e3ecfa0ad0de56590d9776f1ccff5518ffc57c2b1135b938d9a3b65785e3e9ef",
+                "select_by_keyset_sql_sha256": "a5f929dfbc316b48bd031f2dda7df6a47bd13c1a0cd4a551ddf5d71130028ce1",
+                "select_by_single_document_sql_sha256": "4a7f8d1f98e166c6e942e1599471ac40a4036633fb08e435fd1f40ff891b44b3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -175949,8 +175949,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "eecef2ae2b779b199fa89720677c1bf98ea58536852311f3fb844636b9aa1d57",
-                "select_by_single_document_sql_sha256": "7c53ea76937115eb15cb17b5f4f0f11ec88ea3b4096b68dea4c475f281ac3a08",
+                "select_by_keyset_sql_sha256": "fee02c2ee133546a420a22e14c2aee6777d20697d44e8dbe4355399304fed330",
+                "select_by_single_document_sql_sha256": "b716f7a84f8f13e55f58506e954b332565c2652f0bdb8f818c383b72110ae470",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -176566,8 +176566,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8a7f9a5b16414cacae0dc92a8844a33d79df009a5c4f010766efaf334acd7e3a",
-                "select_by_single_document_sql_sha256": "00d8b08342c4482194c2c8ecf80c133c978f10967eafb44a9eeb92e54d6f18ff",
+                "select_by_keyset_sql_sha256": "ab42a8a5d98e2ce292ad973a2bfc9e54e16c6de126c779358a6919f418933581",
+                "select_by_single_document_sql_sha256": "8388cb62be3bbf43e5a96eb701289a39c319f69c25b4475df9fa78f170bf33ed",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -179492,8 +179492,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c4bdbdd241f1323faed3e53cff3219fa09cbdbe14c9a9dece649ad0e97f3dcf0",
-                "select_by_single_document_sql_sha256": "321001e0539f953930dc243cfde01fd0fb2c90af3c640d0cfcb6b938769c651c",
+                "select_by_keyset_sql_sha256": "ea87e53d15945111e527e1427dfa280d1248df3b4bff29893d0c4e0761be83b8",
+                "select_by_single_document_sql_sha256": "d0ec92acc2a8af75e9b17cd2ab533b3dac4151698f8b8b572191ec5805868ea5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -182596,8 +182596,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e26084f16fddc1659047e5848f67fe4ac7e31c59973d45a1469e355a100a8290",
-                "select_by_single_document_sql_sha256": "24be8b13db16ac7179c7a97ed6ccc3cd4ed3fb26cc76ca7802a0c3fe76cc59a2",
+                "select_by_keyset_sql_sha256": "ef92ee3835eecf509bc5e81c01571ec92b53d85a17483a18f71c93e8e315233e",
+                "select_by_single_document_sql_sha256": "ee9b05e717ec7a5f1d8df0df1b47794ebd103b253ec1925b74e00323cdec5ae5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -184636,8 +184636,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "928998a0a4d4272f5798075257e8611d7a845a00243988e5db6c1b1553429964",
-                "select_by_single_document_sql_sha256": "362d705750765aa3a3d216a4d7196f9778bd43fbf37141e83c7647361c5579a7",
+                "select_by_keyset_sql_sha256": "79a7c35ac66f3faf8ac809571dbafc008d486637e6e8a8b87c5c80784c8513b7",
+                "select_by_single_document_sql_sha256": "f4c1513a166097c5c96d4995051e876ff14e8d8a9ab701940096db0eaabb8df2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -190023,8 +190023,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "64efaa7bcdb91a1b74dc3beeb56ac95dc220d4ba11329409a24bb10ec2a5dde1",
-                "select_by_single_document_sql_sha256": "891cc038057ecb3ad34c338693df34c6063daec61a25750e5c61f596536ff861",
+                "select_by_keyset_sql_sha256": "c39e00b63e677f65029ab3948699b373c8e301db3c057c926723e89ba861987b",
+                "select_by_single_document_sql_sha256": "4e846056ae08e843dbe83e4a6e66e6d178526d4e7058075f4242ce1c8cac098e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -191931,8 +191931,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cb1488a685db741673bd4c8f8d9a4c09d870cf5bb29d37395c45bca80ab34649",
-                "select_by_single_document_sql_sha256": "1d535aa7475123e2db3e4846d5f6d84a6ac806e5576a0d1fc30188b92279aefd",
+                "select_by_keyset_sql_sha256": "a5d949c9e06be0d738ceaa8abd16805e1f003ba797244c5abc075a58bd8f1ed7",
+                "select_by_single_document_sql_sha256": "1ed8b5719c4e006728529c2259e83439d057c3b9cc5737f089a25674bf32c115",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -192727,8 +192727,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2679e0d3eca2207eb8c12fe242ad5aa3661768a340f4e8a8372153de6ba95a21",
-                "select_by_single_document_sql_sha256": "03436a07b6557be7ca6cd3a5178fc4bc4291615a401fd358d0f361f57c6f61e1",
+                "select_by_keyset_sql_sha256": "11157630b9ee85baae51536b8eae2ff1e3a353c0e72f7b1638b3e186dafc4c7a",
+                "select_by_single_document_sql_sha256": "40bfb58ff93a51e03c72cde297ac833aae60684c48a5c6a5ee46f2391e2592ab",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -193201,8 +193201,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e478c57f45f20c4a8800d482dcf0b3167cb42644b3a7a0f8780e49255b998a27",
-                "select_by_single_document_sql_sha256": "887e1911d001b32d57fc11614e9b08cb29c4224e3a268f3079e1cc1ee367c728",
+                "select_by_keyset_sql_sha256": "59968fb086aecaa3aba53353e27fec2b2193a015c3cecb7b76c2b92c49739cb8",
+                "select_by_single_document_sql_sha256": "859bb5946a64d4497e057aee5d1ab705cd2bd844664bd3be4f63739d3a618844",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -196843,8 +196843,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ec1600944a415712ba3a20276c4df3e90344a635e61d4862a3fd54e158154f90",
-                "select_by_single_document_sql_sha256": "028a84bd53184b7fb3fe574451a6efeea30ca1478d845ff04f5079c4c44919e1",
+                "select_by_keyset_sql_sha256": "c729d103867d56b086bbd145c9bbd89fcc58ac0f348a9d7d1313968d5050cc77",
+                "select_by_single_document_sql_sha256": "8f6ac5afa8f4540bf3b49417ac33d93a049c4abf921fee9a9c4d6a7bafb3212f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -198011,8 +198011,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "831f0fcfbed7196e8bea7c772c53f439e614a115acd1e16c23b90de7fd2ee67a",
-                "select_by_single_document_sql_sha256": "51cc9810b0ac1f4ba5a96eee979f4f855770df3763f8ca6ff6061f5093e1df2d",
+                "select_by_keyset_sql_sha256": "a548191445ef6040323faa960fc524c7991a3d809ac49630b7358973619db7ec",
+                "select_by_single_document_sql_sha256": "18424c34c176fe7f5cde5d2ff9c36c277f7c896b979dd07832bf316977221812",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -199949,8 +199949,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "043f7a4a4a5eeb39887dfc65da19acdbd6e026147eaf8945d6be8d65dbfdde4f",
-                "select_by_single_document_sql_sha256": "7ba4994666ffaf3f885fec01342f2c4868fdc92bdcfa6a3b1f033dc481f2cc50",
+                "select_by_keyset_sql_sha256": "71921fa31c374375b3e49972da38991650a454ba7356041f494caf39872f3563",
+                "select_by_single_document_sql_sha256": "0bdf20b603a6af5e1a33131889a15b4776c071402ea46193ac6ab4528b5fa778",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -201884,8 +201884,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "57a9eca05a8cf28f05e2823e718af3b4c23f50cde45720277c4d1cefe70f238a",
-                "select_by_single_document_sql_sha256": "fc6fbb8541a60e7c46de8850ac083e2096e6a58d24601e0ef4f5627cc6ac04b1",
+                "select_by_keyset_sql_sha256": "e8debefc1ae64dc347a9733fc897c8d57c5a50f5264d0aedd7618adc7a616a4b",
+                "select_by_single_document_sql_sha256": "44a855b428bcc8b9a067b7b5bdbdb31c231542a4fb18cf043bab6ae47584421f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -203414,8 +203414,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "120582e06667726ad3333deea42d5609a16ae1720592aacf8c675c5039c6eb0c",
-                "select_by_single_document_sql_sha256": "0ea77cbba3a5e8dad63fc450488c2d28a92799ba1bef51aa833697b98638a72e",
+                "select_by_keyset_sql_sha256": "177b897742188a9745beed68ad2580d14480140cf28a7a69b9b8a1bd1abe3533",
+                "select_by_single_document_sql_sha256": "cdf52bf4afd8311de3e99c62cf2039bb5f1de0e00550c63684935393fccb5382",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -204727,8 +204727,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ae4939f77ed17a94817fd95af4073f66646a3aa49dfd9ecd99546a333a970aed",
-                "select_by_single_document_sql_sha256": "fafca9bf24c515b1e19284e440ed337fc15f43fd56b0571894673db2ac522c91",
+                "select_by_keyset_sql_sha256": "e123b08f79d5093328ba6e1c70308fe4bc2e03ba917ea34b6f533506c46cbb63",
+                "select_by_single_document_sql_sha256": "fed980bcf1d2bd434e9759ca70618422053d388535986bc7980b1ab5ee378540",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -206348,8 +206348,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c41c5872d7ecaf82d0f278cf5427c01d1fd4bafe7517959e17f63eb41fdf53d4",
-                "select_by_single_document_sql_sha256": "2fbcdc447fff3cca1b6bb4550b2d42cc99ab9d53230f4e57c6c35a7cc1d26498",
+                "select_by_keyset_sql_sha256": "cddc5f9c8ffcb6abc30836b8b780f34ccc6773b3fc31880953bcf7196ed891e8",
+                "select_by_single_document_sql_sha256": "2c37df0dfcfa8c95c7dde5745b2ca3ee16645581ae554d8f4247c4d987453e77",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -210868,8 +210868,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "198a2c69637bee7daf8505e9480c608a758ca69f66901179f2537d85a9b7f8cc",
-                "select_by_single_document_sql_sha256": "ce6915bab16e7f0bd7ebec65ca81526ff29f80e9bd086cf24c31cc030f2ae94c",
+                "select_by_keyset_sql_sha256": "7acbc52c69ddb3ae10a294d1dc87dc817d55489c25676f31454c4829e8317b2d",
+                "select_by_single_document_sql_sha256": "a1c0b6644e7f11622e1bf2e1bef70ca606d2ac8952467dfcfa81f6a988e80903",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -211989,8 +211989,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3d9a84ac8c98233f29a9a7c2b26e8bf2707d2fc99ce42243c262241cfb1b55b8",
-                "select_by_single_document_sql_sha256": "94b82532709d34a58e9e2e2e2e9b6f7846689f7004469fd6597234fd6b387020",
+                "select_by_keyset_sql_sha256": "2387f7f91cfdbb90eaa1f80baf0224cba480b388941eff858dfb234def6cfbd2",
+                "select_by_single_document_sql_sha256": "6c0554481e0a016f85d89a6f7a3ed1b17a7b0948de6b8f70af2434d91e5bd060",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -213453,8 +213453,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2c7b054da0a1d0f6457d41a097205091aa23d2d45a512780f17bedd5806bad6a",
-                "select_by_single_document_sql_sha256": "4e67ac23654fa5198913bb69a58214a0037667fb21cd6167be36b2cd556fc061",
+                "select_by_keyset_sql_sha256": "b2f99ddd608d7745f8d645e9b8adabf77bf01bc51956703b140353fb53ec1b2d",
+                "select_by_single_document_sql_sha256": "80f8610ceb3a7acb8aaa48023cadab76a3549f6fa5b4d871165451f2711ecffe",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -214154,8 +214154,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ad313a4d862599b90ed2f1a2f80c809d4370f7ace35e475b2369ceb3db7257e5",
-                "select_by_single_document_sql_sha256": "e7ebda46e99d471bd9e60eb9c086609295f8e449809651ba73c6e5fb5e6e544f",
+                "select_by_keyset_sql_sha256": "c885313f8314a4b9208e915479b977d5fa562e4458e0f2f8994cb8053bce55a8",
+                "select_by_single_document_sql_sha256": "b9cd1b77cfd3e18445d3a0ef0f35bded326c1a66a54fe392914bc97430594866",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -214541,8 +214541,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5f948426194dda8587ba2c6802f9aa8611c6967e95d90a88f5cff78e29b2e56d",
-                "select_by_single_document_sql_sha256": "6711489b1fe902e209c3295722201c24d166d75f6b779b0d09018b9a1b510d76",
+                "select_by_keyset_sql_sha256": "5e4b0df10b28172575cc97df5211afd37d5ef060d5e611fd34d8c0baa2c375f0",
+                "select_by_single_document_sql_sha256": "f3369a80c76f960d444c8b6907f396d83ab6bae79acdbad717ced2c4c8d6e691",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -215441,8 +215441,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "158cea9db36736a996533ad84519696af12e4aa035a1ac18cab1f02e703a00b5",
-                "select_by_single_document_sql_sha256": "0978b7d00aa030bbe39e4a890523fe838d8eac44fe924f5173fc987d37cba785",
+                "select_by_keyset_sql_sha256": "e820012a6cc9bae424f2e12f8f3553301cf1c269347166ee9c893ebf364b3b06",
+                "select_by_single_document_sql_sha256": "3a10b623c0710b819e85e74ee27bfa0d966b48c5c3e7f1db96463f274736b640",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -216320,8 +216320,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5782324de47f0e13fc7f110831f841c4fa5b2787fe42be74f9a197f1c55909ad",
-                "select_by_single_document_sql_sha256": "d2c8aa4f785e7735aed9e26f2be348790fd471ec61d096183e5514e783d34a47",
+                "select_by_keyset_sql_sha256": "3eff92fb021d3661e3101a76cd8135db92b4db1b70b691241eb5592734af32ae",
+                "select_by_single_document_sql_sha256": "84bd82810ce4d59f1e341fc115c062dce4196c067322de0f39e297995c430161",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -217172,8 +217172,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05de2823ea37eb3e49b9b162ed6e8b06b44d852a81fc659077f1f1121e33b70e",
-                "select_by_single_document_sql_sha256": "e6e8908cde902095ffcfdb5251801a0ccc5bf9488541a6b891e35602c7a520e6",
+                "select_by_keyset_sql_sha256": "98a30a0ff5ff01492640ef722e621938311d41230fa367ea81e19f8b383477bb",
+                "select_by_single_document_sql_sha256": "c0f1b123716f5fcfb8ac081281cf44cce90201e05be360207428af20ea561cf3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -217957,8 +217957,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0366c0f49c04647fcab738d03fc7a4be5fb41c74d50978d7822fe342099d847d",
-                "select_by_single_document_sql_sha256": "4cca6347b2d4ea4a0892563a09eaf9be9ad75d0a024842eb701881654d1dd6df",
+                "select_by_keyset_sql_sha256": "c5cbebd1baa14c5daf57eb05e1b84417e857239171a9eb4e7c5c52e440747eb3",
+                "select_by_single_document_sql_sha256": "3387a599d2fd9869f782bf54e2bd820311d90fda9bc189ae9aae3d7da3ae6383",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -218431,8 +218431,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b45fd4140cb5ab65a19c2811c39bf9bfa9f31a0df4a3369939af021d75a5c818",
-                "select_by_single_document_sql_sha256": "250a25b369077b9476356e4672f2cc0494f143b6126614d67aaf60f3ff017b8d",
+                "select_by_keyset_sql_sha256": "2fb798036b01977dfb098ac113836fb5f45accf44c5e571fd66f14b2477e143d",
+                "select_by_single_document_sql_sha256": "3e0b3ffb7ff6a86963576c7e8d374decfbc0bb1759ed8b0c31d111ec967f992b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -219702,8 +219702,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "55dac8ac075f20ed8bb1c6ab3dda7e165bcd3122e8033de6ab280802fa9c524e",
-                "select_by_single_document_sql_sha256": "e7c7c83f4cbc0b34376964ecd36aafcb1c24a821df68c2900751200e9710b361",
+                "select_by_keyset_sql_sha256": "70c54df9bc680e26b8660835569635d73338fbb4d50de5eae61e95ff3f4dc061",
+                "select_by_single_document_sql_sha256": "cd84c4653e6727084c7e6e7752a4843db5021483e26af3a315227017b1f4f877",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -220976,8 +220976,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "dcc34842a6b29ba0438c32afa6a1cf9bfce0a751b547e56ae7b00283618589d3",
-                "select_by_single_document_sql_sha256": "bc54f5e293d1d83a077c9b5cb505c1cad684f19ae29f6c03ab72bc4af10664e4",
+                "select_by_keyset_sql_sha256": "f9c831299b9f9632627d7becbbb04885664a8bd1be37eb78445903a6dfb3a5e9",
+                "select_by_single_document_sql_sha256": "9fd0cf0a14c574aa880ffca0d1a0725bd99a2745bd3f9924f1507a7a36ba812d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -221753,8 +221753,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3b42ae5fa3c1f9bcc7a0ec7102bfec41e6f87340429263b8af1ee586df942c46",
-                "select_by_single_document_sql_sha256": "5479ebad7147ad8e0337c120744db5c9970f64c9a9ed07fc83dbdaef1e5fe03d",
+                "select_by_keyset_sql_sha256": "7b03411cc97ee65eb6c03e841d7e83eea4ba42549eb9f4fcd4be9ea3c1504505",
+                "select_by_single_document_sql_sha256": "456d602979e975764eb7ee25deba2792a3ed71f35748475f0ad67d93b2713aee",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -222477,8 +222477,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "54ba1c2f05b44f58d6d297242e605cb77a9e42ba9024fb7b7997e93cde08c1b8",
-                "select_by_single_document_sql_sha256": "2a7c04097f30a5767ff17c9e384e7984a2489018e35112c0df5827d88865c2dd",
+                "select_by_keyset_sql_sha256": "210a3fa24c338ea95b9a40931ba9b2a7a444ef44d6060ababc2ad8b52efd7bef",
+                "select_by_single_document_sql_sha256": "35df3ed6f15bc2886ecd99eb1d0058f803e99f62346604e9c67a3b848340e5b1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -223126,8 +223126,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "58fdfa43d58ae2db8beccf437a3f9616d19efdb952af46108edb5d2d7dc76ad0",
-                "select_by_single_document_sql_sha256": "37b30a3ba0cfd4915313ee78b9d99ac7dd01da9489cd3b19576902b1f9882b5c",
+                "select_by_keyset_sql_sha256": "e5b460b286df8241c48ae56774282f113f6967b2b5b1394ca5040260a26fdf26",
+                "select_by_single_document_sql_sha256": "40969387298c5637baaca45e8d115c37309a871edee08592653c58f79917f00f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -223919,8 +223919,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a0a119d3845609dc423e10869d9b12de3e755c7b93481d5347117b1450159057",
-                "select_by_single_document_sql_sha256": "b2445698357adb54caf8ff88c30ea047b616019352dc8df308def4fdd854fa27",
+                "select_by_keyset_sql_sha256": "baef18e7864dba358b7159c3e01a55b4d9c8f407cfe90fbbaf78bfeae61f3942",
+                "select_by_single_document_sql_sha256": "b83be138e0774df555e4d6c911e73035111370897859c00b7986f9935643cfd4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -224659,8 +224659,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33fa5189b575c2ffc780abcd630756b6b0f38b93288d8756fb53f4105f5cc2b6",
-                "select_by_single_document_sql_sha256": "d2018040454a1e824e85420956bbb4f0a87d210515fbff62872945decf9f02a3",
+                "select_by_keyset_sql_sha256": "5f432e9c07ebb5973da517defa6f07a32688cbd8a45b705daef5ee6fd207b3cc",
+                "select_by_single_document_sql_sha256": "233e87d6d9a764568d22fa8526b8a8412a1e8c1255fb7381789d29e9e2913deb",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226091,8 +226091,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "de439f8260f279ebaddee616e873c2a7d9d6251eda820400971a4dc6faba35b9",
-                "select_by_single_document_sql_sha256": "b11b1b747e4d20df9edaf64634bbf8b88a36cf7000be8dbde4ff89140f1839ef",
+                "select_by_keyset_sql_sha256": "723fdc36dd90ea451d35c39848801d27db9e71de52926d1306cf56b71dd71416",
+                "select_by_single_document_sql_sha256": "ee398f521b2bff66e48af05170fe3cd02e49a18b871852b332f6cc59e60a6458",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226886,8 +226886,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "26f53add54f9a745d03435ea393f3fd5b9576a88df4fc7372a10d24c013844bc",
-                "select_by_single_document_sql_sha256": "e782ed5431f0d2835dbc109d2a2cde9a933ceac3b2f174cc64d22546343ecb37",
+                "select_by_keyset_sql_sha256": "08f7cc83b7814afa94e15721e81c7e664d991d8cc5e0afd94d7679f9c9f9c0ef",
+                "select_by_single_document_sql_sha256": "1b7ae248f9885c465cd3ab05677b7629ab86a5d3f25ce1a1820db2e5c6a41048",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -227743,8 +227743,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2eb097ede19e2729ce9bf5a578aa20c4025ef126d737f1dfccc1b832f0574bac",
-                "select_by_single_document_sql_sha256": "ffc0e74a9d4c1d90d26b55bb1f13c9629c545b124d05eabecf1711fbdf11d19e",
+                "select_by_keyset_sql_sha256": "51a4c0b2705c6a6dd9b4635e9d4206431335d386c8327626f7b4e758787cee11",
+                "select_by_single_document_sql_sha256": "fb4f15741595da8499f62c8333308db318419b6355c271191a508d864d9e0b23",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -228351,8 +228351,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "095cb0c18616ae8681bcc070ae4d65f08757391a1717ab85646ed9d043bebe2b",
-                "select_by_single_document_sql_sha256": "cd9af4e2f5976847fb0c57fb344d35629daf4c851587fa1587e56e4504365fd2",
+                "select_by_keyset_sql_sha256": "f66afff1b1398e068d9deeba7538bad5a5f4bd15d97d5443fcda2944b58d976d",
+                "select_by_single_document_sql_sha256": "b852ad8991ac1aff27b0cc6a7ca5d177c170c7880d21f86ba7fac6beae8b5967",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/ds-5.2/expected/mappingset.manifest.json
@@ -120464,8 +120464,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51f2478482de4aefbd58d5cec3e4a4b69fff672f89b386726aaeb5d163418274",
-                "select_by_single_document_sql_sha256": "061e5e4a07a55aa957aa064c35840082f77b921370b667a6be7e92abb2bf726f",
+                "select_by_keyset_sql_sha256": "f39360e27cd8ae3604263bbdb22cab2166012f7541b0159e8f1b59a50662b44f",
+                "select_by_single_document_sql_sha256": "a6adf4cc94244993f6cce3f66c0cba29972954c0bf90603c60872277d3f9993d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -127854,8 +127854,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51fa3b414ae6a106807924ac8d4ce485113ffb99058eaf37c3513e87966603a7",
-                "select_by_single_document_sql_sha256": "baf677ac9eeddcd19ae6b42b86c02331bbcdf3ad3a6122c04b9bc3bd3a7e65ef",
+                "select_by_keyset_sql_sha256": "17e8ef3129339d54eb0d49607c02e86ae3e8f4c688fc1440bda837875d9107b4",
+                "select_by_single_document_sql_sha256": "897706172ad3d8132e8e7786bc6f22258934eca80532316f1f003de757f77139",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -129497,8 +129497,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "243748542ee50d0cea4f99cf257bdcb413e3888e76c3e17dd0f6d9cea3b94d09",
-                "select_by_single_document_sql_sha256": "daf110933cb950cd3f20796d1c682b807053f42ef599f4b63244e138b763fe61",
+                "select_by_keyset_sql_sha256": "3f82bc02404955b59d6d383ec842371a61f5ddce0d3cc728b23f7ee1786d28ef",
+                "select_by_single_document_sql_sha256": "391fa1e423c91829981178c132d571486a163d7b44404eafd2bc5ab9ff8e8fff",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -131111,8 +131111,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b3f5c167787e3e0826d2b45a35d58ed1a2e1d568ceffd111b7a03b4844da7829",
-                "select_by_single_document_sql_sha256": "321f939510d6dd1a472fc4eb08e37eef5bd8b5d7c599a70b5936b2c7df7b5dd0",
+                "select_by_keyset_sql_sha256": "6a57305308773f8bd3abc382f0fbdeb5128dc0a16aaf39580f2efa4fae6a4ba1",
+                "select_by_single_document_sql_sha256": "293f19dfcd4bf3aa997cf07835c7c6d0badcdee7a3a2f7e50a899e73b4e6cab9",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -131665,8 +131665,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "9113bacf3302224ffb890b71903b52ca374a1a8b5dc3758a99fb1f545e8e4ec8",
-                "select_by_single_document_sql_sha256": "b67683e6def69db8459428589a6e7d6d0f3056a5b9c916b8e41a1d179de312d1",
+                "select_by_keyset_sql_sha256": "fd1b1302ff15175576fc878fc4090e4a726da7baef5d043006cb1c2a141f984f",
+                "select_by_single_document_sql_sha256": "c77d4ab8ffea0d8bb9fbad96b232819d815ef2e3a757cb839ea2f44c6b0f3535",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -133848,8 +133848,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "48f274ce2c741bc9d4f46760f54c85be966dd0fcfe68fa342d9c7a6f259bbbad",
-                "select_by_single_document_sql_sha256": "4adeb5808449e7fddca150f4848c0a9df4961bc6fb89ce39f5fc1c9733c26a5b",
+                "select_by_keyset_sql_sha256": "e576c13f70ffc7060fadb02c1ac85ad7bdc93923c60f248f706715b9d25667d7",
+                "select_by_single_document_sql_sha256": "23a500af182f578ac6429dcae16df9c4627976092132cf3be9a69bc470850c01",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -135539,8 +135539,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7669597d42903d88b67d3626e406877a73d99e4bf94fd3978736b1ff3b9f20ce",
-                "select_by_single_document_sql_sha256": "ae5e95b6007177697e9952d0335b61e980ab007f6c9434df8bbde9e118fec632",
+                "select_by_keyset_sql_sha256": "ab59464dac840fe20120b98f11ab7a4f740f06a0b826ef76f5b6048961b40698",
+                "select_by_single_document_sql_sha256": "9a611932ebde7064b7cee648bb258c297c09fa2f4aa428c43f67ca9791ea3e83",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -138532,8 +138532,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e44d3aaf281d296069372e56b7bcb2b9256eaae75fd2ab44cad14425596ec614",
-                "select_by_single_document_sql_sha256": "1d32d3decb67d897327d43aafd0f2dcd3e6450283654ce2548951e615f515114",
+                "select_by_keyset_sql_sha256": "6f3a37ca8c808cefaa61cd897b65aa18710093af74930a55bc82fcd3d8c1375b",
+                "select_by_single_document_sql_sha256": "7cbc1dd7ff123cb83f7db8a226201fb1598bed11a33748cf10046bf81d2bbad2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139437,8 +139437,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fdf6ad1d9a8ca642444568311d08a3a76a46b93fff9b6b895cf45860b12805e1",
-                "select_by_single_document_sql_sha256": "c2af2c1fdfb594a6677e4c3d63ff3545724ea96856b3876fdea7f54541898e5f",
+                "select_by_keyset_sql_sha256": "4654c6f46919da92cc5c43aeba63ff6d5b42a71c50e59802df91c9e45403c963",
+                "select_by_single_document_sql_sha256": "5aaa655f39db805b93ac72fe2973deb6fb351479a66e63dbdb2f6ee9ed8270d5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -142683,8 +142683,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "93e995147ffeebb599b7c7eba34d09ac2d99ccc5cbfe2331ba6968f186a307d6",
-                "select_by_single_document_sql_sha256": "c87cff1f978b33858f0aa3b51765a43c6734325c700cc650a2604890390163f5",
+                "select_by_keyset_sql_sha256": "33e58c9554ff95d9dca7251e0662b6ab601228f810d40bd4e68751584040c441",
+                "select_by_single_document_sql_sha256": "bcabf740b8151c8e1b788e6923796493632387f824522e73ee48743f5d688adc",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -144153,8 +144153,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "312c48c3eb3bb85ed69430b94e9e765dfc7b6e7d5f13b569827149e7aa854bd5",
-                "select_by_single_document_sql_sha256": "41da8595a7516b485b5cc3c74aaddd86a43f6f22dd76e53e658107b69216ca38",
+                "select_by_keyset_sql_sha256": "63f9fc6b9f8ceec5de78b520ca0d99c5333f10cc03808aa565f7d8124e2e590e",
+                "select_by_single_document_sql_sha256": "9c51d1806735a5698dea2cbcb107285b3e9d34bccd4ed6683c276e1c181a82a7",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -146192,8 +146192,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b68aa07dcab202642f27fef361952d780f765e90416e9c48fd3de913e9135c5a",
-                "select_by_single_document_sql_sha256": "11cce6fa41604d938e7d5303f5125a45ed677ab9f406509579752512bf60da60",
+                "select_by_keyset_sql_sha256": "dd216b84d6c239253c405e162690e7b2020b64bbe592b9c29535fa5328d75932",
+                "select_by_single_document_sql_sha256": "6da9eef1e8eaaca5760eccec0017571c536cee151d64fa2e0740bdb616dfdc2b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148257,8 +148257,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3510f8eb93b6357fff8ff83b05ce598c00a6e054609400b7441248e4753214d0",
-                "select_by_single_document_sql_sha256": "e572734b8178d10ec60caca1bd1f4cdd3d516ac836805de32823ce56e7c75b7e",
+                "select_by_keyset_sql_sha256": "ac936c4c15c2a841607648ba4bff107d2a3f1c82ac2727026ef9066ea34c3487",
+                "select_by_single_document_sql_sha256": "fb62880678fe134ec036429012796b4e06b8fe809a41bfc4436304c5f4e19a58",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -149443,8 +149443,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a471dadc1c3eb8ab8b6564b298b293692b96945bd0207e1a7bf574106cfcef33",
-                "select_by_single_document_sql_sha256": "74c44a4d2ee676569c031d02cad16bd6661cd7291beb8504effa510713dda32b",
+                "select_by_keyset_sql_sha256": "d73f6edd1f02983c122f4edf24f5c017f7a2cedf0137237ed5cfd916dac0b72c",
+                "select_by_single_document_sql_sha256": "9b53c26542917dd0df74b087622f96526e3bda0c89dcb399d474fb0d530626d4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -151261,8 +151261,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "664725560b89f8b1e63eed9175a12eadbf5cc09c9bc5760946054a0bfb28a0e3",
-                "select_by_single_document_sql_sha256": "57f8a72c07898ae81246b46b1be6dbfe3095a361c646446aa0e907ac26fda524",
+                "select_by_keyset_sql_sha256": "e44c81078b7b1b25e36d2ef300014faf3641c43148d4454e5dd15800d5af1d7e",
+                "select_by_single_document_sql_sha256": "ef946fa16c0bad24f1091427d9284f44bc05ca7505042baf66d6319ed9807a74",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -152303,8 +152303,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "753c860c0e3d156a49fac2946afa8efe74e1f22a8ad45f145d93dc490e8bd70a",
-                "select_by_single_document_sql_sha256": "84dcafb0ad50e6dd2599ad34cfe14024f0b7f29cebd7d5191a3fde7a50c9437c",
+                "select_by_keyset_sql_sha256": "8cf4087f2b7c1bb3dd3bba2106ff4bcb7eeaa924503db637d207e107eab5a4c4",
+                "select_by_single_document_sql_sha256": "6f94802ac3d835e728fb03fa90822dd6abfb7cde6fd8f44a50f5f3eccd56843c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -154179,8 +154179,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3e455fd811873be6e097b0d85eaa40d08f35d949e91aced687f23d58283b9467",
-                "select_by_single_document_sql_sha256": "f5e4b8c605e4a0595e0313a741106447de087f3c64a51a6a5f55d50b6c5eb269",
+                "select_by_keyset_sql_sha256": "f92687cbde4d61e50b1aba5bfb3dba6d313c71e298c084d54f737ad9dbc914df",
+                "select_by_single_document_sql_sha256": "215d351e0d6784306d3d44a9a65e9d6c26b487ec92a92ce5eab97224adfb8ef6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -156907,8 +156907,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6630f960929014baab86e0f3d533a001104e7e206095accdca6d221c04e2acf3",
-                "select_by_single_document_sql_sha256": "a77120ae9183c948558e6d929fa37814643f067bd2ee09c148f6e1db76efcab5",
+                "select_by_keyset_sql_sha256": "2f741dcf9308c6fc345e7527c2149c1ecba72af3338a747e9bb9258a5ef7dd20",
+                "select_by_single_document_sql_sha256": "c2479cd91c75fbeb913f72fba5a8ef58c2b6b7c1688bd9207740f99be22c056f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -158111,8 +158111,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "22fb11cc51f27835c48e5bb7539961955dec3c1e3a4986784fcee313cd38a698",
-                "select_by_single_document_sql_sha256": "00a755604cfe5077cf60c7eff936cd7bf1299cccfeabc56350dec2199554475e",
+                "select_by_keyset_sql_sha256": "d463b52e017b62a2be7a968be93c970354fd5bb4839275fd4b47bcefff31718e",
+                "select_by_single_document_sql_sha256": "aa41dabec5237d310ac6b6e00b8c2d03ec1922233b084f3c19facd3195b6e23d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -159347,8 +159347,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a795b7834e963d2d073acc48db716de4ae636c166506bf38dc6da0ec74b4aa0a",
-                "select_by_single_document_sql_sha256": "cf46398551eb2f34fd154f98f1567cfdb2d2a17e61a285e1ba9cd8953376bf10",
+                "select_by_keyset_sql_sha256": "bbd7ec63f6bb8aa1fe49cc76e7713e037fe8622bd62ee93c3c424c3a40c5f815",
+                "select_by_single_document_sql_sha256": "fdf1991bb8c3061e3911895d91aa5759852ea343c4864ae29f461fb865f59598",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -160524,8 +160524,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "35adcdc9ef468b83ffc71afd41ebbe7902c2330eabc999334823b8a50dc0dea4",
-                "select_by_single_document_sql_sha256": "5133f05377209e9f7ef642b6310afc7550579c494cb09f526a642e5ba34d5ea9",
+                "select_by_keyset_sql_sha256": "a36c0e1d5c19accc38ee4a7cd7abbb08d0d8b97bba3c7554457a5c3f8ac0dd74",
+                "select_by_single_document_sql_sha256": "6b7bf3082c1c6abd451b9a8de329917a7532c0d58c3ef8cdcd3c5ded64d7d500",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -164673,8 +164673,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51f6723ecac2f0c61f3eed460cd1e3e8e5ff8f78a9fba0c19f6a8189bef06034",
-                "select_by_single_document_sql_sha256": "61fbabd94fc8b70f5f6381138dc12800bae831a0cfa5693330411fc16cbba234",
+                "select_by_keyset_sql_sha256": "e06c766dc4d2e83f186b1b55b22900598b3ec71d1cb50047179f87db336fc9e4",
+                "select_by_single_document_sql_sha256": "3dd9d236009b8fcbf1db8ac7db3d5201daf6db36714cecc8bf818c2b6b4a3511",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -167895,8 +167895,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1701a0b9be3ea108e96f81c781c432ea5611fa9ba7e6d24d1e1ba4c407fd21b3",
-                "select_by_single_document_sql_sha256": "a4d922b56b48e61a73ee5657606136029be91d3771fd7ecde397a2514daa116b",
+                "select_by_keyset_sql_sha256": "3b2db7d19d86d90c11d2b1bf192994ecd9b593f1b9e76772915e3edd45194e78",
+                "select_by_single_document_sql_sha256": "562e010257e88241970df76d2ca9b7c606dcf89a3357ece0f18c6c600495d8f0",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -168483,8 +168483,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "82db74cd3278ec8f9cfe258f64102328263c776f35adc107a3ede86c1cf520dc",
-                "select_by_single_document_sql_sha256": "f352acedfe64b982c3251ab746d1fce4b5a3c29c6cc1a54a6776b21ff68403da",
+                "select_by_keyset_sql_sha256": "080bad20ddcc9e62739fd7b8fc739b470f0d6e41b1b3e3ecf152b973ba58592d",
+                "select_by_single_document_sql_sha256": "c077302b7de4f06213b25adbf86bdccc9bff5f8cb208fef82fe765b4fb31c1c6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -170352,8 +170352,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3ab7d71e11227c695e93d73fd60622a43e75c36429bd4b0ef4cd8fecd6cea8c6",
-                "select_by_single_document_sql_sha256": "92e845d95ef6019a0b223f53e2118a8375fe5abc84885feba5378dd98eeffa7b",
+                "select_by_keyset_sql_sha256": "831c96a0f3a4bca781ec9079068ff13020bcab848960d8427720fd58146c7b61",
+                "select_by_single_document_sql_sha256": "4feb68e84c774a956796b3f4a5ea98eea661a0d385b717418a398070cac5be70",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -173092,8 +173092,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f73f2c18df0720d1280f43c3fd0c0bc96ba8faccc3239d7c84766a90af55617e",
-                "select_by_single_document_sql_sha256": "ca121129ca86647a2caed26e19ca739b2edc943a3869d0aad66f6a1e9b9122f4",
+                "select_by_keyset_sql_sha256": "ee0f6090b5e2780295487aeab72c7522fa12b436604449796b5871d0a69957ea",
+                "select_by_single_document_sql_sha256": "4238cbbf90e8d8b35cc54c911440a1b76b130337f0fea492d1208d50fa39e99f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -175143,8 +175143,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5f929dfbc316b48bd031f2dda7df6a47bd13c1a0cd4a551ddf5d71130028ce1",
-                "select_by_single_document_sql_sha256": "4a7f8d1f98e166c6e942e1599471ac40a4036633fb08e435fd1f40ff891b44b3",
+                "select_by_keyset_sql_sha256": "eeb63d622b2a225557cb953150d4974a46e3463951405be638caa68a30031886",
+                "select_by_single_document_sql_sha256": "e3ecfa0ad0de56590d9776f1ccff5518ffc57c2b1135b938d9a3b65785e3e9ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -175949,8 +175949,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fee02c2ee133546a420a22e14c2aee6777d20697d44e8dbe4355399304fed330",
-                "select_by_single_document_sql_sha256": "b716f7a84f8f13e55f58506e954b332565c2652f0bdb8f818c383b72110ae470",
+                "select_by_keyset_sql_sha256": "eecef2ae2b779b199fa89720677c1bf98ea58536852311f3fb844636b9aa1d57",
+                "select_by_single_document_sql_sha256": "7c53ea76937115eb15cb17b5f4f0f11ec88ea3b4096b68dea4c475f281ac3a08",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -176566,8 +176566,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ab42a8a5d98e2ce292ad973a2bfc9e54e16c6de126c779358a6919f418933581",
-                "select_by_single_document_sql_sha256": "8388cb62be3bbf43e5a96eb701289a39c319f69c25b4475df9fa78f170bf33ed",
+                "select_by_keyset_sql_sha256": "8a7f9a5b16414cacae0dc92a8844a33d79df009a5c4f010766efaf334acd7e3a",
+                "select_by_single_document_sql_sha256": "00d8b08342c4482194c2c8ecf80c133c978f10967eafb44a9eeb92e54d6f18ff",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -179492,8 +179492,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ea87e53d15945111e527e1427dfa280d1248df3b4bff29893d0c4e0761be83b8",
-                "select_by_single_document_sql_sha256": "d0ec92acc2a8af75e9b17cd2ab533b3dac4151698f8b8b572191ec5805868ea5",
+                "select_by_keyset_sql_sha256": "c4bdbdd241f1323faed3e53cff3219fa09cbdbe14c9a9dece649ad0e97f3dcf0",
+                "select_by_single_document_sql_sha256": "321001e0539f953930dc243cfde01fd0fb2c90af3c640d0cfcb6b938769c651c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -182596,8 +182596,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ef92ee3835eecf509bc5e81c01571ec92b53d85a17483a18f71c93e8e315233e",
-                "select_by_single_document_sql_sha256": "ee9b05e717ec7a5f1d8df0df1b47794ebd103b253ec1925b74e00323cdec5ae5",
+                "select_by_keyset_sql_sha256": "e26084f16fddc1659047e5848f67fe4ac7e31c59973d45a1469e355a100a8290",
+                "select_by_single_document_sql_sha256": "24be8b13db16ac7179c7a97ed6ccc3cd4ed3fb26cc76ca7802a0c3fe76cc59a2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -184636,8 +184636,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "79a7c35ac66f3faf8ac809571dbafc008d486637e6e8a8b87c5c80784c8513b7",
-                "select_by_single_document_sql_sha256": "f4c1513a166097c5c96d4995051e876ff14e8d8a9ab701940096db0eaabb8df2",
+                "select_by_keyset_sql_sha256": "928998a0a4d4272f5798075257e8611d7a845a00243988e5db6c1b1553429964",
+                "select_by_single_document_sql_sha256": "362d705750765aa3a3d216a4d7196f9778bd43fbf37141e83c7647361c5579a7",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -190023,8 +190023,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c39e00b63e677f65029ab3948699b373c8e301db3c057c926723e89ba861987b",
-                "select_by_single_document_sql_sha256": "4e846056ae08e843dbe83e4a6e66e6d178526d4e7058075f4242ce1c8cac098e",
+                "select_by_keyset_sql_sha256": "64efaa7bcdb91a1b74dc3beeb56ac95dc220d4ba11329409a24bb10ec2a5dde1",
+                "select_by_single_document_sql_sha256": "891cc038057ecb3ad34c338693df34c6063daec61a25750e5c61f596536ff861",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -191931,8 +191931,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5d949c9e06be0d738ceaa8abd16805e1f003ba797244c5abc075a58bd8f1ed7",
-                "select_by_single_document_sql_sha256": "1ed8b5719c4e006728529c2259e83439d057c3b9cc5737f089a25674bf32c115",
+                "select_by_keyset_sql_sha256": "cb1488a685db741673bd4c8f8d9a4c09d870cf5bb29d37395c45bca80ab34649",
+                "select_by_single_document_sql_sha256": "1d535aa7475123e2db3e4846d5f6d84a6ac806e5576a0d1fc30188b92279aefd",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -192727,8 +192727,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "11157630b9ee85baae51536b8eae2ff1e3a353c0e72f7b1638b3e186dafc4c7a",
-                "select_by_single_document_sql_sha256": "40bfb58ff93a51e03c72cde297ac833aae60684c48a5c6a5ee46f2391e2592ab",
+                "select_by_keyset_sql_sha256": "2679e0d3eca2207eb8c12fe242ad5aa3661768a340f4e8a8372153de6ba95a21",
+                "select_by_single_document_sql_sha256": "03436a07b6557be7ca6cd3a5178fc4bc4291615a401fd358d0f361f57c6f61e1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -193201,8 +193201,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "59968fb086aecaa3aba53353e27fec2b2193a015c3cecb7b76c2b92c49739cb8",
-                "select_by_single_document_sql_sha256": "859bb5946a64d4497e057aee5d1ab705cd2bd844664bd3be4f63739d3a618844",
+                "select_by_keyset_sql_sha256": "e478c57f45f20c4a8800d482dcf0b3167cb42644b3a7a0f8780e49255b998a27",
+                "select_by_single_document_sql_sha256": "887e1911d001b32d57fc11614e9b08cb29c4224e3a268f3079e1cc1ee367c728",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -196843,8 +196843,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c729d103867d56b086bbd145c9bbd89fcc58ac0f348a9d7d1313968d5050cc77",
-                "select_by_single_document_sql_sha256": "8f6ac5afa8f4540bf3b49417ac33d93a049c4abf921fee9a9c4d6a7bafb3212f",
+                "select_by_keyset_sql_sha256": "ec1600944a415712ba3a20276c4df3e90344a635e61d4862a3fd54e158154f90",
+                "select_by_single_document_sql_sha256": "028a84bd53184b7fb3fe574451a6efeea30ca1478d845ff04f5079c4c44919e1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -198011,8 +198011,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a548191445ef6040323faa960fc524c7991a3d809ac49630b7358973619db7ec",
-                "select_by_single_document_sql_sha256": "18424c34c176fe7f5cde5d2ff9c36c277f7c896b979dd07832bf316977221812",
+                "select_by_keyset_sql_sha256": "831f0fcfbed7196e8bea7c772c53f439e614a115acd1e16c23b90de7fd2ee67a",
+                "select_by_single_document_sql_sha256": "51cc9810b0ac1f4ba5a96eee979f4f855770df3763f8ca6ff6061f5093e1df2d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -199949,8 +199949,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "71921fa31c374375b3e49972da38991650a454ba7356041f494caf39872f3563",
-                "select_by_single_document_sql_sha256": "0bdf20b603a6af5e1a33131889a15b4776c071402ea46193ac6ab4528b5fa778",
+                "select_by_keyset_sql_sha256": "043f7a4a4a5eeb39887dfc65da19acdbd6e026147eaf8945d6be8d65dbfdde4f",
+                "select_by_single_document_sql_sha256": "7ba4994666ffaf3f885fec01342f2c4868fdc92bdcfa6a3b1f033dc481f2cc50",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -201884,8 +201884,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e8debefc1ae64dc347a9733fc897c8d57c5a50f5264d0aedd7618adc7a616a4b",
-                "select_by_single_document_sql_sha256": "44a855b428bcc8b9a067b7b5bdbdb31c231542a4fb18cf043bab6ae47584421f",
+                "select_by_keyset_sql_sha256": "57a9eca05a8cf28f05e2823e718af3b4c23f50cde45720277c4d1cefe70f238a",
+                "select_by_single_document_sql_sha256": "fc6fbb8541a60e7c46de8850ac083e2096e6a58d24601e0ef4f5627cc6ac04b1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -203414,8 +203414,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "177b897742188a9745beed68ad2580d14480140cf28a7a69b9b8a1bd1abe3533",
-                "select_by_single_document_sql_sha256": "cdf52bf4afd8311de3e99c62cf2039bb5f1de0e00550c63684935393fccb5382",
+                "select_by_keyset_sql_sha256": "120582e06667726ad3333deea42d5609a16ae1720592aacf8c675c5039c6eb0c",
+                "select_by_single_document_sql_sha256": "0ea77cbba3a5e8dad63fc450488c2d28a92799ba1bef51aa833697b98638a72e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -204727,8 +204727,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e123b08f79d5093328ba6e1c70308fe4bc2e03ba917ea34b6f533506c46cbb63",
-                "select_by_single_document_sql_sha256": "fed980bcf1d2bd434e9759ca70618422053d388535986bc7980b1ab5ee378540",
+                "select_by_keyset_sql_sha256": "ae4939f77ed17a94817fd95af4073f66646a3aa49dfd9ecd99546a333a970aed",
+                "select_by_single_document_sql_sha256": "fafca9bf24c515b1e19284e440ed337fc15f43fd56b0571894673db2ac522c91",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -206348,8 +206348,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cddc5f9c8ffcb6abc30836b8b780f34ccc6773b3fc31880953bcf7196ed891e8",
-                "select_by_single_document_sql_sha256": "2c37df0dfcfa8c95c7dde5745b2ca3ee16645581ae554d8f4247c4d987453e77",
+                "select_by_keyset_sql_sha256": "c41c5872d7ecaf82d0f278cf5427c01d1fd4bafe7517959e17f63eb41fdf53d4",
+                "select_by_single_document_sql_sha256": "2fbcdc447fff3cca1b6bb4550b2d42cc99ab9d53230f4e57c6c35a7cc1d26498",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -210868,8 +210868,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7acbc52c69ddb3ae10a294d1dc87dc817d55489c25676f31454c4829e8317b2d",
-                "select_by_single_document_sql_sha256": "a1c0b6644e7f11622e1bf2e1bef70ca606d2ac8952467dfcfa81f6a988e80903",
+                "select_by_keyset_sql_sha256": "198a2c69637bee7daf8505e9480c608a758ca69f66901179f2537d85a9b7f8cc",
+                "select_by_single_document_sql_sha256": "ce6915bab16e7f0bd7ebec65ca81526ff29f80e9bd086cf24c31cc030f2ae94c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -211989,8 +211989,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2387f7f91cfdbb90eaa1f80baf0224cba480b388941eff858dfb234def6cfbd2",
-                "select_by_single_document_sql_sha256": "6c0554481e0a016f85d89a6f7a3ed1b17a7b0948de6b8f70af2434d91e5bd060",
+                "select_by_keyset_sql_sha256": "3d9a84ac8c98233f29a9a7c2b26e8bf2707d2fc99ce42243c262241cfb1b55b8",
+                "select_by_single_document_sql_sha256": "94b82532709d34a58e9e2e2e2e9b6f7846689f7004469fd6597234fd6b387020",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -213453,8 +213453,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b2f99ddd608d7745f8d645e9b8adabf77bf01bc51956703b140353fb53ec1b2d",
-                "select_by_single_document_sql_sha256": "80f8610ceb3a7acb8aaa48023cadab76a3549f6fa5b4d871165451f2711ecffe",
+                "select_by_keyset_sql_sha256": "2c7b054da0a1d0f6457d41a097205091aa23d2d45a512780f17bedd5806bad6a",
+                "select_by_single_document_sql_sha256": "4e67ac23654fa5198913bb69a58214a0037667fb21cd6167be36b2cd556fc061",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -214154,8 +214154,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c885313f8314a4b9208e915479b977d5fa562e4458e0f2f8994cb8053bce55a8",
-                "select_by_single_document_sql_sha256": "b9cd1b77cfd3e18445d3a0ef0f35bded326c1a66a54fe392914bc97430594866",
+                "select_by_keyset_sql_sha256": "ad313a4d862599b90ed2f1a2f80c809d4370f7ace35e475b2369ceb3db7257e5",
+                "select_by_single_document_sql_sha256": "e7ebda46e99d471bd9e60eb9c086609295f8e449809651ba73c6e5fb5e6e544f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -214541,8 +214541,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5e4b0df10b28172575cc97df5211afd37d5ef060d5e611fd34d8c0baa2c375f0",
-                "select_by_single_document_sql_sha256": "f3369a80c76f960d444c8b6907f396d83ab6bae79acdbad717ced2c4c8d6e691",
+                "select_by_keyset_sql_sha256": "5f948426194dda8587ba2c6802f9aa8611c6967e95d90a88f5cff78e29b2e56d",
+                "select_by_single_document_sql_sha256": "6711489b1fe902e209c3295722201c24d166d75f6b779b0d09018b9a1b510d76",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -215441,8 +215441,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e820012a6cc9bae424f2e12f8f3553301cf1c269347166ee9c893ebf364b3b06",
-                "select_by_single_document_sql_sha256": "3a10b623c0710b819e85e74ee27bfa0d966b48c5c3e7f1db96463f274736b640",
+                "select_by_keyset_sql_sha256": "158cea9db36736a996533ad84519696af12e4aa035a1ac18cab1f02e703a00b5",
+                "select_by_single_document_sql_sha256": "0978b7d00aa030bbe39e4a890523fe838d8eac44fe924f5173fc987d37cba785",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -216320,8 +216320,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3eff92fb021d3661e3101a76cd8135db92b4db1b70b691241eb5592734af32ae",
-                "select_by_single_document_sql_sha256": "84bd82810ce4d59f1e341fc115c062dce4196c067322de0f39e297995c430161",
+                "select_by_keyset_sql_sha256": "5782324de47f0e13fc7f110831f841c4fa5b2787fe42be74f9a197f1c55909ad",
+                "select_by_single_document_sql_sha256": "d2c8aa4f785e7735aed9e26f2be348790fd471ec61d096183e5514e783d34a47",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -217172,8 +217172,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "98a30a0ff5ff01492640ef722e621938311d41230fa367ea81e19f8b383477bb",
-                "select_by_single_document_sql_sha256": "c0f1b123716f5fcfb8ac081281cf44cce90201e05be360207428af20ea561cf3",
+                "select_by_keyset_sql_sha256": "05de2823ea37eb3e49b9b162ed6e8b06b44d852a81fc659077f1f1121e33b70e",
+                "select_by_single_document_sql_sha256": "e6e8908cde902095ffcfdb5251801a0ccc5bf9488541a6b891e35602c7a520e6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -217957,8 +217957,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c5cbebd1baa14c5daf57eb05e1b84417e857239171a9eb4e7c5c52e440747eb3",
-                "select_by_single_document_sql_sha256": "3387a599d2fd9869f782bf54e2bd820311d90fda9bc189ae9aae3d7da3ae6383",
+                "select_by_keyset_sql_sha256": "0366c0f49c04647fcab738d03fc7a4be5fb41c74d50978d7822fe342099d847d",
+                "select_by_single_document_sql_sha256": "4cca6347b2d4ea4a0892563a09eaf9be9ad75d0a024842eb701881654d1dd6df",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -218431,8 +218431,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2fb798036b01977dfb098ac113836fb5f45accf44c5e571fd66f14b2477e143d",
-                "select_by_single_document_sql_sha256": "3e0b3ffb7ff6a86963576c7e8d374decfbc0bb1759ed8b0c31d111ec967f992b",
+                "select_by_keyset_sql_sha256": "b45fd4140cb5ab65a19c2811c39bf9bfa9f31a0df4a3369939af021d75a5c818",
+                "select_by_single_document_sql_sha256": "250a25b369077b9476356e4672f2cc0494f143b6126614d67aaf60f3ff017b8d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -219702,8 +219702,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "70c54df9bc680e26b8660835569635d73338fbb4d50de5eae61e95ff3f4dc061",
-                "select_by_single_document_sql_sha256": "cd84c4653e6727084c7e6e7752a4843db5021483e26af3a315227017b1f4f877",
+                "select_by_keyset_sql_sha256": "55dac8ac075f20ed8bb1c6ab3dda7e165bcd3122e8033de6ab280802fa9c524e",
+                "select_by_single_document_sql_sha256": "e7c7c83f4cbc0b34376964ecd36aafcb1c24a821df68c2900751200e9710b361",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -220976,8 +220976,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f9c831299b9f9632627d7becbbb04885664a8bd1be37eb78445903a6dfb3a5e9",
-                "select_by_single_document_sql_sha256": "9fd0cf0a14c574aa880ffca0d1a0725bd99a2745bd3f9924f1507a7a36ba812d",
+                "select_by_keyset_sql_sha256": "dcc34842a6b29ba0438c32afa6a1cf9bfce0a751b547e56ae7b00283618589d3",
+                "select_by_single_document_sql_sha256": "bc54f5e293d1d83a077c9b5cb505c1cad684f19ae29f6c03ab72bc4af10664e4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -221753,8 +221753,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7b03411cc97ee65eb6c03e841d7e83eea4ba42549eb9f4fcd4be9ea3c1504505",
-                "select_by_single_document_sql_sha256": "456d602979e975764eb7ee25deba2792a3ed71f35748475f0ad67d93b2713aee",
+                "select_by_keyset_sql_sha256": "3b42ae5fa3c1f9bcc7a0ec7102bfec41e6f87340429263b8af1ee586df942c46",
+                "select_by_single_document_sql_sha256": "5479ebad7147ad8e0337c120744db5c9970f64c9a9ed07fc83dbdaef1e5fe03d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -222477,8 +222477,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "210a3fa24c338ea95b9a40931ba9b2a7a444ef44d6060ababc2ad8b52efd7bef",
-                "select_by_single_document_sql_sha256": "35df3ed6f15bc2886ecd99eb1d0058f803e99f62346604e9c67a3b848340e5b1",
+                "select_by_keyset_sql_sha256": "54ba1c2f05b44f58d6d297242e605cb77a9e42ba9024fb7b7997e93cde08c1b8",
+                "select_by_single_document_sql_sha256": "2a7c04097f30a5767ff17c9e384e7984a2489018e35112c0df5827d88865c2dd",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -223126,8 +223126,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e5b460b286df8241c48ae56774282f113f6967b2b5b1394ca5040260a26fdf26",
-                "select_by_single_document_sql_sha256": "40969387298c5637baaca45e8d115c37309a871edee08592653c58f79917f00f",
+                "select_by_keyset_sql_sha256": "58fdfa43d58ae2db8beccf437a3f9616d19efdb952af46108edb5d2d7dc76ad0",
+                "select_by_single_document_sql_sha256": "37b30a3ba0cfd4915313ee78b9d99ac7dd01da9489cd3b19576902b1f9882b5c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -223919,8 +223919,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "baef18e7864dba358b7159c3e01a55b4d9c8f407cfe90fbbaf78bfeae61f3942",
-                "select_by_single_document_sql_sha256": "b83be138e0774df555e4d6c911e73035111370897859c00b7986f9935643cfd4",
+                "select_by_keyset_sql_sha256": "a0a119d3845609dc423e10869d9b12de3e755c7b93481d5347117b1450159057",
+                "select_by_single_document_sql_sha256": "b2445698357adb54caf8ff88c30ea047b616019352dc8df308def4fdd854fa27",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -224659,8 +224659,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5f432e9c07ebb5973da517defa6f07a32688cbd8a45b705daef5ee6fd207b3cc",
-                "select_by_single_document_sql_sha256": "233e87d6d9a764568d22fa8526b8a8412a1e8c1255fb7381789d29e9e2913deb",
+                "select_by_keyset_sql_sha256": "33fa5189b575c2ffc780abcd630756b6b0f38b93288d8756fb53f4105f5cc2b6",
+                "select_by_single_document_sql_sha256": "d2018040454a1e824e85420956bbb4f0a87d210515fbff62872945decf9f02a3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226091,8 +226091,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "723fdc36dd90ea451d35c39848801d27db9e71de52926d1306cf56b71dd71416",
-                "select_by_single_document_sql_sha256": "ee398f521b2bff66e48af05170fe3cd02e49a18b871852b332f6cc59e60a6458",
+                "select_by_keyset_sql_sha256": "de439f8260f279ebaddee616e873c2a7d9d6251eda820400971a4dc6faba35b9",
+                "select_by_single_document_sql_sha256": "b11b1b747e4d20df9edaf64634bbf8b88a36cf7000be8dbde4ff89140f1839ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226886,8 +226886,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "08f7cc83b7814afa94e15721e81c7e664d991d8cc5e0afd94d7679f9c9f9c0ef",
-                "select_by_single_document_sql_sha256": "1b7ae248f9885c465cd3ab05677b7629ab86a5d3f25ce1a1820db2e5c6a41048",
+                "select_by_keyset_sql_sha256": "26f53add54f9a745d03435ea393f3fd5b9576a88df4fc7372a10d24c013844bc",
+                "select_by_single_document_sql_sha256": "e782ed5431f0d2835dbc109d2a2cde9a933ceac3b2f174cc64d22546343ecb37",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -227743,8 +227743,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51a4c0b2705c6a6dd9b4635e9d4206431335d386c8327626f7b4e758787cee11",
-                "select_by_single_document_sql_sha256": "fb4f15741595da8499f62c8333308db318419b6355c271191a508d864d9e0b23",
+                "select_by_keyset_sql_sha256": "2eb097ede19e2729ce9bf5a578aa20c4025ef126d737f1dfccc1b832f0574bac",
+                "select_by_single_document_sql_sha256": "ffc0e74a9d4c1d90d26b55bb1f13c9629c545b124d05eabecf1711fbdf11d19e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -228351,8 +228351,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f66afff1b1398e068d9deeba7538bad5a5f4bd15d97d5443fcda2944b58d976d",
-                "select_by_single_document_sql_sha256": "b852ad8991ac1aff27b0cc6a7ca5d177c170c7880d21f86ba7fac6beae8b5967",
+                "select_by_keyset_sql_sha256": "095cb0c18616ae8681bcc070ae4d65f08757391a1717ab85646ed9d043bebe2b",
+                "select_by_single_document_sql_sha256": "cd9af4e2f5976847fb0c57fb344d35629daf4c851587fa1587e56e4504365fd2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/sample/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/sample/expected/mappingset.manifest.json
@@ -128729,8 +128729,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51f2478482de4aefbd58d5cec3e4a4b69fff672f89b386726aaeb5d163418274",
-                "select_by_single_document_sql_sha256": "061e5e4a07a55aa957aa064c35840082f77b921370b667a6be7e92abb2bf726f",
+                "select_by_keyset_sql_sha256": "f39360e27cd8ae3604263bbdb22cab2166012f7541b0159e8f1b59a50662b44f",
+                "select_by_single_document_sql_sha256": "a6adf4cc94244993f6cce3f66c0cba29972954c0bf90603c60872277d3f9993d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -136119,8 +136119,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51fa3b414ae6a106807924ac8d4ce485113ffb99058eaf37c3513e87966603a7",
-                "select_by_single_document_sql_sha256": "baf677ac9eeddcd19ae6b42b86c02331bbcdf3ad3a6122c04b9bc3bd3a7e65ef",
+                "select_by_keyset_sql_sha256": "17e8ef3129339d54eb0d49607c02e86ae3e8f4c688fc1440bda837875d9107b4",
+                "select_by_single_document_sql_sha256": "897706172ad3d8132e8e7786bc6f22258934eca80532316f1f003de757f77139",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -137762,8 +137762,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "243748542ee50d0cea4f99cf257bdcb413e3888e76c3e17dd0f6d9cea3b94d09",
-                "select_by_single_document_sql_sha256": "daf110933cb950cd3f20796d1c682b807053f42ef599f4b63244e138b763fe61",
+                "select_by_keyset_sql_sha256": "3f82bc02404955b59d6d383ec842371a61f5ddce0d3cc728b23f7ee1786d28ef",
+                "select_by_single_document_sql_sha256": "391fa1e423c91829981178c132d571486a163d7b44404eafd2bc5ab9ff8e8fff",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139376,8 +139376,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b3f5c167787e3e0826d2b45a35d58ed1a2e1d568ceffd111b7a03b4844da7829",
-                "select_by_single_document_sql_sha256": "321f939510d6dd1a472fc4eb08e37eef5bd8b5d7c599a70b5936b2c7df7b5dd0",
+                "select_by_keyset_sql_sha256": "6a57305308773f8bd3abc382f0fbdeb5128dc0a16aaf39580f2efa4fae6a4ba1",
+                "select_by_single_document_sql_sha256": "293f19dfcd4bf3aa997cf07835c7c6d0badcdee7a3a2f7e50a899e73b4e6cab9",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139930,8 +139930,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "9113bacf3302224ffb890b71903b52ca374a1a8b5dc3758a99fb1f545e8e4ec8",
-                "select_by_single_document_sql_sha256": "b67683e6def69db8459428589a6e7d6d0f3056a5b9c916b8e41a1d179de312d1",
+                "select_by_keyset_sql_sha256": "fd1b1302ff15175576fc878fc4090e4a726da7baef5d043006cb1c2a141f984f",
+                "select_by_single_document_sql_sha256": "c77d4ab8ffea0d8bb9fbad96b232819d815ef2e3a757cb839ea2f44c6b0f3535",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -143295,8 +143295,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a674a1787207c8d6dd37f8d1ed3c8fa8b4fbdc638145a5cc79753d5d1bf5911b",
-                "select_by_single_document_sql_sha256": "695634d3309a6d3766aadd2456fe407acd4e06a0ff4a3358617fb989c06fdece",
+                "select_by_keyset_sql_sha256": "113e5bab0c1c8650b862aa977649aa1967ef2f8b44fa48b81b6506a2319edf33",
+                "select_by_single_document_sql_sha256": "7b38ba74fc5f067f84a07d76761a6e4af9079617085faef3a03deaf88e47b9e4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -145034,8 +145034,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7669597d42903d88b67d3626e406877a73d99e4bf94fd3978736b1ff3b9f20ce",
-                "select_by_single_document_sql_sha256": "ae5e95b6007177697e9952d0335b61e980ab007f6c9434df8bbde9e118fec632",
+                "select_by_keyset_sql_sha256": "ab59464dac840fe20120b98f11ab7a4f740f06a0b826ef76f5b6048961b40698",
+                "select_by_single_document_sql_sha256": "9a611932ebde7064b7cee648bb258c297c09fa2f4aa428c43f67ca9791ea3e83",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148027,8 +148027,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e44d3aaf281d296069372e56b7bcb2b9256eaae75fd2ab44cad14425596ec614",
-                "select_by_single_document_sql_sha256": "1d32d3decb67d897327d43aafd0f2dcd3e6450283654ce2548951e615f515114",
+                "select_by_keyset_sql_sha256": "6f3a37ca8c808cefaa61cd897b65aa18710093af74930a55bc82fcd3d8c1375b",
+                "select_by_single_document_sql_sha256": "7cbc1dd7ff123cb83f7db8a226201fb1598bed11a33748cf10046bf81d2bbad2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148932,8 +148932,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fdf6ad1d9a8ca642444568311d08a3a76a46b93fff9b6b895cf45860b12805e1",
-                "select_by_single_document_sql_sha256": "c2af2c1fdfb594a6677e4c3d63ff3545724ea96856b3876fdea7f54541898e5f",
+                "select_by_keyset_sql_sha256": "4654c6f46919da92cc5c43aeba63ff6d5b42a71c50e59802df91c9e45403c963",
+                "select_by_single_document_sql_sha256": "5aaa655f39db805b93ac72fe2973deb6fb351479a66e63dbdb2f6ee9ed8270d5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -152178,8 +152178,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "93e995147ffeebb599b7c7eba34d09ac2d99ccc5cbfe2331ba6968f186a307d6",
-                "select_by_single_document_sql_sha256": "c87cff1f978b33858f0aa3b51765a43c6734325c700cc650a2604890390163f5",
+                "select_by_keyset_sql_sha256": "33e58c9554ff95d9dca7251e0662b6ab601228f810d40bd4e68751584040c441",
+                "select_by_single_document_sql_sha256": "bcabf740b8151c8e1b788e6923796493632387f824522e73ee48743f5d688adc",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -153648,8 +153648,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "312c48c3eb3bb85ed69430b94e9e765dfc7b6e7d5f13b569827149e7aa854bd5",
-                "select_by_single_document_sql_sha256": "41da8595a7516b485b5cc3c74aaddd86a43f6f22dd76e53e658107b69216ca38",
+                "select_by_keyset_sql_sha256": "63f9fc6b9f8ceec5de78b520ca0d99c5333f10cc03808aa565f7d8124e2e590e",
+                "select_by_single_document_sql_sha256": "9c51d1806735a5698dea2cbcb107285b3e9d34bccd4ed6683c276e1c181a82a7",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -155687,8 +155687,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b68aa07dcab202642f27fef361952d780f765e90416e9c48fd3de913e9135c5a",
-                "select_by_single_document_sql_sha256": "11cce6fa41604d938e7d5303f5125a45ed677ab9f406509579752512bf60da60",
+                "select_by_keyset_sql_sha256": "dd216b84d6c239253c405e162690e7b2020b64bbe592b9c29535fa5328d75932",
+                "select_by_single_document_sql_sha256": "6da9eef1e8eaaca5760eccec0017571c536cee151d64fa2e0740bdb616dfdc2b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -157752,8 +157752,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3510f8eb93b6357fff8ff83b05ce598c00a6e054609400b7441248e4753214d0",
-                "select_by_single_document_sql_sha256": "e572734b8178d10ec60caca1bd1f4cdd3d516ac836805de32823ce56e7c75b7e",
+                "select_by_keyset_sql_sha256": "ac936c4c15c2a841607648ba4bff107d2a3f1c82ac2727026ef9066ea34c3487",
+                "select_by_single_document_sql_sha256": "fb62880678fe134ec036429012796b4e06b8fe809a41bfc4436304c5f4e19a58",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -158938,8 +158938,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a471dadc1c3eb8ab8b6564b298b293692b96945bd0207e1a7bf574106cfcef33",
-                "select_by_single_document_sql_sha256": "74c44a4d2ee676569c031d02cad16bd6661cd7291beb8504effa510713dda32b",
+                "select_by_keyset_sql_sha256": "d73f6edd1f02983c122f4edf24f5c017f7a2cedf0137237ed5cfd916dac0b72c",
+                "select_by_single_document_sql_sha256": "9b53c26542917dd0df74b087622f96526e3bda0c89dcb399d474fb0d530626d4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -160756,8 +160756,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "664725560b89f8b1e63eed9175a12eadbf5cc09c9bc5760946054a0bfb28a0e3",
-                "select_by_single_document_sql_sha256": "57f8a72c07898ae81246b46b1be6dbfe3095a361c646446aa0e907ac26fda524",
+                "select_by_keyset_sql_sha256": "e44c81078b7b1b25e36d2ef300014faf3641c43148d4454e5dd15800d5af1d7e",
+                "select_by_single_document_sql_sha256": "ef946fa16c0bad24f1091427d9284f44bc05ca7505042baf66d6319ed9807a74",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -161798,8 +161798,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "753c860c0e3d156a49fac2946afa8efe74e1f22a8ad45f145d93dc490e8bd70a",
-                "select_by_single_document_sql_sha256": "84dcafb0ad50e6dd2599ad34cfe14024f0b7f29cebd7d5191a3fde7a50c9437c",
+                "select_by_keyset_sql_sha256": "8cf4087f2b7c1bb3dd3bba2106ff4bcb7eeaa924503db637d207e107eab5a4c4",
+                "select_by_single_document_sql_sha256": "6f94802ac3d835e728fb03fa90822dd6abfb7cde6fd8f44a50f5f3eccd56843c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -163674,8 +163674,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3e455fd811873be6e097b0d85eaa40d08f35d949e91aced687f23d58283b9467",
-                "select_by_single_document_sql_sha256": "f5e4b8c605e4a0595e0313a741106447de087f3c64a51a6a5f55d50b6c5eb269",
+                "select_by_keyset_sql_sha256": "f92687cbde4d61e50b1aba5bfb3dba6d313c71e298c084d54f737ad9dbc914df",
+                "select_by_single_document_sql_sha256": "215d351e0d6784306d3d44a9a65e9d6c26b487ec92a92ce5eab97224adfb8ef6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -166402,8 +166402,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6630f960929014baab86e0f3d533a001104e7e206095accdca6d221c04e2acf3",
-                "select_by_single_document_sql_sha256": "a77120ae9183c948558e6d929fa37814643f067bd2ee09c148f6e1db76efcab5",
+                "select_by_keyset_sql_sha256": "2f741dcf9308c6fc345e7527c2149c1ecba72af3338a747e9bb9258a5ef7dd20",
+                "select_by_single_document_sql_sha256": "c2479cd91c75fbeb913f72fba5a8ef58c2b6b7c1688bd9207740f99be22c056f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -167606,8 +167606,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "22fb11cc51f27835c48e5bb7539961955dec3c1e3a4986784fcee313cd38a698",
-                "select_by_single_document_sql_sha256": "00a755604cfe5077cf60c7eff936cd7bf1299cccfeabc56350dec2199554475e",
+                "select_by_keyset_sql_sha256": "d463b52e017b62a2be7a968be93c970354fd5bb4839275fd4b47bcefff31718e",
+                "select_by_single_document_sql_sha256": "aa41dabec5237d310ac6b6e00b8c2d03ec1922233b084f3c19facd3195b6e23d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -168842,8 +168842,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a795b7834e963d2d073acc48db716de4ae636c166506bf38dc6da0ec74b4aa0a",
-                "select_by_single_document_sql_sha256": "cf46398551eb2f34fd154f98f1567cfdb2d2a17e61a285e1ba9cd8953376bf10",
+                "select_by_keyset_sql_sha256": "bbd7ec63f6bb8aa1fe49cc76e7713e037fe8622bd62ee93c3c424c3a40c5f815",
+                "select_by_single_document_sql_sha256": "fdf1991bb8c3061e3911895d91aa5759852ea343c4864ae29f461fb865f59598",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -170019,8 +170019,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "35adcdc9ef468b83ffc71afd41ebbe7902c2330eabc999334823b8a50dc0dea4",
-                "select_by_single_document_sql_sha256": "5133f05377209e9f7ef642b6310afc7550579c494cb09f526a642e5ba34d5ea9",
+                "select_by_keyset_sql_sha256": "a36c0e1d5c19accc38ee4a7cd7abbb08d0d8b97bba3c7554457a5c3f8ac0dd74",
+                "select_by_single_document_sql_sha256": "6b7bf3082c1c6abd451b9a8de329917a7532c0d58c3ef8cdcd3c5ded64d7d500",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -174168,8 +174168,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51f6723ecac2f0c61f3eed460cd1e3e8e5ff8f78a9fba0c19f6a8189bef06034",
-                "select_by_single_document_sql_sha256": "61fbabd94fc8b70f5f6381138dc12800bae831a0cfa5693330411fc16cbba234",
+                "select_by_keyset_sql_sha256": "e06c766dc4d2e83f186b1b55b22900598b3ec71d1cb50047179f87db336fc9e4",
+                "select_by_single_document_sql_sha256": "3dd9d236009b8fcbf1db8ac7db3d5201daf6db36714cecc8bf818c2b6b4a3511",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -177390,8 +177390,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1701a0b9be3ea108e96f81c781c432ea5611fa9ba7e6d24d1e1ba4c407fd21b3",
-                "select_by_single_document_sql_sha256": "a4d922b56b48e61a73ee5657606136029be91d3771fd7ecde397a2514daa116b",
+                "select_by_keyset_sql_sha256": "3b2db7d19d86d90c11d2b1bf192994ecd9b593f1b9e76772915e3edd45194e78",
+                "select_by_single_document_sql_sha256": "562e010257e88241970df76d2ca9b7c606dcf89a3357ece0f18c6c600495d8f0",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -177978,8 +177978,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "82db74cd3278ec8f9cfe258f64102328263c776f35adc107a3ede86c1cf520dc",
-                "select_by_single_document_sql_sha256": "f352acedfe64b982c3251ab746d1fce4b5a3c29c6cc1a54a6776b21ff68403da",
+                "select_by_keyset_sql_sha256": "080bad20ddcc9e62739fd7b8fc739b470f0d6e41b1b3e3ecf152b973ba58592d",
+                "select_by_single_document_sql_sha256": "c077302b7de4f06213b25adbf86bdccc9bff5f8cb208fef82fe765b4fb31c1c6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -179847,8 +179847,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3ab7d71e11227c695e93d73fd60622a43e75c36429bd4b0ef4cd8fecd6cea8c6",
-                "select_by_single_document_sql_sha256": "92e845d95ef6019a0b223f53e2118a8375fe5abc84885feba5378dd98eeffa7b",
+                "select_by_keyset_sql_sha256": "831c96a0f3a4bca781ec9079068ff13020bcab848960d8427720fd58146c7b61",
+                "select_by_single_document_sql_sha256": "4feb68e84c774a956796b3f4a5ea98eea661a0d385b717418a398070cac5be70",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -182587,8 +182587,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f73f2c18df0720d1280f43c3fd0c0bc96ba8faccc3239d7c84766a90af55617e",
-                "select_by_single_document_sql_sha256": "ca121129ca86647a2caed26e19ca739b2edc943a3869d0aad66f6a1e9b9122f4",
+                "select_by_keyset_sql_sha256": "ee0f6090b5e2780295487aeab72c7522fa12b436604449796b5871d0a69957ea",
+                "select_by_single_document_sql_sha256": "4238cbbf90e8d8b35cc54c911440a1b76b130337f0fea492d1208d50fa39e99f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -184638,8 +184638,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5f929dfbc316b48bd031f2dda7df6a47bd13c1a0cd4a551ddf5d71130028ce1",
-                "select_by_single_document_sql_sha256": "4a7f8d1f98e166c6e942e1599471ac40a4036633fb08e435fd1f40ff891b44b3",
+                "select_by_keyset_sql_sha256": "eeb63d622b2a225557cb953150d4974a46e3463951405be638caa68a30031886",
+                "select_by_single_document_sql_sha256": "e3ecfa0ad0de56590d9776f1ccff5518ffc57c2b1135b938d9a3b65785e3e9ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -185444,8 +185444,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fee02c2ee133546a420a22e14c2aee6777d20697d44e8dbe4355399304fed330",
-                "select_by_single_document_sql_sha256": "b716f7a84f8f13e55f58506e954b332565c2652f0bdb8f818c383b72110ae470",
+                "select_by_keyset_sql_sha256": "eecef2ae2b779b199fa89720677c1bf98ea58536852311f3fb844636b9aa1d57",
+                "select_by_single_document_sql_sha256": "7c53ea76937115eb15cb17b5f4f0f11ec88ea3b4096b68dea4c475f281ac3a08",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -186061,8 +186061,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ab42a8a5d98e2ce292ad973a2bfc9e54e16c6de126c779358a6919f418933581",
-                "select_by_single_document_sql_sha256": "8388cb62be3bbf43e5a96eb701289a39c319f69c25b4475df9fa78f170bf33ed",
+                "select_by_keyset_sql_sha256": "8a7f9a5b16414cacae0dc92a8844a33d79df009a5c4f010766efaf334acd7e3a",
+                "select_by_single_document_sql_sha256": "00d8b08342c4482194c2c8ecf80c133c978f10967eafb44a9eeb92e54d6f18ff",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -188987,8 +188987,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ea87e53d15945111e527e1427dfa280d1248df3b4bff29893d0c4e0761be83b8",
-                "select_by_single_document_sql_sha256": "d0ec92acc2a8af75e9b17cd2ab533b3dac4151698f8b8b572191ec5805868ea5",
+                "select_by_keyset_sql_sha256": "c4bdbdd241f1323faed3e53cff3219fa09cbdbe14c9a9dece649ad0e97f3dcf0",
+                "select_by_single_document_sql_sha256": "321001e0539f953930dc243cfde01fd0fb2c90af3c640d0cfcb6b938769c651c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -192329,8 +192329,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "458a16f67b43631e41ae5d5b6eb3b1ebf4ba7cf5ed1027669552a0728089935b",
-                "select_by_single_document_sql_sha256": "6600eacae6e3f1eb9b03a837123726a8d94e133567db2e4e71fb5bfe84f7facf",
+                "select_by_keyset_sql_sha256": "13b895bb73e83791da21aa13c215f3cc4789f026d429f6232c2f8248ef26044d",
+                "select_by_single_document_sql_sha256": "cdcd18c31e4df12327721498c28932f0d8aff786188a439441bb9f47c8f5ee71",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -194381,8 +194381,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "79a7c35ac66f3faf8ac809571dbafc008d486637e6e8a8b87c5c80784c8513b7",
-                "select_by_single_document_sql_sha256": "f4c1513a166097c5c96d4995051e876ff14e8d8a9ab701940096db0eaabb8df2",
+                "select_by_keyset_sql_sha256": "928998a0a4d4272f5798075257e8611d7a845a00243988e5db6c1b1553429964",
+                "select_by_single_document_sql_sha256": "362d705750765aa3a3d216a4d7196f9778bd43fbf37141e83c7647361c5579a7",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -199942,8 +199942,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c39e00b63e677f65029ab3948699b373c8e301db3c057c926723e89ba861987b",
-                "select_by_single_document_sql_sha256": "4e846056ae08e843dbe83e4a6e66e6d178526d4e7058075f4242ce1c8cac098e",
+                "select_by_keyset_sql_sha256": "64efaa7bcdb91a1b74dc3beeb56ac95dc220d4ba11329409a24bb10ec2a5dde1",
+                "select_by_single_document_sql_sha256": "891cc038057ecb3ad34c338693df34c6063daec61a25750e5c61f596536ff861",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -201850,8 +201850,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5d949c9e06be0d738ceaa8abd16805e1f003ba797244c5abc075a58bd8f1ed7",
-                "select_by_single_document_sql_sha256": "1ed8b5719c4e006728529c2259e83439d057c3b9cc5737f089a25674bf32c115",
+                "select_by_keyset_sql_sha256": "cb1488a685db741673bd4c8f8d9a4c09d870cf5bb29d37395c45bca80ab34649",
+                "select_by_single_document_sql_sha256": "1d535aa7475123e2db3e4846d5f6d84a6ac806e5576a0d1fc30188b92279aefd",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -202646,8 +202646,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "11157630b9ee85baae51536b8eae2ff1e3a353c0e72f7b1638b3e186dafc4c7a",
-                "select_by_single_document_sql_sha256": "40bfb58ff93a51e03c72cde297ac833aae60684c48a5c6a5ee46f2391e2592ab",
+                "select_by_keyset_sql_sha256": "2679e0d3eca2207eb8c12fe242ad5aa3661768a340f4e8a8372153de6ba95a21",
+                "select_by_single_document_sql_sha256": "03436a07b6557be7ca6cd3a5178fc4bc4291615a401fd358d0f361f57c6f61e1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -203120,8 +203120,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "59968fb086aecaa3aba53353e27fec2b2193a015c3cecb7b76c2b92c49739cb8",
-                "select_by_single_document_sql_sha256": "859bb5946a64d4497e057aee5d1ab705cd2bd844664bd3be4f63739d3a618844",
+                "select_by_keyset_sql_sha256": "e478c57f45f20c4a8800d482dcf0b3167cb42644b3a7a0f8780e49255b998a27",
+                "select_by_single_document_sql_sha256": "887e1911d001b32d57fc11614e9b08cb29c4224e3a268f3079e1cc1ee367c728",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -206762,8 +206762,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c729d103867d56b086bbd145c9bbd89fcc58ac0f348a9d7d1313968d5050cc77",
-                "select_by_single_document_sql_sha256": "8f6ac5afa8f4540bf3b49417ac33d93a049c4abf921fee9a9c4d6a7bafb3212f",
+                "select_by_keyset_sql_sha256": "ec1600944a415712ba3a20276c4df3e90344a635e61d4862a3fd54e158154f90",
+                "select_by_single_document_sql_sha256": "028a84bd53184b7fb3fe574451a6efeea30ca1478d845ff04f5079c4c44919e1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -208431,8 +208431,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bb151c97106e86688ec249425250d05483f0591b3f2834758820917b21694504",
-                "select_by_single_document_sql_sha256": "f3569d409af5968045579b245658bfe32ed7f4726a048d2f4f86c0850d58ec87",
+                "select_by_keyset_sql_sha256": "1cf987b26dbaf33065bea7b5824bd825d46823804908c0d6e49890d96cb623f6",
+                "select_by_single_document_sql_sha256": "29c11a429eaf4b9ee38bb6ea87c51500146a71e0796499cd6200600caba9baf0",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -210444,8 +210444,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "71921fa31c374375b3e49972da38991650a454ba7356041f494caf39872f3563",
-                "select_by_single_document_sql_sha256": "0bdf20b603a6af5e1a33131889a15b4776c071402ea46193ac6ab4528b5fa778",
+                "select_by_keyset_sql_sha256": "043f7a4a4a5eeb39887dfc65da19acdbd6e026147eaf8945d6be8d65dbfdde4f",
+                "select_by_single_document_sql_sha256": "7ba4994666ffaf3f885fec01342f2c4868fdc92bdcfa6a3b1f033dc481f2cc50",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -212379,8 +212379,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e8debefc1ae64dc347a9733fc897c8d57c5a50f5264d0aedd7618adc7a616a4b",
-                "select_by_single_document_sql_sha256": "44a855b428bcc8b9a067b7b5bdbdb31c231542a4fb18cf043bab6ae47584421f",
+                "select_by_keyset_sql_sha256": "57a9eca05a8cf28f05e2823e718af3b4c23f50cde45720277c4d1cefe70f238a",
+                "select_by_single_document_sql_sha256": "fc6fbb8541a60e7c46de8850ac083e2096e6a58d24601e0ef4f5627cc6ac04b1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -213909,8 +213909,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "177b897742188a9745beed68ad2580d14480140cf28a7a69b9b8a1bd1abe3533",
-                "select_by_single_document_sql_sha256": "cdf52bf4afd8311de3e99c62cf2039bb5f1de0e00550c63684935393fccb5382",
+                "select_by_keyset_sql_sha256": "120582e06667726ad3333deea42d5609a16ae1720592aacf8c675c5039c6eb0c",
+                "select_by_single_document_sql_sha256": "0ea77cbba3a5e8dad63fc450488c2d28a92799ba1bef51aa833697b98638a72e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -215284,8 +215284,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e123b08f79d5093328ba6e1c70308fe4bc2e03ba917ea34b6f533506c46cbb63",
-                "select_by_single_document_sql_sha256": "fed980bcf1d2bd434e9759ca70618422053d388535986bc7980b1ab5ee378540",
+                "select_by_keyset_sql_sha256": "ae4939f77ed17a94817fd95af4073f66646a3aa49dfd9ecd99546a333a970aed",
+                "select_by_single_document_sql_sha256": "fafca9bf24c515b1e19284e440ed337fc15f43fd56b0571894673db2ac522c91",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -216905,8 +216905,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cddc5f9c8ffcb6abc30836b8b780f34ccc6773b3fc31880953bcf7196ed891e8",
-                "select_by_single_document_sql_sha256": "2c37df0dfcfa8c95c7dde5745b2ca3ee16645581ae554d8f4247c4d987453e77",
+                "select_by_keyset_sql_sha256": "c41c5872d7ecaf82d0f278cf5427c01d1fd4bafe7517959e17f63eb41fdf53d4",
+                "select_by_single_document_sql_sha256": "2fbcdc447fff3cca1b6bb4550b2d42cc99ab9d53230f4e57c6c35a7cc1d26498",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -222894,8 +222894,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a525e349da86d031a4200e23e72f2ec0051bf44623c2c9c19d62bf5a9ab39cee",
-                "select_by_single_document_sql_sha256": "dd099dfbc8f80c5cf9fcb8ec2dd2335877e7885d47bfef9ee42441e5548a32d5",
+                "select_by_keyset_sql_sha256": "aadfa799c5caab8416eb6c74f66229b125bb98bef6de41277f2e8afc15eadb40",
+                "select_by_single_document_sql_sha256": "a47434f0ca64633a1b0af218c58105905e1eee97be5438e17baa0ed373372b14",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -224039,8 +224039,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2387f7f91cfdbb90eaa1f80baf0224cba480b388941eff858dfb234def6cfbd2",
-                "select_by_single_document_sql_sha256": "6c0554481e0a016f85d89a6f7a3ed1b17a7b0948de6b8f70af2434d91e5bd060",
+                "select_by_keyset_sql_sha256": "3d9a84ac8c98233f29a9a7c2b26e8bf2707d2fc99ce42243c262241cfb1b55b8",
+                "select_by_single_document_sql_sha256": "94b82532709d34a58e9e2e2e2e9b6f7846689f7004469fd6597234fd6b387020",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -225503,8 +225503,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b2f99ddd608d7745f8d645e9b8adabf77bf01bc51956703b140353fb53ec1b2d",
-                "select_by_single_document_sql_sha256": "80f8610ceb3a7acb8aaa48023cadab76a3549f6fa5b4d871165451f2711ecffe",
+                "select_by_keyset_sql_sha256": "2c7b054da0a1d0f6457d41a097205091aa23d2d45a512780f17bedd5806bad6a",
+                "select_by_single_document_sql_sha256": "4e67ac23654fa5198913bb69a58214a0037667fb21cd6167be36b2cd556fc061",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226204,8 +226204,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c885313f8314a4b9208e915479b977d5fa562e4458e0f2f8994cb8053bce55a8",
-                "select_by_single_document_sql_sha256": "b9cd1b77cfd3e18445d3a0ef0f35bded326c1a66a54fe392914bc97430594866",
+                "select_by_keyset_sql_sha256": "ad313a4d862599b90ed2f1a2f80c809d4370f7ace35e475b2369ceb3db7257e5",
+                "select_by_single_document_sql_sha256": "e7ebda46e99d471bd9e60eb9c086609295f8e449809651ba73c6e5fb5e6e544f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226591,8 +226591,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5e4b0df10b28172575cc97df5211afd37d5ef060d5e611fd34d8c0baa2c375f0",
-                "select_by_single_document_sql_sha256": "f3369a80c76f960d444c8b6907f396d83ab6bae79acdbad717ced2c4c8d6e691",
+                "select_by_keyset_sql_sha256": "5f948426194dda8587ba2c6802f9aa8611c6967e95d90a88f5cff78e29b2e56d",
+                "select_by_single_document_sql_sha256": "6711489b1fe902e209c3295722201c24d166d75f6b779b0d09018b9a1b510d76",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -227491,8 +227491,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e820012a6cc9bae424f2e12f8f3553301cf1c269347166ee9c893ebf364b3b06",
-                "select_by_single_document_sql_sha256": "3a10b623c0710b819e85e74ee27bfa0d966b48c5c3e7f1db96463f274736b640",
+                "select_by_keyset_sql_sha256": "158cea9db36736a996533ad84519696af12e4aa035a1ac18cab1f02e703a00b5",
+                "select_by_single_document_sql_sha256": "0978b7d00aa030bbe39e4a890523fe838d8eac44fe924f5173fc987d37cba785",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -228370,8 +228370,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3eff92fb021d3661e3101a76cd8135db92b4db1b70b691241eb5592734af32ae",
-                "select_by_single_document_sql_sha256": "84bd82810ce4d59f1e341fc115c062dce4196c067322de0f39e297995c430161",
+                "select_by_keyset_sql_sha256": "5782324de47f0e13fc7f110831f841c4fa5b2787fe42be74f9a197f1c55909ad",
+                "select_by_single_document_sql_sha256": "d2c8aa4f785e7735aed9e26f2be348790fd471ec61d096183e5514e783d34a47",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -229222,8 +229222,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "98a30a0ff5ff01492640ef722e621938311d41230fa367ea81e19f8b383477bb",
-                "select_by_single_document_sql_sha256": "c0f1b123716f5fcfb8ac081281cf44cce90201e05be360207428af20ea561cf3",
+                "select_by_keyset_sql_sha256": "05de2823ea37eb3e49b9b162ed6e8b06b44d852a81fc659077f1f1121e33b70e",
+                "select_by_single_document_sql_sha256": "e6e8908cde902095ffcfdb5251801a0ccc5bf9488541a6b891e35602c7a520e6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -230007,8 +230007,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c5cbebd1baa14c5daf57eb05e1b84417e857239171a9eb4e7c5c52e440747eb3",
-                "select_by_single_document_sql_sha256": "3387a599d2fd9869f782bf54e2bd820311d90fda9bc189ae9aae3d7da3ae6383",
+                "select_by_keyset_sql_sha256": "0366c0f49c04647fcab738d03fc7a4be5fb41c74d50978d7822fe342099d847d",
+                "select_by_single_document_sql_sha256": "4cca6347b2d4ea4a0892563a09eaf9be9ad75d0a024842eb701881654d1dd6df",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -230481,8 +230481,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2fb798036b01977dfb098ac113836fb5f45accf44c5e571fd66f14b2477e143d",
-                "select_by_single_document_sql_sha256": "3e0b3ffb7ff6a86963576c7e8d374decfbc0bb1759ed8b0c31d111ec967f992b",
+                "select_by_keyset_sql_sha256": "b45fd4140cb5ab65a19c2811c39bf9bfa9f31a0df4a3369939af021d75a5c818",
+                "select_by_single_document_sql_sha256": "250a25b369077b9476356e4672f2cc0494f143b6126614d67aaf60f3ff017b8d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -231752,8 +231752,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "70c54df9bc680e26b8660835569635d73338fbb4d50de5eae61e95ff3f4dc061",
-                "select_by_single_document_sql_sha256": "cd84c4653e6727084c7e6e7752a4843db5021483e26af3a315227017b1f4f877",
+                "select_by_keyset_sql_sha256": "55dac8ac075f20ed8bb1c6ab3dda7e165bcd3122e8033de6ab280802fa9c524e",
+                "select_by_single_document_sql_sha256": "e7c7c83f4cbc0b34376964ecd36aafcb1c24a821df68c2900751200e9710b361",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -233081,8 +233081,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8204814c65c25705b0d63826be05040f735dcd60fb0b614dd75a1f1a9b3c6e97",
-                "select_by_single_document_sql_sha256": "12eef18c063b6e85098166dbb133fac924c4e76c8676e07f0666b402f541363d",
+                "select_by_keyset_sql_sha256": "e6359376151a5fa967927bdefe89075eaf20f6c364cdd252b47c6a48ed3f75bf",
+                "select_by_single_document_sql_sha256": "e6b4ec89c70d56a0956a07684ff209cfaeba32b86f478e89267aa6da4c2f72d3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -233870,8 +233870,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7b03411cc97ee65eb6c03e841d7e83eea4ba42549eb9f4fcd4be9ea3c1504505",
-                "select_by_single_document_sql_sha256": "456d602979e975764eb7ee25deba2792a3ed71f35748475f0ad67d93b2713aee",
+                "select_by_keyset_sql_sha256": "3b42ae5fa3c1f9bcc7a0ec7102bfec41e6f87340429263b8af1ee586df942c46",
+                "select_by_single_document_sql_sha256": "5479ebad7147ad8e0337c120744db5c9970f64c9a9ed07fc83dbdaef1e5fe03d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -234594,8 +234594,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "210a3fa24c338ea95b9a40931ba9b2a7a444ef44d6060ababc2ad8b52efd7bef",
-                "select_by_single_document_sql_sha256": "35df3ed6f15bc2886ecd99eb1d0058f803e99f62346604e9c67a3b848340e5b1",
+                "select_by_keyset_sql_sha256": "54ba1c2f05b44f58d6d297242e605cb77a9e42ba9024fb7b7997e93cde08c1b8",
+                "select_by_single_document_sql_sha256": "2a7c04097f30a5767ff17c9e384e7984a2489018e35112c0df5827d88865c2dd",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -235243,8 +235243,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e5b460b286df8241c48ae56774282f113f6967b2b5b1394ca5040260a26fdf26",
-                "select_by_single_document_sql_sha256": "40969387298c5637baaca45e8d115c37309a871edee08592653c58f79917f00f",
+                "select_by_keyset_sql_sha256": "58fdfa43d58ae2db8beccf437a3f9616d19efdb952af46108edb5d2d7dc76ad0",
+                "select_by_single_document_sql_sha256": "37b30a3ba0cfd4915313ee78b9d99ac7dd01da9489cd3b19576902b1f9882b5c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -236329,8 +236329,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bd59b8f49b84c0e96e01c70d8e7b436a5732f9c06e2e7bdc6113cc28878c3dee",
-                "select_by_single_document_sql_sha256": "ed5d9c7744f2e25dbe4b38b9de0cfa7c52e148612fe9054d447bf28a62216a80",
+                "select_by_keyset_sql_sha256": "615e22593e55d3247b5ae6a04df24eee9537b18aa7efa8df132248c33470dae0",
+                "select_by_single_document_sql_sha256": "348b69bacdcda42871ed0cfcb1d41738d6756a434f352d1e784cccabf998d7c6",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -237081,8 +237081,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5f432e9c07ebb5973da517defa6f07a32688cbd8a45b705daef5ee6fd207b3cc",
-                "select_by_single_document_sql_sha256": "233e87d6d9a764568d22fa8526b8a8412a1e8c1255fb7381789d29e9e2913deb",
+                "select_by_keyset_sql_sha256": "33fa5189b575c2ffc780abcd630756b6b0f38b93288d8756fb53f4105f5cc2b6",
+                "select_by_single_document_sql_sha256": "d2018040454a1e824e85420956bbb4f0a87d210515fbff62872945decf9f02a3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -238513,8 +238513,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "723fdc36dd90ea451d35c39848801d27db9e71de52926d1306cf56b71dd71416",
-                "select_by_single_document_sql_sha256": "ee398f521b2bff66e48af05170fe3cd02e49a18b871852b332f6cc59e60a6458",
+                "select_by_keyset_sql_sha256": "de439f8260f279ebaddee616e873c2a7d9d6251eda820400971a4dc6faba35b9",
+                "select_by_single_document_sql_sha256": "b11b1b747e4d20df9edaf64634bbf8b88a36cf7000be8dbde4ff89140f1839ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -239308,8 +239308,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "08f7cc83b7814afa94e15721e81c7e664d991d8cc5e0afd94d7679f9c9f9c0ef",
-                "select_by_single_document_sql_sha256": "1b7ae248f9885c465cd3ab05677b7629ab86a5d3f25ce1a1820db2e5c6a41048",
+                "select_by_keyset_sql_sha256": "26f53add54f9a745d03435ea393f3fd5b9576a88df4fc7372a10d24c013844bc",
+                "select_by_single_document_sql_sha256": "e782ed5431f0d2835dbc109d2a2cde9a933ceac3b2f174cc64d22546343ecb37",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -240165,8 +240165,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "51a4c0b2705c6a6dd9b4635e9d4206431335d386c8327626f7b4e758787cee11",
-                "select_by_single_document_sql_sha256": "fb4f15741595da8499f62c8333308db318419b6355c271191a508d864d9e0b23",
+                "select_by_keyset_sql_sha256": "2eb097ede19e2729ce9bf5a578aa20c4025ef126d737f1dfccc1b832f0574bac",
+                "select_by_single_document_sql_sha256": "ffc0e74a9d4c1d90d26b55bb1f13c9629c545b124d05eabecf1711fbdf11d19e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -240773,8 +240773,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f66afff1b1398e068d9deeba7538bad5a5f4bd15d97d5443fcda2944b58d976d",
-                "select_by_single_document_sql_sha256": "b852ad8991ac1aff27b0cc6a7ca5d177c170c7880d21f86ba7fac6beae8b5967",
+                "select_by_keyset_sql_sha256": "095cb0c18616ae8681bcc070ae4d65f08757391a1717ab85646ed9d043bebe2b",
+                "select_by_single_document_sql_sha256": "cd9af4e2f5976847fb0c57fb344d35629daf4c851587fa1587e56e4504365fd2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -248236,8 +248236,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0d4924a2cc619dc859004020ece40bb8b122c976a894a1621809ab91c592c290",
-                "select_by_single_document_sql_sha256": "6b1d8650bf773570f033bf65f61c1bd834a552c9174815bc9f6835ea795b90fe",
+                "select_by_keyset_sql_sha256": "fb72583cd28e61bfa7dd6b03d9487ba182cfb56b976935cafc345e26cd1b2f86",
+                "select_by_single_document_sql_sha256": "ec3ee3b4e594325863e41d88a5ce5b28eddda4dcdfbd08cbd44f68b7b44bc58c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -249682,8 +249682,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7269048137df3565eee0900b7708a831ad7b143c037e7e76650e78a02991e0fa",
-                "select_by_single_document_sql_sha256": "879eb0c7cbb00c0c6a48cced5e2904335c7a79c26dfaa8347b6de5208693140f",
+                "select_by_keyset_sql_sha256": "fbaab42f19e9cebc45d7bbeb2e4859c31829c368b5c592168ab7eeca20483dc9",
+                "select_by_single_document_sql_sha256": "6a7da4ad5fccc6d1d3ee001d06efed0c64b55677d190906b8b6162cd99f0d152",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -251055,8 +251055,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "85117a577307a86f0e14b09e7fbc6b91e0434a6697392c7e9210447c1759f24a",
-                "select_by_single_document_sql_sha256": "b988f09c7b6aea106e233e162169002082f4dd0e48a912accaf86632914489ae",
+                "select_by_keyset_sql_sha256": "d02a14581392c5ac56a384c317859fd8ae9a828d2e9303f85f4b4d68d09c36dd",
+                "select_by_single_document_sql_sha256": "db4fb7a5e765eced37a8d22f373a6e819163158229f875d7c436d01d193c4b4f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/sample/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/authoritative/sample/expected/mappingset.manifest.json
@@ -3106,7 +3106,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "46d43c48e9bd79709c57e21eac11abc23a2c9b6b797d924063b9a49caa4082bf",
+                "select_by_keyset_sql_sha256": "0dda696acf72c8ba3a270651e8b4534d787816c196024a29101e4c11f51005ba",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -10496,7 +10496,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7b1e1b185873bb47d29ec54cba1f23b5edd99da34822ca0a9ba26928b0816e37",
+                "select_by_keyset_sql_sha256": "eb27e81398030a66595259297cf65842a2d70a64fac46dc0f765a5bf77e7e112",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -12139,7 +12139,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bc2cd5e2aada102da9d093b35739395c025c16bd4ef9401f9f05411f8cb2b7bf",
+                "select_by_keyset_sql_sha256": "9226b5947f9c81c988dc1199eac6eab757669d7b119eec456f2704856bcf88a5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -13753,7 +13753,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "faa1aad2f0e92c7f07250cf0ce1470b7a300be102ed9b152ab3aefcbd4a1bd01",
+                "select_by_keyset_sql_sha256": "8fa9edfa62a556166406b1dcebc52915f63a644d1b81bfe43bd02b7b684e4acb",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -14307,7 +14307,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "93de0f631ef6e9bc2dc7bc347b3cdc54606ec545aca28c33748f217f75ac969e",
+                "select_by_keyset_sql_sha256": "f38fd1ee844771d4474814fac1734815dc02723e317c93f927b134134adbcc3c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -17672,7 +17672,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fe7ccc162244c46ff67a59857820db699f971ece58d5986b7b615bdac63391c1",
+                "select_by_keyset_sql_sha256": "fefc3e597207fa43feb21cde0ccf335d182f9356bccca92305d06fcbbd5abe42",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -19411,7 +19411,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "615a0f450fca204b69e9f540dbb22ea115691e5d853795f5300e61a0ea7cd434",
+                "select_by_keyset_sql_sha256": "e0c9f8f99b438652e0951b87553a6d9a71c370412130dca78f760cd596562087",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -22404,7 +22404,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "4c3b582b29d1e87cd32085d7f4cdcea5b897aff2cfe534876476f747de0b2ab8",
+                "select_by_keyset_sql_sha256": "438b93867495a7f9de39853b193d4b49a93bb9ce7b973f5850dc91cbba81a6b9",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -23309,7 +23309,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33197c8664a235cfc6251c0467ca5b70c7027e539b1d20d46613c26dab7f71f8",
+                "select_by_keyset_sql_sha256": "620e147e80dddec4d97a346df63ebe62519442193739fcb446a7404fa49b486f",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -26555,7 +26555,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cde41b2ffed383d99bf56d220b2f7eb5b41c4b07491e7b5c2b8bf5838895ce1f",
+                "select_by_keyset_sql_sha256": "b48d241337c3708cad9ba3f6115d96aa5cac6f6ef5f3262b7b536247e340e3ee",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -28025,7 +28025,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0599bde9cde57ca56e7322a70215a420170c45e179a54bacbc188ffc7d85cb05",
+                "select_by_keyset_sql_sha256": "5e0c958d18337caa86a7bbd2440bb8813c9beaebb47c83dbc3e3df265c6df803",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -30064,7 +30064,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ff7e4a576b981a9ee16235fa67e71d40fda09b89db61cd48faa60c9cae4f856d",
+                "select_by_keyset_sql_sha256": "810b2263317b2684c2f51630b3d3e9ce2a73187c8d90c168c902790c9fe8d6f0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -32129,7 +32129,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7398607c60590b3fa78c5b3c502c825841f5c9cf4eaa0dcff3cc65d1d627b17c",
+                "select_by_keyset_sql_sha256": "b04075d273e2857561012b262448a634353fc68ffbe3060745d40b4e877ffcc7",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -33315,7 +33315,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1a9bc54bae72a43d77128fae43dd2196283b9f5a7304512721bc02be7fbd185b",
+                "select_by_keyset_sql_sha256": "57fd1cdd638b9efd8da90211747b978b2ee925c4324b7287279e8607862547f1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -35133,7 +35133,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8c239d88c2f18f6bf1c8e00c6f6677d09a876a10546ffcf6ce7b839f8a0a3b85",
+                "select_by_keyset_sql_sha256": "445f8ec47a7448ef5288e0ce0356467663ee482131ac29cbbe3e1c35d4d6cf95",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -36175,7 +36175,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b4766d488150ead5f389f55bc316f516ca74f6d4ec6ca37bf2857dce53dd7cc5",
+                "select_by_keyset_sql_sha256": "b0cb08b19c4adec2eaaca5f35c76fbf87c3f0cae23871e2ec1dd977782fa3743",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -38051,7 +38051,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2de6b4bccc16353529843cb19c4bbfb84a6e6be507e5ee29413a148b6809e0cc",
+                "select_by_keyset_sql_sha256": "25406fdff467fcf5998119e8610b08e7435a918ee189b48c10530d555df706df",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -40779,7 +40779,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a5d18245eab5c581147cb742b030f77817a1bbf906b187f2364181ea1afc94a6",
+                "select_by_keyset_sql_sha256": "d479499fbca318b4aece6c218cdaa9c3ee2e9deec6f1012582e0e5d0c6e6da6d",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -41983,7 +41983,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2b09f30b0d17d7a1544fe4c635ddff7098cde668f10dd3a72033f2bd65ac03b1",
+                "select_by_keyset_sql_sha256": "c038b2b11de42ff022c09f1fb21f8aff11a684d3b2c08f278794849ac7a90f91",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -43219,7 +43219,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a944f4bde761239f5f25bce9e5f6fc0213a50954c8980c77e266e7f960639e50",
+                "select_by_keyset_sql_sha256": "414d738aa726d83e01ff985f513d12d324a3630d910aa9c0d8d1aea143c00f38",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -44396,7 +44396,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cf003de20bb83536b50d107bb08a09dcadfba2475573360a327a12acbd45712e",
+                "select_by_keyset_sql_sha256": "a16357df8e0d28f556ac6ed921e10a37c95132b3f0bf48850e57f171906b8f8b",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -48545,7 +48545,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "acf768f2b438ffacdb86ef57666ce7215cfedfbb8c1bc5f7f0665b97c6366acd",
+                "select_by_keyset_sql_sha256": "f02ff7c4b1b98846bcd0f040b1c4a1e598dffefb8b61281f13b6d803c32da372",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -51767,7 +51767,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "102526328b978fd644fde8b715e09f4f672f062b04ed0f32e8cd3d5c174ac34f",
+                "select_by_keyset_sql_sha256": "1e6c43ac8520cd549e42e18f07a2a4661f1e180056359f549631316aab2bc8f0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -52355,7 +52355,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d5359589399bc8d23ef09da07774f731cef588f15435cf4322c08fd23a863aef",
+                "select_by_keyset_sql_sha256": "0f32c6e34f33bcd722dc9193e1c0f29e172aa5bd9fd53d806f137336d19bcd4e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -54224,7 +54224,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a488e818262dc23031956ae5426e40cdaf2e379442b42e3f1d2c15c57b5e2a3",
+                "select_by_keyset_sql_sha256": "e06d9c6d14085adb8bab5497ab3ef45d158890a5ee65248d1a3f984b2701b478",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -56964,7 +56964,7 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7d8f216c224984a9047b365dff0bf629b489fb55fa44a7a57e05611064a42e5b",
+                "select_by_keyset_sql_sha256": "f7c72227c02f3b58db7f84aad0cf42567949eb220c3eeed128cb9e3d69243ad1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -59015,7 +59015,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ebfc7e2ce61b1f47321732a411b9e0b557d4cab18e966e9fcf4a42cc908aa8e2",
+                "select_by_keyset_sql_sha256": "7a923c908401c45bf34b471e1ff6f4549b3ec44219e68cff69e0aec92f1e6014",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -59821,7 +59821,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1984fd68c99f30774765cb0bb9008e279dc3420a1340208a5ef429f63f8864a9",
+                "select_by_keyset_sql_sha256": "aba70dd2120efae13da450769e2d658fbae278294ead55453c966280ad95b5a4",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -60438,7 +60438,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "929c6cc856a1826a23669d072f4297610048de4268c2b11c8e70fe98b013c1d5",
+                "select_by_keyset_sql_sha256": "24b8de6c0e3e9ca20f561a13112c2b310012015929a2450ba7096d70e08a2d93",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -63364,7 +63364,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bfa5552c025d3b41e8001c13e223e6d58a7650f6aa9de28c8c1c865b980654f5",
+                "select_by_keyset_sql_sha256": "6b26d061c38db405c9bb9517e5aeed9ea50e876ae051f9ee73e71c9f8ae88bd5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -66706,7 +66706,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "19170fc7d445c3066cd00331a242ec8cbd4addfba5c16378a58c42175bfdea2f",
+                "select_by_keyset_sql_sha256": "2276d4b06058d746e9e207f9e5ea7ef844fdfe7e72a94f844915b365d869cb43",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -68758,7 +68758,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "07ff3b411b776a92e06a597e4ce928c6c03bc3594a1a4de35959d4c8293cedc1",
+                "select_by_keyset_sql_sha256": "829ddad67ee941cfabcbcfaec1e46f95709d3d9db3efc8731a3ddfa94a16f23e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -74319,7 +74319,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bf64144f0a9e09a18879c78c825778ded71569ca086f5952a1c2f9d6f7e9965d",
+                "select_by_keyset_sql_sha256": "2206f5f92cbcd9944162ef7c6860dc4d518c478ab690431b86e795154b429902",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -76227,7 +76227,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5803df217858638468682a7244366cb911879f31bfa380bc0d51db9cd9e66880",
+                "select_by_keyset_sql_sha256": "c872ff6054c3260fc0d1b10a52d3d97789b8ed16f2d268f4bb24919228604a1d",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -77023,7 +77023,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b36f37f47e93b210b0a28f2aae790cf5120ead460e19b0b63223a59f3fde1008",
+                "select_by_keyset_sql_sha256": "d872e5b00c1dc420c0c67457f6b1b6f9f216391c0e3a4fcf6e81c131b7953bfc",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -77497,7 +77497,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b522c1f500bf16c0dc06d8dfb25edc3169be071326e40916a51131e27d8658de",
+                "select_by_keyset_sql_sha256": "2385d53b88e655fd78279000503951a195ee2c9ad509e3683f62961ac9ce077c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -81139,7 +81139,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "86cc904a80db045baa50d0755f9314efd361c9e860db6f17ae55e309221427c2",
+                "select_by_keyset_sql_sha256": "b26a935fbf5d0907a3c8c0239df18c63c9782d159316bdaeb02312f0f366432f",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -82808,7 +82808,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c616ad661782742875cd39596211d6fabbee8b01be53d7be9ac989a85f38509d",
+                "select_by_keyset_sql_sha256": "5c3ce16d55e8db7b62add6178a06805f93e8d27161751f4aa9b1bd9497bb0b22",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -84821,7 +84821,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05a360d303bde3527da705d9b235cdd8ede2064b413fb0d5a6564c0aeefe1895",
+                "select_by_keyset_sql_sha256": "628afd53a9e4ac086be5894861a74b72ab62d864d1a3fca2c7fd81eccc7baf96",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -86756,7 +86756,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "606d11982f45706fada9cb52d5f375d103356b99f7a253442446daf0f960729f",
+                "select_by_keyset_sql_sha256": "a0f85019b8483acdc9201f728d07e9456effa21fa08da4c1374a6965593d2427",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -88286,7 +88286,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "7413eadaebc60cf6f4fad9cdc9475972d587c32df5a3f4940187a17def5b71fd",
+                "select_by_keyset_sql_sha256": "dbca182c963078859ec7011b9fa3f4844ecd255cacba5fc51acd5f1a41cc3d79",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -89661,7 +89661,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a25c14fa54a6e688856a2c7abd9618f9dc17bcee815eb5a187e8feef2e93cd0",
+                "select_by_keyset_sql_sha256": "016f860e025f04fb2fc342902ab43215303ac2cb8c9942a37739a13fd8f24da0",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -91282,7 +91282,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e3e3ed34bf4474cfa1dcfe0ee41525b7263c713a0084e5f7cfaf1449ec8e6955",
+                "select_by_keyset_sql_sha256": "7430aacc37b74e99bb346e758424ec5b1caa55242cdea4264e82fd35d4d70773",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -97271,7 +97271,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3cc542ceec63f7f003c0ae1f2827f0c684ab756113ba12a5e590d8f7efbf6f14",
+                "select_by_keyset_sql_sha256": "dc89fb8e63238fa95b4301b8c33b68d6191b76297b98a625b7fb416494682770",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -98416,7 +98416,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "169b6c7ae64105496ddfeda0a98f272ea34c05e922086ce6527152c2c94d0abd",
+                "select_by_keyset_sql_sha256": "c9d4a52d71af3057653bfbd276a7039ed22367a0bd4847a6039f5a835b4ed18e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -99880,7 +99880,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "83227a77dc0a5be8f8025c3666f410483b40b9b443bc17d5e3a3e40aef597fee",
+                "select_by_keyset_sql_sha256": "69b30e96f517ce6a3313fa4c70c97a475421c028634310b3766eb1bc1409d0d5",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -100581,7 +100581,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0b3f99c4f435f36300f9f680fd64f24c242133fb51042ecb80baac254de27f30",
+                "select_by_keyset_sql_sha256": "ebd6f823e8cd54d4a871fe506f30f62bd16a0d4812b9eba64e8fa1e4e94abf1c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -100968,7 +100968,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3972719fe4375bafeefaeda2ce8838bb5e28e43af3e98dee22f9616ecb1ad02b",
+                "select_by_keyset_sql_sha256": "77342edd06bb60981fb69328d18737390be32d1232e774ed056b098b085c988e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -101868,7 +101868,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1d0da06c993ab8aa413cfbb09f474f423685f939640fc4675692bd2cec40a30d",
+                "select_by_keyset_sql_sha256": "7fd4aace8dce2b3f106bca72079643be3063346d05363ff6348ec796ee65aa3e",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -102747,7 +102747,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "664ace47fc239d93b4bb070fd4dda09f0ad0d2b9bbd40b78215f26e98dba0f75",
+                "select_by_keyset_sql_sha256": "04ff6d0d9b4bc673f20de6f37fa64cba75e9415f0424cbc82fb1c75615d208bd",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -103599,7 +103599,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5a9c6e1bca250fdab68aa6325f0f77a85fc7b3cbac07e3c44e52def1a467f1f1",
+                "select_by_keyset_sql_sha256": "4df4d1dce234b061049f6bf968c51a3e8d81aa1d1e15c3760f5b742e2f6079d8",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -104384,7 +104384,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "75aeed4c8c2db75a839cd442ab1d087637cd941190671f56183e63aef9fce361",
+                "select_by_keyset_sql_sha256": "4ff78e097eba6114cde885bd62897e5e499803c71244b722aa272b54d94a0ce6",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -104858,7 +104858,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "16938c26de3a1a4e4e7260e8c5c8a43825c33359359b95f0d025bec8cd964ef3",
+                "select_by_keyset_sql_sha256": "69e642940418747107c4dc79db67efd46135c8ae00a64de896421f584fd665da",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -106129,7 +106129,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e08b5a716b92cef659e20a19bda361007551006042262dc6215a79a60eaf87b0",
+                "select_by_keyset_sql_sha256": "92879425de21a98a1f2e591e5ee9c7ea282d67ee8249a0910079f081a8f9a2e7",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -107458,7 +107458,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "9cfdb246b9c64dc66c980f7143651fe8348a6a0a635435365e96bb175930f13e",
+                "select_by_keyset_sql_sha256": "fad1073635699788d0a46d5b9872144046a3102fbd2c992ad0b1cb47d1ae1aea",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -108247,7 +108247,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05ed9dd9f13ac5c1f7d3ea8ed54a76cdf79e17ce9e6df2ead3b04ee0b7ce3172",
+                "select_by_keyset_sql_sha256": "64a3d060b63dff18dedf157a0476a2fceb0b23c244d6bb97ef2d5cb08fe2cbac",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -108971,7 +108971,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ca14bc865362ac84c91e30b9339fa8a2fe9e76eb079b3c0a8705c38dda7d934a",
+                "select_by_keyset_sql_sha256": "153a3cfbdeff38b78906821e3cf3c4d6d6f7b90dcb8f2bdcbe32573a6d1ab0f3",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -109620,7 +109620,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c0c9b7e9224ac4afa648c57f0acb915def5982a58ed6108d1c94547e64fd1d1f",
+                "select_by_keyset_sql_sha256": "7a82907fb046d8cdc6424af57955c364c726f57708fdc4ce6c916ad98289f6e1",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -110706,7 +110706,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "44c34c24278099de4088260ca036fb823e450362c5baa3525184d18865a02cb8",
+                "select_by_keyset_sql_sha256": "6f0317785e18df707e7f932d2e2e005d6e045277391d84fe1a14878893b2ee74",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -111458,7 +111458,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "02bf694239b7a60c50bb23c4c309b13af1f100f134ad7a2c4c6e4dc3e8db4152",
+                "select_by_keyset_sql_sha256": "bed43877000b159c654f46de10d2493a3ac32ea860175cab1d6de02ac49a0edc",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -112890,7 +112890,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "67e9bda399367d8d8964f6656c9e3935f589446215bb94b0af3394dbf0b4ba89",
+                "select_by_keyset_sql_sha256": "7846736f79a49fb7ac5c1bfb2a21ecda1b285806bd3e7b704e3c9dbc45e490af",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -113685,7 +113685,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "9358d1fab731a8219d326ad3c26a94ac65d3bd7d0060d10bd4c54f74cbe95792",
+                "select_by_keyset_sql_sha256": "4947825e5b13166ec7fed0501193abdb6786bfab89f5995ae5fe718012c9c305",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -114542,7 +114542,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5d5d919822433e82bbf91206f600f7a74c51b44066c51c5709203d9f0f3cba27",
+                "select_by_keyset_sql_sha256": "95f9e309c84b69a6c5b0401b79c349fec1beedcc4593bf101fdf92f16ecab216",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -115150,7 +115150,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "900795b62986f0f7295a5bad7523a813ebd1e2e49e3a12f9ba838148f7811635",
+                "select_by_keyset_sql_sha256": "f6fd62f99670604d7f508cc9bf394942ce3662946bec2a2abe548c78f64a05fd",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -122613,7 +122613,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "98fe24c7a3beb0476e427f16a6318c601aee1a4695a19767d327fbeb77fdd7e7",
+                "select_by_keyset_sql_sha256": "afd4dd3da8c58da6d6d608e139679d65769effdccebfb500cb250e5f98a61364",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -124059,7 +124059,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0b0da0364e49c4383923a87f1919d036f5b3c514b42e28f46bef19a869e7b650",
+                "select_by_keyset_sql_sha256": "9f2ed5de65c98c51b85ee338c2961005cb7ea66bf72fdd17a531852da9c1435c",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -125432,7 +125432,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3a867e23deed136c56d80a346501182e00d43dcc04c7c9e65c36487845532e4d",
+                "select_by_keyset_sql_sha256": "0ec0e4e5363387c227f165b85c6d9b47445285f37af1400607c64b58d61d393f",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -128729,8 +128729,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f39360e27cd8ae3604263bbdb22cab2166012f7541b0159e8f1b59a50662b44f",
-                "select_by_single_document_sql_sha256": "a6adf4cc94244993f6cce3f66c0cba29972954c0bf90603c60872277d3f9993d",
+                "select_by_keyset_sql_sha256": "51f2478482de4aefbd58d5cec3e4a4b69fff672f89b386726aaeb5d163418274",
+                "select_by_single_document_sql_sha256": "061e5e4a07a55aa957aa064c35840082f77b921370b667a6be7e92abb2bf726f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -136119,8 +136119,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "17e8ef3129339d54eb0d49607c02e86ae3e8f4c688fc1440bda837875d9107b4",
-                "select_by_single_document_sql_sha256": "897706172ad3d8132e8e7786bc6f22258934eca80532316f1f003de757f77139",
+                "select_by_keyset_sql_sha256": "51fa3b414ae6a106807924ac8d4ce485113ffb99058eaf37c3513e87966603a7",
+                "select_by_single_document_sql_sha256": "baf677ac9eeddcd19ae6b42b86c02331bbcdf3ad3a6122c04b9bc3bd3a7e65ef",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -137762,8 +137762,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3f82bc02404955b59d6d383ec842371a61f5ddce0d3cc728b23f7ee1786d28ef",
-                "select_by_single_document_sql_sha256": "391fa1e423c91829981178c132d571486a163d7b44404eafd2bc5ab9ff8e8fff",
+                "select_by_keyset_sql_sha256": "243748542ee50d0cea4f99cf257bdcb413e3888e76c3e17dd0f6d9cea3b94d09",
+                "select_by_single_document_sql_sha256": "daf110933cb950cd3f20796d1c682b807053f42ef599f4b63244e138b763fe61",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139376,8 +139376,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6a57305308773f8bd3abc382f0fbdeb5128dc0a16aaf39580f2efa4fae6a4ba1",
-                "select_by_single_document_sql_sha256": "293f19dfcd4bf3aa997cf07835c7c6d0badcdee7a3a2f7e50a899e73b4e6cab9",
+                "select_by_keyset_sql_sha256": "b3f5c167787e3e0826d2b45a35d58ed1a2e1d568ceffd111b7a03b4844da7829",
+                "select_by_single_document_sql_sha256": "321f939510d6dd1a472fc4eb08e37eef5bd8b5d7c599a70b5936b2c7df7b5dd0",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -139930,8 +139930,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fd1b1302ff15175576fc878fc4090e4a726da7baef5d043006cb1c2a141f984f",
-                "select_by_single_document_sql_sha256": "c77d4ab8ffea0d8bb9fbad96b232819d815ef2e3a757cb839ea2f44c6b0f3535",
+                "select_by_keyset_sql_sha256": "9113bacf3302224ffb890b71903b52ca374a1a8b5dc3758a99fb1f545e8e4ec8",
+                "select_by_single_document_sql_sha256": "b67683e6def69db8459428589a6e7d6d0f3056a5b9c916b8e41a1d179de312d1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -143295,8 +143295,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "113e5bab0c1c8650b862aa977649aa1967ef2f8b44fa48b81b6506a2319edf33",
-                "select_by_single_document_sql_sha256": "7b38ba74fc5f067f84a07d76761a6e4af9079617085faef3a03deaf88e47b9e4",
+                "select_by_keyset_sql_sha256": "a674a1787207c8d6dd37f8d1ed3c8fa8b4fbdc638145a5cc79753d5d1bf5911b",
+                "select_by_single_document_sql_sha256": "695634d3309a6d3766aadd2456fe407acd4e06a0ff4a3358617fb989c06fdece",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -145034,8 +145034,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ab59464dac840fe20120b98f11ab7a4f740f06a0b826ef76f5b6048961b40698",
-                "select_by_single_document_sql_sha256": "9a611932ebde7064b7cee648bb258c297c09fa2f4aa428c43f67ca9791ea3e83",
+                "select_by_keyset_sql_sha256": "7669597d42903d88b67d3626e406877a73d99e4bf94fd3978736b1ff3b9f20ce",
+                "select_by_single_document_sql_sha256": "ae5e95b6007177697e9952d0335b61e980ab007f6c9434df8bbde9e118fec632",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148027,8 +148027,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "6f3a37ca8c808cefaa61cd897b65aa18710093af74930a55bc82fcd3d8c1375b",
-                "select_by_single_document_sql_sha256": "7cbc1dd7ff123cb83f7db8a226201fb1598bed11a33748cf10046bf81d2bbad2",
+                "select_by_keyset_sql_sha256": "e44d3aaf281d296069372e56b7bcb2b9256eaae75fd2ab44cad14425596ec614",
+                "select_by_single_document_sql_sha256": "1d32d3decb67d897327d43aafd0f2dcd3e6450283654ce2548951e615f515114",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -148932,8 +148932,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "4654c6f46919da92cc5c43aeba63ff6d5b42a71c50e59802df91c9e45403c963",
-                "select_by_single_document_sql_sha256": "5aaa655f39db805b93ac72fe2973deb6fb351479a66e63dbdb2f6ee9ed8270d5",
+                "select_by_keyset_sql_sha256": "fdf6ad1d9a8ca642444568311d08a3a76a46b93fff9b6b895cf45860b12805e1",
+                "select_by_single_document_sql_sha256": "c2af2c1fdfb594a6677e4c3d63ff3545724ea96856b3876fdea7f54541898e5f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -152178,8 +152178,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33e58c9554ff95d9dca7251e0662b6ab601228f810d40bd4e68751584040c441",
-                "select_by_single_document_sql_sha256": "bcabf740b8151c8e1b788e6923796493632387f824522e73ee48743f5d688adc",
+                "select_by_keyset_sql_sha256": "93e995147ffeebb599b7c7eba34d09ac2d99ccc5cbfe2331ba6968f186a307d6",
+                "select_by_single_document_sql_sha256": "c87cff1f978b33858f0aa3b51765a43c6734325c700cc650a2604890390163f5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -153648,8 +153648,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "63f9fc6b9f8ceec5de78b520ca0d99c5333f10cc03808aa565f7d8124e2e590e",
-                "select_by_single_document_sql_sha256": "9c51d1806735a5698dea2cbcb107285b3e9d34bccd4ed6683c276e1c181a82a7",
+                "select_by_keyset_sql_sha256": "312c48c3eb3bb85ed69430b94e9e765dfc7b6e7d5f13b569827149e7aa854bd5",
+                "select_by_single_document_sql_sha256": "41da8595a7516b485b5cc3c74aaddd86a43f6f22dd76e53e658107b69216ca38",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -155687,8 +155687,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "dd216b84d6c239253c405e162690e7b2020b64bbe592b9c29535fa5328d75932",
-                "select_by_single_document_sql_sha256": "6da9eef1e8eaaca5760eccec0017571c536cee151d64fa2e0740bdb616dfdc2b",
+                "select_by_keyset_sql_sha256": "b68aa07dcab202642f27fef361952d780f765e90416e9c48fd3de913e9135c5a",
+                "select_by_single_document_sql_sha256": "11cce6fa41604d938e7d5303f5125a45ed677ab9f406509579752512bf60da60",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -157752,8 +157752,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ac936c4c15c2a841607648ba4bff107d2a3f1c82ac2727026ef9066ea34c3487",
-                "select_by_single_document_sql_sha256": "fb62880678fe134ec036429012796b4e06b8fe809a41bfc4436304c5f4e19a58",
+                "select_by_keyset_sql_sha256": "3510f8eb93b6357fff8ff83b05ce598c00a6e054609400b7441248e4753214d0",
+                "select_by_single_document_sql_sha256": "e572734b8178d10ec60caca1bd1f4cdd3d516ac836805de32823ce56e7c75b7e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -158938,8 +158938,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d73f6edd1f02983c122f4edf24f5c017f7a2cedf0137237ed5cfd916dac0b72c",
-                "select_by_single_document_sql_sha256": "9b53c26542917dd0df74b087622f96526e3bda0c89dcb399d474fb0d530626d4",
+                "select_by_keyset_sql_sha256": "a471dadc1c3eb8ab8b6564b298b293692b96945bd0207e1a7bf574106cfcef33",
+                "select_by_single_document_sql_sha256": "74c44a4d2ee676569c031d02cad16bd6661cd7291beb8504effa510713dda32b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -160756,8 +160756,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e44c81078b7b1b25e36d2ef300014faf3641c43148d4454e5dd15800d5af1d7e",
-                "select_by_single_document_sql_sha256": "ef946fa16c0bad24f1091427d9284f44bc05ca7505042baf66d6319ed9807a74",
+                "select_by_keyset_sql_sha256": "664725560b89f8b1e63eed9175a12eadbf5cc09c9bc5760946054a0bfb28a0e3",
+                "select_by_single_document_sql_sha256": "57f8a72c07898ae81246b46b1be6dbfe3095a361c646446aa0e907ac26fda524",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -161798,8 +161798,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8cf4087f2b7c1bb3dd3bba2106ff4bcb7eeaa924503db637d207e107eab5a4c4",
-                "select_by_single_document_sql_sha256": "6f94802ac3d835e728fb03fa90822dd6abfb7cde6fd8f44a50f5f3eccd56843c",
+                "select_by_keyset_sql_sha256": "753c860c0e3d156a49fac2946afa8efe74e1f22a8ad45f145d93dc490e8bd70a",
+                "select_by_single_document_sql_sha256": "84dcafb0ad50e6dd2599ad34cfe14024f0b7f29cebd7d5191a3fde7a50c9437c",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -163674,8 +163674,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "f92687cbde4d61e50b1aba5bfb3dba6d313c71e298c084d54f737ad9dbc914df",
-                "select_by_single_document_sql_sha256": "215d351e0d6784306d3d44a9a65e9d6c26b487ec92a92ce5eab97224adfb8ef6",
+                "select_by_keyset_sql_sha256": "3e455fd811873be6e097b0d85eaa40d08f35d949e91aced687f23d58283b9467",
+                "select_by_single_document_sql_sha256": "f5e4b8c605e4a0595e0313a741106447de087f3c64a51a6a5f55d50b6c5eb269",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -166402,8 +166402,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2f741dcf9308c6fc345e7527c2149c1ecba72af3338a747e9bb9258a5ef7dd20",
-                "select_by_single_document_sql_sha256": "c2479cd91c75fbeb913f72fba5a8ef58c2b6b7c1688bd9207740f99be22c056f",
+                "select_by_keyset_sql_sha256": "6630f960929014baab86e0f3d533a001104e7e206095accdca6d221c04e2acf3",
+                "select_by_single_document_sql_sha256": "a77120ae9183c948558e6d929fa37814643f067bd2ee09c148f6e1db76efcab5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -167606,8 +167606,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d463b52e017b62a2be7a968be93c970354fd5bb4839275fd4b47bcefff31718e",
-                "select_by_single_document_sql_sha256": "aa41dabec5237d310ac6b6e00b8c2d03ec1922233b084f3c19facd3195b6e23d",
+                "select_by_keyset_sql_sha256": "22fb11cc51f27835c48e5bb7539961955dec3c1e3a4986784fcee313cd38a698",
+                "select_by_single_document_sql_sha256": "00a755604cfe5077cf60c7eff936cd7bf1299cccfeabc56350dec2199554475e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -168842,8 +168842,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "bbd7ec63f6bb8aa1fe49cc76e7713e037fe8622bd62ee93c3c424c3a40c5f815",
-                "select_by_single_document_sql_sha256": "fdf1991bb8c3061e3911895d91aa5759852ea343c4864ae29f461fb865f59598",
+                "select_by_keyset_sql_sha256": "a795b7834e963d2d073acc48db716de4ae636c166506bf38dc6da0ec74b4aa0a",
+                "select_by_single_document_sql_sha256": "cf46398551eb2f34fd154f98f1567cfdb2d2a17e61a285e1ba9cd8953376bf10",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -170019,8 +170019,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "a36c0e1d5c19accc38ee4a7cd7abbb08d0d8b97bba3c7554457a5c3f8ac0dd74",
-                "select_by_single_document_sql_sha256": "6b7bf3082c1c6abd451b9a8de329917a7532c0d58c3ef8cdcd3c5ded64d7d500",
+                "select_by_keyset_sql_sha256": "35adcdc9ef468b83ffc71afd41ebbe7902c2330eabc999334823b8a50dc0dea4",
+                "select_by_single_document_sql_sha256": "5133f05377209e9f7ef642b6310afc7550579c494cb09f526a642e5ba34d5ea9",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -174168,8 +174168,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e06c766dc4d2e83f186b1b55b22900598b3ec71d1cb50047179f87db336fc9e4",
-                "select_by_single_document_sql_sha256": "3dd9d236009b8fcbf1db8ac7db3d5201daf6db36714cecc8bf818c2b6b4a3511",
+                "select_by_keyset_sql_sha256": "51f6723ecac2f0c61f3eed460cd1e3e8e5ff8f78a9fba0c19f6a8189bef06034",
+                "select_by_single_document_sql_sha256": "61fbabd94fc8b70f5f6381138dc12800bae831a0cfa5693330411fc16cbba234",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -177390,8 +177390,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3b2db7d19d86d90c11d2b1bf192994ecd9b593f1b9e76772915e3edd45194e78",
-                "select_by_single_document_sql_sha256": "562e010257e88241970df76d2ca9b7c606dcf89a3357ece0f18c6c600495d8f0",
+                "select_by_keyset_sql_sha256": "1701a0b9be3ea108e96f81c781c432ea5611fa9ba7e6d24d1e1ba4c407fd21b3",
+                "select_by_single_document_sql_sha256": "a4d922b56b48e61a73ee5657606136029be91d3771fd7ecde397a2514daa116b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -177978,8 +177978,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "080bad20ddcc9e62739fd7b8fc739b470f0d6e41b1b3e3ecf152b973ba58592d",
-                "select_by_single_document_sql_sha256": "c077302b7de4f06213b25adbf86bdccc9bff5f8cb208fef82fe765b4fb31c1c6",
+                "select_by_keyset_sql_sha256": "82db74cd3278ec8f9cfe258f64102328263c776f35adc107a3ede86c1cf520dc",
+                "select_by_single_document_sql_sha256": "f352acedfe64b982c3251ab746d1fce4b5a3c29c6cc1a54a6776b21ff68403da",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -179847,8 +179847,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "831c96a0f3a4bca781ec9079068ff13020bcab848960d8427720fd58146c7b61",
-                "select_by_single_document_sql_sha256": "4feb68e84c774a956796b3f4a5ea98eea661a0d385b717418a398070cac5be70",
+                "select_by_keyset_sql_sha256": "3ab7d71e11227c695e93d73fd60622a43e75c36429bd4b0ef4cd8fecd6cea8c6",
+                "select_by_single_document_sql_sha256": "92e845d95ef6019a0b223f53e2118a8375fe5abc84885feba5378dd98eeffa7b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -182587,8 +182587,8 @@
             "reference_identity_projection_plans_in_dependency_order": [],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ee0f6090b5e2780295487aeab72c7522fa12b436604449796b5871d0a69957ea",
-                "select_by_single_document_sql_sha256": "4238cbbf90e8d8b35cc54c911440a1b76b130337f0fea492d1208d50fa39e99f",
+                "select_by_keyset_sql_sha256": "f73f2c18df0720d1280f43c3fd0c0bc96ba8faccc3239d7c84766a90af55617e",
+                "select_by_single_document_sql_sha256": "ca121129ca86647a2caed26e19ca739b2edc943a3869d0aad66f6a1e9b9122f4",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -184638,8 +184638,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "eeb63d622b2a225557cb953150d4974a46e3463951405be638caa68a30031886",
-                "select_by_single_document_sql_sha256": "e3ecfa0ad0de56590d9776f1ccff5518ffc57c2b1135b938d9a3b65785e3e9ef",
+                "select_by_keyset_sql_sha256": "a5f929dfbc316b48bd031f2dda7df6a47bd13c1a0cd4a551ddf5d71130028ce1",
+                "select_by_single_document_sql_sha256": "4a7f8d1f98e166c6e942e1599471ac40a4036633fb08e435fd1f40ff891b44b3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -185444,8 +185444,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "eecef2ae2b779b199fa89720677c1bf98ea58536852311f3fb844636b9aa1d57",
-                "select_by_single_document_sql_sha256": "7c53ea76937115eb15cb17b5f4f0f11ec88ea3b4096b68dea4c475f281ac3a08",
+                "select_by_keyset_sql_sha256": "fee02c2ee133546a420a22e14c2aee6777d20697d44e8dbe4355399304fed330",
+                "select_by_single_document_sql_sha256": "b716f7a84f8f13e55f58506e954b332565c2652f0bdb8f818c383b72110ae470",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -186061,8 +186061,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "8a7f9a5b16414cacae0dc92a8844a33d79df009a5c4f010766efaf334acd7e3a",
-                "select_by_single_document_sql_sha256": "00d8b08342c4482194c2c8ecf80c133c978f10967eafb44a9eeb92e54d6f18ff",
+                "select_by_keyset_sql_sha256": "ab42a8a5d98e2ce292ad973a2bfc9e54e16c6de126c779358a6919f418933581",
+                "select_by_single_document_sql_sha256": "8388cb62be3bbf43e5a96eb701289a39c319f69c25b4475df9fa78f170bf33ed",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -188987,8 +188987,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c4bdbdd241f1323faed3e53cff3219fa09cbdbe14c9a9dece649ad0e97f3dcf0",
-                "select_by_single_document_sql_sha256": "321001e0539f953930dc243cfde01fd0fb2c90af3c640d0cfcb6b938769c651c",
+                "select_by_keyset_sql_sha256": "ea87e53d15945111e527e1427dfa280d1248df3b4bff29893d0c4e0761be83b8",
+                "select_by_single_document_sql_sha256": "d0ec92acc2a8af75e9b17cd2ab533b3dac4151698f8b8b572191ec5805868ea5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -192329,8 +192329,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "13b895bb73e83791da21aa13c215f3cc4789f026d429f6232c2f8248ef26044d",
-                "select_by_single_document_sql_sha256": "cdcd18c31e4df12327721498c28932f0d8aff786188a439441bb9f47c8f5ee71",
+                "select_by_keyset_sql_sha256": "458a16f67b43631e41ae5d5b6eb3b1ebf4ba7cf5ed1027669552a0728089935b",
+                "select_by_single_document_sql_sha256": "6600eacae6e3f1eb9b03a837123726a8d94e133567db2e4e71fb5bfe84f7facf",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -194381,8 +194381,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "928998a0a4d4272f5798075257e8611d7a845a00243988e5db6c1b1553429964",
-                "select_by_single_document_sql_sha256": "362d705750765aa3a3d216a4d7196f9778bd43fbf37141e83c7647361c5579a7",
+                "select_by_keyset_sql_sha256": "79a7c35ac66f3faf8ac809571dbafc008d486637e6e8a8b87c5c80784c8513b7",
+                "select_by_single_document_sql_sha256": "f4c1513a166097c5c96d4995051e876ff14e8d8a9ab701940096db0eaabb8df2",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -199942,8 +199942,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "64efaa7bcdb91a1b74dc3beeb56ac95dc220d4ba11329409a24bb10ec2a5dde1",
-                "select_by_single_document_sql_sha256": "891cc038057ecb3ad34c338693df34c6063daec61a25750e5c61f596536ff861",
+                "select_by_keyset_sql_sha256": "c39e00b63e677f65029ab3948699b373c8e301db3c057c926723e89ba861987b",
+                "select_by_single_document_sql_sha256": "4e846056ae08e843dbe83e4a6e66e6d178526d4e7058075f4242ce1c8cac098e",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -201850,8 +201850,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "cb1488a685db741673bd4c8f8d9a4c09d870cf5bb29d37395c45bca80ab34649",
-                "select_by_single_document_sql_sha256": "1d535aa7475123e2db3e4846d5f6d84a6ac806e5576a0d1fc30188b92279aefd",
+                "select_by_keyset_sql_sha256": "a5d949c9e06be0d738ceaa8abd16805e1f003ba797244c5abc075a58bd8f1ed7",
+                "select_by_single_document_sql_sha256": "1ed8b5719c4e006728529c2259e83439d057c3b9cc5737f089a25674bf32c115",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -202646,8 +202646,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2679e0d3eca2207eb8c12fe242ad5aa3661768a340f4e8a8372153de6ba95a21",
-                "select_by_single_document_sql_sha256": "03436a07b6557be7ca6cd3a5178fc4bc4291615a401fd358d0f361f57c6f61e1",
+                "select_by_keyset_sql_sha256": "11157630b9ee85baae51536b8eae2ff1e3a353c0e72f7b1638b3e186dafc4c7a",
+                "select_by_single_document_sql_sha256": "40bfb58ff93a51e03c72cde297ac833aae60684c48a5c6a5ee46f2391e2592ab",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -203120,8 +203120,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e478c57f45f20c4a8800d482dcf0b3167cb42644b3a7a0f8780e49255b998a27",
-                "select_by_single_document_sql_sha256": "887e1911d001b32d57fc11614e9b08cb29c4224e3a268f3079e1cc1ee367c728",
+                "select_by_keyset_sql_sha256": "59968fb086aecaa3aba53353e27fec2b2193a015c3cecb7b76c2b92c49739cb8",
+                "select_by_single_document_sql_sha256": "859bb5946a64d4497e057aee5d1ab705cd2bd844664bd3be4f63739d3a618844",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -206762,8 +206762,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ec1600944a415712ba3a20276c4df3e90344a635e61d4862a3fd54e158154f90",
-                "select_by_single_document_sql_sha256": "028a84bd53184b7fb3fe574451a6efeea30ca1478d845ff04f5079c4c44919e1",
+                "select_by_keyset_sql_sha256": "c729d103867d56b086bbd145c9bbd89fcc58ac0f348a9d7d1313968d5050cc77",
+                "select_by_single_document_sql_sha256": "8f6ac5afa8f4540bf3b49417ac33d93a049c4abf921fee9a9c4d6a7bafb3212f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -208431,8 +208431,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "1cf987b26dbaf33065bea7b5824bd825d46823804908c0d6e49890d96cb623f6",
-                "select_by_single_document_sql_sha256": "29c11a429eaf4b9ee38bb6ea87c51500146a71e0796499cd6200600caba9baf0",
+                "select_by_keyset_sql_sha256": "bb151c97106e86688ec249425250d05483f0591b3f2834758820917b21694504",
+                "select_by_single_document_sql_sha256": "f3569d409af5968045579b245658bfe32ed7f4726a048d2f4f86c0850d58ec87",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -210444,8 +210444,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "043f7a4a4a5eeb39887dfc65da19acdbd6e026147eaf8945d6be8d65dbfdde4f",
-                "select_by_single_document_sql_sha256": "7ba4994666ffaf3f885fec01342f2c4868fdc92bdcfa6a3b1f033dc481f2cc50",
+                "select_by_keyset_sql_sha256": "71921fa31c374375b3e49972da38991650a454ba7356041f494caf39872f3563",
+                "select_by_single_document_sql_sha256": "0bdf20b603a6af5e1a33131889a15b4776c071402ea46193ac6ab4528b5fa778",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -212379,8 +212379,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "57a9eca05a8cf28f05e2823e718af3b4c23f50cde45720277c4d1cefe70f238a",
-                "select_by_single_document_sql_sha256": "fc6fbb8541a60e7c46de8850ac083e2096e6a58d24601e0ef4f5627cc6ac04b1",
+                "select_by_keyset_sql_sha256": "e8debefc1ae64dc347a9733fc897c8d57c5a50f5264d0aedd7618adc7a616a4b",
+                "select_by_single_document_sql_sha256": "44a855b428bcc8b9a067b7b5bdbdb31c231542a4fb18cf043bab6ae47584421f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -213909,8 +213909,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "120582e06667726ad3333deea42d5609a16ae1720592aacf8c675c5039c6eb0c",
-                "select_by_single_document_sql_sha256": "0ea77cbba3a5e8dad63fc450488c2d28a92799ba1bef51aa833697b98638a72e",
+                "select_by_keyset_sql_sha256": "177b897742188a9745beed68ad2580d14480140cf28a7a69b9b8a1bd1abe3533",
+                "select_by_single_document_sql_sha256": "cdf52bf4afd8311de3e99c62cf2039bb5f1de0e00550c63684935393fccb5382",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -215284,8 +215284,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ae4939f77ed17a94817fd95af4073f66646a3aa49dfd9ecd99546a333a970aed",
-                "select_by_single_document_sql_sha256": "fafca9bf24c515b1e19284e440ed337fc15f43fd56b0571894673db2ac522c91",
+                "select_by_keyset_sql_sha256": "e123b08f79d5093328ba6e1c70308fe4bc2e03ba917ea34b6f533506c46cbb63",
+                "select_by_single_document_sql_sha256": "fed980bcf1d2bd434e9759ca70618422053d388535986bc7980b1ab5ee378540",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -216905,8 +216905,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c41c5872d7ecaf82d0f278cf5427c01d1fd4bafe7517959e17f63eb41fdf53d4",
-                "select_by_single_document_sql_sha256": "2fbcdc447fff3cca1b6bb4550b2d42cc99ab9d53230f4e57c6c35a7cc1d26498",
+                "select_by_keyset_sql_sha256": "cddc5f9c8ffcb6abc30836b8b780f34ccc6773b3fc31880953bcf7196ed891e8",
+                "select_by_single_document_sql_sha256": "2c37df0dfcfa8c95c7dde5745b2ca3ee16645581ae554d8f4247c4d987453e77",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -222894,8 +222894,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "aadfa799c5caab8416eb6c74f66229b125bb98bef6de41277f2e8afc15eadb40",
-                "select_by_single_document_sql_sha256": "a47434f0ca64633a1b0af218c58105905e1eee97be5438e17baa0ed373372b14",
+                "select_by_keyset_sql_sha256": "a525e349da86d031a4200e23e72f2ec0051bf44623c2c9c19d62bf5a9ab39cee",
+                "select_by_single_document_sql_sha256": "dd099dfbc8f80c5cf9fcb8ec2dd2335877e7885d47bfef9ee42441e5548a32d5",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -224039,8 +224039,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3d9a84ac8c98233f29a9a7c2b26e8bf2707d2fc99ce42243c262241cfb1b55b8",
-                "select_by_single_document_sql_sha256": "94b82532709d34a58e9e2e2e2e9b6f7846689f7004469fd6597234fd6b387020",
+                "select_by_keyset_sql_sha256": "2387f7f91cfdbb90eaa1f80baf0224cba480b388941eff858dfb234def6cfbd2",
+                "select_by_single_document_sql_sha256": "6c0554481e0a016f85d89a6f7a3ed1b17a7b0948de6b8f70af2434d91e5bd060",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -225503,8 +225503,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2c7b054da0a1d0f6457d41a097205091aa23d2d45a512780f17bedd5806bad6a",
-                "select_by_single_document_sql_sha256": "4e67ac23654fa5198913bb69a58214a0037667fb21cd6167be36b2cd556fc061",
+                "select_by_keyset_sql_sha256": "b2f99ddd608d7745f8d645e9b8adabf77bf01bc51956703b140353fb53ec1b2d",
+                "select_by_single_document_sql_sha256": "80f8610ceb3a7acb8aaa48023cadab76a3549f6fa5b4d871165451f2711ecffe",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226204,8 +226204,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ad313a4d862599b90ed2f1a2f80c809d4370f7ace35e475b2369ceb3db7257e5",
-                "select_by_single_document_sql_sha256": "e7ebda46e99d471bd9e60eb9c086609295f8e449809651ba73c6e5fb5e6e544f",
+                "select_by_keyset_sql_sha256": "c885313f8314a4b9208e915479b977d5fa562e4458e0f2f8994cb8053bce55a8",
+                "select_by_single_document_sql_sha256": "b9cd1b77cfd3e18445d3a0ef0f35bded326c1a66a54fe392914bc97430594866",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -226591,8 +226591,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5f948426194dda8587ba2c6802f9aa8611c6967e95d90a88f5cff78e29b2e56d",
-                "select_by_single_document_sql_sha256": "6711489b1fe902e209c3295722201c24d166d75f6b779b0d09018b9a1b510d76",
+                "select_by_keyset_sql_sha256": "5e4b0df10b28172575cc97df5211afd37d5ef060d5e611fd34d8c0baa2c375f0",
+                "select_by_single_document_sql_sha256": "f3369a80c76f960d444c8b6907f396d83ab6bae79acdbad717ced2c4c8d6e691",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -227491,8 +227491,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "158cea9db36736a996533ad84519696af12e4aa035a1ac18cab1f02e703a00b5",
-                "select_by_single_document_sql_sha256": "0978b7d00aa030bbe39e4a890523fe838d8eac44fe924f5173fc987d37cba785",
+                "select_by_keyset_sql_sha256": "e820012a6cc9bae424f2e12f8f3553301cf1c269347166ee9c893ebf364b3b06",
+                "select_by_single_document_sql_sha256": "3a10b623c0710b819e85e74ee27bfa0d966b48c5c3e7f1db96463f274736b640",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -228370,8 +228370,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "5782324de47f0e13fc7f110831f841c4fa5b2787fe42be74f9a197f1c55909ad",
-                "select_by_single_document_sql_sha256": "d2c8aa4f785e7735aed9e26f2be348790fd471ec61d096183e5514e783d34a47",
+                "select_by_keyset_sql_sha256": "3eff92fb021d3661e3101a76cd8135db92b4db1b70b691241eb5592734af32ae",
+                "select_by_single_document_sql_sha256": "84bd82810ce4d59f1e341fc115c062dce4196c067322de0f39e297995c430161",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -229222,8 +229222,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "05de2823ea37eb3e49b9b162ed6e8b06b44d852a81fc659077f1f1121e33b70e",
-                "select_by_single_document_sql_sha256": "e6e8908cde902095ffcfdb5251801a0ccc5bf9488541a6b891e35602c7a520e6",
+                "select_by_keyset_sql_sha256": "98a30a0ff5ff01492640ef722e621938311d41230fa367ea81e19f8b383477bb",
+                "select_by_single_document_sql_sha256": "c0f1b123716f5fcfb8ac081281cf44cce90201e05be360207428af20ea561cf3",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -230007,8 +230007,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "0366c0f49c04647fcab738d03fc7a4be5fb41c74d50978d7822fe342099d847d",
-                "select_by_single_document_sql_sha256": "4cca6347b2d4ea4a0892563a09eaf9be9ad75d0a024842eb701881654d1dd6df",
+                "select_by_keyset_sql_sha256": "c5cbebd1baa14c5daf57eb05e1b84417e857239171a9eb4e7c5c52e440747eb3",
+                "select_by_single_document_sql_sha256": "3387a599d2fd9869f782bf54e2bd820311d90fda9bc189ae9aae3d7da3ae6383",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -230481,8 +230481,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "b45fd4140cb5ab65a19c2811c39bf9bfa9f31a0df4a3369939af021d75a5c818",
-                "select_by_single_document_sql_sha256": "250a25b369077b9476356e4672f2cc0494f143b6126614d67aaf60f3ff017b8d",
+                "select_by_keyset_sql_sha256": "2fb798036b01977dfb098ac113836fb5f45accf44c5e571fd66f14b2477e143d",
+                "select_by_single_document_sql_sha256": "3e0b3ffb7ff6a86963576c7e8d374decfbc0bb1759ed8b0c31d111ec967f992b",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -231752,8 +231752,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "55dac8ac075f20ed8bb1c6ab3dda7e165bcd3122e8033de6ab280802fa9c524e",
-                "select_by_single_document_sql_sha256": "e7c7c83f4cbc0b34376964ecd36aafcb1c24a821df68c2900751200e9710b361",
+                "select_by_keyset_sql_sha256": "70c54df9bc680e26b8660835569635d73338fbb4d50de5eae61e95ff3f4dc061",
+                "select_by_single_document_sql_sha256": "cd84c4653e6727084c7e6e7752a4843db5021483e26af3a315227017b1f4f877",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -233081,8 +233081,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "e6359376151a5fa967927bdefe89075eaf20f6c364cdd252b47c6a48ed3f75bf",
-                "select_by_single_document_sql_sha256": "e6b4ec89c70d56a0956a07684ff209cfaeba32b86f478e89267aa6da4c2f72d3",
+                "select_by_keyset_sql_sha256": "8204814c65c25705b0d63826be05040f735dcd60fb0b614dd75a1f1a9b3c6e97",
+                "select_by_single_document_sql_sha256": "12eef18c063b6e85098166dbb133fac924c4e76c8676e07f0666b402f541363d",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -233870,8 +233870,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "3b42ae5fa3c1f9bcc7a0ec7102bfec41e6f87340429263b8af1ee586df942c46",
-                "select_by_single_document_sql_sha256": "5479ebad7147ad8e0337c120744db5c9970f64c9a9ed07fc83dbdaef1e5fe03d",
+                "select_by_keyset_sql_sha256": "7b03411cc97ee65eb6c03e841d7e83eea4ba42549eb9f4fcd4be9ea3c1504505",
+                "select_by_single_document_sql_sha256": "456d602979e975764eb7ee25deba2792a3ed71f35748475f0ad67d93b2713aee",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -234594,8 +234594,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "54ba1c2f05b44f58d6d297242e605cb77a9e42ba9024fb7b7997e93cde08c1b8",
-                "select_by_single_document_sql_sha256": "2a7c04097f30a5767ff17c9e384e7984a2489018e35112c0df5827d88865c2dd",
+                "select_by_keyset_sql_sha256": "210a3fa24c338ea95b9a40931ba9b2a7a444ef44d6060ababc2ad8b52efd7bef",
+                "select_by_single_document_sql_sha256": "35df3ed6f15bc2886ecd99eb1d0058f803e99f62346604e9c67a3b848340e5b1",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -235243,8 +235243,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "58fdfa43d58ae2db8beccf437a3f9616d19efdb952af46108edb5d2d7dc76ad0",
-                "select_by_single_document_sql_sha256": "37b30a3ba0cfd4915313ee78b9d99ac7dd01da9489cd3b19576902b1f9882b5c",
+                "select_by_keyset_sql_sha256": "e5b460b286df8241c48ae56774282f113f6967b2b5b1394ca5040260a26fdf26",
+                "select_by_single_document_sql_sha256": "40969387298c5637baaca45e8d115c37309a871edee08592653c58f79917f00f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -236329,8 +236329,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "615e22593e55d3247b5ae6a04df24eee9537b18aa7efa8df132248c33470dae0",
-                "select_by_single_document_sql_sha256": "348b69bacdcda42871ed0cfcb1d41738d6756a434f352d1e784cccabf998d7c6",
+                "select_by_keyset_sql_sha256": "bd59b8f49b84c0e96e01c70d8e7b436a5732f9c06e2e7bdc6113cc28878c3dee",
+                "select_by_single_document_sql_sha256": "ed5d9c7744f2e25dbe4b38b9de0cfa7c52e148612fe9054d447bf28a62216a80",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -237081,8 +237081,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "33fa5189b575c2ffc780abcd630756b6b0f38b93288d8756fb53f4105f5cc2b6",
-                "select_by_single_document_sql_sha256": "d2018040454a1e824e85420956bbb4f0a87d210515fbff62872945decf9f02a3",
+                "select_by_keyset_sql_sha256": "5f432e9c07ebb5973da517defa6f07a32688cbd8a45b705daef5ee6fd207b3cc",
+                "select_by_single_document_sql_sha256": "233e87d6d9a764568d22fa8526b8a8412a1e8c1255fb7381789d29e9e2913deb",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -238513,8 +238513,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "de439f8260f279ebaddee616e873c2a7d9d6251eda820400971a4dc6faba35b9",
-                "select_by_single_document_sql_sha256": "b11b1b747e4d20df9edaf64634bbf8b88a36cf7000be8dbde4ff89140f1839ef",
+                "select_by_keyset_sql_sha256": "723fdc36dd90ea451d35c39848801d27db9e71de52926d1306cf56b71dd71416",
+                "select_by_single_document_sql_sha256": "ee398f521b2bff66e48af05170fe3cd02e49a18b871852b332f6cc59e60a6458",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -239308,8 +239308,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "26f53add54f9a745d03435ea393f3fd5b9576a88df4fc7372a10d24c013844bc",
-                "select_by_single_document_sql_sha256": "e782ed5431f0d2835dbc109d2a2cde9a933ceac3b2f174cc64d22546343ecb37",
+                "select_by_keyset_sql_sha256": "08f7cc83b7814afa94e15721e81c7e664d991d8cc5e0afd94d7679f9c9f9c0ef",
+                "select_by_single_document_sql_sha256": "1b7ae248f9885c465cd3ab05677b7629ab86a5d3f25ce1a1820db2e5c6a41048",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -240165,8 +240165,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "2eb097ede19e2729ce9bf5a578aa20c4025ef126d737f1dfccc1b832f0574bac",
-                "select_by_single_document_sql_sha256": "ffc0e74a9d4c1d90d26b55bb1f13c9629c545b124d05eabecf1711fbdf11d19e",
+                "select_by_keyset_sql_sha256": "51a4c0b2705c6a6dd9b4635e9d4206431335d386c8327626f7b4e758787cee11",
+                "select_by_single_document_sql_sha256": "fb4f15741595da8499f62c8333308db318419b6355c271191a508d864d9e0b23",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -240773,8 +240773,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "095cb0c18616ae8681bcc070ae4d65f08757391a1717ab85646ed9d043bebe2b",
-                "select_by_single_document_sql_sha256": "cd9af4e2f5976847fb0c57fb344d35629daf4c851587fa1587e56e4504365fd2",
+                "select_by_keyset_sql_sha256": "f66afff1b1398e068d9deeba7538bad5a5f4bd15d97d5443fcda2944b58d976d",
+                "select_by_single_document_sql_sha256": "b852ad8991ac1aff27b0cc6a7ca5d177c170c7880d21f86ba7fac6beae8b5967",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -248236,8 +248236,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fb72583cd28e61bfa7dd6b03d9487ba182cfb56b976935cafc345e26cd1b2f86",
-                "select_by_single_document_sql_sha256": "ec3ee3b4e594325863e41d88a5ce5b28eddda4dcdfbd08cbd44f68b7b44bc58c",
+                "select_by_keyset_sql_sha256": "0d4924a2cc619dc859004020ece40bb8b122c976a894a1621809ab91c592c290",
+                "select_by_single_document_sql_sha256": "6b1d8650bf773570f033bf65f61c1bd834a552c9174815bc9f6835ea795b90fe",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -249682,8 +249682,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "fbaab42f19e9cebc45d7bbeb2e4859c31829c368b5c592168ab7eeca20483dc9",
-                "select_by_single_document_sql_sha256": "6a7da4ad5fccc6d1d3ee001d06efed0c64b55677d190906b8b6162cd99f0d152",
+                "select_by_keyset_sql_sha256": "7269048137df3565eee0900b7708a831ad7b143c037e7e76650e78a02991e0fa",
+                "select_by_single_document_sql_sha256": "879eb0c7cbb00c0c6a48cced5e2904335c7a79c26dfaa8347b6de5208693140f",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1
@@ -251055,8 +251055,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "d02a14581392c5ac56a384c317859fd8ae9a828d2e9303f85f4b4d68d09c36dd",
-                "select_by_single_document_sql_sha256": "db4fb7a5e765eced37a8d22f373a6e819163158229f875d7c436d01d193c4b4f",
+                "select_by_keyset_sql_sha256": "85117a577307a86f0e14b09e7fbc6b91e0434a6697392c7e9210447c1759f24a",
+                "select_by_single_document_sql_sha256": "b988f09c7b6aea106e233e162169002082f4dd0e48a912accaf86632914489ae",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
@@ -592,8 +592,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "c5f3d0edffd6a454ac8ff5738f1286fa951a42d3f6c1ba0dc5e77c0a84db7e72",
-                "select_by_single_document_sql_sha256": "22c8e25d3ffc5e191ec79f0aa6246cd1c418a5990eb42314970dec0296062729",
+                "select_by_keyset_sql_sha256": "79508cb5b93b36d9e38ec41fc861516b25c88ed0317790f135e85d3cc5a95e3b",
+                "select_by_single_document_sql_sha256": "7c7b9b7a02c2324b1f1c2630a922b43c87fa72be649535d891b6e12d92c32801",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/Fixtures/runtime-plan-compilation/projection/expected/mappingset.manifest.json
@@ -208,7 +208,7 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "ec55cbb077e5ae47b9f42656a155b19c5f137be3445f22a686dbd6854e6155de",
+                "select_by_keyset_sql_sha256": "a3468ecfdbbeb8e5f410b4e6eba6ba96ffa3e18331692315f434207cfe043c72",
                 "select_by_single_document_sql_sha256": null,
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
@@ -592,8 +592,8 @@
             ],
             "descriptor_projection_plans_in_order": [
               {
-                "select_by_keyset_sql_sha256": "79508cb5b93b36d9e38ec41fc861516b25c88ed0317790f135e85d3cc5a95e3b",
-                "select_by_single_document_sql_sha256": "7c7b9b7a02c2324b1f1c2630a922b43c87fa72be649535d891b6e12d92c32801",
+                "select_by_keyset_sql_sha256": "c5f3d0edffd6a454ac8ff5738f1286fa951a42d3f6c1ba0dc5e77c0a84db7e72",
+                "select_by_single_document_sql_sha256": "22c8e25d3ffc5e191ec79f0aa6246cd1c418a5990eb42314970dec0296062729",
                 "result_shape": {
                   "descriptor_id_ordinal": 0,
                   "uri_ordinal": 1

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/PlanNamingConventionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/PlanNamingConventionsTests.cs
@@ -179,6 +179,7 @@ public class Given_PlanNamingConventions
         PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Table).Should().Be("t");
         PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Document).Should().Be("doc");
         PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Descriptor).Should().Be("d");
+        PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.RowSet).Should().Be("v");
     }
 
     private static IReadOnlyList<string> DeduplicateWithCurrentCulture(
@@ -231,5 +232,31 @@ public class Given_PlanSqlTableAliasAllocator
         var newAllocator = PlanNamingConventions.CreateTableAliasAllocator();
 
         newAllocator.AllocateNext().Should().Be("t0");
+    }
+
+    [Test]
+    public void It_should_pair_each_table_alias_with_a_row_set_alias_of_the_same_ordinal()
+    {
+        _allocator
+            .AllocateNextSourceAliases()
+            .Should()
+            .Be(new PlanSqlSourceAliases(TableAlias: "t0", RowSetAlias: "v0"));
+        _allocator
+            .AllocateNextSourceAliases()
+            .Should()
+            .Be(new PlanSqlSourceAliases(TableAlias: "t1", RowSetAlias: "v1"));
+    }
+
+    [Test]
+    public void It_should_share_one_ordinal_sequence_across_both_allocation_methods()
+    {
+        _allocator.AllocateNext().Should().Be("t0");
+
+        _allocator
+            .AllocateNextSourceAliases()
+            .Should()
+            .Be(new PlanSqlSourceAliases(TableAlias: "t1", RowSetAlias: "v1"));
+
+        _allocator.AllocateNext().Should().Be("t2");
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
@@ -1724,15 +1724,11 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     d."Uri"
                 FROM
                     (
-                        SELECT t0."SchoolYearTypeDescriptorIdCanonical" AS "DescriptorId"
+                        SELECT DISTINCT v0."DescriptorId"
                         FROM "edfi"."Student" t0
                         INNER JOIN "page" k ON t0."DocumentId" = k."DocumentId"
-                        WHERE t0."SchoolYearTypeDescriptorIdCanonical" IS NOT NULL
-                        UNION
-                        SELECT t1."ProgramTypeDescriptorId" AS "DescriptorId"
-                        FROM "edfi"."Student" t1
-                        INNER JOIN "page" k ON t1."DocumentId" = k."DocumentId"
-                        WHERE t1."ProgramTypeDescriptorId" IS NOT NULL
+                        CROSS JOIN LATERAL (VALUES (t0."SchoolYearTypeDescriptorIdCanonical"), (t0."ProgramTypeDescriptorId")) AS v0("DescriptorId")
+                        WHERE v0."DescriptorId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Descriptor" d ON d."DocumentId" = p."DescriptorId"
                 ORDER BY
@@ -1756,7 +1752,7 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
     }
 
     [Test]
-    public void It_should_emit_exact_pgsql_DescriptorProjection_single_document_sql_for_multiple_sources_joined_with_UNION()
+    public void It_should_emit_exact_pgsql_DescriptorProjection_single_document_sql_for_multiple_sources_on_one_table_as_a_single_scan()
     {
         var model = CreateKeyUnifiedDescriptorProjectionResourceModelWithStoredDescriptorSource();
         var descriptorProjectionPlans = CompileDescriptorProjectionPlans(
@@ -1777,15 +1773,11 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     d."Uri"
                 FROM
                     (
-                        SELECT t0."SchoolYearTypeDescriptorIdCanonical" AS "DescriptorId"
+                        SELECT DISTINCT v0."DescriptorId"
                         FROM "edfi"."Student" t0
+                        CROSS JOIN LATERAL (VALUES (t0."SchoolYearTypeDescriptorIdCanonical"), (t0."ProgramTypeDescriptorId")) AS v0("DescriptorId")
                         WHERE t0."DocumentId" = @DocumentId
-                        AND t0."SchoolYearTypeDescriptorIdCanonical" IS NOT NULL
-                        UNION
-                        SELECT t1."ProgramTypeDescriptorId" AS "DescriptorId"
-                        FROM "edfi"."Student" t1
-                        WHERE t1."DocumentId" = @DocumentId
-                        AND t1."ProgramTypeDescriptorId" IS NOT NULL
+                        AND v0."DescriptorId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Descriptor" d ON d."DocumentId" = p."DescriptorId"
                 ORDER BY
@@ -1794,6 +1786,45 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
 
                 """
             );
+    }
+
+    [Test]
+    public void It_should_emit_exact_mssql_DescriptorProjection_sql_for_multiple_sources_on_one_table_as_a_single_scan()
+    {
+        var model = CreateKeyUnifiedDescriptorProjectionResourceModelWithStoredDescriptorSource();
+        var descriptorProjectionPlans = CompileDescriptorProjectionPlans(
+            model,
+            SqlDialect.Mssql,
+            CreateHydrationColumnOrdinalsExcludingStorageOnlyColumns(model.Root)
+        );
+
+        descriptorProjectionPlans.Should().ContainSingle();
+
+        var descriptorProjectionPlan = descriptorProjectionPlans.Single();
+
+        descriptorProjectionPlan
+            .SelectByKeysetSql.Should()
+            .Be(
+                """
+                SELECT
+                    p.[DescriptorId],
+                    d.[Uri]
+                FROM
+                    (
+                        SELECT DISTINCT v0.[DescriptorId]
+                        FROM [edfi].[Student] t0
+                        INNER JOIN [#page] k ON t0.[DocumentId] = k.[DocumentId]
+                        CROSS APPLY (VALUES (t0.[SchoolYearTypeDescriptorIdCanonical]), (t0.[ProgramTypeDescriptorId])) AS v0([DescriptorId])
+                        WHERE v0.[DescriptorId] IS NOT NULL
+                    ) p
+                INNER JOIN [dms].[Descriptor] d ON d.[DocumentId] = p.[DescriptorId]
+                ORDER BY
+                    p.[DescriptorId] ASC
+                ;
+
+                """
+            );
+        descriptorProjectionPlan.SelectBySingleDocumentSql.Should().BeNull();
     }
 
     [TestCase(SqlDialect.Pgsql)]
@@ -1847,6 +1878,14 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
             sourceIndex: 2,
             tableModel: alignedExtensionTable
         );
+
+        // Three distinct source tables each contributing one descriptor column stay three separate
+        // branches, and none is expanded through the row-set primitive.
+        descriptorProjectionPlan
+            .SelectByKeysetSql.Split("UNION", StringSplitOptions.None)
+            .Should()
+            .HaveCount(3);
+        descriptorProjectionPlan.SelectByKeysetSql.Should().NotContain("VALUES (");
 
         if (dialect is SqlDialect.Mssql)
         {

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
@@ -1724,11 +1724,15 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     d."Uri"
                 FROM
                     (
-                        SELECT DISTINCT v0."DescriptorId"
+                        SELECT t0."SchoolYearTypeDescriptorIdCanonical" AS "DescriptorId"
                         FROM "edfi"."Student" t0
                         INNER JOIN "page" k ON t0."DocumentId" = k."DocumentId"
-                        CROSS JOIN LATERAL (VALUES (t0."SchoolYearTypeDescriptorIdCanonical"), (t0."ProgramTypeDescriptorId")) AS v0("DescriptorId")
-                        WHERE v0."DescriptorId" IS NOT NULL
+                        WHERE t0."SchoolYearTypeDescriptorIdCanonical" IS NOT NULL
+                        UNION
+                        SELECT t1."ProgramTypeDescriptorId" AS "DescriptorId"
+                        FROM "edfi"."Student" t1
+                        INNER JOIN "page" k ON t1."DocumentId" = k."DocumentId"
+                        WHERE t1."ProgramTypeDescriptorId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Descriptor" d ON d."DocumentId" = p."DescriptorId"
                 ORDER BY
@@ -1752,7 +1756,7 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
     }
 
     [Test]
-    public void It_should_emit_exact_pgsql_DescriptorProjection_single_document_sql_for_multiple_sources_on_one_table_as_a_single_scan()
+    public void It_should_emit_exact_pgsql_DescriptorProjection_single_document_sql_for_multiple_sources_joined_with_UNION()
     {
         var model = CreateKeyUnifiedDescriptorProjectionResourceModelWithStoredDescriptorSource();
         var descriptorProjectionPlans = CompileDescriptorProjectionPlans(
@@ -1773,11 +1777,15 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     d."Uri"
                 FROM
                     (
-                        SELECT DISTINCT v0."DescriptorId"
+                        SELECT t0."SchoolYearTypeDescriptorIdCanonical" AS "DescriptorId"
                         FROM "edfi"."Student" t0
-                        CROSS JOIN LATERAL (VALUES (t0."SchoolYearTypeDescriptorIdCanonical"), (t0."ProgramTypeDescriptorId")) AS v0("DescriptorId")
                         WHERE t0."DocumentId" = @DocumentId
-                        AND v0."DescriptorId" IS NOT NULL
+                        AND t0."SchoolYearTypeDescriptorIdCanonical" IS NOT NULL
+                        UNION
+                        SELECT t1."ProgramTypeDescriptorId" AS "DescriptorId"
+                        FROM "edfi"."Student" t1
+                        WHERE t1."DocumentId" = @DocumentId
+                        AND t1."ProgramTypeDescriptorId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Descriptor" d ON d."DocumentId" = p."DescriptorId"
                 ORDER BY

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans.Tests.Unit/ReadPlanCompilerTests.cs
@@ -1015,7 +1015,7 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
     }
 
     [Test]
-    public void It_should_emit_exact_pgsql_DocumentReferenceLookup_sql_for_multiple_bindings_joined_with_UNION()
+    public void It_should_emit_exact_pgsql_DocumentReferenceLookup_sql_for_multiple_bindings_on_one_table_as_a_single_scan()
     {
         var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(
             CreateRootMultiBindingReferenceProjectionResourceModel()
@@ -1033,15 +1033,11 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     doc."ResourceKeyId"
                 FROM
                     (
-                        SELECT t0."School_DocumentId" AS "DocumentId"
+                        SELECT DISTINCT v0."DocumentId"
                         FROM "edfi"."StudentReferenceProjection" t0
                         INNER JOIN "page" k ON t0."DocumentId" = k."DocumentId"
-                        WHERE t0."School_DocumentId" IS NOT NULL
-                        UNION
-                        SELECT t1."Calendar_DocumentId" AS "DocumentId"
-                        FROM "edfi"."StudentReferenceProjection" t1
-                        INNER JOIN "page" k ON t1."DocumentId" = k."DocumentId"
-                        WHERE t1."Calendar_DocumentId" IS NOT NULL
+                        CROSS JOIN LATERAL (VALUES (t0."School_DocumentId"), (t0."Calendar_DocumentId")) AS v0("DocumentId")
+                        WHERE v0."DocumentId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Document" doc ON doc."DocumentId" = p."DocumentId"
                 ORDER BY
@@ -1051,6 +1047,7 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                 """
             );
 
+        lookup.SelectByKeysetSql.Should().NotContain("UNION");
         lookup
             .SourcesInOrder.Select(static source => source.FkColumn.Value)
             .Should()
@@ -1062,7 +1059,41 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
     }
 
     [Test]
-    public void It_should_emit_exact_pgsql_DocumentReferenceLookup_single_document_sql_for_multiple_bindings_joined_with_UNION()
+    public void It_should_emit_exact_mssql_DocumentReferenceLookup_sql_for_multiple_bindings_on_one_table_as_a_single_scan()
+    {
+        var readPlan = new ReadPlanCompiler(SqlDialect.Mssql).Compile(
+            CreateRootMultiBindingReferenceProjectionResourceModel()
+        );
+        var lookup = readPlan.DocumentReferenceLookup;
+
+        lookup.Should().NotBeNull();
+        lookup!
+            .SelectByKeysetSql.Should()
+            .Be(
+                """
+                SELECT
+                    doc.[DocumentId],
+                    doc.[DocumentUuid],
+                    doc.[ResourceKeyId]
+                FROM
+                    (
+                        SELECT DISTINCT v0.[DocumentId]
+                        FROM [edfi].[StudentReferenceProjection] t0
+                        INNER JOIN [#page] k ON t0.[DocumentId] = k.[DocumentId]
+                        CROSS APPLY (VALUES (t0.[School_DocumentId]), (t0.[Calendar_DocumentId])) AS v0([DocumentId])
+                        WHERE v0.[DocumentId] IS NOT NULL
+                    ) p
+                INNER JOIN [dms].[Document] doc ON doc.[DocumentId] = p.[DocumentId]
+                ORDER BY
+                    doc.[DocumentId] ASC
+                ;
+
+                """
+            );
+    }
+
+    [Test]
+    public void It_should_emit_exact_pgsql_DocumentReferenceLookup_single_document_sql_for_multiple_bindings_on_one_table_as_a_single_scan()
     {
         var readPlan = new ReadPlanCompiler(SqlDialect.Pgsql).Compile(
             CreateRootMultiBindingReferenceProjectionResourceModel()
@@ -1080,15 +1111,11 @@ public class Given_ReadPlanCompiler : WritePlanCompilerTestBase
                     doc."ResourceKeyId"
                 FROM
                     (
-                        SELECT t0."School_DocumentId" AS "DocumentId"
+                        SELECT DISTINCT v0."DocumentId"
                         FROM "edfi"."StudentReferenceProjection" t0
+                        CROSS JOIN LATERAL (VALUES (t0."School_DocumentId"), (t0."Calendar_DocumentId")) AS v0("DocumentId")
                         WHERE t0."DocumentId" = @DocumentId
-                        AND t0."School_DocumentId" IS NOT NULL
-                        UNION
-                        SELECT t1."Calendar_DocumentId" AS "DocumentId"
-                        FROM "edfi"."StudentReferenceProjection" t1
-                        WHERE t1."DocumentId" = @DocumentId
-                        AND t1."Calendar_DocumentId" IS NOT NULL
+                        AND v0."DocumentId" IS NOT NULL
                     ) p
                 INNER JOIN "dms"."Document" doc ON doc."DocumentId" = p."DocumentId"
                 ORDER BY

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
@@ -151,6 +151,11 @@ internal sealed class DescriptorProjectionPlanCompiler(SqlDialect dialect)
 
         var descriptorAlias = PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Descriptor);
         var tableAliasAllocator = PlanNamingConventions.CreateTableAliasAllocator();
+        var sourceGroups = ProjectionSourceBranchSql.GroupByTable(
+            sqlSources,
+            static source => source.TableModel,
+            static source => source.StorageColumn
+        );
         var writer = new SqlWriter(_sqlDialect);
 
         writer.AppendLine("SELECT");
@@ -172,22 +177,20 @@ internal sealed class DescriptorProjectionPlanCompiler(SqlDialect dialect)
 
             using (writer.Indent())
             {
-                for (var index = 0; index < sqlSources.Count; index++)
+                for (var index = 0; index < sourceGroups.Count; index++)
                 {
-                    var sqlSource = sqlSources[index];
-
                     ProjectionSourceBranchSql.Append(
                         writer,
                         _planSqlDialect,
-                        new ProjectionSourceTableGroup(sqlSource.TableModel, [sqlSource.StorageColumn]),
+                        sourceGroups[index],
                         tableAliasAllocator.AllocateNextSourceAliases(),
                         _descriptorIdProjectionColumn,
                         sourceFilter,
-                        emitDistinct: sqlSources.Count == 1,
+                        emitDistinct: sourceGroups.Count == 1,
                         "descriptor projection plan"
                     );
 
-                    if (index + 1 < sqlSources.Count)
+                    if (index + 1 < sourceGroups.Count)
                     {
                         writer.AppendLine("UNION");
                     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
@@ -175,25 +175,15 @@ internal sealed class DescriptorProjectionPlanCompiler(SqlDialect dialect)
                 for (var index = 0; index < sqlSources.Count; index++)
                 {
                     var sqlSource = sqlSources[index];
-                    var tableModel = sqlSource.TableModel;
-                    var tableAlias = tableAliasAllocator.AllocateNext();
 
-                    writer.Append("SELECT ");
-
-                    if (sqlSources.Count == 1)
-                    {
-                        writer.Append("DISTINCT ");
-                    }
-
-                    AppendQualifiedColumn(writer, tableAlias, sqlSource.StorageColumn);
-                    writer.Append(" AS ").AppendQuoted(_descriptorIdProjectionColumn.Value).AppendLine();
-                    writer.Append("FROM ").AppendTable(tableModel.Table).AppendLine($" {tableAlias}");
-                    ProjectionSourceFilterSql.Append(
+                    ProjectionSourceBranchSql.Append(
                         writer,
-                        tableModel,
-                        tableAlias,
-                        sqlSource.StorageColumn,
+                        _planSqlDialect,
+                        new ProjectionSourceTableGroup(sqlSource.TableModel, [sqlSource.StorageColumn]),
+                        tableAliasAllocator.AllocateNextSourceAliases(),
+                        _descriptorIdProjectionColumn,
                         sourceFilter,
+                        emitDistinct: sqlSources.Count == 1,
                         "descriptor projection plan"
                     );
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DescriptorProjectionPlanCompiler.cs
@@ -151,11 +151,7 @@ internal sealed class DescriptorProjectionPlanCompiler(SqlDialect dialect)
 
         var descriptorAlias = PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Descriptor);
         var tableAliasAllocator = PlanNamingConventions.CreateTableAliasAllocator();
-        var sourceGroups = ProjectionSourceBranchSql.GroupByTable(
-            sqlSources,
-            static source => source.TableModel,
-            static source => source.StorageColumn
-        );
+        var sourceGroups = BuildSourceGroups(sqlSources);
         var writer = new SqlWriter(_sqlDialect);
 
         writer.AppendLine("SELECT");
@@ -215,6 +211,41 @@ internal sealed class DescriptorProjectionPlanCompiler(SqlDialect dialect)
         writer.AppendLine(";");
 
         return writer.ToString();
+    }
+
+    /// <summary>
+    /// Determines the SQL-emission source grouping for descriptor projection.
+    /// </summary>
+    /// <remarks>
+    /// SQL Server groups by owning table, so a table contributing several descriptor columns is
+    /// scanned once and its columns expanded inline. PostgreSQL deliberately keeps one branch per
+    /// column: its planner cannot estimate distinctness through the row-set expansion, and the
+    /// resulting estimate collapse switches the comparatively small <c>dms.Descriptor</c> join from a
+    /// hash join to per-row nested loops. The expansion's offsetting saving is planning time, which
+    /// the read path does not pay once statements are auto-prepared, leaving only the join
+    /// regression. The document-reference lookup is unaffected because <c>dms.Document</c> is large
+    /// enough that nested loops are already the appropriate join for it.
+    /// </remarks>
+    private IReadOnlyList<ProjectionSourceTableGroup> BuildSourceGroups(
+        IReadOnlyList<DescriptorProjectionSqlSource> sqlSources
+    )
+    {
+        if (_planSqlDialect.Dialect is SqlDialect.Mssql)
+        {
+            return ProjectionSourceBranchSql.GroupByTable(
+                sqlSources,
+                static source => source.TableModel,
+                static source => source.StorageColumn
+            );
+        }
+
+        return
+        [
+            .. sqlSources.Select(static source => new ProjectionSourceTableGroup(
+                source.TableModel,
+                [source.StorageColumn]
+            )),
+        ];
     }
 
     private static DbColumnName ResolveStorageColumnOrThrow(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReferenceLookupPlanCompiler.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/DocumentReferenceLookupPlanCompiler.cs
@@ -139,6 +139,11 @@ internal sealed class DocumentReferenceLookupPlanCompiler(SqlDialect dialect)
 
         var documentAlias = PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Document);
         var tableAliasAllocator = PlanNamingConventions.CreateTableAliasAllocator();
+        var sourceGroups = ProjectionSourceBranchSql.GroupByTable(
+            sqlSources,
+            static source => source.TableModel,
+            static source => source.FkColumn
+        );
         var writer = new SqlWriter(_sqlDialect);
 
         writer.AppendLine("SELECT");
@@ -158,32 +163,20 @@ internal sealed class DocumentReferenceLookupPlanCompiler(SqlDialect dialect)
 
             using (writer.Indent())
             {
-                for (var index = 0; index < sqlSources.Count; index++)
+                for (var index = 0; index < sourceGroups.Count; index++)
                 {
-                    var sqlSource = sqlSources[index];
-                    var tableModel = sqlSource.TableModel;
-                    var tableAlias = tableAliasAllocator.AllocateNext();
-
-                    writer.Append("SELECT ");
-
-                    if (sqlSources.Count == 1)
-                    {
-                        writer.Append("DISTINCT ");
-                    }
-
-                    AppendQualifiedColumn(writer, tableAlias, sqlSource.FkColumn);
-                    writer.Append(" AS ").AppendQuoted(_documentIdColumn.Value).AppendLine();
-                    writer.Append("FROM ").AppendTable(tableModel.Table).AppendLine($" {tableAlias}");
-                    ProjectionSourceFilterSql.Append(
+                    ProjectionSourceBranchSql.Append(
                         writer,
-                        tableModel,
-                        tableAlias,
-                        sqlSource.FkColumn,
+                        _planSqlDialect,
+                        sourceGroups[index],
+                        tableAliasAllocator.AllocateNextSourceAliases(),
+                        _documentIdColumn,
                         sourceFilter,
+                        emitDistinct: sourceGroups.Count == 1,
                         "document-reference lookup plan"
                     );
 
-                    if (index + 1 < sqlSources.Count)
+                    if (index + 1 < sourceGroups.Count)
                     {
                         writer.AppendLine("UNION");
                     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/IPlanSqlDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/IPlanSqlDialect.cs
@@ -31,6 +31,12 @@ internal interface IPlanSqlDialect
     bool SupportsSingleDocumentHydration { get; }
 
     /// <summary>
+    /// Gets the dialect keyword that joins a correlated inline row set (a <c>VALUES</c> list
+    /// referencing columns of a preceding FROM-clause source) to that source.
+    /// </summary>
+    string CorrelatedRowSetJoinKeyword { get; }
+
+    /// <summary>
     /// Appends a dialect-specific paging clause.
     /// </summary>
     /// <param name="writer">The SQL writer to append to.</param>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MssqlPlanDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/MssqlPlanDialect.cs
@@ -26,6 +26,9 @@ internal sealed class MssqlPlanDialect : IPlanSqlDialect
     /// <inheritdoc />
     public bool SupportsSingleDocumentHydration => false;
 
+    /// <inheritdoc />
+    public string CorrelatedRowSetJoinKeyword => "CROSS APPLY";
+
     /// <summary>
     /// Appends a SQL Server <c>OFFSET</c>/<c>FETCH NEXT</c> paging clause.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PgsqlPlanDialect.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PgsqlPlanDialect.cs
@@ -25,6 +25,9 @@ internal sealed class PgsqlPlanDialect : IPlanSqlDialect
     /// <inheritdoc />
     public bool SupportsSingleDocumentHydration => true;
 
+    /// <inheritdoc />
+    public string CorrelatedRowSetJoinKeyword => "CROSS JOIN LATERAL";
+
     /// <summary>
     /// Appends a PostgreSQL <c>LIMIT</c>/<c>OFFSET</c> paging clause.
     /// </summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PlanNamingConventions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/PlanNamingConventions.cs
@@ -265,6 +265,7 @@ public static class PlanNamingConventions
             PlanSqlAliasRole.Table => "t",
             PlanSqlAliasRole.Document => "doc",
             PlanSqlAliasRole.Descriptor => "d",
+            PlanSqlAliasRole.RowSet => "v",
             _ => throw new ArgumentOutOfRangeException(nameof(role), role, "Unknown SQL alias role."),
         };
     }
@@ -325,7 +326,19 @@ public enum PlanSqlAliasRole
     /// Descriptor projection/join alias.
     /// </summary>
     Descriptor,
+
+    /// <summary>
+    /// Correlated inline row-set alias used to expand several source columns from one table scan.
+    /// </summary>
+    RowSet,
 }
+
+/// <summary>
+/// A source table alias paired with the correlated row-set alias that expands its columns.
+/// </summary>
+/// <param name="TableAlias">The source table alias (<c>t0</c>, <c>t1</c>, ...).</param>
+/// <param name="RowSetAlias">The matching inline row-set alias (<c>v0</c>, <c>v1</c>, ...).</param>
+public readonly record struct PlanSqlSourceAliases(string TableAlias, string RowSetAlias);
 
 /// <summary>
 /// Deterministic allocator for repeated table aliases.
@@ -339,9 +352,22 @@ public sealed class PlanSqlTableAliasAllocator
     /// </summary>
     public string AllocateNext()
     {
-        var alias = $"{PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Table)}{_nextTableAliasOrdinal}";
+        return AllocateNextSourceAliases().TableAlias;
+    }
+
+    /// <summary>
+    /// Allocates the next table alias together with the correlated row-set alias that shares its
+    /// ordinal (<c>t0</c>/<c>v0</c>, <c>t1</c>/<c>v1</c>, ...), so an expanded source reads
+    /// unambiguously in the emitted SQL.
+    /// </summary>
+    public PlanSqlSourceAliases AllocateNextSourceAliases()
+    {
+        var ordinal = _nextTableAliasOrdinal;
         _nextTableAliasOrdinal++;
 
-        return alias;
+        return new PlanSqlSourceAliases(
+            $"{PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Table)}{ordinal}",
+            $"{PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.RowSet)}{ordinal}"
+        );
     }
 }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ProjectionSourceBranchSql.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ProjectionSourceBranchSql.cs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Ddl;
+using EdFi.DataManagementService.Backend.External;
+
+namespace EdFi.DataManagementService.Backend.Plans;
+
+/// <summary>
+/// A source table paired with every column it contributes to a projection, in deterministic
+/// emission order.
+/// </summary>
+internal sealed record ProjectionSourceTableGroup(
+    DbTableModel TableModel,
+    IReadOnlyList<DbColumnName> ColumnsInOrder
+);
+
+/// <summary>
+/// Emits one page-scoped source branch of a projection's unified id list. The document-reference
+/// lookup and descriptor URI projection differ only in which column they project, so both share
+/// this emitter.
+/// </summary>
+/// <remarks>
+/// A table contributing several columns is scanned once and its columns expanded through a
+/// correlated inline row set, so the keyset join is paid once per source table rather than once per
+/// projected column. The non-null predicate then applies to the expanded value, which keeps a row
+/// contributing only its populated columns rather than dropping it whenever any column is null.
+/// </remarks>
+internal static class ProjectionSourceBranchSql
+{
+    /// <summary>
+    /// Groups ordered projection sources by owning table, preserving both the incoming table order
+    /// and the incoming column order within each table.
+    /// </summary>
+    public static IReadOnlyList<ProjectionSourceTableGroup> GroupByTable<TSource>(
+        IReadOnlyList<TSource> sourcesInEmissionOrder,
+        Func<TSource, DbTableModel> tableModelSelector,
+        Func<TSource, DbColumnName> columnSelector
+    )
+    {
+        return
+        [
+            .. sourcesInEmissionOrder
+                .GroupBy(source => tableModelSelector(source).Table)
+                .Select(group => new ProjectionSourceTableGroup(
+                    tableModelSelector(group.First()),
+                    [.. group.Select(columnSelector)]
+                )),
+        ];
+    }
+
+    /// <summary>
+    /// Appends a single source branch.
+    /// </summary>
+    /// <param name="projectedColumn">Name the branch projects its ids under.</param>
+    /// <param name="emitDistinct">
+    /// Whether the branch deduplicates on its own. Set only when the branch is the sole source,
+    /// because a multi-branch projection deduplicates through the enclosing <c>UNION</c> instead.
+    /// </param>
+    public static void Append(
+        SqlWriter writer,
+        IPlanSqlDialect planDialect,
+        ProjectionSourceTableGroup sourceGroup,
+        PlanSqlSourceAliases aliases,
+        DbColumnName projectedColumn,
+        ProjectionSourceFilter sourceFilter,
+        bool emitDistinct,
+        string planDescription
+    )
+    {
+        var rootScopeLocatorColumn =
+            RelationalResourceModelCompileValidator.ResolveRootScopeLocatorColumnOrThrow(
+                sourceGroup.TableModel,
+                planDescription
+            );
+        var isExpanded = sourceGroup.ColumnsInOrder.Count > 1;
+
+        writer.Append("SELECT ");
+
+        if (emitDistinct)
+        {
+            writer.Append("DISTINCT ");
+        }
+
+        if (isExpanded)
+        {
+            AppendQualifiedColumn(writer, aliases.RowSetAlias, projectedColumn);
+            writer.AppendLine();
+        }
+        else
+        {
+            AppendQualifiedColumn(writer, aliases.TableAlias, sourceGroup.ColumnsInOrder[0]);
+            writer.Append(" AS ").AppendQuoted(projectedColumn.Value).AppendLine();
+        }
+
+        writer.Append("FROM ").AppendTable(sourceGroup.TableModel.Table).AppendLine($" {aliases.TableAlias}");
+
+        ProjectionSourceFilterSql.AppendSourceJoin(
+            writer,
+            aliases.TableAlias,
+            rootScopeLocatorColumn,
+            sourceFilter
+        );
+
+        if (isExpanded)
+        {
+            AppendCorrelatedRowSet(writer, planDialect, sourceGroup, aliases, projectedColumn);
+        }
+
+        ProjectionSourceFilterSql.AppendSourceWhere(
+            writer,
+            aliases.TableAlias,
+            rootScopeLocatorColumn,
+            isExpanded ? aliases.RowSetAlias : aliases.TableAlias,
+            isExpanded ? projectedColumn : sourceGroup.ColumnsInOrder[0],
+            sourceFilter
+        );
+    }
+
+    private static void AppendCorrelatedRowSet(
+        SqlWriter writer,
+        IPlanSqlDialect planDialect,
+        ProjectionSourceTableGroup sourceGroup,
+        PlanSqlSourceAliases aliases,
+        DbColumnName projectedColumn
+    )
+    {
+        writer.Append(planDialect.CorrelatedRowSetJoinKeyword).Append(" (VALUES ");
+
+        for (var index = 0; index < sourceGroup.ColumnsInOrder.Count; index++)
+        {
+            if (index > 0)
+            {
+                writer.Append(", ");
+            }
+
+            writer.Append("(");
+            AppendQualifiedColumn(writer, aliases.TableAlias, sourceGroup.ColumnsInOrder[index]);
+            writer.Append(")");
+        }
+
+        writer.Append($") AS {aliases.RowSetAlias}(").AppendQuoted(projectedColumn.Value).AppendLine(")");
+    }
+
+    private static void AppendQualifiedColumn(SqlWriter writer, string tableAlias, DbColumnName columnName)
+    {
+        writer.Append($"{tableAlias}.").AppendQuoted(columnName.Value);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ProjectionSourceFilterSql.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Plans/ProjectionSourceFilterSql.cs
@@ -9,60 +9,70 @@ using EdFi.DataManagementService.Backend.External.Plans;
 
 namespace EdFi.DataManagementService.Backend.Plans;
 
+/// <summary>
+/// Emits the page-scoping clauses shared by projection source branches. Scoping is split into a
+/// join phase and a where phase so a caller can place additional FROM-clause sources between them.
+/// </summary>
 internal static class ProjectionSourceFilterSql
 {
-    public static void Append(
-        SqlWriter writer,
-        DbTableModel tableModel,
-        string tableAlias,
-        DbColumnName nonNullColumn,
-        ProjectionSourceFilter sourceFilter,
-        string planDescription
-    )
-    {
-        var rootScopeLocatorColumn =
-            RelationalResourceModelCompileValidator.ResolveRootScopeLocatorColumnOrThrow(
-                tableModel,
-                planDescription
-            );
-
-        Append(writer, tableAlias, rootScopeLocatorColumn, nonNullColumn, sourceFilter);
-    }
-
-    private static void Append(
+    /// <summary>
+    /// Appends the FROM-clause join that scopes a projection source to the page keyset. Emits
+    /// nothing for the single-document filter, which scopes through a WHERE predicate instead.
+    /// </summary>
+    public static void AppendSourceJoin(
         SqlWriter writer,
         string tableAlias,
         DbColumnName rootScopeLocatorColumn,
+        ProjectionSourceFilter sourceFilter
+    )
+    {
+        if (sourceFilter.KeysetTable is null)
+        {
+            return;
+        }
+
+        var keysetAlias = PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Keyset);
+
+        writer
+            .Append("INNER JOIN ")
+            .AppendRelation(sourceFilter.KeysetTable.Table)
+            .Append($" {keysetAlias} ON ");
+        AppendQualifiedColumn(writer, tableAlias, rootScopeLocatorColumn);
+        writer.Append(" = ");
+        AppendQualifiedColumn(writer, keysetAlias, sourceFilter.KeysetTable.DocumentIdColumnName);
+        writer.AppendLine();
+    }
+
+    /// <summary>
+    /// Appends the WHERE clause for a projection source: the single-document root-scope predicate
+    /// when the filter is not keyset-based, followed by the non-null predicate on the projected
+    /// value.
+    /// </summary>
+    /// <param name="nonNullAlias">
+    /// Alias owning the projected value. This is the source table for a single-column branch and
+    /// the correlated row-set alias for a branch that expands several columns.
+    /// </param>
+    public static void AppendSourceWhere(
+        SqlWriter writer,
+        string tableAlias,
+        DbColumnName rootScopeLocatorColumn,
+        string nonNullAlias,
         DbColumnName nonNullColumn,
         ProjectionSourceFilter sourceFilter
     )
     {
-        if (sourceFilter.KeysetTable is not null)
-        {
-            var keysetAlias = PlanNamingConventions.GetFixedAlias(PlanSqlAliasRole.Keyset);
+        writer.Append("WHERE ");
 
-            writer
-                .Append("INNER JOIN ")
-                .AppendRelation(sourceFilter.KeysetTable.Table)
-                .Append($" {keysetAlias} ON ");
+        if (sourceFilter.KeysetTable is null)
+        {
             AppendQualifiedColumn(writer, tableAlias, rootScopeLocatorColumn);
             writer.Append(" = ");
-            AppendQualifiedColumn(writer, keysetAlias, sourceFilter.KeysetTable.DocumentIdColumnName);
+            writer.AppendParameter(HydrationSqlConventions.SingleDocumentIdParameterName);
             writer.AppendLine();
-            writer.Append("WHERE ");
-            AppendQualifiedColumn(writer, tableAlias, nonNullColumn);
-            writer.AppendLine(" IS NOT NULL");
-
-            return;
+            writer.Append("AND ");
         }
 
-        writer.Append("WHERE ");
-        AppendQualifiedColumn(writer, tableAlias, rootScopeLocatorColumn);
-        writer.Append(" = ");
-        writer.AppendParameter(HydrationSqlConventions.SingleDocumentIdParameterName);
-        writer.AppendLine();
-        writer.Append("AND ");
-        AppendQualifiedColumn(writer, tableAlias, nonNullColumn);
+        AppendQualifiedColumn(writer, nonNullAlias, nonNullColumn);
         writer.AppendLine(" IS NOT NULL");
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorStampingTriggerTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorStampingTriggerTests.cs
@@ -155,12 +155,24 @@ public class Given_A_Provisioned_Postgresql_Database_With_Descriptor_Stamping_Tr
         return await _database.ExecuteScalarAsync<long>("""SELECT "dms"."GetMaxChangeVersion"();""");
     }
 
-    private async Task DelayForDistinctTimestampsAsync()
+    private async Task<DateTime> BackdateDocumentContentStampAsync(long documentId)
     {
-        // Server-side delay so the post-write ContentLastModifiedAt is strictly greater
-        // than the seed stamp, letting assertions use BeAfter instead of the weaker
-        // BeOnOrAfter (which cannot catch a stamp that never moved).
-        await _database.ExecuteNonQueryAsync("SELECT pg_sleep(0.02);");
+        // Moving the seed stamp deterministically into the past keeps the strict BeAfter
+        // assertions independent of server clock granularity: now() can return an identical
+        // value for two reads milliseconds apart, but never one five minutes stale.
+        // Strictness is what catches a stamp the trigger never wrote, since such a stamp stays
+        // at the backdated value; BeOnOrAfter would accept it.
+        // No trigger exists on dms."Document", so this write neither stamps nor allocates a version.
+        await _database.ExecuteNonQueryAsync(
+            """
+            UPDATE dms."Document"
+            SET "ContentLastModifiedAt" = now() - interval '5 minutes'
+            WHERE "DocumentId" = @documentId;
+            """,
+            new NpgsqlParameter("documentId", documentId)
+        );
+
+        return (await ReadDocumentStampAsync(documentId)).ContentLastModifiedAt;
     }
 
     private sealed record StampPair(StampValues Document, StampValues Mirror);
@@ -188,7 +200,7 @@ public class Given_A_Provisioned_Postgresql_Database_With_Descriptor_Stamping_Tr
     {
         var seed = await SeedAsync();
         var beforeMaxChangeVersion = await ReadMaxChangeVersionAsync();
-        await DelayForDistinctTimestampsAsync();
+        var seedContentLastModifiedAt = await BackdateDocumentContentStampAsync(seed.DocumentId);
 
         await _database.ExecuteNonQueryAsync(
             """
@@ -201,7 +213,7 @@ public class Given_A_Provisioned_Postgresql_Database_With_Descriptor_Stamping_Tr
         var afterMaxChangeVersion = await ReadMaxChangeVersionAsync();
         var afterDocument = await ReadDocumentStampAsync(seed.DocumentId);
         afterDocument.ContentVersion.Should().BeGreaterThan(seed.ContentVersion);
-        afterDocument.ContentLastModifiedAt.Should().BeAfter(seed.ContentLastModifiedAt);
+        afterDocument.ContentLastModifiedAt.Should().BeAfter(seedContentLastModifiedAt);
         (afterMaxChangeVersion - beforeMaxChangeVersion)
             .Should()
             .Be(1L, "a descriptor delete must allocate exactly one content stamp");
@@ -212,7 +224,7 @@ public class Given_A_Provisioned_Postgresql_Database_With_Descriptor_Stamping_Tr
     {
         var seed = await SeedAsync();
         var beforeMaxChangeVersion = await ReadMaxChangeVersionAsync();
-        await DelayForDistinctTimestampsAsync();
+        var seedContentLastModifiedAt = await BackdateDocumentContentStampAsync(seed.DocumentId);
 
         await _database.ExecuteNonQueryAsync(
             """
@@ -227,7 +239,7 @@ public class Given_A_Provisioned_Postgresql_Database_With_Descriptor_Stamping_Tr
         var after = await ReadStampPairAsync(seed.DocumentId);
         after.Mirror.Should().Be(after.Document);
         after.Document.ContentVersion.Should().BeGreaterThan(seed.ContentVersion);
-        after.Document.ContentLastModifiedAt.Should().BeAfter(seed.ContentLastModifiedAt);
+        after.Document.ContentLastModifiedAt.Should().BeAfter(seedContentLastModifiedAt);
         (afterMaxChangeVersion - beforeMaxChangeVersion)
             .Should()
             .Be(1L, "a single descriptor value change must allocate exactly one content stamp");

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
@@ -163,6 +163,12 @@ public class Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_Refere
     }
 
     [Test]
+    public void It_reconstitutes_the_whole_page_exactly_with_no_link_objects()
+    {
+        DocumentReferenceLookupPageFixture.AssertNonLinkPageMatchesExactly(_reconstitutedPage);
+    }
+
+    [Test]
     public void It_reconstitutes_a_fully_populated_document_with_every_reference_and_descriptor()
     {
         var document = _reconstitutedPage[0];

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using FluentAssertions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Page-level document-reference lookup coverage against a real PostgreSQL database, using a
+/// resource shaped like StudentSectionAssociation: a root table carrying three reference columns
+/// plus a descriptor edge, and a child collection carrying a fourth reference. That shape exercises
+/// both branch forms of the lookup at once — the root is scanned once with its columns expanded
+/// inline, the child keeps the plain single-column projection.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_References
+{
+    private const string TestSchema = "refpage";
+
+    private NpgsqlDataSource _dataSource = null!;
+    private ResourceReadPlan _plan = null!;
+    private HydratedPage _result = null!;
+    private IReadOnlyList<JsonNode> _reconstitutedPage = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlProvisionSql(TestSchema));
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlSeedSql(TestSchema));
+
+        _plan = HydrationTestHelper.BuildStudentSectionAssociationReadPlan(TestSchema, SqlDialect.Pgsql);
+
+        await using var hydrationConnection = await _dataSource.OpenConnectionAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            _plan,
+            PostgresqlDocumentReferenceLookupPageKeyset.ExcludingOffPageDocument(TestSchema),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+
+        _reconstitutedPage = DocumentReconstituter.ReconstitutePage(_plan, _result);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync();
+            await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlCleanupSql(TestSchema));
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_hydrates_only_the_page_documents()
+    {
+        _result
+            .DocumentMetadata.Select(static row => row.DocumentId)
+            .Should()
+            .Equal(DocumentReferenceLookupPageFixture.PageDocumentIdsInOrder);
+    }
+
+    [Test]
+    public void It_returns_each_distinct_referenced_document_exactly_once_in_document_id_order()
+    {
+        _result.DocumentReferenceLookup.Should().NotBeNull();
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row => row.DocumentId)
+            .Should()
+            .Equal(
+                DocumentReferenceLookupPageFixture.ExpectedReferencedDocumentIdsInOrder,
+                "ids repeated across columns of one row, across rows, and across the root and child tables collapse to one row each"
+            );
+    }
+
+    [Test]
+    public void It_excludes_references_reachable_only_from_off_page_child_rows()
+    {
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row => row.DocumentId)
+            .Should()
+            .NotContain(
+                DocumentReferenceLookupPageFixture.OffPageProgram,
+                "the child branch scopes through the child's root-scope locator, not its own key"
+            );
+    }
+
+    [Test]
+    public void It_returns_the_document_uuid_and_resource_key_for_each_referenced_document()
+    {
+        _result
+            .DocumentReferenceLookup!.Rows.Select(static row =>
+                (row.DocumentId, row.DocumentUuid, row.ResourceKeyId)
+            )
+            .Should()
+            .Equal(
+                (
+                    DocumentReferenceLookupPageFixture.StudentA,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.StudentA),
+                    DocumentReferenceLookupPageFixture.StudentResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.StudentB,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.StudentB),
+                    DocumentReferenceLookupPageFixture.StudentResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.Section,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.Section),
+                    DocumentReferenceLookupPageFixture.SectionResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.DualCreditEdOrg,
+                    DocumentReferenceLookupPageFixture.UuidFor(
+                        DocumentReferenceLookupPageFixture.DualCreditEdOrg
+                    ),
+                    DocumentReferenceLookupPageFixture.EducationOrganizationResourceKeyId
+                ),
+                (
+                    DocumentReferenceLookupPageFixture.Program,
+                    DocumentReferenceLookupPageFixture.UuidFor(DocumentReferenceLookupPageFixture.Program),
+                    DocumentReferenceLookupPageFixture.ProgramResourceKeyId
+                )
+            );
+    }
+
+    [Test]
+    public void It_resolves_the_descriptor_uri_for_the_page()
+    {
+        _result
+            .DescriptorRowsInPlanOrder.Single()
+            .Rows.Select(static row => (row.DescriptorId, row.Uri))
+            .Should()
+            .Equal(
+                (
+                    DocumentReferenceLookupPageFixture.AttemptStatusDescriptorId,
+                    DocumentReferenceLookupPageFixture.AttemptStatusUri
+                )
+            );
+    }
+
+    [Test]
+    public void It_reconstitutes_one_document_per_page_row()
+    {
+        _reconstitutedPage
+            .Should()
+            .HaveCount(DocumentReferenceLookupPageFixture.PageDocumentIdsInOrder.Length);
+    }
+
+    [Test]
+    public void It_reconstitutes_a_fully_populated_document_with_every_reference_and_descriptor()
+    {
+        var document = _reconstitutedPage[0];
+
+        document["attemptStatusDescriptor"]!
+            .GetValue<string>()
+            .Should()
+            .Be(DocumentReferenceLookupPageFixture.AttemptStatusUri);
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-701");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-X");
+        document["dualCreditEducationOrganizationReference"]!["educationOrganizationId"]!
+            .GetValue<long>()
+            .Should()
+            .Be(255901);
+
+        var programs = document["programs"]!.AsArray();
+        programs.Should().HaveCount(2);
+        programs[0]!["programReference"]!["programName"]!.GetValue<string>().Should().Be("Program P");
+        programs[1]!["programReference"]!["programName"]!
+            .GetValue<string>()
+            .Should()
+            .Be("Program Named Like Student");
+    }
+
+    [Test]
+    public void It_reconstitutes_a_document_whose_optional_reference_is_null_but_others_are_populated()
+    {
+        var document = _reconstitutedPage[1];
+
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-702");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-X");
+        document["dualCreditEducationOrganizationReference"]
+            .Should()
+            .BeNull("a null reference column must not produce a partial reference object");
+        document["attemptStatusDescriptor"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_omits_every_reference_object_for_a_document_whose_references_are_all_null()
+    {
+        var document = _reconstitutedPage[2];
+
+        document["studentReference"].Should().BeNull();
+        document["sectionReference"].Should().BeNull();
+        document["dualCreditEducationOrganizationReference"].Should().BeNull();
+        document["attemptStatusDescriptor"].Should().BeNull();
+        document["programs"].Should().BeNull();
+    }
+
+    [Test]
+    public void It_reconstitutes_a_document_that_repeats_one_referenced_document_across_columns()
+    {
+        var document = _reconstitutedPage[3];
+
+        document["studentReference"]!["studentUniqueId"]!.GetValue<string>().Should().Be("S-730");
+        document["sectionReference"]!["sectionIdentifier"]!.GetValue<string>().Should().Be("SEC-DUP");
+        document["dualCreditEducationOrganizationReference"]!["educationOrganizationId"]!
+            .GetValue<long>()
+            .Should()
+            .Be(255902);
+    }
+
+    private static async Task ExecuteSql(NpgsqlConnection connection, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Confirms an empty page produces no document-reference lookup rows rather than failing or
+/// leaking references belonging to documents outside the page.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_A_Postgresql_Empty_Page_With_Document_References
+{
+    private const string TestSchema = "refpageempty";
+
+    private NpgsqlDataSource _dataSource = null!;
+    private HydratedPage _result = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlProvisionSql(TestSchema));
+        await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlSeedSql(TestSchema));
+
+        var plan = HydrationTestHelper.BuildStudentSectionAssociationReadPlan(TestSchema, SqlDialect.Pgsql);
+
+        await using var hydrationConnection = await _dataSource.OpenConnectionAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            plan,
+            PostgresqlDocumentReferenceLookupPageKeyset.Empty(TestSchema),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync();
+            await ExecuteSql(connection, DocumentReferenceLookupPageFixture.PostgresqlCleanupSql(TestSchema));
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_no_documents()
+    {
+        _result.DocumentMetadata.Should().BeEmpty();
+    }
+
+    [Test]
+    public void It_returns_an_empty_document_reference_lookup_result_set()
+    {
+        _result.DocumentReferenceLookup.Should().NotBeNull();
+        _result.DocumentReferenceLookup!.Rows.Should().BeEmpty();
+    }
+
+    private static async Task ExecuteSql(NpgsqlConnection connection, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+/// <summary>
+/// Confirms a resource carrying descriptor edges but no document references compiles without a
+/// document-reference lookup, so the hydration batch emits the descriptor projection result set and
+/// no lookup result set at all.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_A_Postgresql_Descriptor_Only_Resource_Page
+{
+    private const string TestSchema = "refpagedesc";
+    private const long GradeLevelDescriptorId = 810;
+    private const string GradeLevelUri = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade";
+
+    private NpgsqlDataSource _dataSource = null!;
+    private ResourceReadPlan _plan = null!;
+    private HydratedPage _result = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _dataSource = NpgsqlDataSource.Create(Configuration.DatabaseConnectionString);
+
+        await using var connection = await _dataSource.OpenConnectionAsync();
+
+        await ExecuteSql(
+            connection,
+            $"""
+            DROP SCHEMA IF EXISTS {TestSchema} CASCADE;
+            CREATE SCHEMA {TestSchema};
+            CREATE SCHEMA IF NOT EXISTS dms;
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {TestSchema}."DescriptorOnly" (
+                "DocumentId" bigint PRIMARY KEY,
+                "GradeLevelDescriptor_DescriptorId" bigint NULL
+            );
+            """
+        );
+
+        await ExecuteSql(connection, CleanupRowsSql);
+        await ExecuteSql(
+            connection,
+            $"""
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId")
+            VALUES
+                (901, '00000000-0000-0000-0000-000000000901', 30),
+                (902, '00000000-0000-0000-0000-000000000902', 30);
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Uri")
+            VALUES ({GradeLevelDescriptorId}, '{GradeLevelUri}');
+
+            INSERT INTO {TestSchema}."DescriptorOnly" ("DocumentId", "GradeLevelDescriptor_DescriptorId")
+            VALUES (901, {GradeLevelDescriptorId}), (902, NULL);
+            """
+        );
+
+        _plan = HydrationTestHelper.BuildDescriptorOnlyReadPlan(TestSchema, SqlDialect.Pgsql);
+
+        await using var hydrationConnection = await _dataSource.OpenConnectionAsync();
+        _result = await HydrationExecutor.ExecuteAsync(
+            hydrationConnection,
+            _plan,
+            new PageKeysetSpec.Query(
+                new PageDocumentIdSqlPlan(
+                    PageDocumentIdSql: $"""
+                    SELECT "DocumentId" FROM {TestSchema}."DescriptorOnly"
+                    ORDER BY "DocumentId"
+                    LIMIT @limit OFFSET @offset
+                    """,
+                    TotalCountSql: null,
+                    PageParametersInOrder:
+                    [
+                        new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                        new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                    ],
+                    TotalCountParametersInOrder: null
+                ),
+                new Dictionary<string, object?> { ["offset"] = 0L, ["limit"] = 25L }
+            ),
+            SqlDialect.Pgsql,
+            CancellationToken.None
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource is not null)
+        {
+            await using var connection = await _dataSource.OpenConnectionAsync();
+            await ExecuteSql(connection, $"DROP SCHEMA IF EXISTS {TestSchema} CASCADE;");
+            await ExecuteSql(connection, CleanupRowsSql);
+            await _dataSource.DisposeAsync();
+        }
+    }
+
+    private static string CleanupRowsSql =>
+        $"""
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (901, 902);
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" = {GradeLevelDescriptorId};
+            """;
+
+    [Test]
+    public void It_compiles_no_document_reference_lookup_plan()
+    {
+        _plan.DocumentReferenceLookup.Should().BeNull();
+    }
+
+    [Test]
+    public void It_returns_no_document_reference_lookup_result_set()
+    {
+        _result.DocumentReferenceLookup.Should().BeNull();
+    }
+
+    [Test]
+    public void It_still_resolves_descriptor_uris_for_the_page()
+    {
+        _result.DocumentMetadata.Should().HaveCount(2);
+        _result
+            .DescriptorRowsInPlanOrder.Single()
+            .Rows.Select(static row => (row.DescriptorId, row.Uri))
+            .Should()
+            .Equal((GradeLevelDescriptorId, GradeLevelUri));
+    }
+
+    private static async Task ExecuteSql(NpgsqlConnection connection, string sql)
+    {
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}
+
+internal static class PostgresqlDocumentReferenceLookupPageKeyset
+{
+    public static PageKeysetSpec ExcludingOffPageDocument(string schema) =>
+        Create(
+            $"""
+            SELECT "DocumentId" FROM {schema}."StudentSectionAssociation"
+            WHERE "DocumentId" <> {DocumentReferenceLookupPageFixture.OffPageDocumentId}
+            ORDER BY "DocumentId"
+            LIMIT @limit OFFSET @offset
+            """,
+            limit: 25L
+        );
+
+    public static PageKeysetSpec Empty(string schema) =>
+        Create(
+            $"""
+            SELECT "DocumentId" FROM {schema}."StudentSectionAssociation"
+            ORDER BY "DocumentId"
+            LIMIT @limit OFFSET @offset
+            """,
+            limit: 0L
+        );
+
+    private static PageKeysetSpec Create(string pageDocumentIdSql, long limit) =>
+        new PageKeysetSpec.Query(
+            new PageDocumentIdSqlPlan(
+                PageDocumentIdSql: pageDocumentIdSql,
+                TotalCountSql: null,
+                PageParametersInOrder:
+                [
+                    new QuerySqlParameter(QuerySqlParameterRole.Offset, "offset"),
+                    new QuerySqlParameter(QuerySqlParameterRole.Limit, "limit"),
+                ],
+                TotalCountParametersInOrder: null
+            ),
+            new Dictionary<string, object?> { ["offset"] = 0L, ["limit"] = limit }
+        );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDocumentReferenceLookupPageTests.cs
@@ -23,6 +23,8 @@ namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
 /// </summary>
 [TestFixture]
 [NonParallelizable]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
 public class Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_References
 {
     private const string TestSchema = "refpage";
@@ -244,6 +246,8 @@ public class Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_Refere
 /// </summary>
 [TestFixture]
 [NonParallelizable]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
 public class Given_A_Postgresql_Empty_Page_With_Document_References
 {
     private const string TestSchema = "refpageempty";
@@ -310,6 +314,8 @@ public class Given_A_Postgresql_Empty_Page_With_Document_References
 /// </summary>
 [TestFixture]
 [NonParallelizable]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
 public class Given_A_Postgresql_Descriptor_Only_Resource_Page
 {
     private const string TestSchema = "refpagedesc";

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
@@ -391,11 +391,13 @@ public class Given_A_Postgresql_Page_Of_AcademicWeeks_With_Link_Injection
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-page-link-injection-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.ApiSchema;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.Configuration;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Extraction;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Postgresql.Tests.Integration;
+
+/// <summary>
+/// Page-level link-injection coverage: a query returning several documents must emit
+/// <c>link.rel</c>/<c>link.href</c> on every document's reference, resolved from the page-scoped
+/// document-reference lookup rather than from any single document's own read.
+/// </summary>
+/// <remarks>
+/// Runs against the real generated DS-5.2 DDL with a genuine <see cref="MappingSet"/>, so it
+/// exercises the production write and read pipeline end to end. The exact contents of the
+/// document-reference lookup for multi-column and child-collection sources are asserted separately
+/// by <c>Given_A_Postgresql_Page_With_Multi_Column_And_Child_Document_References</c>; this fixture
+/// covers the link-emission half over a genuine page.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("DatabaseIntegration")]
+[Category("PostgresqlIntegration")]
+public class Given_A_Postgresql_Page_Of_AcademicWeeks_With_Link_Injection
+{
+    private const string FixtureRelativePath = "src/dms/backend/Fixtures/authoritative/ds-5.2";
+    private const int MaximumPageSize = 500;
+
+    private static readonly QualifiedResourceName SchoolResource = new("Ed-Fi", "School");
+
+    private static readonly PageLinkInjectionSeed[] _seeds =
+    [
+        new(
+            SchoolId: 255911,
+            WeekIdentifier: "Page-Week-2025-08-15",
+            SchoolDocumentUuid: new DocumentUuid(Guid.Parse("aaaaaaaa-0000-0000-0000-000000000011")),
+            AcademicWeekDocumentUuid: new DocumentUuid(Guid.Parse("bbbbbbbb-0000-0000-0000-000000000012"))
+        ),
+        new(
+            SchoolId: 255912,
+            WeekIdentifier: "Page-Week-2025-08-22",
+            SchoolDocumentUuid: new DocumentUuid(Guid.Parse("aaaaaaaa-0000-0000-0000-000000000013")),
+            AcademicWeekDocumentUuid: new DocumentUuid(Guid.Parse("bbbbbbbb-0000-0000-0000-000000000014"))
+        ),
+    ];
+
+    private PostgresqlGeneratedDdlFixture _fixture = null!;
+    private MappingSet _mappingSet = null!;
+    private PostgresqlGeneratedDdlTestDatabase _database = null!;
+    private ServiceProvider _serviceProvider = null!;
+    private ResourceInfo _schoolResourceInfo = null!;
+    private ResourceSchema _schoolResourceSchema = null!;
+    private ResourceInfo _academicWeekResourceInfo = null!;
+    private ResourceSchema _academicWeekResourceSchema = null!;
+    private QueryResult _queryResult = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        _fixture = PostgresqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(
+            FixtureRelativePath,
+            strict: true
+        );
+        _mappingSet = _fixture.MappingSet;
+        _database = await PostgresqlGeneratedDdlTestDatabase.CreateProvisionedAsync(_fixture.GeneratedDdl);
+        _serviceProvider = CreateServiceProvider();
+
+        (ProjectSchema schoolProjectSchema, ResourceSchema schoolSchema) = GetResourceSchema(
+            _fixture.EffectiveSchemaSet,
+            "ed-fi",
+            "School"
+        );
+        _schoolResourceInfo = CreateResourceInfo(schoolProjectSchema, schoolSchema);
+        _schoolResourceSchema = schoolSchema;
+
+        (ProjectSchema academicWeekProjectSchema, ResourceSchema academicWeekSchema) = GetResourceSchema(
+            _fixture.EffectiveSchemaSet,
+            "ed-fi",
+            "AcademicWeek"
+        );
+        _academicWeekResourceInfo = CreateResourceInfo(academicWeekProjectSchema, academicWeekSchema);
+        _academicWeekResourceSchema = academicWeekSchema;
+
+        await SeedReferenceDataAsync();
+
+        foreach (PageLinkInjectionSeed seed in _seeds)
+        {
+            UpsertResult schoolResult = await UpsertSchoolAsync(seed);
+            schoolResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+
+            UpsertResult academicWeekResult = await UpsertAcademicWeekAsync(seed);
+            academicWeekResult.Should().BeOfType<UpsertResult.InsertSuccess>();
+        }
+
+        _queryResult = await QueryAcademicWeeksAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_serviceProvider is not null)
+        {
+            await _serviceProvider.DisposeAsync();
+        }
+
+        if (_database is not null)
+        {
+            await _database.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void It_returns_every_academic_week_in_the_page()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        success.EdfiDocs.Should().HaveCount(_seeds.Length);
+    }
+
+    [Test]
+    public void It_emits_link_rel_and_link_href_on_every_document_in_the_page()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        foreach (PageLinkInjectionSeed seed in _seeds)
+        {
+            JsonNode document = success.EdfiDocs.Single(candidate =>
+                string.Equals(
+                    candidate!["weekIdentifier"]!.GetValue<string>(),
+                    seed.WeekIdentifier,
+                    StringComparison.Ordinal
+                )
+            )!;
+
+            document["id"]!.GetValue<string>().Should().Be(seed.AcademicWeekDocumentUuid.Value.ToString("D"));
+
+            JsonNode schoolReference = document["schoolReference"]!;
+            schoolReference.Should().NotBeNull();
+            schoolReference["schoolId"]!.GetValue<long>().Should().Be(seed.SchoolId);
+
+            LinkInjectionAssertions.AssertLink(
+                schoolReference,
+                expectedRel: "School",
+                expectedProjectEndpointName: "ed-fi",
+                expectedEndpointName: "schools",
+                expectedDocumentUuid: seed.SchoolDocumentUuid.Value
+            );
+        }
+    }
+
+    [Test]
+    public void It_resolves_each_document_reference_to_its_own_referenced_document()
+    {
+        QueryResult.QuerySuccess success = _queryResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        string[] hrefsInWeekOrder =
+        [
+            .. success
+                .EdfiDocs.OrderBy(
+                    static document => document!["weekIdentifier"]!.GetValue<string>(),
+                    StringComparer.Ordinal
+                )
+                .Select(static document =>
+                    document!["schoolReference"]!["link"]!["href"]!.GetValue<string>()
+                ),
+        ];
+
+        hrefsInWeekOrder
+            .Should()
+            .Equal(
+                [
+                    .. _seeds
+                        .OrderBy(static seed => seed.WeekIdentifier, StringComparer.Ordinal)
+                        .Select(static seed =>
+                            $"/ed-fi/schools/{seed.SchoolDocumentUuid.Value.ToString("D")}"
+                        ),
+                ],
+                "a page-scoped lookup must not collapse distinct references onto one referenced document"
+            );
+    }
+
+    private ServiceProvider CreateServiceProvider()
+    {
+        ServiceCollection services = [];
+
+        services.AddSingleton(typeof(ILogger<>), typeof(NullLogger<>));
+        services.AddSingleton<NpgsqlDataSourceCache>();
+        services.AddScoped<IDataStoreSelection, DataStoreSelection>();
+        services.AddScoped<NpgsqlDataSourceProvider>();
+        services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
+        services.AddTestReadableProfileProjector();
+        services.AddScoped<RelationalDocumentStoreRepository>();
+        services.AddPostgresqlReferenceResolver();
+
+        short schoolResourceKeyId = _mappingSet.ResourceKeyIdByResource[SchoolResource];
+        Dictionary<short, DocumentLinkSlugTriple> slugByResourceKeyId = new()
+        {
+            [schoolResourceKeyId] = new DocumentLinkSlugTriple(
+                ProjectEndpointName: "ed-fi",
+                EndpointName: "schools",
+                ResourceName: "School"
+            ),
+        };
+        services.Replace(
+            ServiceDescriptor.Singleton<IDocumentLinkSlugResolver>(
+                new DeterministicLinkSlugResolver(slugByResourceKeyId)
+            )
+        );
+        services.Configure<ResourceLinksOptions>(static options => options.Enabled = true);
+
+        return services.BuildServiceProvider(
+            new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true }
+        );
+    }
+
+    private static (ProjectSchema ProjectSchema, ResourceSchema ResourceSchema) GetResourceSchema(
+        EffectiveSchemaSet effectiveSchemaSet,
+        string projectEndpointName,
+        string resourceName
+    )
+    {
+        EffectiveProjectSchema effectiveProjectSchema = effectiveSchemaSet.ProjectsInEndpointOrder.Single(
+            project =>
+                string.Equals(
+                    project.ProjectEndpointName,
+                    projectEndpointName,
+                    StringComparison.OrdinalIgnoreCase
+                )
+        );
+
+        ProjectSchema projectSchema = new(effectiveProjectSchema.ProjectSchema, NullLogger.Instance);
+        JsonNode resourceSchemaNode =
+            projectSchema.FindResourceSchemaNodeByResourceName(new ResourceName(resourceName))
+            ?? projectSchema
+                .GetAllResourceSchemaNodes()
+                .SingleOrDefault(node =>
+                    string.Equals(
+                        node["resourceName"]?.GetValue<string>(),
+                        resourceName,
+                        StringComparison.Ordinal
+                    )
+                )
+            ?? throw new InvalidOperationException(
+                $"Could not find resource '{resourceName}' in project '{projectEndpointName}'."
+            );
+
+        return (projectSchema, new ResourceSchema(resourceSchemaNode));
+    }
+
+    private static ResourceInfo CreateResourceInfo(
+        ProjectSchema projectSchema,
+        ResourceSchema resourceSchema
+    ) =>
+        new(
+            ProjectName: projectSchema.ProjectName,
+            ResourceName: resourceSchema.ResourceName,
+            IsDescriptor: resourceSchema.IsDescriptor,
+            ResourceVersion: projectSchema.ResourceVersion,
+            AllowIdentityUpdates: resourceSchema.AllowIdentityUpdates
+        );
+
+    private async Task SeedReferenceDataAsync()
+    {
+        await SeedDescriptorAsync(
+            Guid.Parse("c1000001-0000-0000-0000-000000000001"),
+            "EducationOrganizationCategoryDescriptor",
+            "Ed-Fi:EducationOrganizationCategoryDescriptor",
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School",
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor",
+            "School",
+            "School"
+        );
+        await SeedDescriptorAsync(
+            Guid.Parse("c1000002-0000-0000-0000-000000000002"),
+            "GradeLevelDescriptor",
+            "Ed-Fi:GradeLevelDescriptor",
+            "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade",
+            "uri://ed-fi.org/GradeLevelDescriptor",
+            "Ninth grade",
+            "Ninth grade"
+        );
+    }
+
+    private async Task SeedDescriptorAsync(
+        Guid documentUuid,
+        string resourceName,
+        string discriminator,
+        string uri,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        short resourceKeyId = await GetResourceKeyIdAsync("Ed-Fi", resourceName);
+        long documentId = await InsertDescriptorAsync(
+            documentUuid,
+            resourceKeyId,
+            discriminator,
+            uri,
+            @namespace,
+            codeValue,
+            shortDescription
+        );
+
+        await InsertReferentialIdentityAsync(
+            CreateDescriptorReferentialId("Ed-Fi", resourceName, uri),
+            documentId,
+            resourceKeyId
+        );
+    }
+
+    private async Task<UpsertResult> UpsertSchoolAsync(PageLinkInjectionSeed seed)
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        JsonNode requestBody = CreateSchoolRequestBody(seed);
+        UpsertRequest request = new(
+            ResourceInfo: _schoolResourceInfo,
+            DocumentInfo: RelationalDocumentInfoTestHelper.CreateDocumentInfo(
+                requestBody,
+                _schoolResourceInfo,
+                _schoolResourceSchema,
+                _mappingSet
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("pg-page-link-injection-seed-school"),
+            DocumentUuid: seed.SchoolDocumentUuid
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .UpsertDocument(request);
+    }
+
+    private async Task<UpsertResult> UpsertAcademicWeekAsync(PageLinkInjectionSeed seed)
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        JsonNode requestBody = CreateAcademicWeekRequestBody(seed);
+        UpsertRequest request = new(
+            ResourceInfo: _academicWeekResourceInfo,
+            DocumentInfo: RelationalDocumentInfoTestHelper.CreateDocumentInfo(
+                requestBody,
+                _academicWeekResourceInfo,
+                _academicWeekResourceSchema,
+                _mappingSet
+            ),
+            MappingSet: _mappingSet,
+            EdfiDoc: requestBody,
+            Headers: [],
+            TraceId: new TraceId("pg-page-link-injection-seed-academicweek"),
+            DocumentUuid: seed.AcademicWeekDocumentUuid
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .UpsertDocument(request);
+    }
+
+    private async Task<QueryResult> QueryAcademicWeeksAsync()
+    {
+        await using AsyncServiceScope scope = _serviceProvider.CreateAsyncScope();
+        SetSelectedInstance(scope.ServiceProvider);
+
+        RelationalQueryRequest request = new(
+            ResourceInfo: _academicWeekResourceInfo,
+            AuthorizationContext: new RelationalAuthorizationContext([]),
+            MappingSet: _mappingSet,
+            QueryElements: [],
+            AuthorizationStrategyEvaluators: [],
+            PaginationParameters: new PaginationParameters(
+                Limit: 25,
+                Offset: 0,
+                TotalCount: false,
+                MaximumPageSize: MaximumPageSize
+            ),
+            TraceId: new TraceId("pg-page-link-injection-query-academicweek")
+        );
+
+        return await scope
+            .ServiceProvider.GetRequiredService<RelationalDocumentStoreRepository>()
+            .QueryDocuments(request);
+    }
+
+    private static JsonNode CreateSchoolRequestBody(PageLinkInjectionSeed seed)
+    {
+        return JsonNode.Parse(
+            $$"""
+            {
+              "schoolId": {{seed.SchoolId}},
+              "nameOfInstitution": "Page Link Injection Test High School {{seed.SchoolId}}",
+              "educationOrganizationCategories": [
+                {
+                  "educationOrganizationCategoryDescriptor": "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School"
+                }
+              ],
+              "gradeLevels": [
+                {
+                  "gradeLevelDescriptor": "uri://ed-fi.org/GradeLevelDescriptor#Ninth grade"
+                }
+              ]
+            }
+            """
+        )!;
+    }
+
+    private static JsonNode CreateAcademicWeekRequestBody(PageLinkInjectionSeed seed)
+    {
+        return JsonNode.Parse(
+            $$"""
+            {
+              "weekIdentifier": "{{seed.WeekIdentifier}}",
+              "schoolReference": { "schoolId": {{seed.SchoolId}} },
+              "beginDate": "2025-08-15",
+              "endDate": "2025-08-22",
+              "totalInstructionalDays": 5
+            }
+            """
+        )!;
+    }
+
+    private void SetSelectedInstance(IServiceProvider serviceProvider)
+    {
+        serviceProvider
+            .GetRequiredService<IDataStoreSelection>()
+            .SetSelectedDataStore(
+                new DataStore(
+                    Id: 1,
+                    DataStoreType: "test",
+                    Name: "PostgresqlPageLinkInjection",
+                    ConnectionString: _database.ConnectionString,
+                    RouteContext: []
+                )
+            );
+    }
+
+    private async Task<short> GetResourceKeyIdAsync(string projectName, string resourceName)
+    {
+        return await _database.ExecuteScalarAsync<short>(
+            """
+            SELECT "ResourceKeyId"
+            FROM "dms"."ResourceKey"
+            WHERE "ProjectName" = @projectName
+              AND "ResourceName" = @resourceName;
+            """,
+            new NpgsqlParameter("projectName", projectName),
+            new NpgsqlParameter("resourceName", resourceName)
+        );
+    }
+
+    private async Task<long> InsertDocumentAsync(Guid documentUuid, short resourceKeyId)
+    {
+        return await _database.ExecuteScalarAsync<long>(
+            """
+            INSERT INTO "dms"."Document" ("DocumentUuid", "ResourceKeyId")
+            VALUES (@documentUuid, @resourceKeyId)
+            RETURNING "DocumentId";
+            """,
+            new NpgsqlParameter("documentUuid", documentUuid),
+            new NpgsqlParameter("resourceKeyId", resourceKeyId)
+        );
+    }
+
+    private async Task<long> InsertDescriptorAsync(
+        Guid documentUuid,
+        short resourceKeyId,
+        string discriminator,
+        string uri,
+        string @namespace,
+        string codeValue,
+        string shortDescription
+    )
+    {
+        long documentId = await InsertDocumentAsync(documentUuid, resourceKeyId);
+
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "dms"."Descriptor" (
+                "DocumentId",
+                "ResourceKeyId",
+                "Namespace",
+                "CodeValue",
+                "ShortDescription",
+                "Description",
+                "Discriminator",
+                "Uri"
+            )
+            VALUES (
+                @documentId,
+                @resourceKeyId,
+                @namespace,
+                @codeValue,
+                @shortDescription,
+                @description,
+                @discriminator,
+                @uri
+            );
+            """,
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("resourceKeyId", resourceKeyId),
+            new NpgsqlParameter("namespace", @namespace),
+            new NpgsqlParameter("codeValue", codeValue),
+            new NpgsqlParameter("shortDescription", shortDescription),
+            new NpgsqlParameter("description", shortDescription),
+            new NpgsqlParameter("discriminator", discriminator),
+            new NpgsqlParameter("uri", uri)
+        );
+
+        return documentId;
+    }
+
+    private async Task InsertReferentialIdentityAsync(
+        ReferentialId referentialId,
+        long documentId,
+        short resourceKeyId
+    )
+    {
+        await _database.ExecuteNonQueryAsync(
+            """
+            INSERT INTO "dms"."ReferentialIdentity" ("ReferentialId", "DocumentId", "ResourceKeyId")
+            VALUES (@referentialId, @documentId, @resourceKeyId)
+            ON CONFLICT ("ReferentialId") DO NOTHING;
+            """,
+            new NpgsqlParameter("referentialId", referentialId.Value),
+            new NpgsqlParameter("documentId", documentId),
+            new NpgsqlParameter("resourceKeyId", resourceKeyId)
+        );
+    }
+
+    private static ReferentialId CreateDescriptorReferentialId(
+        string projectName,
+        string resourceName,
+        string descriptorUri
+    )
+    {
+        return ReferentialIdCalculator.ReferentialIdFrom(
+            new BaseResourceInfo(new ProjectName(projectName), new ResourceName(resourceName), true),
+            new DocumentIdentity([
+                new DocumentIdentityElement(
+                    DocumentIdentity.DescriptorIdentityJsonPath,
+                    descriptorUri.ToLowerInvariant()
+                ),
+            ])
+        );
+    }
+}
+
+/// <summary>
+/// One School plus the AcademicWeek that references it, seeded so the query under test returns a
+/// page of several documents whose references resolve to different referenced documents.
+/// </summary>
+internal sealed record PageLinkInjectionSeed(
+    long SchoolId,
+    string WeekIdentifier,
+    DocumentUuid SchoolDocumentUuid,
+    DocumentUuid AcademicWeekDocumentUuid
+);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlPageLinkInjectionIntegrationTests.cs
@@ -209,7 +209,7 @@ public class Given_A_Postgresql_Page_Of_AcademicWeeks_With_Link_Injection
         services.Configure<DatabaseOptions>(options => options.IsolationLevel = IsolationLevel.ReadCommitted);
         services.AddTestReadableProfileProjector();
         services.AddScoped<RelationalDocumentStoreRepository>();
-        services.AddPostgresqlReferenceResolver();
+        services.AddPostgresqlBackendIntegrationTestServices();
 
         short schoolResourceKeyId = _mappingSet.ResourceKeyIdByResource[SchoolResource];
         Dictionary<short, DocumentLinkSlugTriple> slugByResourceKeyId = new()

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/DocumentReferenceLookupPageFixture.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/DocumentReferenceLookupPageFixture.cs
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Globalization;
+
+namespace EdFi.DataManagementService.Backend.Tests.Common;
+
+/// <summary>
+/// Shared provisioning and seed data for the page-level document-reference lookup integration
+/// tests, so PostgreSQL and SQL Server assert against identical documents and references.
+/// </summary>
+/// <remarks>
+/// The referenced document ids are chosen to exercise duplicate collapsing rather than to model
+/// realistic Ed-Fi semantics. Document 601 references distinct documents from several columns and
+/// from its child rows; 602 repeats 601's section in a different row; 603 leaves every reference
+/// null; 605 repeats one id across all three of its reference columns; and 604 sits outside the
+/// page and is the sole referent of <see cref="OffPageProgram"/>.
+/// </remarks>
+public static class DocumentReferenceLookupPageFixture
+{
+    public const long FullyPopulatedDocumentId = 601;
+    public const long PartiallyPopulatedDocumentId = 602;
+    public const long AllNullReferencesDocumentId = 603;
+    public const long OffPageDocumentId = 604;
+    public const long RepeatedReferenceDocumentId = 605;
+
+    public const long StudentA = 701;
+    public const long StudentB = 702;
+    public const long Section = 710;
+    public const long DualCreditEdOrg = 720;
+    public const long Program = 730;
+    public const long OffPageProgram = 740;
+
+    public const long AttemptStatusDescriptorId = 800;
+    public const string AttemptStatusUri = "uri://ed-fi.org/AttemptStatusDescriptor#Active";
+
+    public const short StudentResourceKeyId = 21;
+    public const short SectionResourceKeyId = 22;
+    public const short EducationOrganizationResourceKeyId = 23;
+    public const short ProgramResourceKeyId = 24;
+
+    /// <summary>
+    /// Document ids that make up the page under test, in ascending order. Excludes
+    /// <see cref="OffPageDocumentId"/>.
+    /// </summary>
+    public static readonly long[] PageDocumentIdsInOrder =
+    [
+        FullyPopulatedDocumentId,
+        PartiallyPopulatedDocumentId,
+        AllNullReferencesDocumentId,
+        RepeatedReferenceDocumentId,
+    ];
+
+    /// <summary>
+    /// Distinct referenced document ids the lookup must return for the page, in ascending order.
+    /// </summary>
+    public static readonly long[] ExpectedReferencedDocumentIdsInOrder =
+    [
+        StudentA,
+        StudentB,
+        Section,
+        DualCreditEdOrg,
+        Program,
+    ];
+
+    /// <summary>
+    /// Deterministic <c>DocumentUuid</c> for a seeded document id.
+    /// </summary>
+    public static Guid UuidFor(long documentId) =>
+        Guid.Parse(string.Create(CultureInfo.InvariantCulture, $"00000000-0000-0000-0000-{documentId:D12}"));
+
+    public static string PostgresqlProvisionSql(string schema) =>
+        $"""
+            DROP SCHEMA IF EXISTS {schema} CASCADE;
+            CREATE SCHEMA {schema};
+            CREATE SCHEMA IF NOT EXISTS dms;
+
+            CREATE TABLE IF NOT EXISTS dms."Document" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DocumentUuid" uuid NOT NULL,
+                "ResourceKeyId" smallint NOT NULL DEFAULT 0,
+                "ContentVersion" bigint NOT NULL DEFAULT 1,
+                "IdentityVersion" bigint NOT NULL DEFAULT 1,
+                "ContentLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "IdentityLastModifiedAt" timestamptz NOT NULL DEFAULT now(),
+                "CreatedAt" timestamptz NOT NULL DEFAULT now()
+            );
+
+            CREATE TABLE IF NOT EXISTS dms."Descriptor" (
+                "DocumentId" bigint PRIMARY KEY,
+                "Namespace" varchar(255) NOT NULL DEFAULT '',
+                "CodeValue" varchar(50) NOT NULL DEFAULT '',
+                "ShortDescription" varchar(75) NOT NULL DEFAULT '',
+                "Description" varchar(1024) NULL,
+                "EffectiveBeginDate" date NULL,
+                "EffectiveEndDate" date NULL,
+                "Discriminator" varchar(128) NOT NULL DEFAULT '',
+                "Uri" varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {schema}."StudentSectionAssociation" (
+                "DocumentId" bigint PRIMARY KEY,
+                "DualCreditEducationOrganization_DocumentId" bigint NULL,
+                "DualCreditEducationOrganization_EducationOrganizationId" bigint NULL,
+                "Section_DocumentId" bigint NULL,
+                "Section_SectionIdentifier" varchar(255) NULL,
+                "Student_DocumentId" bigint NULL,
+                "Student_StudentUniqueId" varchar(32) NULL,
+                "AttemptStatusDescriptor_DescriptorId" bigint NULL
+            );
+
+            CREATE TABLE {schema}."StudentSectionAssociationProgram" (
+                "CollectionItemId" bigint PRIMARY KEY,
+                "StudentSectionAssociation_DocumentId" bigint NOT NULL,
+                "Ordinal" integer NOT NULL,
+                "Program_DocumentId" bigint NULL,
+                "Program_ProgramName" varchar(60) NULL
+            );
+            """;
+
+    public static string PostgresqlSeedSql(string schema) =>
+        $"""
+            {PostgresqlDeleteSeedRowsSql}
+
+            INSERT INTO dms."Document" ("DocumentId", "DocumentUuid", "ResourceKeyId")
+            VALUES
+                ({FullyPopulatedDocumentId}, '{UuidFor(FullyPopulatedDocumentId)}', 20),
+                ({PartiallyPopulatedDocumentId}, '{UuidFor(PartiallyPopulatedDocumentId)}', 20),
+                ({AllNullReferencesDocumentId}, '{UuidFor(AllNullReferencesDocumentId)}', 20),
+                ({OffPageDocumentId}, '{UuidFor(OffPageDocumentId)}', 20),
+                ({RepeatedReferenceDocumentId}, '{UuidFor(RepeatedReferenceDocumentId)}', 20),
+                ({StudentA}, '{UuidFor(StudentA)}', {StudentResourceKeyId}),
+                ({StudentB}, '{UuidFor(StudentB)}', {StudentResourceKeyId}),
+                ({Section}, '{UuidFor(Section)}', {SectionResourceKeyId}),
+                ({DualCreditEdOrg}, '{UuidFor(DualCreditEdOrg)}', {EducationOrganizationResourceKeyId}),
+                ({Program}, '{UuidFor(Program)}', {ProgramResourceKeyId}),
+                ({OffPageProgram}, '{UuidFor(OffPageProgram)}', {ProgramResourceKeyId});
+
+            INSERT INTO dms."Descriptor" ("DocumentId", "Uri")
+            VALUES ({AttemptStatusDescriptorId}, '{AttemptStatusUri}');
+
+            INSERT INTO {schema}."StudentSectionAssociation"
+            VALUES
+                ({FullyPopulatedDocumentId}, {DualCreditEdOrg}, 255901, {Section}, 'SEC-X', {StudentA}, 'S-701', {AttemptStatusDescriptorId}),
+                ({PartiallyPopulatedDocumentId}, NULL, NULL, {Section}, 'SEC-X', {StudentB}, 'S-702', NULL),
+                ({AllNullReferencesDocumentId}, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ({OffPageDocumentId}, NULL, NULL, {Section}, 'SEC-X', {StudentA}, 'S-701', NULL),
+                ({RepeatedReferenceDocumentId}, {Program}, 255902, {Program}, 'SEC-DUP', {Program}, 'S-730', NULL);
+
+            INSERT INTO {schema}."StudentSectionAssociationProgram"
+            VALUES
+                (1, {FullyPopulatedDocumentId}, 0, {Program}, 'Program P'),
+                (2, {FullyPopulatedDocumentId}, 1, {StudentA}, 'Program Named Like Student'),
+                (3, {OffPageDocumentId}, 0, {OffPageProgram}, 'Program Q');
+            """;
+
+    public static string PostgresqlCleanupSql(string schema) =>
+        $"""
+            DROP SCHEMA IF EXISTS {schema} CASCADE;
+            {PostgresqlDeleteSeedRowsSql}
+            """;
+
+    private static string PostgresqlDeleteSeedRowsSql =>
+        $"""
+            DELETE FROM dms."Document" WHERE "DocumentId" IN (
+                {FullyPopulatedDocumentId}, {PartiallyPopulatedDocumentId}, {AllNullReferencesDocumentId},
+                {OffPageDocumentId}, {RepeatedReferenceDocumentId}, {StudentA}, {StudentB}, {Section},
+                {DualCreditEdOrg}, {Program}, {OffPageProgram});
+            DELETE FROM dms."Descriptor" WHERE "DocumentId" = {AttemptStatusDescriptorId};
+            """;
+
+    public static string MssqlProvisionSql(string schema) =>
+        $"""
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'dms') EXEC('CREATE SCHEMA [dms]');
+            IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = '{schema}') EXEC('CREATE SCHEMA [{schema}]');
+
+            IF OBJECT_ID('dms.Document', 'U') IS NULL
+            CREATE TABLE dms.[Document] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DocumentUuid] uniqueidentifier NOT NULL,
+                [ResourceKeyId] smallint NOT NULL DEFAULT 0,
+                [ContentVersion] bigint NOT NULL DEFAULT 1,
+                [IdentityVersion] bigint NOT NULL DEFAULT 1,
+                [ContentLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [IdentityLastModifiedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset(),
+                [CreatedAt] datetimeoffset NOT NULL DEFAULT sysdatetimeoffset()
+            );
+
+            IF OBJECT_ID('dms.Descriptor', 'U') IS NULL
+            CREATE TABLE dms.[Descriptor] (
+                [DocumentId] bigint PRIMARY KEY,
+                [Namespace] varchar(255) NOT NULL DEFAULT '',
+                [CodeValue] varchar(50) NOT NULL DEFAULT '',
+                [ShortDescription] varchar(75) NOT NULL DEFAULT '',
+                [Description] varchar(1024) NULL,
+                [EffectiveBeginDate] date NULL,
+                [EffectiveEndDate] date NULL,
+                [Discriminator] varchar(128) NOT NULL DEFAULT '',
+                [Uri] varchar(306) NOT NULL
+            );
+
+            CREATE TABLE {schema}.[StudentSectionAssociation] (
+                [DocumentId] bigint PRIMARY KEY,
+                [DualCreditEducationOrganization_DocumentId] bigint NULL,
+                [DualCreditEducationOrganization_EducationOrganizationId] bigint NULL,
+                [Section_DocumentId] bigint NULL,
+                [Section_SectionIdentifier] varchar(255) NULL,
+                [Student_DocumentId] bigint NULL,
+                [Student_StudentUniqueId] varchar(32) NULL,
+                [AttemptStatusDescriptor_DescriptorId] bigint NULL
+            );
+
+            CREATE TABLE {schema}.[StudentSectionAssociationProgram] (
+                [CollectionItemId] bigint PRIMARY KEY,
+                [StudentSectionAssociation_DocumentId] bigint NOT NULL,
+                [Ordinal] int NOT NULL,
+                [Program_DocumentId] bigint NULL,
+                [Program_ProgramName] varchar(60) NULL
+            );
+            """;
+
+    public static string MssqlSeedSql(string schema) =>
+        $"""
+            INSERT INTO dms.[Document] ([DocumentId], [DocumentUuid], [ResourceKeyId])
+            VALUES
+                ({FullyPopulatedDocumentId}, '{UuidFor(FullyPopulatedDocumentId)}', 20),
+                ({PartiallyPopulatedDocumentId}, '{UuidFor(PartiallyPopulatedDocumentId)}', 20),
+                ({AllNullReferencesDocumentId}, '{UuidFor(AllNullReferencesDocumentId)}', 20),
+                ({OffPageDocumentId}, '{UuidFor(OffPageDocumentId)}', 20),
+                ({RepeatedReferenceDocumentId}, '{UuidFor(RepeatedReferenceDocumentId)}', 20),
+                ({StudentA}, '{UuidFor(StudentA)}', {StudentResourceKeyId}),
+                ({StudentB}, '{UuidFor(StudentB)}', {StudentResourceKeyId}),
+                ({Section}, '{UuidFor(Section)}', {SectionResourceKeyId}),
+                ({DualCreditEdOrg}, '{UuidFor(DualCreditEdOrg)}', {EducationOrganizationResourceKeyId}),
+                ({Program}, '{UuidFor(Program)}', {ProgramResourceKeyId}),
+                ({OffPageProgram}, '{UuidFor(OffPageProgram)}', {ProgramResourceKeyId});
+
+            INSERT INTO dms.[Descriptor] ([DocumentId], [Uri])
+            VALUES ({AttemptStatusDescriptorId}, '{AttemptStatusUri}');
+
+            INSERT INTO {schema}.[StudentSectionAssociation]
+            VALUES
+                ({FullyPopulatedDocumentId}, {DualCreditEdOrg}, 255901, {Section}, 'SEC-X', {StudentA}, 'S-701', {AttemptStatusDescriptorId}),
+                ({PartiallyPopulatedDocumentId}, NULL, NULL, {Section}, 'SEC-X', {StudentB}, 'S-702', NULL),
+                ({AllNullReferencesDocumentId}, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+                ({OffPageDocumentId}, NULL, NULL, {Section}, 'SEC-X', {StudentA}, 'S-701', NULL),
+                ({RepeatedReferenceDocumentId}, {Program}, 255902, {Program}, 'SEC-DUP', {Program}, 'S-730', NULL);
+
+            INSERT INTO {schema}.[StudentSectionAssociationProgram]
+            VALUES
+                (1, {FullyPopulatedDocumentId}, 0, {Program}, 'Program P'),
+                (2, {FullyPopulatedDocumentId}, 1, {StudentA}, 'Program Named Like Student'),
+                (3, {OffPageDocumentId}, 0, {OffPageProgram}, 'Program Q');
+            """;
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/DocumentReferenceLookupPageFixture.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/DocumentReferenceLookupPageFixture.cs
@@ -4,6 +4,9 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using FluentAssertions;
 
 namespace EdFi.DataManagementService.Backend.Tests.Common;
 
@@ -64,6 +67,115 @@ public static class DocumentReferenceLookupPageFixture
         DualCreditEdOrg,
         Program,
     ];
+
+    /// <summary>
+    /// The complete page produced by the non-link reconstitution overload, in document order with
+    /// child collections in ordinal order.
+    /// </summary>
+    /// <remarks>
+    /// This is property-complete rather than a set of spot checks: it names every property each
+    /// document is expected to carry, so a comparison against it fails on an unexpected property, a
+    /// missing property, a partial reference object, or a reordered document or child element.
+    /// Document <c>603</c> is the empty object because every one of its references is null.
+    /// </remarks>
+    public const string ExpectedNonLinkPageJson = """
+        [
+          {
+            "attemptStatusDescriptor": "uri://ed-fi.org/AttemptStatusDescriptor#Active",
+            "dualCreditEducationOrganizationReference": { "educationOrganizationId": 255901 },
+            "programs": [
+              { "programReference": { "programName": "Program P" } },
+              { "programReference": { "programName": "Program Named Like Student" } }
+            ],
+            "sectionReference": { "sectionIdentifier": "SEC-X" },
+            "studentReference": { "studentUniqueId": "S-701" }
+          },
+          {
+            "sectionReference": { "sectionIdentifier": "SEC-X" },
+            "studentReference": { "studentUniqueId": "S-702" }
+          },
+          {},
+          {
+            "dualCreditEducationOrganizationReference": { "educationOrganizationId": 255902 },
+            "sectionReference": { "sectionIdentifier": "SEC-DUP" },
+            "studentReference": { "studentUniqueId": "S-730" }
+          }
+        ]
+        """;
+
+    /// <summary>
+    /// Asserts a reconstituted page equals <see cref="ExpectedNonLinkPageJson"/> exactly and carries
+    /// no <c>link</c> object anywhere, which is what the non-link reconstitution overload must produce.
+    /// </summary>
+    public static void AssertNonLinkPageMatchesExactly(IReadOnlyList<JsonNode> reconstitutedPage)
+    {
+        ArgumentNullException.ThrowIfNull(reconstitutedPage);
+
+        JsonArray actual = [];
+
+        foreach (var document in reconstitutedPage)
+        {
+            actual.Add(document.DeepClone());
+        }
+
+        var expected =
+            JsonNode.Parse(ExpectedNonLinkPageJson)
+            ?? throw new InvalidOperationException("Expected non-link page JSON did not parse.");
+
+        JsonNode
+            .DeepEquals(actual, expected)
+            .Should()
+            .BeTrue(
+                "the reconstituted page must match the expected non-link payload exactly."
+                    + $"{Environment.NewLine}Actual:{Environment.NewLine}{Serialize(actual)}"
+                    + $"{Environment.NewLine}Expected:{Environment.NewLine}{Serialize(expected)}"
+            );
+
+        CollectLinkPaths(actual)
+            .Should()
+            .BeEmpty("the non-link reconstitution overload must not emit link objects");
+    }
+
+    private static string Serialize(JsonNode node) =>
+        node.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+
+    /// <summary>
+    /// Collects the JSON paths of every <c>link</c> property reachable in the supplied node.
+    /// </summary>
+    private static List<string> CollectLinkPaths(JsonNode node)
+    {
+        List<string> linkPaths = [];
+        Visit(node);
+
+        return linkPaths;
+
+        void Visit(JsonNode? current)
+        {
+            switch (current)
+            {
+                case JsonObject jsonObject:
+                    foreach (var property in jsonObject)
+                    {
+                        if (string.Equals(property.Key, "link", StringComparison.Ordinal))
+                        {
+                            linkPaths.Add(jsonObject.GetPath() + "." + property.Key);
+                        }
+
+                        Visit(property.Value);
+                    }
+
+                    break;
+
+                case JsonArray jsonArray:
+                    foreach (var element in jsonArray)
+                    {
+                        Visit(element);
+                    }
+
+                    break;
+            }
+        }
+    }
 
     /// <summary>
     /// Deterministic <c>DocumentUuid</c> for a seeded document id.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/HydrationTestHelper.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/HydrationTestHelper.cs
@@ -361,4 +361,390 @@ public static class HydrationTestHelper
 
         return new ReadPlanCompiler(dialect).Compile(model);
     }
+
+    /// <summary>
+    /// Builds a <see cref="ResourceReadPlan"/> shaped like the Ed-Fi StudentSectionAssociation
+    /// resource: a root table carrying three document references (one of them nullable) plus a
+    /// descriptor edge, and a child collection table carrying a fourth document reference.
+    /// </summary>
+    /// <remarks>
+    /// This is the shape that exercises both document-reference lookup branch forms at once. The
+    /// root contributes several reference columns, so it is scanned once and expanded inline; the
+    /// child contributes one, so it keeps the plain projection. The child also verifies that the
+    /// lookup scopes through the child's root-scope locator rather than its own key, so references
+    /// held only by child rows of off-page documents are excluded.
+    /// </remarks>
+    public static ResourceReadPlan BuildStudentSectionAssociationReadPlan(
+        string schemaName,
+        SqlDialect dialect
+    )
+    {
+        var schema = new DbSchemaName(schemaName);
+
+        var studentReferencePath = new JsonPathExpression(
+            "$.studentReference",
+            [new JsonPathSegment.Property("studentReference")]
+        );
+        var studentUniqueIdPath = new JsonPathExpression(
+            "$.studentReference.studentUniqueId",
+            [
+                new JsonPathSegment.Property("studentReference"),
+                new JsonPathSegment.Property("studentUniqueId"),
+            ]
+        );
+        var sectionReferencePath = new JsonPathExpression(
+            "$.sectionReference",
+            [new JsonPathSegment.Property("sectionReference")]
+        );
+        var sectionIdentifierPath = new JsonPathExpression(
+            "$.sectionReference.sectionIdentifier",
+            [
+                new JsonPathSegment.Property("sectionReference"),
+                new JsonPathSegment.Property("sectionIdentifier"),
+            ]
+        );
+        var dualCreditReferencePath = new JsonPathExpression(
+            "$.dualCreditEducationOrganizationReference",
+            [new JsonPathSegment.Property("dualCreditEducationOrganizationReference")]
+        );
+        var dualCreditEducationOrganizationIdPath = new JsonPathExpression(
+            "$.dualCreditEducationOrganizationReference.educationOrganizationId",
+            [
+                new JsonPathSegment.Property("dualCreditEducationOrganizationReference"),
+                new JsonPathSegment.Property("educationOrganizationId"),
+            ]
+        );
+        var attemptStatusDescriptorPath = new JsonPathExpression(
+            "$.attemptStatusDescriptor",
+            [new JsonPathSegment.Property("attemptStatusDescriptor")]
+        );
+        var programReferencePath = new JsonPathExpression(
+            "$.programs[*].programReference",
+            [
+                new JsonPathSegment.Property("programs"),
+                new JsonPathSegment.AnyArrayElement(),
+                new JsonPathSegment.Property("programReference"),
+            ]
+        );
+        var programNamePath = new JsonPathExpression(
+            "$.programs[*].programReference.programName",
+            [
+                new JsonPathSegment.Property("programs"),
+                new JsonPathSegment.AnyArrayElement(),
+                new JsonPathSegment.Property("programReference"),
+                new JsonPathSegment.Property("programName"),
+            ]
+        );
+
+        var rootTable = new DbTableModel(
+            Table: new DbTableName(schema, "StudentSectionAssociation"),
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                ConstraintName: "PK_StudentSectionAssociation",
+                Columns: [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DualCreditEducationOrganization_DocumentId"),
+                    Kind: ColumnKind.DocumentFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: dualCreditReferencePath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "EducationOrganization")
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DualCreditEducationOrganization_EducationOrganizationId"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: dualCreditEducationOrganizationIdPath,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Section_DocumentId"),
+                    Kind: ColumnKind.DocumentFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: sectionReferencePath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Section")
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Section_SectionIdentifier"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 255),
+                    IsNullable: true,
+                    SourceJsonPath: sectionIdentifierPath,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Student_DocumentId"),
+                    Kind: ColumnKind.DocumentFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: studentReferencePath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Student")
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Student_StudentUniqueId"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 32),
+                    IsNullable: true,
+                    SourceJsonPath: studentUniqueIdPath,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("AttemptStatusDescriptor_DescriptorId"),
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: attemptStatusDescriptorPath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "AttemptStatusDescriptor")
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+        var programTable = new DbTableModel(
+            Table: new DbTableName(schema, "StudentSectionAssociationProgram"),
+            JsonScope: new JsonPathExpression(
+                "$.programs[*]",
+                [new JsonPathSegment.Property("programs"), new JsonPathSegment.AnyArrayElement()]
+            ),
+            Key: new TableKey(
+                ConstraintName: "PK_StudentSectionAssociationProgram",
+                Columns: [new DbKeyColumn(new DbColumnName("CollectionItemId"), ColumnKind.CollectionKey)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("CollectionItemId"),
+                    Kind: ColumnKind.CollectionKey,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("StudentSectionAssociation_DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Ordinal"),
+                    Kind: ColumnKind.Ordinal,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int32),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Program_DocumentId"),
+                    Kind: ColumnKind.DocumentFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: programReferencePath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Program")
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("Program_ProgramName"),
+                    Kind: ColumnKind.Scalar,
+                    ScalarType: new RelationalScalarType(ScalarKind.String, MaxLength: 60),
+                    IsNullable: true,
+                    SourceJsonPath: programNamePath,
+                    TargetResource: null
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Collection,
+                PhysicalRowIdentityColumns: [new DbColumnName("CollectionItemId")],
+                RootScopeLocatorColumns: [new DbColumnName("StudentSectionAssociation_DocumentId")],
+                ImmediateParentScopeLocatorColumns:
+                [
+                    new DbColumnName("StudentSectionAssociation_DocumentId"),
+                ],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+        var model = new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "StudentSectionAssociation"),
+            PhysicalSchema: schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable, programTable],
+            DocumentReferenceBindings:
+            [
+                new DocumentReferenceBinding(
+                    IsIdentityComponent: false,
+                    ReferenceObjectPath: dualCreditReferencePath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("DualCreditEducationOrganization_DocumentId"),
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "EducationOrganization"),
+                    IdentityBindings:
+                    [
+                        new ReferenceIdentityBinding(
+                            IdentityJsonPath: dualCreditEducationOrganizationIdPath,
+                            ReferenceJsonPath: dualCreditEducationOrganizationIdPath,
+                            Column: new DbColumnName(
+                                "DualCreditEducationOrganization_EducationOrganizationId"
+                            )
+                        ),
+                    ]
+                ),
+                new DocumentReferenceBinding(
+                    IsIdentityComponent: true,
+                    ReferenceObjectPath: sectionReferencePath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("Section_DocumentId"),
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Section"),
+                    IdentityBindings:
+                    [
+                        new ReferenceIdentityBinding(
+                            IdentityJsonPath: sectionIdentifierPath,
+                            ReferenceJsonPath: sectionIdentifierPath,
+                            Column: new DbColumnName("Section_SectionIdentifier")
+                        ),
+                    ]
+                ),
+                new DocumentReferenceBinding(
+                    IsIdentityComponent: true,
+                    ReferenceObjectPath: studentReferencePath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("Student_DocumentId"),
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Student"),
+                    IdentityBindings:
+                    [
+                        new ReferenceIdentityBinding(
+                            IdentityJsonPath: studentUniqueIdPath,
+                            ReferenceJsonPath: studentUniqueIdPath,
+                            Column: new DbColumnName("Student_StudentUniqueId")
+                        ),
+                    ]
+                ),
+                new DocumentReferenceBinding(
+                    IsIdentityComponent: false,
+                    ReferenceObjectPath: programReferencePath,
+                    Table: programTable.Table,
+                    FkColumn: new DbColumnName("Program_DocumentId"),
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "Program"),
+                    IdentityBindings:
+                    [
+                        new ReferenceIdentityBinding(
+                            IdentityJsonPath: programNamePath,
+                            ReferenceJsonPath: programNamePath,
+                            Column: new DbColumnName("Program_ProgramName")
+                        ),
+                    ]
+                ),
+            ],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: attemptStatusDescriptorPath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("AttemptStatusDescriptor_DescriptorId"),
+                    DescriptorResource: new QualifiedResourceName("Ed-Fi", "AttemptStatusDescriptor")
+                ),
+            ]
+        );
+
+        return new ReadPlanCompiler(dialect).Compile(model);
+    }
+
+    /// <summary>
+    /// Builds a <see cref="ResourceReadPlan"/> for a resource that carries a descriptor edge but no
+    /// document references, so the compiled plan has no document-reference lookup at all.
+    /// </summary>
+    public static ResourceReadPlan BuildDescriptorOnlyReadPlan(string schemaName, SqlDialect dialect)
+    {
+        var schema = new DbSchemaName(schemaName);
+        var gradeLevelDescriptorPath = new JsonPathExpression(
+            "$.gradeLevelDescriptor",
+            [new JsonPathSegment.Property("gradeLevelDescriptor")]
+        );
+
+        var rootTable = new DbTableModel(
+            Table: new DbTableName(schema, "DescriptorOnly"),
+            JsonScope: new JsonPathExpression("$", []),
+            Key: new TableKey(
+                ConstraintName: "PK_DescriptorOnly",
+                Columns: [new DbKeyColumn(new DbColumnName("DocumentId"), ColumnKind.ParentKeyPart)]
+            ),
+            Columns:
+            [
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("DocumentId"),
+                    Kind: ColumnKind.ParentKeyPart,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: false,
+                    SourceJsonPath: null,
+                    TargetResource: null
+                ),
+                new DbColumnModel(
+                    ColumnName: new DbColumnName("GradeLevelDescriptor_DescriptorId"),
+                    Kind: ColumnKind.DescriptorFk,
+                    ScalarType: new RelationalScalarType(ScalarKind.Int64),
+                    IsNullable: true,
+                    SourceJsonPath: gradeLevelDescriptorPath,
+                    TargetResource: new QualifiedResourceName("Ed-Fi", "GradeLevelDescriptor")
+                ),
+            ],
+            Constraints: []
+        )
+        {
+            IdentityMetadata = new DbTableIdentityMetadata(
+                TableKind: DbTableKind.Root,
+                PhysicalRowIdentityColumns: [],
+                RootScopeLocatorColumns: [new DbColumnName("DocumentId")],
+                ImmediateParentScopeLocatorColumns: [],
+                SemanticIdentityBindings: []
+            ),
+        };
+
+        var model = new RelationalResourceModel(
+            Resource: new QualifiedResourceName("Ed-Fi", "DescriptorOnly"),
+            PhysicalSchema: schema,
+            StorageKind: ResourceStorageKind.RelationalTables,
+            Root: rootTable,
+            TablesInDependencyOrder: [rootTable],
+            DocumentReferenceBindings: [],
+            DescriptorEdgeSources:
+            [
+                new DescriptorEdgeSource(
+                    IsIdentityComponent: false,
+                    DescriptorValuePath: gradeLevelDescriptorPath,
+                    Table: rootTable.Table,
+                    FkColumn: new DbColumnName("GradeLevelDescriptor_DescriptorId"),
+                    DescriptorResource: new QualifiedResourceName("Ed-Fi", "GradeLevelDescriptor")
+                ),
+            ]
+        );
+
+        return new ReadPlanCompiler(dialect).Compile(model);
+    }
 }


### PR DESCRIPTION
## What changed

`DocumentReferenceLookupPlanCompiler` and `DescriptorProjectionPlanCompiler` deduplicated their SQL
emission sources on `(table, column)` instead of on `table`. A table with *k* reference or descriptor
columns emitted *k* `UNION` branches, and **each branch independently re-joined that table to the page
keyset**. For a resource shaped like `StudentSectionAssociation` (3 reference columns on the root, 1 on
`StudentSectionAssociationProgram`, 4 descriptor columns on the root, 1 on the child), one GET-many page
paid 9 keyset-driven passes where 2 suffice.

Sources are now grouped by owning table: each table is scanned once and its columns expanded inline
through the provider's row-set primitive — `CROSS JOIN LATERAL (VALUES …)` on PostgreSQL, `CROSS APPLY
(VALUES …)` on SQL Server. The null predicate moves onto the expanded value, so a row still contributes
only its populated references instead of being dropped when any single column is null.

Production diff is 8 files under `Backend.Plans/`, entirely SQL emission. No application code, DDL,
indexes, result ordinals, or plan contracts changed, and a table contributing one column emits
byte-for-byte identical SQL.

## Provider divergence — intentional

Reference lookup is grouped on **both** providers. Descriptor projection is grouped on **SQL Server
only**, documented at `BuildSourceGroups`.

Grouping descriptor projection on PostgreSQL regressed it. The planner cannot estimate distinctness
through a row-set expansion, so the row estimate collapsed (892 → 4) and the comparatively small
`dms.Descriptor` join flipped from a hash join over a sequential scan to per-row nested loops (buffers
102 → 244). The apparent break-even came entirely from planning time (2.68 → 0.79 ms), which the
production path never pays because connections auto-prepare (`NpgsqlDataSourceCache`:
`AutoPrepareMinUsages = 3`). At steady state only the regression remains. The reference lookup keeps
grouping on PostgreSQL because `dms.Document` is large enough that nested loops are already the right
join — its buffer count measured unchanged.

Anyone unifying the two compilers later must re-measure on the auto-prepared path rather than assume
symmetry.

## Measured effect

| | PostgreSQL | SQL Server |
|---|---|---|
| Reference lookup | Source access 21 → 7 buffers; keyset scans 3 → 1 | Source reads 3120 → 1040; total −34% |
| Descriptor projection | Not applied (see above) | Source reads 4160 → 1040; total 4330 → 1198 |

## Performance AC is not met

Acceptance criterion 1 (≤30 ms on the DMS-1236 rig) is **unverified and not waived** — the rig is not in
this repository, the harness story (DMS-1019) is unimplemented, and DMS-1236 owns the environment. This
was a deliberate human disposition, not an oversight.

Reviewers should not expect this change alone to reach 61 → 30 ms on PostgreSQL: the `dms.Document` join
is ~99.8% of that statement's buffer traffic (4100 of 4107), so removing the redundant source scans is
correct and free but addresses ~0.3% of the cost. Closing the gap likely needs a follow-on — a covering
index on `dms.Document (DocumentId) INCLUDE (DocumentUuid, ResourceKeyId)`, which must be weighed
against DMS-1251 having just removed indexes from that table, or reference-column denormalization.

## Tests and goldens

New page-level integration fixtures, mirrored document-for-document across providers: null references,
duplicates across columns/rows/tables, child-collection correlation with an off-page guard,
descriptor-only resources, empty pages, ordering, and whole-page JSON equivalence via
`JsonNode.DeepEquals` against one shared expectation — which also establishes that both providers emit
*identical* payloads, not merely self-consistent ones. Page-level link-injection fixtures were added
alongside the existing single-document ones rather than replacing them.

Three `mappingset.manifest.json` goldens regenerated: **132 changed values, all `mssql`
`descriptor_projection_plans_in_order[].select_by_keyset_sql_sha256`**. All 464 `pgsql` descriptor
hashes are byte-identical to baseline, and the flattened key set is unchanged.

The two `DescriptorStampingTriggerTests` files are unrelated to the optimization: their strict
`BeAfter` timestamp assertions relied on a 50 ms delay producing two distinct clock reads, which flaked
in CI on this branch. The seed stamp is now backdated instead, so the assertion stays strict — it still
catches a stamp the trigger never wrote — while surviving a stalled clock. The same pattern remains in
seven other backend fixtures and needs its own ticket.

## Residual risk

PostgreSQL's row estimate for the reference lookup also degrades (1025 → 3). Benign at this data shape —
plan choice unchanged, `dms.Document` buffers unchanged — but it is a real estimate change that could
matter at another shape.

<details>
<summary>Alternatives evaluated (AC 2)</summary>

| Candidate | Verdict |
|---|---|
| `UNION ALL` + application dedup | Rejected — `UNION` is already one dedup pass; this moves dedup *after* the `dms.Document` join, multiplying probes. |
| Single `dms.Document` join over a unified id list | **Selected** — already one join; the defect was that the id list was built by N keyset passes. |
| Carry `DocumentUuid`/`ResourceKeyId` on reference columns | Rejected here — removes the join, but needs DDL on every reference column, write-path propagation, a migration, and storage growth that runs against DMS-1251. |
| Resolve UUIDs in the row fetch | Rejected — more database work (un-deduplicated per-column joins) and breaks the hydration result-set contract, reconstitution ordinals, and goldens. |
| Fold descriptor-URI resolution into the same statement | Rejected — different source columns and target table, incompatible result shapes, zero round trips saved. |

</details>
