### PR TITLE
[DMS-1301] Fail test targets that would run zero tests

### DIFF
--- a/.github/workflows/on-config-pullrequest.yml
+++ b/.github/workflows/on-config-pullrequest.yml
@@ -196,6 +196,15 @@ jobs:
               throw "$($result.FailedCount) OpenIddict crypto test(s) failed."
           }
 
+      # Guards build-config.ps1's test targets against reporting success when the test-assembly glob
+      # matched nothing, which would otherwise exit 0 having executed zero tests.
+      - name: Run Build Script Zero-Test Guard Tests
+        run: |
+          $result = Invoke-Pester -Path "eng/ci/tests/BuildScriptTestGuards.Tests.ps1" -Output Detailed -PassThru
+          if ($result.FailedCount -gt 0) {
+              throw "$($result.FailedCount) build script zero-test guard test(s) failed."
+          }
+
   run-unit-tests:
     name: Run Unit Tests
     needs: detect-fresh-build-changes

--- a/.github/workflows/on-dms-pullrequest.yml
+++ b/.github/workflows/on-dms-pullrequest.yml
@@ -209,6 +209,7 @@ jobs:
             "eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1",
             "eng/docker-compose/tests/E2ETeardownSafety.Tests.ps1",
             "eng/docker-compose/tests/InstanceE2EForwarding.Tests.ps1",
+            "eng/ci/tests/BuildScriptTestGuards.Tests.ps1",
             "eng/ci/tests/Sanitize-E2EArtifacts.Tests.ps1",
             "eng/ci/tests/DmsPullRequestMssqlWorkflow.Tests.ps1",
             "eng/DatabaseTemplates/tests/Template-Management.Tests.ps1",

--- a/build-config.ps1
+++ b/build-config.ps1
@@ -230,12 +230,7 @@ function RunTests {
         $TestFilter
     )
 
-    $testAssemblyPath = "$solutionRoot/*/$Filter/bin/$Configuration/"
-    $testAssemblies = Get-ChildItem -Path $testAssemblyPath -Filter "$Filter.dll" -Recurse
-
-    if ($testAssemblies.Length -eq 0) {
-        Write-Output "no test assemblies found in $testAssemblyPath"
-    }
+    $testAssemblies = @(Get-RequiredTestAssembly -SolutionRoot $solutionRoot -Filter $Filter -Configuration $Configuration)
 
     Write-Output "Tests Assemblies List"
     Write-Output $testAssemblies

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -586,14 +586,13 @@ function RunTests {
         $ResultNameSuffix
     )
 
-    $testAssemblyPath = "$solutionRoot/*/$Filter/bin/$Configuration/"
-    $testAssemblies = Get-ChildItem -Path $testAssemblyPath -Filter "$Filter.dll" -Recurse |
-    Sort-Object -Property { $_.Name.Length }
+    # @() so $testAssemblies[-1] below is well defined when exactly one assembly matches: the
+    # pipeline hands back a bare FileInfo in that case rather than a single-element array.
+    $testAssemblies = @(
+        Get-RequiredTestAssembly -SolutionRoot $solutionRoot -Filter $Filter -Configuration $Configuration |
+            Sort-Object -Property { $_.Name.Length }
+    )
     $normalizedTestFilter = ConvertTo-NormalizedTestFilter -TestFilter $TestFilter
-
-    if ($testAssemblies.Length -eq 0) {
-        Write-Output "no test assemblies found in $testAssemblyPath"
-    }
 
     Write-Output "Tests Assemblies List"
     Write-Output $testAssemblies

--- a/eng/build-helpers.psm1
+++ b/eng/build-helpers.psm1
@@ -71,6 +71,43 @@ function Invoke-Main {
 
 <#
     .DESCRIPTION
+    Resolve the built test assemblies for a test target, failing when the glob matches nothing.
+
+    An empty match means the target would execute zero tests, and a target that executes zero tests
+    must never report success: there would be no signal separating "everything passed" from "nothing
+    ran". The glob is easy to miss (assemblies built under a different -Configuration, a renamed test
+    project, a changed directory layout, or a skipped build step), so this is a hard failure.
+#>
+function Get-RequiredTestAssembly {
+    param (
+        # Root of the solution whose test projects are being searched
+        [string]
+        $SolutionRoot,
+
+        # File search filter, e.g. "*.Tests.Unit"
+        [string]
+        $Filter,
+
+        # .NET build configuration the assemblies were built under
+        [string]
+        $Configuration
+    )
+
+    $testAssemblyPath = "$SolutionRoot/*/$Filter/bin/$Configuration/"
+
+    # @() so the emptiness test below is a count. Get-ChildItem returns a bare FileInfo when exactly
+    # one file matches, and FileInfo.Length is the file's size in bytes, not an item count.
+    $testAssemblies = @(Get-ChildItem -Path $testAssemblyPath -Filter "$Filter.dll" -Recurse)
+
+    if ($testAssemblies.Count -eq 0) {
+        throw "no test assemblies found in $testAssemblyPath. Nothing matching '$Filter' was built for configuration '$Configuration', so this target would run zero tests."
+    }
+
+    return $testAssemblies
+}
+
+<#
+    .DESCRIPTION
     Display a command and its arguments on the console
 #>
 function Write-Command($message){

--- a/eng/ci/tests/BuildScriptTestGuards.Tests.ps1
+++ b/eng/ci/tests/BuildScriptTestGuards.Tests.ps1
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+#Requires -Version 7
+
+# DMS-1301: a test target whose assembly glob matches nothing must not report success. The empty
+# match used to be informational, so the run loop executed nothing and the target still exited 0,
+# leaving no signal that separated "everything passed" from "nothing ran". The guard lives in
+# eng/build-helpers.psm1 so build-dms.ps1 and build-config.ps1 share one copy, and so these specs
+# can exercise it directly instead of running either build script.
+
+Describe "Build script zero-test guards (DMS-1301)" {
+    BeforeAll {
+        $script:repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../.."))
+        $script:helpersModule = Join-Path $script:repoRoot "eng/build-helpers.psm1"
+        Import-Module $script:helpersModule -Force
+
+        function Add-TestAssemblyFixture {
+            param(
+                [string] $SolutionRoot,
+                [string] $ProjectGroup,
+                [string] $ProjectName,
+                [string] $Configuration
+            )
+
+            $binDirectory = Join-Path $SolutionRoot "$ProjectGroup/$ProjectName/bin/$Configuration"
+            New-Item -ItemType Directory -Path $binDirectory -Force | Out-Null
+
+            $assemblyPath = Join-Path $binDirectory "$ProjectName.dll"
+            Set-Content -LiteralPath $assemblyPath -Value "test assembly fixture"
+
+            return $assemblyPath
+        }
+    }
+
+    AfterAll {
+        Remove-Module build-helpers -Force -ErrorAction SilentlyContinue
+    }
+
+    Context "Get-RequiredTestAssembly rejects an empty glob" {
+        BeforeEach {
+            $script:solutionRoot = Join-Path $TestDrive ([guid]::NewGuid().ToString())
+            New-Item -ItemType Directory -Path $script:solutionRoot -Force | Out-Null
+        }
+
+        It "throws when nothing matches, instead of reporting a zero-test run as success" {
+            {
+                Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release"
+            } | Should -Throw -ExpectedMessage "*no test assemblies found*"
+        }
+
+        It "names the searched path and the configuration so the cause is diagnosable" {
+            $thrown = $null
+            try {
+                Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release"
+            }
+            catch {
+                $thrown = $_.Exception.Message
+            }
+
+            $thrown | Should -Not -BeNullOrEmpty
+            $thrown | Should -BeLike "*$($script:solutionRoot)*"
+            $thrown | Should -BeLike "*`*.Tests.Unit*"
+            $thrown | Should -BeLike "*Release*"
+        }
+
+        It "throws when assemblies exist only under a different configuration" {
+            Add-TestAssemblyFixture -SolutionRoot $script:solutionRoot -ProjectGroup "core" -ProjectName "EdFi.Fixture.Tests.Unit" -Configuration "Debug" | Out-Null
+
+            {
+                Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release"
+            } | Should -Throw -ExpectedMessage "*no test assemblies found*"
+        }
+
+        It "returns the assembly without throwing when exactly one matches" {
+            # Regression guard: the previous emptiness test read .Length on the pipeline output, and a
+            # single match is a bare FileInfo whose .Length is the file size in bytes, not a count.
+            Add-TestAssemblyFixture -SolutionRoot $script:solutionRoot -ProjectGroup "core" -ProjectName "EdFi.Fixture.Tests.Unit" -Configuration "Release" | Out-Null
+
+            $found = @(Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release")
+
+            $found.Count | Should -Be 1
+            $found[0].Name | Should -Be "EdFi.Fixture.Tests.Unit.dll"
+        }
+
+        It "returns every match when several projects match the filter" {
+            Add-TestAssemblyFixture -SolutionRoot $script:solutionRoot -ProjectGroup "core" -ProjectName "EdFi.Core.Tests.Unit" -Configuration "Release" | Out-Null
+            Add-TestAssemblyFixture -SolutionRoot $script:solutionRoot -ProjectGroup "backend" -ProjectName "EdFi.Backend.Tests.Unit" -Configuration "Release" | Out-Null
+
+            $found = @(Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release")
+
+            @($found.Name) | Sort-Object | Should -Be @("EdFi.Backend.Tests.Unit.dll", "EdFi.Core.Tests.Unit.dll")
+        }
+
+        It "does not match a project whose assembly is outside the filter" {
+            Add-TestAssemblyFixture -SolutionRoot $script:solutionRoot -ProjectGroup "core" -ProjectName "EdFi.Core.Tests.Integration" -Configuration "Release" | Out-Null
+
+            {
+                Get-RequiredTestAssembly -SolutionRoot $script:solutionRoot -Filter "*.Tests.Unit" -Configuration "Release"
+            } | Should -Throw -ExpectedMessage "*no test assemblies found*"
+        }
+    }
+
+    Context "Both build scripts route through the shared guard" {
+        BeforeAll {
+            $script:buildScripts = @{
+                "build-dms.ps1"    = Get-Content -LiteralPath (Join-Path $script:repoRoot "build-dms.ps1") -Raw
+                "build-config.ps1" = Get-Content -LiteralPath (Join-Path $script:repoRoot "build-config.ps1") -Raw
+            }
+        }
+
+        It "<name> resolves its test assemblies through Get-RequiredTestAssembly" -ForEach @(
+            @{ Name = "build-dms.ps1" }
+            @{ Name = "build-config.ps1" }
+        ) {
+            $script:buildScripts[$name] | Should -BeLike "*Get-RequiredTestAssembly*"
+        }
+
+        It "<name> keeps no private copy of the assembly glob" -ForEach @(
+            @{ Name = "build-dms.ps1" }
+            @{ Name = "build-config.ps1" }
+        ) {
+            # The glob and its guard belong to the helper. A reintroduced local copy would drift.
+            $script:buildScripts[$name] | Should -Not -BeLike "*Get-ChildItem -Path `$testAssemblyPath*"
+        }
+
+        It "<name> no longer treats an empty assembly list as informational" -ForEach @(
+            @{ Name = "build-dms.ps1" }
+            @{ Name = "build-config.ps1" }
+        ) {
+            $script:buildScripts[$name] | Should -Not -BeLike "*Write-Output `"no test assemblies found*"
+        }
+    }
+}

--- a/eng/ci/tests/BuildScriptTestGuards.Tests.ps1
+++ b/eng/ci/tests/BuildScriptTestGuards.Tests.ps1
@@ -104,33 +104,102 @@ Describe "Build script zero-test guards (DMS-1301)" {
     }
 
     Context "Both build scripts route through the shared guard" {
+        # These assertions are anchored on the parsed syntax tree of each script's RunTests, not on
+        # raw file text. Text matching over the whole file is satisfied or broken by a comment that
+        # merely mentions a name, and it cannot tell which function a match came from.
         BeforeAll {
-            $script:buildScripts = @{
-                "build-dms.ps1"    = Get-Content -LiteralPath (Join-Path $script:repoRoot "build-dms.ps1") -Raw
-                "build-config.ps1" = Get-Content -LiteralPath (Join-Path $script:repoRoot "build-config.ps1") -Raw
+            function Get-ScriptFunctionAst {
+                param(
+                    [string] $ScriptPath,
+                    [string] $FunctionName
+                )
+
+                $parseErrors = $null
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                    $ScriptPath, [ref]$null, [ref]$parseErrors
+                )
+
+                # Report a parse failure as itself. Without this the FindAll below returns nothing and
+                # the script reads as missing RunTests, which points at the wrong cause.
+                if (@($parseErrors).Count -gt 0) {
+                    throw "Failed to parse '$ScriptPath': $(@($parseErrors)[0].Message)"
+                }
+
+                $functionAst = $ast.FindAll(
+                    { param($node)
+                        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                        $node.Name -eq $FunctionName },
+                    $true
+                ) | Select-Object -First 1
+
+                if ($null -eq $functionAst) {
+                    throw "Function '$FunctionName' was not found in '$ScriptPath'."
+                }
+
+                return $functionAst
+            }
+
+            function Get-InvokedCommandName {
+                param(
+                    [System.Management.Automation.Language.Ast] $FunctionAst
+                )
+
+                return @(
+                    $FunctionAst.FindAll(
+                        { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+                        $true
+                    ) |
+                        ForEach-Object { $_.GetCommandName() } |
+                        Where-Object { $_ }
+                )
+            }
+
+            function Get-RunTestsAst {
+                param(
+                    [string] $ScriptFile
+                )
+
+                return Get-ScriptFunctionAst `
+                    -ScriptPath (Join-Path $script:repoRoot $ScriptFile) `
+                    -FunctionName "RunTests"
             }
         }
 
-        It "<name> resolves its test assemblies through Get-RequiredTestAssembly" -ForEach @(
-            @{ Name = "build-dms.ps1" }
-            @{ Name = "build-config.ps1" }
+        It "<ScriptFile> resolves its test assemblies through Get-RequiredTestAssembly" -ForEach @(
+            @{ ScriptFile = "build-dms.ps1" }
+            @{ ScriptFile = "build-config.ps1" }
         ) {
-            $script:buildScripts[$name] | Should -BeLike "*Get-RequiredTestAssembly*"
+            Get-InvokedCommandName -FunctionAst (Get-RunTestsAst -ScriptFile $ScriptFile) |
+                Should -Contain "Get-RequiredTestAssembly"
         }
 
-        It "<name> keeps no private copy of the assembly glob" -ForEach @(
-            @{ Name = "build-dms.ps1" }
-            @{ Name = "build-config.ps1" }
+        It "<ScriptFile> keeps no private copy of the assembly discovery" -ForEach @(
+            @{ ScriptFile = "build-dms.ps1" }
+            @{ ScriptFile = "build-config.ps1" }
         ) {
-            # The glob and its guard belong to the helper. A reintroduced local copy would drift.
-            $script:buildScripts[$name] | Should -Not -BeLike "*Get-ChildItem -Path `$testAssemblyPath*"
+            # Assembly discovery belongs to the helper. A Get-ChildItem back inside RunTests means a
+            # local copy of the glob has returned, and with it the chance of a divergent guard.
+            Get-InvokedCommandName -FunctionAst (Get-RunTestsAst -ScriptFile $ScriptFile) |
+                Should -Not -Contain "Get-ChildItem"
         }
 
-        It "<name> no longer treats an empty assembly list as informational" -ForEach @(
-            @{ Name = "build-dms.ps1" }
-            @{ Name = "build-config.ps1" }
+        It "<ScriptFile> no longer reports an empty assembly list as informational" -ForEach @(
+            @{ ScriptFile = "build-dms.ps1" }
+            @{ ScriptFile = "build-config.ps1" }
         ) {
-            $script:buildScripts[$name] | Should -Not -BeLike "*Write-Output `"no test assemblies found*"
+            # Anchored on real Write-Output commands, so this catches the message in both literal and
+            # interpolated form while ignoring any comment that quotes it.
+            $writeOutputCalls = @(
+                (Get-RunTestsAst -ScriptFile $ScriptFile).FindAll(
+                    { param($node)
+                        $node -is [System.Management.Automation.Language.CommandAst] -and
+                        $node.GetCommandName() -eq "Write-Output" },
+                    $true
+                )
+            )
+
+            @($writeOutputCalls | Where-Object { $_.Extent.Text -like "*no test assemblies found*" }) |
+                Should -BeNullOrEmpty
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/ApiSchemaProviderTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/ApiSchema/ApiSchemaProviderTests.cs
@@ -296,6 +296,11 @@ public class Given_ApiSchemaProvider_workspace_path_resolver
         Directory.CreateDirectory(_workspaceRoot);
         Directory.CreateDirectory(_outsideRoot);
         _resolver = new ApiSchemaWorkspacePathResolver(_workspaceRoot);
+
+        // The resolver canonicalizes symbolic links by design. macOS exposes TMPDIR under /var,
+        // itself a symlink to /private/var, so the fixture root has to be canonical too or every
+        // expectation compares a pre-resolution path against a post-resolution one.
+        _workspaceRoot = _resolver.CanonicalWorkspaceRoot;
     }
 
     [TearDown]

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Content/ApiSchemaAssetManifestProviderTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Content/ApiSchemaAssetManifestProviderTests.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.ApiSchema;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Frontend.AspNetCore.Content;
 using FakeItEasy;
@@ -26,6 +27,11 @@ public class Given_a_valid_manifest_workspace
     {
         _workspaceRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(_workspaceRoot);
+
+        // The provider canonicalizes symbolic links, and macOS exposes TMPDIR under /var, itself a
+        // symlink to /private/var. Canonicalize the fixture root so resolved-path expectations are
+        // not comparing a pre-resolution path against a post-resolution one.
+        _workspaceRoot = new ApiSchemaWorkspacePathResolver(_workspaceRoot).CanonicalWorkspaceRoot;
 
         var manifestJson = """
             {
@@ -819,6 +825,11 @@ public class Given_path_validation_in_manifest_provider
     {
         _workspaceRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         Directory.CreateDirectory(_workspaceRoot);
+
+        // The provider canonicalizes symbolic links, and macOS exposes TMPDIR under /var, itself a
+        // symlink to /private/var. Canonicalize the fixture root so resolved-path expectations are
+        // not comparing a pre-resolution path against a post-resolution one.
+        _workspaceRoot = new ApiSchemaWorkspacePathResolver(_workspaceRoot).CanonicalWorkspaceRoot;
 
         var manifestJson = """
             {


### PR DESCRIPTION
## Problem

`RunTests` in both build scripts treated an empty test-assembly glob as success: it printed `no test assemblies found in <path>` and fell through, so the `ForEach-Object` over the empty list ran nothing and the target exited 0. Any invocation whose glob matched nothing reported a passing run having executed zero tests, with no signal separating "everything passed" from "nothing ran".

The glob is `$solutionRoot/*/$Filter/bin/$Configuration/`, so the empty-match case is easy to reach: assemblies built under a different `-Configuration`, a renamed test project, a changed directory layout, or a skipped build step.

This backs the `UnitTest`, `IntegrationTest`, and `E2ETest` targets of both scripts, which CI invokes across five workflows. CI passes today because its build steps populate the glob, but any regression in the path pattern, configuration name, or build ordering would have silently turned whole suites green.

Reproduced on an unbuilt tree before the fix:

```
$ pwsh -NoProfile -File ./build-dms.ps1 UnitTest -Configuration Release
no test assemblies found in .../src/dms/*/*.Tests.Unit/bin/Release/
Build Succeeded
### exit=0
```

## Fix

`Get-RequiredTestAssembly` in `eng/build-helpers.psm1` resolves the glob and throws when it matches nothing. Both scripts call it, so the guard lives in one place rather than being duplicated. The `throw` propagates through `Invoke-Execute` → `Invoke-Step` → `Invoke-Main`, whose `catch` writes `Build Failed` and exits 1.

Two details worth flagging for review:

**`throw`, not `exit 1`.** The ticket suggested `Invoke-Execute { exit 1 }` as an alternative. `exit` inside `Invoke-Command` terminates the script in place, bypassing the `Invoke-Main` catch and losing the `Build Failed` banner. `throw` also matches existing practice in the same script (`build-dms.ps1` already throws for a missing provisioning hash).

**`@(...).Count`, not `.Length`.** `Get-ChildItem` returns a bare `FileInfo` when exactly one file matches, and `FileInfo.Length` is the file's size in bytes, not an item count. The previous check worked only because a compiled test dll is never 0 bytes; promoting it to a hard failure unchanged would have turned a missed message into a spurious build break. This is not hypothetical for this repo - both E2E targets match exactly one assembly. Wrapping in `@()` at the call site in `build-dms.ps1` also makes `$testAssemblies[-1]`, the unit-test coverage-threshold selector, well defined for a single match.

No behavior change for any run that finds assemblies: assembly list output, normalized-filter message, trx paths, the coverlet threshold branch, and last-assembly selection are all untouched.

## Second commit: macOS-only unit test failures

Separate, off-ticket, test-only. Three assertions built their expected value from raw `Path.GetTempPath()` while the code under test canonicalizes symbolic links by design. On macOS `TMPDIR` lives under `/var`, a symlink to `/private/var`, so the expected and actual paths differed. On the CI runners temp has no symlink in the chain, so canonical equals raw and these have always passed - this was never a CI failure.

The consequence locally was larger than three red tests: `build-dms.ps1 UnitTest` aborts on the first failing assembly, so `Core.Tests.Unit` failing meant the remaining six assemblies never ran, making the unit target unusable as a local gate on macOS.

The fix canonicalizes the fixture root in `Setup()` for the three affected fixtures. No OS check and no production change; the value is byte-identical wherever the path has no symlinks, so CI behavior is unchanged. The symlink-escape tests, which create real symlinks explicitly and pass everywhere, are untouched.

## Verification

| Check | Result |
|---|---|
| Guard on unbuilt tree, `UnitTest` + `IntegrationTest`, both scripts | exit 1, `Build Failed`, message names path/filter/configuration |
| Guard through the E2E filter path, both scripts | fires (the `E2ETest` target can't isolate it locally - Docker starts first) |
| All six CI-invoked globs after a clean Release build | 8, 6, 1 / 2, 2, 1 - all non-empty, so no green leg newly fails |
| New Pester spec | 12/12 |
| Full CI bootstrap Pester lane | 987 passed, 0 failed |
| PSScriptAnalyzer on all changed PowerShell | 0 findings (repo baseline is 0 across 35 files) |
| `build-dms.ps1 UnitTest` end to end | 8/8 assemblies, 8,762 tests, exit 0 |

The new spec is registered in both PR workflows. Both `detect-fresh-build-changes` filters already treat `build-*.ps1`, `eng/*`, and `.github/workflows/*` as relevant, so it runs on this PR and on any future PR touching these files.

## Deliberately out of scope

Adjacent exposures were investigated and left alone, to keep this at the ticket's stated scope:

- **A filter that selects zero tests.** `dotnet test --filter` matching nothing also exits 0 (verified on this stack; `--treat-no-tests-as-error` is rejected under VSTest). Every filter CI passes through the build scripts selects a non-empty set today, so this is latent drift risk rather than an observed failure.
- **`RunInstanceE2E`** (`build-dms.ps1`), which runs `dotnet test <csproj>` on its own path. Not exposed to the empty-glob bug, since it builds the project it runs.
- **Ten direct `dotnet test` steps** in `on-dms-pullrequest.yml` that bypass the build scripts entirely.

Draft while CI runs.
