### PR TITLE
[DMS-1299] Raise the default rate limit to 20000 per 10-second window

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -220,6 +220,35 @@ Basic rate limiting can be applied by supplying a `RateLimit` object in the
 not configured for the application. Rate limiting (when applied) will be set
 globally and apply to all application endpoints.
 
+The shipped default is `PermitLimit: 20000`, `Window: 10`, `QueueLimit: 0`,
+an average of 2,000 requests per second; a fixed window permits the full
+20,000 as a burst at any point within each 10-second window, then rejects
+until the window resets. `RateLimit__*` environment variables
+shadow `appsettings.json`; the Docker Compose stacks set these from
+`DMS_RATE_LIMIT_PERMIT_LIMIT`, `DMS_RATE_LIMIT_QUEUE_LIMIT`, and
+`DMS_RATE_LIMIT_WINDOW` (see `.env.example`).
+
+Omitting the `RateLimit` object disables limiting entirely, but that only
+applies to a deployment configured purely through `appsettings.json`. The
+provided compose stacks always set the `RateLimit__*` variables, and their
+`${VAR:-default}` fallback supplies the shipped default even when the
+variable is set but empty, so in those stacks the limiter is always on - it
+can be raised, but not disabled.
+
+Bulk and seed loads driven by `BulkLoadClient` are bursty, and a
+`PermitLimit` set below the load's peak 10-second demand fails the load
+outright with a storm of `429` responses rather than merely slowing it
+down. Operators running a load larger than the `Populated` seed template
+should raise `DMS_RATE_LIMIT_PERMIT_LIMIT` for the duration of the load.
+
+The limiter partitions on the raw value of the request's `Host` header, so
+every client sending the same hostname shares one bucket. It caps load per
+distinct `Host` value, not per client, and because the default
+`AllowedHosts` is `*`, a client that varies the `Host` header obtains
+additional buckets, so it is not a strict cap on total backend load either.
+Treat it as a coarse backstop; per-client isolation and DoS protection
+belong at the application gateway.
+
 The `RateLimit` object should have the following parameters.
 
 | Parameter   | Description                                                                                                                                                                                                                                                                |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -47,11 +47,13 @@ the services.
 
 ### Rate Limiting
 
-Rate limiting should be employed to limit both denial of service (DoS) attacks
-and brute-force authentication attempts. While the application gateway is the
-best place to apply rate limiting, the Ed-Fi API and Ed-Fi API
-Configuration Service will both have built-in rate limiting capabilities to fall
-back on.
+The application gateway remains the best place to apply rate limiting and DoS
+controls. Only the Ed-Fi API has a built-in rate limiter as a fallback; the
+Configuration Service has none today. The API's limiter partitions on the raw
+Host header value: clients sharing a hostname share one bucket, while varied
+Host values create separate buckets, so it neither isolates clients nor
+strictly bounds total backend load. It is a coarse backstop only and must not
+be relied on for DoS or brute-force protection.
 
 ### Authentication and Authorization
 

--- a/eng/DatabaseTemplates/Template-Management.psm1
+++ b/eng/DatabaseTemplates/Template-Management.psm1
@@ -380,10 +380,12 @@ function Get-BulkLoadFailureClassification {
 
 .DESCRIPTION
     PostgreSQL keeps Invoke-BulkLoad's established defaults. MSSQL uses conservative
-    relational-backend settings so a populated load stays below DMS's fixed-window rate limiter
-    without creating enough concurrent writes to deadlock SQL Server dimension inserts. Extra
-    retries cover the remaining transient relational conflicts without cascading failures into
-    unresolved references or authorization errors.
+    relational-backend settings so a populated load stays well below DMS's fixed-window
+    rate limiter (PermitLimit=20000/10s) without creating enough concurrent writes to
+    deadlock SQL Server dimension inserts. This throttle predates the 20000/10s default
+    and is retained for the deadlock protection it provides independent of the rate limit.
+    Extra retries cover the remaining transient relational conflicts without cascading
+    failures into unresolved references or authorization errors.
 #>
 function Get-TemplateBulkLoadTuning {
     param (

--- a/eng/azure-vm/compose/.env.example
+++ b/eng/azure-vm/compose/.env.example
@@ -51,6 +51,12 @@ POSTGRES_PASSWORD=CHANGEME_postgres_pw_1!
 LOG_LEVEL=Information
 DMS_CONFIG_LOG_LEVEL=Information
 DMS_JWT_AUDIENCE=account
+# DMS request rate limit (requests per Host-header value per window; see docs/CONFIGURATION.md).
+# Bulk loads are bursty: raise DMS_RATE_LIMIT_PERMIT_LIMIT before a parallel bulk load larger
+# than the populated template (see TROUBLESHOOTING.md).
+DMS_RATE_LIMIT_PERMIT_LIMIT=20000
+DMS_RATE_LIMIT_QUEUE_LIMIT=0
+DMS_RATE_LIMIT_WINDOW=10
 # Multi-tenant route qualifier segments (comma-separated). Drives /mt-dms routing:
 #   /mt-dms/<tenant>/<schoolYear>/data/ed-fi/...
 ROUTE_QUALIFIER_SEGMENTS=schoolYear

--- a/eng/azure-vm/compose/docker-compose.yml
+++ b/eng/azure-vm/compose/docker-compose.yml
@@ -38,6 +38,9 @@ x-dms-common-env: &dms-common-env
   Serilog__MinimumLevel__Default: "${LOG_LEVEL:-Information}"
   AppSettings__MaskRequestBodyInLogs: "true"
   AppSettings__MaximumPageSize: "500"
+  RateLimit__PermitLimit: "${DMS_RATE_LIMIT_PERMIT_LIMIT:-20000}"
+  RateLimit__QueueLimit: "${DMS_RATE_LIMIT_QUEUE_LIMIT:-0}"
+  RateLimit__Window: "${DMS_RATE_LIMIT_WINDOW:-10}"
   # Forwarded headers are honored only from the trusted sources below (DMS-1067). Trust the
   # Docker container address pools: the dms-sec network subnet is assigned dynamically, and the
   # gateway is this stack's only published ingress, so in-network spoofing is not part of the

--- a/eng/docker-compose/.env.example
+++ b/eng/docker-compose/.env.example
@@ -124,6 +124,12 @@ SAMPLING_DURATION_SECONDS=10
 MINIMUM_THROUGHPUT=2
 BREAK_DURATION_SECONDS=30
 
+# Rate limiting (requests per hostname per window; see docs/CONFIGURATION.md).
+# Bulk loads are bursty: raise DMS_RATE_LIMIT_PERMIT_LIMIT before loads larger than the Populated template.
+DMS_RATE_LIMIT_PERMIT_LIMIT=20000
+DMS_RATE_LIMIT_QUEUE_LIMIT=0
+DMS_RATE_LIMIT_WINDOW=10
+
 # DMS connecting to Configuration Service
 CONFIG_SERVICE_URL=http://ed-fi-api-config:8081
 CONFIG_SERVICE_CLIENT_ID=CMSReadOnlyAccess

--- a/eng/docker-compose/load-dms-seed-data.ps1
+++ b/eng/docker-compose/load-dms-seed-data.ps1
@@ -1555,7 +1555,7 @@ function Invoke-BulkLoadClient {
     (FailureRatio=0.01, MinimumThroughput=2, 10s sampling window, 30s break) trips almost
     immediately under the BulkLoadClient's unbounded default concurrency, causing all
     subsequent requests to 500 (BrokenCircuit) and retry-storming the rate limiter
-    (PermitLimit=5000/10s, QueueLimit=0) into a flood of 429s. The reference values used
+    (PermitLimit=20000/10s, QueueLimit=0) into a flood of 429s. The reference values used
     by the CI bulk-load path (eng/bulkLoad/modules/BulkLoad.psm1 -c 100 -l 500 -t 50)
     prove the approach; bootstrap seed delivery uses conservative equivalents for the
     relational backend.
@@ -1573,14 +1573,19 @@ function Invoke-BulkLoadClient {
     )
 
     # Conservative tuning for the relational backend's circuit-breaker sensitivity and
-    # rate-limiter headroom (PermitLimit=5000/10s, QueueLimit=0):
+    # rate-limiter headroom (PermitLimit=20000/10s, QueueLimit=0):
     # -c  max concurrent HTTP connections
     # -l  max simultaneous API requests (same as -c but guards a different internal queue)
     # -t  task buffer capacity
     # -r  per-resource retry count (tolerate transient 500s before a circuit trip)
-    # Low concurrency prevents exhausting the 5000/10s rate-limit window on large files
-    # such as StudentTranscript.xml (~15k CourseTranscript records). Reference CI values
-    # in eng/bulkLoad/modules/BulkLoad.psm1 use -c 100 -l 500 for non-rate-limited paths.
+    # This conservative tuning predates the 20000/10s default: it was sized so that
+    # large files such as StudentTranscript.xml (~15k CourseTranscript records) could
+    # not exhaust the old 5000/10s window. Reference CI values in
+    # eng/bulkLoad/modules/BulkLoad.psm1 use -c 100 -l 500 against the same default
+    # rate limit over the same corpus; the higher concurrency makes that path burstier
+    # per window, and both profiles' measured peak 10-second demand fits under the
+    # shipped default. The low tuning here is retained for the relational backend's
+    # circuit-breaker sensitivity, which the CI path tolerates differently.
     $connectionLimit  = 10
     $maxRequests      = 10
     $taskCapacity     = 5

--- a/eng/docker-compose/local-dms.yml
+++ b/eng/docker-compose/local-dms.yml
@@ -34,7 +34,7 @@ services:
       DatabaseOptions__IsolationLevel: ${DATABASE_ISOLATION_LEVEL:-RepeatableRead}
       # "DATABASE_CONNECTION_STRING_ADMIN" can have alternate credentials with elevated permissions for creating database objects
       DATABASE_CONNECTION_STRING_ADMIN: ${DATABASE_CONNECTION_STRING_ADMIN:-host=dms-postgresql;port=5432;username=postgres;password=${POSTGRES_PASSWORD};database=${POSTGRES_DB_NAME};}
-      RateLimit__PermitLimit: ${DMS_RATE_LIMIT_PERMIT_LIMIT:-5000}
+      RateLimit__PermitLimit: ${DMS_RATE_LIMIT_PERMIT_LIMIT:-20000}
       RateLimit__QueueLimit: ${DMS_RATE_LIMIT_QUEUE_LIMIT:-0}
       RateLimit__Window: ${DMS_RATE_LIMIT_WINDOW:-10}
       CircuitBreaker__FailureRatio: ${FAILURE_RATIO:-0.01}

--- a/eng/docker-compose/published-dms.yml
+++ b/eng/docker-compose/published-dms.yml
@@ -33,6 +33,9 @@ services:
       CircuitBreaker__SamplingDurationSeconds: ${SAMPLING_DURATION_SECONDS:-10}
       CircuitBreaker__MinimumThroughput: ${MINIMUM_THROUGHPUT:-2}
       CircuitBreaker__BreakDurationSeconds: ${BREAK_DURATION_SECONDS:-30}
+      RateLimit__PermitLimit: ${DMS_RATE_LIMIT_PERMIT_LIMIT:-20000}
+      RateLimit__QueueLimit: ${DMS_RATE_LIMIT_QUEUE_LIMIT:-0}
+      RateLimit__Window: ${DMS_RATE_LIMIT_WINDOW:-10}
       ConfigurationServiceSettings__BaseUrl: ${CONFIG_SERVICE_URL:-http://ed-fi-api-config:8081}
       ConfigurationServiceSettings__ClientId: ${CONFIG_SERVICE_CLIENT_ID:-CMSReadOnlyAccess}
       ConfigurationServiceSettings__Scope: ${CONFIG_SERVICE_CLIENT_SCOPE:-edfi_admin_api/readonly_access}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/EndpointsTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/EndpointsTests.cs
@@ -21,7 +21,8 @@ public class EndpointsTests
         // Arrange
         await using var factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
-            // This environment has an extreme rate limit
+            // The Test environment layers appsettings.Test.json over the base appsettings.json,
+            // so it inherits the default rate limit, which is ample for this test's requests.
             builder.UseEnvironment("Test");
             builder.ConfigureServices(
                 (collection) =>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.json
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.json
@@ -75,7 +75,7 @@
     "RoleClaimType": "role"
   },
   "RateLimit": {
-    "PermitLimit": 5000,
+    "PermitLimit": 20000,
     "QueueLimit": 0,
     "Window": 10
   },


### PR DESCRIPTION
## Problem

The shipped rate limiter default (`PermitLimit: 5000` per 10-second window, ~500 req/s) is below what the repo's own bulk-load tooling generates.
On fast hardware the Populated seed load stalls at 8% of documents (8,377 of 104,796) with 254,263 `429` responses, and the loader's fail-fast retries amplify any real error burst into an undiagnosable log - the baseline run also produced 35,000 phantom `Forbidden` responses because the 429 stall starved prerequisite enrollment records, pointing investigation at authorization instead of the limiter.
The CI template builds run the heaviest client profile (`-c 100 -l 500 -t 50`) against this same default and currently pass only on runner-speed margin.

## Calibration

The value was measured, not chosen.
Peak demand within a rolling 10-second window (the statistic a `Window: 10` fixed limiter gates on) was sampled from `dms."Document"` during clean full loads:

| Load profile | Mean | Peak 10s window |
| --- | --- | --- |
| Seed (`-c 10 -l 10 -t 5`) | 888 docs/s | 13,095 |
| CI template (`-c 100 -l 500 -t 50`) | 838 docs/s | 16,538 |

Verification ladder (full Populated bootstrap per candidate, fresh database each time):

| PermitLimit | Outcome | Documents | `Too Many Requests` |
| --- | --- | --- | --- |
| 5,000 (old default) | fail, exit 1 | 8,377 (8%) | 254,263 |
| 10,000 | fail, exit 1 | 104,429 (99.65%) | 1,101 |
| 15,000 | pass | 104,796 | 0 |
| 20,000 | pass (both profiles) | 104,796 | 0 |

15,000 passes but sits below the CI profile's measured peak (16,538), so its passes depend on where fixed-window boundaries happen to fall; 20,000 is the lowest 5,000 increment that exceeds measured peak demand for every in-repo client, making the outcome alignment-independent.
The 10,000 row is the cautionary one: 99.65% loaded, all content gates green, and only the exit code and 1,101 log lines betray it.

## Changes

- Default raised 5,000 to 20,000 in both places that define it: `appsettings.json` and the `local-dms.yml` env fallback.
  Environment variables shadow `appsettings.json`, and the compose fallback governs every locally started stack including the CI template builds, so changing appsettings alone would not have fixed the observed surfaces.
- `RateLimit__*` wiring added to `published-dms.yml` and the azure-vm compose anchor, which previously had no override path even though the azure-vm troubleshooting docs instruct operators to raise the rate limit before parallel bulk loads.
- `DMS_RATE_LIMIT_PERMIT_LIMIT`, `DMS_RATE_LIMIT_QUEUE_LIMIT`, and `DMS_RATE_LIMIT_WINDOW` documented in both `.env.example` files.
- `docs/CONFIGURATION.md` and `docs/OPERATIONS.md` corrected to match the code: fixed-window burst semantics (the full allowance may be consumed instantly), partitioning on the raw Host header value (neither per-client isolation nor a strict total cap while `AllowedHosts` is `*`), and built-in limiting existing on the API only - the gateway remains the recommended control point.
- Stale comments that were calibrated to the old default updated; no loader tuning value changed, including the mssql template throttle.

## Headroom note for reviewers

20,000 leaves roughly 21% over the heaviest measured peak.
Peak demand scales with hardware, and the calibration host (Apple Silicon, local NVMe) is faster than GitHub-hosted runners, with the backend as the bottleneck in every measured run.
No CI override is pinned on purpose: the template-build and smoke legs on this PR are the proof that the shipped default suffices unaided.
If a future runner class outruns it, the failure is now diagnosable and the override knob exists on every deployment surface.

## Validation

- End to end, on images built from this branch at the new default: `bootstrap-local-dms.ps1 -LoadSeedData -SeedTemplate Populated` exits 0 with zero `Too Many Requests` and exactly 104,796 documents.
- Unit: rate-limit tests pass; the full suite is green apart from two pre-existing macOS-only path-resolution failures addressed separately in #1141.
- Integration: all five assemblies green against dockerized PostgreSQL and SQL Server (147/147, 203/207, 725/736, 4/4, 721/721).
- Pester suites covering the edited scripts and compose surfaces pass (227 passed, 0 failed).

## Related

Follow-ups filed during this investigation: DMS-1375 (429 response conformance), DMS-1376 (per-client partitioning), DMS-1377 (exclude /health from the limiter), DMS-1378 (Configuration Service rate limiting), ODS-6858 (BulkLoadClient 429 backoff, upstream).
