### PR TITLE
[DMS-1286] Add real-MSSQL integration coverage for NamespaceBased CRUD authorization

### DIFF
--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorNamespaceAuthorizationTests.cs
@@ -1,0 +1,626 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Real-SQL-Server coverage for NamespaceBased authorization on descriptor resources (DMS-1286). Descriptors
+/// store their securable namespace on the shared <c>dms.Descriptor</c> root table and bypass the generic
+/// resource write executor, so their read and write handlers carry their own namespace seams and must be
+/// certified separately from the ordinary-resource paths.
+/// </summary>
+/// <remarks>
+/// Every operation is issued through <c>RelationalDocumentStoreRepository</c>, which routes descriptor
+/// resources into the production <c>DescriptorReadHandler</c> and <c>DescriptorWriteHandler</c> and carries the
+/// authorization context with them, so the routing seam is exercised rather than bypassed.
+/// <para>
+/// A <em>missing</em> proposed descriptor namespace is deliberately not covered here: <c>namespace</c> is
+/// required on every Ed-Fi descriptor, so JSON schema validation is the production boundary for that case and
+/// <c>DescriptorWriteBodyExtractor</c> treats its absence as an internal pipeline bug rather than an
+/// authorization outcome. The missing-proposed-value authorization path is covered on the ordinary-resource
+/// write suite, whose synthetic resource has an optional namespace.
+/// </para>
+/// <para>
+/// A descriptor's identity is its uri — <c>namespace#codeValue</c> — so a POST carrying a namespace other than
+/// the stored one addresses a different descriptor and takes the create path. A proposed-value denial on the
+/// upsert-as-update path is therefore structurally unreachable; that value source is covered by descriptor POST
+/// create and descriptor PUT, which targets by document uuid and can legitimately carry a changed namespace.
+/// </para>
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category("RelationalNamespace")]
+[Category(MssqlCiShards.Shard4)]
+public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authoritative_Sample_Fixture
+{
+    private const string FixtureRelativePath = "src/dms/backend/Fixtures/authoritative/sample";
+    private const string ProjectEndpointName = "ed-fi";
+    private const string ResourceName = "SchoolTypeDescriptor";
+    private const string AuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.AuthorizedNamespacePrefix;
+    private const string SecondAuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.SecondAuthorizedNamespacePrefix;
+    private const string UnauthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedNamespacePrefix;
+    private const string AuthorizedNamespace = AuthorizedPrefix + ResourceName;
+    private const string SecondAuthorizedNamespace = SecondAuthorizedPrefix + ResourceName;
+    private const string UnauthorizedNamespace = UnauthorizedPrefix + ResourceName;
+    private const string StaleETag = "\"stale-etag\"";
+
+    private static readonly IReadOnlyList<string> _configuredPrefixes =
+        RelationshipAuthorizationCrudTestSupport.ConfiguredNamespacePrefixes;
+    private static readonly IReadOnlyList<string> _namespaceStrategy =
+        RelationshipAuthorizationCrudTestSupport.NamespaceBasedStrategyNames;
+
+    /// <summary>
+    /// The descriptor's own tracking columns, which live on <c>dms.Descriptor</c> rather than
+    /// <c>dms.Document</c>. A denial snapshot that omitted them could not prove descriptor tracking state was
+    /// preserved, so their presence is asserted whenever a snapshot is taken.
+    /// </summary>
+    private static readonly string[] _requiredDescriptorTrackingColumns =
+    [
+        "ResourceKeyId",
+        "ContentVersion",
+        "ContentLastModifiedAt",
+    ];
+
+    private MssqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _context = new MssqlRelationalQueryAuthorizationTestContext();
+        await _context.InitializeAsync(FixtureRelativePath, strict: true, replaceReadTargetLookup: false);
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        // A descriptor row is self-contained, so no reference data is needed after the reset.
+        await _context.Database.ResetAsync();
+        _context.ResetRecorder();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    // ── Reads ───────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_descriptor_get_by_id_for_a_matching_namespace()
+    {
+        var documentUuid = await SeedDescriptorAsync("Authorized", AuthorizedNamespace);
+
+        var result = await GetByIdAsync(documentUuid);
+
+        var success = result.Should().BeOfType<GetResult.GetSuccess>().Subject;
+        success.DocumentUuid.Should().Be(documentUuid);
+        success.EdfiDoc["namespace"]!.GetValue<string>().Should().Be(AuthorizedNamespace);
+    }
+
+    [Test]
+    public async Task It_denies_descriptor_get_by_id_for_a_mismatching_namespace_without_exposing_the_document()
+    {
+        var documentUuid = await SeedDescriptorAsync("Denied", UnauthorizedNamespace);
+
+        var result = await GetByIdAsync(documentUuid);
+
+        // The denial result carries no document at all, so the stored descriptor is never exposed.
+        AssertNamespaceDenied(
+            result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject.NamespaceFailure,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+    }
+
+    [Test]
+    public async Task It_filters_descriptor_get_many_to_authorized_namespaces_before_paging_and_total_count()
+    {
+        // Seeded in document order: authorized, denied, authorized, denied, authorized. Skipping one
+        // authorized row must yield the second and third authorized rows; paging before filtering would
+        // instead window the unfiltered rows 2 and 3 and return a single authorized row.
+        var first = await SeedDescriptorAsync("First", AuthorizedNamespace);
+        await SeedDescriptorAsync("Second", UnauthorizedNamespace);
+        var third = await SeedDescriptorAsync("Third", SecondAuthorizedNamespace);
+        await SeedDescriptorAsync("Fourth", UnauthorizedNamespace);
+        var fifth = await SeedDescriptorAsync("Fifth", AuthorizedNamespace);
+        _context.ResetRecorder();
+
+        var pagedResult = await QueryAsync(limit: 2, offset: 1);
+
+        var pagedSuccess = pagedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        AssertReturnedDocuments(pagedSuccess, third, fifth);
+        pagedSuccess.TotalCount.Should().Be(3, "totalCount must count only namespace-authorized descriptors");
+
+        var unpagedResult = await QueryAsync();
+
+        AssertReturnedDocuments(
+            unpagedResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject,
+            first,
+            third,
+            fifth
+        );
+    }
+
+    // ── POST create ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_descriptor_post_create_and_inserts_document_and_descriptor_rows()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("c1c1c1c1-0000-0000-0000-000000000001"));
+
+        var result = await UpsertAsync(
+            CreateDescriptorBody("CreateAuthorized", AuthorizedNamespace),
+            documentUuid
+        );
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        var state = await ReadStateAsync(documentUuid);
+        state.Descriptor["Namespace"].Should().Be(AuthorizedNamespace);
+        state.Descriptor["CodeValue"].Should().Be("CreateAuthorized");
+
+        // Pins the stored uri to the value the descriptor-absence probes key on, so those probes cannot pass
+        // by querying a uri the production write path never stores.
+        state.Descriptor["Uri"].Should().Be(DescriptorUri("CreateAuthorized", AuthorizedNamespace));
+    }
+
+    [Test]
+    public async Task It_denies_descriptor_post_create_with_a_mismatching_proposed_namespace_and_writes_nothing()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("c1c1c1c1-0000-0000-0000-000000000002"));
+
+        var result = await UpsertAsync(
+            CreateDescriptorBody("CreateDenied", UnauthorizedNamespace),
+            documentUuid
+        );
+
+        AssertNamespaceDenied(
+            result
+                .Should()
+                .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            NamespaceAuthorizationFailureValueSource.Proposed
+        );
+        await AssertNoDescriptorRowsExistAsync(
+            documentUuid,
+            DescriptorUri("CreateDenied", UnauthorizedNamespace)
+        );
+        _context.AssertNoPersistenceAfterNamespaceAuthorization();
+    }
+
+    // ── PUT ─────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_descriptor_put_and_updates_the_descriptor_row()
+    {
+        var documentUuid = await SeedDescriptorAsync("PutAuthorized", AuthorizedNamespace);
+        var before = await ReadStateAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(
+            CreateDescriptorBody("PutAuthorized", AuthorizedNamespace, "Updated short description"),
+            documentUuid
+        );
+
+        result.Should().BeOfType<UpdateResult.UpdateSuccess>();
+        var after = await ReadStateAsync(documentUuid);
+        after.Descriptor["ShortDescription"].Should().Be("Updated short description");
+        Convert
+            .ToInt64(after.Document["ContentVersion"])
+            .Should()
+            .BeGreaterThan(Convert.ToInt64(before.Document["ContentVersion"]));
+    }
+
+    [TestCase(
+        false,
+        NamespaceAuthorizationFailureValueSource.Stored,
+        TestName = "It_denies_descriptor_put_on_an_unauthorized_stored_namespace_even_when_the_proposed_namespace_matches"
+    )]
+    [TestCase(
+        true,
+        NamespaceAuthorizationFailureValueSource.Proposed,
+        TestName = "It_denies_descriptor_put_with_a_mismatching_proposed_namespace_after_stored_authorization_passes"
+    )]
+    public async Task It_denies_descriptor_put_and_leaves_document_and_descriptor_rows_unchanged(
+        bool storedAuthorized,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    )
+    {
+        // Each case pairs one authorized side with one unauthorized side, so a proposed failure is only
+        // reachable once the stored check passed — which is what establishes the stored-then-proposed order.
+        const string CodeValue = "PutDenied";
+        var storedNamespace = storedAuthorized ? AuthorizedNamespace : UnauthorizedNamespace;
+        var proposedNamespace = storedAuthorized ? UnauthorizedNamespace : AuthorizedNamespace;
+        var documentUuid = await SeedDescriptorAsync(CodeValue, storedNamespace);
+        var before = await ReadStateAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(
+            CreateDescriptorBody(CodeValue, proposedNamespace, "Denied short description"),
+            documentUuid
+        );
+
+        AssertNamespaceDenied(
+            result
+                .Should()
+                .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            expectedValueSource
+        );
+        await AssertStateUnchangedAsync(documentUuid, before);
+    }
+
+    // ── POST-as-update ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_descriptor_post_as_update_and_updates_the_existing_descriptor()
+    {
+        const string CodeValue = "UpsertAuthorized";
+        var existingUuid = await SeedDescriptorAsync(CodeValue, AuthorizedNamespace);
+        var candidateUuid = new DocumentUuid(Guid.Parse("c2c2c2c2-0000-0000-0000-000000000001"));
+        var before = await ReadStateAsync(existingUuid);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(
+            CreateDescriptorBody(CodeValue, AuthorizedNamespace, "Upserted short description"),
+            candidateUuid
+        );
+
+        var success = result.Should().BeOfType<UpsertResult.UpdateSuccess>().Subject;
+        success.ExistingDocumentUuid.Should().Be(existingUuid);
+        var after = await ReadStateAsync(existingUuid);
+        after.Descriptor["ShortDescription"].Should().Be("Upserted short description");
+        Convert
+            .ToInt64(after.Document["ContentVersion"])
+            .Should()
+            .BeGreaterThan(Convert.ToInt64(before.Document["ContentVersion"]));
+        (await _context.CountDocumentRowsAsync(candidateUuid))
+            .Should()
+            .Be(0, "the candidate uuid must not create a second descriptor document");
+    }
+
+    [Test]
+    public async Task It_denies_descriptor_post_as_update_on_an_unauthorized_stored_namespace_and_leaves_rows_unchanged()
+    {
+        // A descriptor's identity is its uri — namespace#codeValue — so a POST carrying a different namespace
+        // addresses a different descriptor and takes the create path, whose proposed-value denial is covered
+        // above. An upsert that resolves to an existing target therefore always carries the stored namespace,
+        // which makes attributing this denial to the stored value the ordering proof: had the proposed check
+        // run first, the identical proposed value would have reported Proposed instead.
+        const string CodeValue = "UpsertDenied";
+        var existingUuid = await SeedDescriptorAsync(CodeValue, UnauthorizedNamespace);
+        var candidateUuid = new DocumentUuid(Guid.Parse("c2c2c2c2-0000-0000-0000-000000000002"));
+        var before = await ReadStateAsync(existingUuid);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(
+            CreateDescriptorBody(CodeValue, UnauthorizedNamespace, "Denied short description"),
+            candidateUuid
+        );
+
+        AssertNamespaceDenied(
+            result
+                .Should()
+                .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(existingUuid, before);
+        (await _context.CountDocumentRowsAsync(candidateUuid)).Should().Be(0);
+    }
+
+    // ── DELETE ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_descriptor_delete_and_removes_document_and_descriptor_rows()
+    {
+        var documentUuid = await SeedDescriptorAsync("DeleteAuthorized", AuthorizedNamespace);
+        var documentId = await GetDocumentIdAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(documentUuid);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        await AssertNoDescriptorRowsExistAsync(
+            documentUuid,
+            DescriptorUri("DeleteAuthorized", AuthorizedNamespace),
+            documentId
+        );
+    }
+
+    [Test]
+    public async Task It_returns_403_before_if_match_and_preserves_the_descriptor_when_both_would_fail()
+    {
+        var documentUuid = await SeedDescriptorAsync("DeleteCollision", UnauthorizedNamespace);
+        var before = await ReadStateAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(documentUuid, ifMatch: StaleETag);
+
+        AssertNamespaceDenied(
+            result
+                .Should()
+                .BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(documentUuid, before);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_descriptor_delete_if_match_once_namespace_authorization_passes()
+    {
+        var documentUuid = await SeedDescriptorAsync("DeletePrecondition", AuthorizedNamespace);
+        var before = await ReadStateAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(documentUuid, ifMatch: StaleETag);
+
+        result
+            .Should()
+            .BeOfType<DeleteResult.DeleteFailureETagMisMatch>(
+                "the precondition result must survive unchanged once authorization succeeds"
+            );
+        await AssertStateUnchangedAsync(documentUuid, before);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>The descriptor's stored uri, which keys <c>dms.Descriptor</c> independently of the document.</summary>
+    private static string DescriptorUri(string codeValue, string @namespace) => $"{@namespace}#{codeValue}";
+
+    private static JsonNode CreateDescriptorBody(
+        string codeValue,
+        string @namespace,
+        string? shortDescription = null
+    ) =>
+        new JsonObject
+        {
+            ["namespace"] = @namespace,
+            ["codeValue"] = codeValue,
+            ["shortDescription"] = shortDescription ?? codeValue,
+        };
+
+    /// <summary>
+    /// Seeds an existing descriptor through the production POST path with no strategies configured, so any
+    /// stored namespace — authorized or not — is established without first passing namespace authorization.
+    /// </summary>
+    private async Task<DocumentUuid> SeedDescriptorAsync(string codeValue, string @namespace)
+    {
+        var documentUuid = new DocumentUuid(Guid.NewGuid());
+
+        var result = await _context.UpsertDescriptorAsync(
+            ProjectEndpointName,
+            ResourceName,
+            CreateDescriptorBody(codeValue, @namespace),
+            documentUuid,
+            [],
+            []
+        );
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(result);
+
+        return documentUuid;
+    }
+
+    private async Task<UpsertResult> UpsertAsync(
+        JsonNode requestBody,
+        DocumentUuid documentUuid,
+        string? ifMatch = null
+    ) =>
+        await _context.UpsertDescriptorAsync(
+            ProjectEndpointName,
+            ResourceName,
+            requestBody,
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            _configuredPrefixes,
+            ifMatch
+        );
+
+    private async Task<UpdateResult> UpdateAsync(
+        JsonNode requestBody,
+        DocumentUuid documentUuid,
+        string? ifMatch = null
+    ) =>
+        await _context.UpdateDescriptorByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            requestBody,
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            _configuredPrefixes,
+            ifMatch
+        );
+
+    private async Task<GetResult> GetByIdAsync(DocumentUuid documentUuid) =>
+        await _context.GetByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            namespacePrefixes: _configuredPrefixes
+        );
+
+    private async Task<QueryResult> QueryAsync(int? limit = null, int? offset = null) =>
+        await _context.QueryAsync(
+            ProjectEndpointName,
+            ResourceName,
+            [],
+            _namespaceStrategy,
+            limit: limit,
+            offset: offset,
+            namespacePrefixes: _configuredPrefixes
+        );
+
+    private async Task<DeleteResult> DeleteAsync(DocumentUuid documentUuid, string? ifMatch = null) =>
+        await _context.DeleteByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            ifMatch,
+            namespacePrefixes: _configuredPrefixes
+        );
+
+    /// <summary>
+    /// Snapshots every column of both authoritative rows. The projection is <c>SELECT *</c> rather than a
+    /// column list so the comparison covers the descriptor's own tracking state — <c>ResourceKeyId</c>,
+    /// <c>ContentVersion</c>, and <c>ContentLastModifiedAt</c> — and cannot silently narrow when a column is
+    /// added to either table.
+    /// </summary>
+    private async Task<DescriptorAuthorizationState> ReadStateAsync(DocumentUuid documentUuid)
+    {
+        var documentId = await GetDocumentIdAsync(documentUuid);
+        var state = new DescriptorAuthorizationState(
+            await ReadFullRowAsync("Document", documentId),
+            await ReadFullRowAsync("Descriptor", documentId)
+        );
+
+        // Guard the snapshot's completeness so a future narrowing of the projection fails here rather than
+        // quietly weakening every unchanged-state assertion below.
+        state
+            .Descriptor.Keys.Should()
+            .Contain(
+                _requiredDescriptorTrackingColumns,
+                "the descriptor snapshot must include the descriptor's own tracking columns"
+            );
+
+        return state;
+    }
+
+    /// <summary>
+    /// Both authoritative descriptor rows — the <c>dms.Document</c> stamps and the complete
+    /// <c>dms.Descriptor</c> row including its tracking columns — are exactly what they were, and the write
+    /// session issued no persistence after authorization.
+    /// </summary>
+    private async Task AssertStateUnchangedAsync(
+        DocumentUuid documentUuid,
+        DescriptorAuthorizationState before
+    )
+    {
+        var after = await ReadStateAsync(documentUuid);
+
+        after.Should().BeEquivalentTo(before);
+        _context.AssertNoPersistenceAfterNamespaceAuthorization();
+    }
+
+    /// <summary>
+    /// Proves no descriptor row survives, keyed independently of <c>dms.Document</c>. Joining through the
+    /// document would be vacuous once the document itself is gone, so the descriptor table is probed directly
+    /// by its uri and — when the row previously existed — by the captured <c>DocumentId</c>.
+    /// </summary>
+    private async Task AssertNoDescriptorRowsExistAsync(
+        DocumentUuid documentUuid,
+        string descriptorUri,
+        long? previousDocumentId = null
+    )
+    {
+        (await _context.CountDocumentRowsAsync(documentUuid)).Should().Be(0);
+
+        (
+            await _context.Database.ExecuteScalarAsync<long>(
+                """
+                SELECT COUNT_BIG(*) FROM [dms].[Descriptor] WHERE [Uri] = @uri;
+                """,
+                new SqlParameter("@uri", descriptorUri)
+            )
+        ).Should().Be(0, "no dms.Descriptor row may remain for the descriptor uri");
+
+        if (previousDocumentId is not { } documentId)
+        {
+            return;
+        }
+
+        (
+            await _context.Database.ExecuteScalarAsync<long>(
+                """
+                SELECT COUNT_BIG(*) FROM [dms].[Descriptor] WHERE [DocumentId] = @documentId;
+                """,
+                new SqlParameter("@documentId", documentId)
+            )
+        ).Should().Be(0, "no dms.Descriptor row may remain for the deleted document id");
+    }
+
+    private async Task<IReadOnlyDictionary<string, object?>> ReadFullRowAsync(
+        string tableName,
+        long documentId
+    )
+    {
+        var rows = await _context.Database.QueryRowsAsync(
+            $"""
+            SELECT * FROM [dms].[{tableName}] WHERE [DocumentId] = @documentId;
+            """,
+            new SqlParameter("@documentId", documentId)
+        );
+
+        return rows.Count == 1
+            ? rows[0]
+            : throw new InvalidOperationException(
+                $"Expected exactly one dms.{tableName} row for DocumentId {documentId}, but found {rows.Count}."
+            );
+    }
+
+    private async Task<long> GetDocumentIdAsync(DocumentUuid documentUuid) =>
+        await _context.Database.ExecuteScalarAsync<long>(
+            """
+            SELECT [DocumentId] FROM [dms].[Document] WHERE [DocumentUuid] = @documentUuid;
+            """,
+            new SqlParameter("@documentUuid", documentUuid.Value)
+        );
+
+    private static void AssertReturnedDocuments(
+        QueryResult.QuerySuccess success,
+        params DocumentUuid[] expectedDocumentUuids
+    ) =>
+        success
+            .EdfiDocs.Select(static document => document!["id"]!.GetValue<string>())
+            .Should()
+            .Equal(expectedDocumentUuids.Select(static documentUuid => documentUuid.Value.ToString()));
+
+    private static void AssertNamespaceDenied(
+        NamespaceAuthorizationFailure failure,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    )
+    {
+        failure.FailureKind.Should().Be(NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        failure.ValueSource.Should().Be(expectedValueSource);
+        failure.StrategyName.Should().Be(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+        failure.ConfiguredNamespacePrefixes.Should().Equal(_configuredPrefixes);
+    }
+
+    private sealed record DescriptorAuthorizationState(
+        IReadOnlyDictionary<string, object?> Document,
+        IReadOnlyDictionary<string, object?> Descriptor
+    );
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorNamespaceAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorNamespaceAuthorizationTests.cs
@@ -254,6 +254,7 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
     {
         // Each case pairs one authorized side with one unauthorized side, so a proposed failure is only
         // reachable once the stored check passed — which is what establishes the stored-then-proposed order.
+        // Both run under a stale If-Match, so each reachable denial is also shown to beat the precondition.
         const string CodeValue = "PutDenied";
         var storedNamespace = storedAuthorized ? AuthorizedNamespace : UnauthorizedNamespace;
         var proposedNamespace = storedAuthorized ? UnauthorizedNamespace : AuthorizedNamespace;
@@ -263,7 +264,8 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
 
         var result = await UpdateAsync(
             CreateDescriptorBody(CodeValue, proposedNamespace, "Denied short description"),
-            documentUuid
+            documentUuid,
+            ifMatch: StaleETag
         );
 
         AssertNamespaceDenied(
@@ -273,6 +275,28 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
                 .Subject.NamespaceFailure,
             expectedValueSource
         );
+        await AssertStateUnchangedAsync(documentUuid, before);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_descriptor_put_if_match_once_namespace_authorization_passes()
+    {
+        const string CodeValue = "PutPrecondition";
+        var documentUuid = await SeedDescriptorAsync(CodeValue, AuthorizedNamespace);
+        var before = await ReadStateAsync(documentUuid);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(
+            CreateDescriptorBody(CodeValue, AuthorizedNamespace, "Precondition short description"),
+            documentUuid,
+            ifMatch: StaleETag
+        );
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>(
+                "the precondition result must survive unchanged once both namespace checks pass"
+            );
         await AssertStateUnchangedAsync(documentUuid, before);
     }
 
@@ -312,7 +336,8 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
         // addresses a different descriptor and takes the create path, whose proposed-value denial is covered
         // above. An upsert that resolves to an existing target therefore always carries the stored namespace,
         // which makes attributing this denial to the stored value the ordering proof: had the proposed check
-        // run first, the identical proposed value would have reported Proposed instead.
+        // run first, the identical proposed value would have reported Proposed instead. The stale If-Match
+        // additionally shows the denial beats the precondition.
         const string CodeValue = "UpsertDenied";
         var existingUuid = await SeedDescriptorAsync(CodeValue, UnauthorizedNamespace);
         var candidateUuid = new DocumentUuid(Guid.Parse("c2c2c2c2-0000-0000-0000-000000000002"));
@@ -321,7 +346,8 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
 
         var result = await UpsertAsync(
             CreateDescriptorBody(CodeValue, UnauthorizedNamespace, "Denied short description"),
-            candidateUuid
+            candidateUuid,
+            ifMatch: StaleETag
         );
 
         AssertNamespaceDenied(
@@ -331,6 +357,30 @@ public class Given_A_Mssql_Descriptor_Namespace_Authorization_With_The_Authorita
                 .Subject.NamespaceFailure,
             NamespaceAuthorizationFailureValueSource.Stored
         );
+        await AssertStateUnchangedAsync(existingUuid, before);
+        (await _context.CountDocumentRowsAsync(candidateUuid)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_descriptor_post_as_update_if_match_once_namespace_authorization_passes()
+    {
+        const string CodeValue = "UpsertPrecondition";
+        var existingUuid = await SeedDescriptorAsync(CodeValue, AuthorizedNamespace);
+        var candidateUuid = new DocumentUuid(Guid.Parse("c2c2c2c2-0000-0000-0000-000000000003"));
+        var before = await ReadStateAsync(existingUuid);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(
+            CreateDescriptorBody(CodeValue, AuthorizedNamespace, "Precondition short description"),
+            candidateUuid,
+            ifMatch: StaleETag
+        );
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>(
+                "the precondition result must survive unchanged once both namespace checks pass"
+            );
         await AssertStateUnchangedAsync(existingUuid, before);
         (await _context.CountDocumentRowsAsync(candidateUuid)).Should().Be(0);
     }

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNamespaceAuthorizationCommandAssertions.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNamespaceAuthorizationCommandAssertions.cs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Assertions over the commands a recorded write session issued, used to prove that a NamespaceBased denial
+/// wrote nothing. Because <c>SessionRelationalCommandExecutor.ForSession</c> routes every command issued
+/// inside a write session — including every persister statement — through
+/// <c>IRelationalWriteSession.CreateCommand</c>, the absence of persistence DML after the authorization
+/// statement establishes that no document, root, child, extension, identity, or tracking write occurred.
+/// </summary>
+/// <remarks>
+/// Markers are resilient substrings rather than full SQL equality. Co-batching is tolerated without masking
+/// bad ordering: a write can plan a stored check and a proposed check, so the boundary is the <em>final</em>
+/// namespace authorization command, and within it the <em>last</em> namespace marker. Persistence is rejected
+/// before that command, before that marker inside it, and in any later command. The AUTH1 raise aborts the
+/// remainder of its batch, and the caller's before/after state snapshot proves nothing was committed.
+/// </remarks>
+internal static class MssqlNamespaceAuthorizationCommandAssertions
+{
+    /// <summary>
+    /// The namespace AUTH1 payload discriminator the MSSQL compiler embeds in its
+    /// <c>CAST('AUTH1 - ns1|&lt;index&gt;|&lt;kind&gt;' AS INT)</c> raise, which distinguishes a namespace
+    /// authorization statement from a relationship one.
+    /// </summary>
+    private const string NamespaceAuthorizationMarker = "AUTH1 - ns1|";
+
+    private static readonly string[] _persistenceMarkers =
+    [
+        "INSERT INTO",
+        "UPDATE ",
+        "DELETE FROM",
+        "MERGE ",
+    ];
+
+    public static bool IsNamespaceAuthorizationCommand(string commandText) =>
+        commandText.Contains(NamespaceAuthorizationMarker, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Asserts that namespace authorization executed and that the operation persisted nothing: no persistence
+    /// DML before the final namespace authorization command, none ahead of that command's last namespace
+    /// marker, and none in any later command.
+    /// </summary>
+    public static void AssertNoPersistenceAfterNamespaceAuthorization(
+        IReadOnlyList<MssqlRelationalQueryAuthorizationRecordedCommand> commands
+    )
+    {
+        ArgumentNullException.ThrowIfNull(commands);
+
+        // A write can plan both a stored and a proposed check, so the boundary is the last authorization
+        // command rather than the first: only the final check can legitimately share a batch with persistence.
+        var finalAuthorizationIndex = FindFinalNamespaceAuthorizationCommandIndex(commands);
+
+        finalAuthorizationIndex
+            .Should()
+            .BeGreaterThanOrEqualTo(
+                0,
+                "the denial must come from an executed namespace authorization statement, so this assertion "
+                    + "cannot pass without one"
+            );
+
+        DescribePersistenceCommands(commands.Take(finalAuthorizationIndex))
+            .Should()
+            .BeEmpty(
+                "nothing may be persisted before namespace authorization completes, so no command ahead of "
+                    + "the final authorization statement may carry persistence DML"
+            );
+
+        var authorizationCommandText = commands[finalAuthorizationIndex].CommandText;
+        var lastMarkerIndex = authorizationCommandText.LastIndexOf(
+            NamespaceAuthorizationMarker,
+            StringComparison.Ordinal
+        );
+
+        // Co-batched shape: authorization and persistence arrive as one command. Every persistence occurrence
+        // must follow the last namespace marker, so the whole authorization statement — including the CASE
+        // branch that raises AUTH1 — precedes the DML and aborts the batch before it can persist.
+        FindPersistenceOccurrences(authorizationCommandText)
+            .Where(occurrence => occurrence.Index < lastMarkerIndex)
+            .Select(occurrence => occurrence.Describe())
+            .Should()
+            .BeEmpty(
+                "every persistence statement co-batched with namespace authorization must follow the "
+                    + "authorization statement so the AUTH1 raise aborts the batch before it persists"
+            );
+
+        DescribePersistenceCommands(commands.Skip(finalAuthorizationIndex + 1))
+            .Should()
+            .BeEmpty(
+                "a denied namespace authorization must not be followed by any persistence command, so no "
+                    + "document, root, child, extension, referential identity, or tracking row can change"
+            );
+    }
+
+    /// <summary>
+    /// Asserts the operation issued no write-session command at all, which is how a planner-terminal denial
+    /// (for example the SQL Server namespace prefix cap) must fail closed — before any session opens.
+    /// </summary>
+    public static void AssertNoCommandsIssued(
+        IReadOnlyList<MssqlRelationalQueryAuthorizationRecordedCommand> commands
+    )
+    {
+        ArgumentNullException.ThrowIfNull(commands);
+
+        commands
+            .Select(static command => command.CommandText)
+            .Should()
+            .BeEmpty("a planner-terminal denial must resolve before the write session issues any command");
+    }
+
+    private static int FindFinalNamespaceAuthorizationCommandIndex(
+        IReadOnlyList<MssqlRelationalQueryAuthorizationRecordedCommand> commands
+    )
+    {
+        for (var index = commands.Count - 1; index >= 0; index--)
+        {
+            if (IsNamespaceAuthorizationCommand(commands[index].CommandText))
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static IReadOnlyList<string> DescribePersistenceCommands(
+        IEnumerable<MssqlRelationalQueryAuthorizationRecordedCommand> commands
+    ) =>
+        [
+            .. commands
+                .Where(static command => FindPersistenceOccurrences(command.CommandText).Count != 0)
+                .Select(static command => Summarize(command.CommandText)),
+        ];
+
+    /// <summary>
+    /// Every occurrence of every persistence marker in <paramref name="commandText"/>, ordered by position, so
+    /// a batch carrying more than one statement is evaluated in full rather than by its first match alone.
+    /// </summary>
+    private static IReadOnlyList<PersistenceOccurrence> FindPersistenceOccurrences(string commandText)
+    {
+        List<PersistenceOccurrence> occurrences = [];
+
+        foreach (var marker in _persistenceMarkers)
+        {
+            var searchIndex = commandText.IndexOf(marker, StringComparison.Ordinal);
+
+            while (searchIndex >= 0)
+            {
+                occurrences.Add(new PersistenceOccurrence(marker, searchIndex));
+                searchIndex = commandText.IndexOf(
+                    marker,
+                    searchIndex + marker.Length,
+                    StringComparison.Ordinal
+                );
+            }
+        }
+
+        return [.. occurrences.OrderBy(static occurrence => occurrence.Index)];
+    }
+
+    private static string Summarize(string commandText) =>
+        commandText.Length <= SummarizedCommandLength
+            ? commandText
+            : commandText[..SummarizedCommandLength] + "…";
+
+    private const int SummarizedCommandLength = 240;
+
+    private sealed record PersistenceOccurrence(string Marker, int Index)
+    {
+        public string Describe() => $"'{Marker}' at index {Index}";
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNamespaceAuthorizationCommandAssertionsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNamespaceAuthorizationCommandAssertionsTests.cs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+using FluentAssertions;
+using NUnit.Framework;
+
+// Sibling namespace outside the MSSQL integration setup-fixture scope so these pure-string assertions never
+// provision a database; the Integration namespace is imported only for the internal assertion helper, the
+// recorded-command record, and the MssqlCiShards.Shard4 category constant.
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.CommandAssertions;
+
+/// <summary>
+/// Guards the no-mutation boundary itself. <see cref="MssqlNamespaceAuthorizationCommandAssertions"/> is the
+/// generic proof that a NamespaceBased denial wrote nothing — including extension, identity, and tracking
+/// rows — so a hole in its ordering logic would silently weaken every denial test that depends on it.
+/// </summary>
+[TestFixture]
+[Category(MssqlCiShards.Shard4)]
+public class Given_The_Mssql_Namespace_Authorization_Command_Assertions
+{
+    private const string LockCommand =
+        "SELECT [ContentVersion] FROM [dms].[Document] WITH (UPDLOCK, ROWLOCK, HOLDLOCK) WHERE [DocumentId] = @documentId;";
+
+    private const string DocumentInsert =
+        "INSERT INTO [dms].[Document] ([DocumentUuid], [ResourceKeyId]) VALUES (@documentUuid, @resourceKeyId);";
+
+    private const string RootUpdate =
+        "UPDATE [authz].[AuthorizationNamespaceResource] SET [Name] = @name WHERE [DocumentId] = @documentId;";
+
+    [Test]
+    public void It_passes_when_separate_stored_and_proposed_checks_persist_nothing()
+    {
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, LockCommand),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, StoredCheck()),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, ProposedCheck()),
+            ]);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void It_passes_when_the_final_check_is_co_batched_ahead_of_its_persistence()
+    {
+        // The stored check runs as its own command and the proposed check shares a batch with the insert. The
+        // insert follows every namespace marker in that batch, so the AUTH1 raise aborts before persisting.
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, StoredCheck()),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(
+                    1,
+                    ProposedCheck() + "\n" + DocumentInsert
+                ),
+            ]);
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void It_fails_when_persistence_precedes_the_only_authorization_command()
+    {
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, DocumentInsert),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, StoredCheck()),
+            ]);
+
+        act.Should().Throw<AssertionException>().WithMessage("*before namespace authorization completes*");
+    }
+
+    [Test]
+    public void It_fails_when_persistence_falls_between_the_stored_and_proposed_checks()
+    {
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, StoredCheck()),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, DocumentInsert),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, ProposedCheck()),
+            ]);
+
+        act.Should().Throw<AssertionException>().WithMessage("*before namespace authorization completes*");
+    }
+
+    [Test]
+    public void It_fails_when_co_batched_persistence_precedes_the_last_namespace_marker()
+    {
+        // Same batch, wrong order: the insert sits between two namespace markers, so a later CASE branch
+        // could raise AUTH1 only after the row was already written.
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(
+                    1,
+                    "SELECT CASE WHEN EXISTS (...) THEN CAST('AUTH1 - ns1|0|u' AS INT)\n"
+                        + DocumentInsert
+                        + "\nELSE CAST('AUTH1 - ns1|0|m' AS INT) END;"
+                ),
+            ]);
+
+        act.Should().Throw<AssertionException>().WithMessage("*co-batched with namespace authorization*");
+    }
+
+    [Test]
+    public void It_fails_when_persistence_follows_the_authorization_command()
+    {
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, StoredCheck()),
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, RootUpdate),
+            ]);
+
+        act.Should().Throw<AssertionException>().WithMessage("*must not be followed by any persistence*");
+    }
+
+    [Test]
+    public void It_fails_when_no_namespace_authorization_command_was_recorded()
+    {
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, LockCommand),
+            ]);
+
+        act.Should()
+            .Throw<AssertionException>()
+            .WithMessage("*cannot pass without*", "the boundary must never pass vacuously");
+    }
+
+    [Test]
+    public void It_ignores_a_relationship_authorization_payload_when_locating_the_boundary()
+    {
+        // A relationship AUTH1 payload ('1|...') is not a namespace marker, so a command carrying only that
+        // payload cannot satisfy the boundary — and persistence beside it is still rejected.
+        var act = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(
+                    1,
+                    "SELECT CASE WHEN ... THEN CAST('AUTH1 - 1|0|1|0:0:n' AS INT) END; " + DocumentInsert
+                ),
+            ]);
+
+        act.Should().Throw<AssertionException>().WithMessage("*cannot pass without*");
+    }
+
+    [Test]
+    public void It_requires_an_empty_command_list_for_a_planner_terminal_denial()
+    {
+        var passing = () => MssqlNamespaceAuthorizationCommandAssertions.AssertNoCommandsIssued([]);
+        var failing = () =>
+            MssqlNamespaceAuthorizationCommandAssertions.AssertNoCommandsIssued([
+                new MssqlRelationalQueryAuthorizationRecordedCommand(1, LockCommand),
+            ]);
+
+        passing.Should().NotThrow();
+        failing.Should().Throw<AssertionException>().WithMessage("*before the write session issues*");
+    }
+
+    /// <summary>
+    /// Shape of the compiled stored-value check: one namespace marker per failing CASE branch, so the last
+    /// marker — not the first — is the ordering boundary inside the statement.
+    /// </summary>
+    private static string StoredCheck() =>
+        "SELECT CASE\n"
+        + "WHEN EXISTS (SELECT 1 FROM [authz].[AuthorizationNamespaceResource] r WHERE r.[DocumentId] = @documentId AND (r.[Namespace] IS NOT NULL AND (r.[Namespace] LIKE @namespacePrefixes_0 ESCAPE '\\'))) THEN 1\n"
+        + "WHEN EXISTS (SELECT 1 FROM [authz].[AuthorizationNamespaceResource] r WHERE r.[DocumentId] = @documentId AND (r.[Namespace] IS NULL OR r.[Namespace] = '')) THEN CAST('AUTH1 - ns1|0|u' AS INT)\n"
+        + "WHEN NOT EXISTS (SELECT 1 FROM [authz].[AuthorizationNamespaceResource] r WHERE r.[DocumentId] = @documentId) THEN CAST('AUTH1 - ns1|0|s' AS INT)\n"
+        + "ELSE CAST('AUTH1 - ns1|0|m' AS INT)\n"
+        + "END;";
+
+    private static string ProposedCheck() =>
+        "SELECT CASE\n"
+        + "WHEN @proposedNamespace IS NULL OR @proposedNamespace = '' THEN CAST('AUTH1 - ns1|0|r' AS INT)\n"
+        + "WHEN @proposedNamespace LIKE @namespacePrefixes_0 ESCAPE '\\' THEN 1\n"
+        + "ELSE CAST('AUTH1 - ns1|0|m' AS INT)\n"
+        + "END;";
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceReadAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceReadAuthorizationTests.cs
@@ -47,6 +47,13 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
     private const int UnauthorizedSchoolId = (int)
         RelationshipAuthorizationCrudTestSupport.UnauthorizedSchoolId;
 
+    /// <summary>
+    /// A school reachable only through the inverted relationship branch, so a row referencing it satisfies the
+    /// OR group without the normal branch.
+    /// </summary>
+    private const int InvertedOnlySchoolId = (int)
+        RelationshipAuthorizationCrudTestSupport.SecondAuthorizedSchoolId;
+
     /// <summary>The engine error number SQL Server raises for the compiler's intentional AUTH1 cast failure.</summary>
     private const int ConversionFailedErrorNumber = 245;
 
@@ -56,6 +63,13 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
         RelationshipAuthorizationCrudTestSupport.NamespaceBasedStrategyNames;
     private static readonly IReadOnlyList<string> _namespaceAndEdOrgStrategies =
         RelationshipAuthorizationCrudTestSupport.NamespaceBasedPlusEdOrgOnlyStrategyNames;
+    private static readonly IReadOnlyList<string> _namespaceAndRelationshipOrGroupStrategies =
+        RelationshipAuthorizationCrudTestSupport.NamespaceBasedPlusEdOrgNormalOrInvertedStrategyNames;
+    private static readonly IReadOnlyList<string> _namespaceAndEdOrgInvertedStrategies =
+    [
+        RelationshipAuthorizationCrudTestSupport.NamespaceBased,
+        RelationshipAuthorizationCrudTestSupport.RelationshipsWithEdOrgsOnlyInverted,
+    ];
 
     private static readonly QuerySchoolSeed[] _schoolSeeds =
     [
@@ -69,6 +83,12 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
             UnauthorizedSchoolId,
             "West"
         ),
+        // Reached only by the inverted branch: the seeded edge runs school 200 -> claim, never claim -> 200.
+        new(
+            new DocumentUuid(Guid.Parse("a1a1a1a1-0000-0000-0000-000000000003")),
+            InvertedOnlySchoolId,
+            "South"
+        ),
     ];
 
     private static readonly ClassPeriodSeed _classPeriodSeed = new(
@@ -79,11 +99,17 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
 
     // Seeded in this order, so dms.Document identity order — the GET-many sort order — matches the array
     // order. Authorized-by-namespace rows are indexes 0, 2, and 5.
+    //
+    // The school each row references decides which relationship branch can satisfy it, which is what makes the
+    // composed truth table below reachable:
+    //   school 100 — normal branch only   (edge claim -> 100)
+    //   school 200 — inverted branch only (edge 200 -> claim)
+    //   school 300 — neither branch       (no edge in either direction)
     private static readonly AuthorizationNamespaceSeed[] _seeds =
     [
         NamespaceSeed(1, "first-matching-prefix", AuthorizedPrefix + "assessments", AuthorizedSchoolId),
         NamespaceSeed(2, "second-nonmatching-prefix", UnauthorizedPrefix + "assessments", AuthorizedSchoolId),
-        NamespaceSeed(3, "third-second-prefix", SecondAuthorizedPrefix + "surveys", AuthorizedSchoolId),
+        NamespaceSeed(3, "third-second-prefix", SecondAuthorizedPrefix + "surveys", InvertedOnlySchoolId),
         NamespaceSeed(4, "fourth-null-namespace", null, AuthorizedSchoolId),
         NamespaceSeed(5, "fifth-empty-namespace", string.Empty, AuthorizedSchoolId),
         NamespaceSeed(
@@ -93,6 +119,12 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
             UnauthorizedSchoolId
         ),
         NamespaceSeed(7, "seventh-stale-target", UnauthorizedPrefix + "stale", AuthorizedSchoolId),
+        NamespaceSeed(
+            8,
+            "eighth-nonmatching-inverted-edorg",
+            UnauthorizedPrefix + "surveys",
+            InvertedOnlySchoolId
+        ),
     ];
 
     private static readonly AuthorizationNamespaceSeed _matchingSeed = _seeds[0];
@@ -146,8 +178,15 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
             );
         }
 
+        // One edge per branch, in one direction only, so the normal and inverted strategies are independently
+        // satisfiable and no row can satisfy both. The reverse edges are deleted explicitly because a row that
+        // satisfied both branches would make the OR group indistinguishable from a single strategy.
         await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, AuthorizedSchoolId);
+        await _context.DeleteAuthEdgeAsync(AuthorizedSchoolId, ClaimEducationOrganizationId);
+        await _context.InsertAuthEdgeAsync(InvertedOnlySchoolId, ClaimEducationOrganizationId);
+        await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, InvertedOnlySchoolId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, UnauthorizedSchoolId);
+        await _context.DeleteAuthEdgeAsync(UnauthorizedSchoolId, ClaimEducationOrganizationId);
         await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
     }
 
@@ -247,6 +286,10 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
             .BeOfType<GetResult.GetFailureNotExists>(
                 "a target that vanished between lookup and authorization must follow the stale-target path"
             );
+
+        // The 404 must come from decoding the stale-target payload, not from an early re-query that never ran
+        // the authorization check: an implementation that skipped the check would record no provider exception.
+        AssertDecodedFromRealSqlException("AUTH1 - ns1|0|s");
     }
 
     [Test]
@@ -338,13 +381,43 @@ public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthe
     [Test]
     public async Task It_ands_namespace_authorization_around_the_relationship_or_group()
     {
-        // Seeds 1 and 3 satisfy both sides. Seed 6 matches a configured prefix but its EdOrg has no
-        // relationship, and seed 2 has an authorized EdOrg but a nonmatching prefix, so both are excluded —
-        // proving NamespaceBased is an AND condition around the relationship OR group rather than an
-        // alternative to it.
-        var result = await QueryAsync(
+        // Namespace AND (normal OR inverted), with both relationship branches independently satisfiable:
+        //
+        //   seed | namespace | normal | inverted | expected
+        //   -----+-----------+--------+----------+---------
+        //      1 | match     | true   | false    | included
+        //      3 | match     | false  | true     | included
+        //      6 | match     | false  | false    | excluded
+        //      2 | mismatch  | true   | false    | excluded
+        //      8 | mismatch  | false  | true     | excluded
+        //
+        // Seeds 1 and 3 prove each relationship branch alone satisfies the OR group. Seed 6 proves the OR group
+        // is still required. Seeds 2 and 8 falsify the two incorrect flattenings: under
+        // (Namespace AND R1) OR R2 seed 8 would be included, and under R1 OR (Namespace AND R2) seed 2 would be.
+        //
+        // The normal and inverted columns are established rather than assumed: composing the namespace check
+        // with one branch at a time must return that branch's row alone.
+        var normalOnlyResult = await QueryAsync(
             claimEducationOrganizationIds: [ClaimEducationOrganizationId],
             strategyNames: _namespaceAndEdOrgStrategies
+        );
+        AssertReturnedDocuments(
+            normalOnlyResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject,
+            _seeds[0]
+        );
+
+        var invertedOnlyResult = await QueryAsync(
+            claimEducationOrganizationIds: [ClaimEducationOrganizationId],
+            strategyNames: _namespaceAndEdOrgInvertedStrategies
+        );
+        AssertReturnedDocuments(
+            invertedOnlyResult.Should().BeOfType<QueryResult.QuerySuccess>().Subject,
+            _seeds[2]
+        );
+
+        var result = await QueryAsync(
+            claimEducationOrganizationIds: [ClaimEducationOrganizationId],
+            strategyNames: _namespaceAndRelationshipOrGroupStrategies
         );
 
         var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceReadAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceReadAuthorizationTests.cs
@@ -1,0 +1,610 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.External.Plans;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Real-SQL-Server coverage for NamespaceBased read authorization (DMS-1286). Exercises the production MSSQL
+/// backend against the synthetic <c>AuthorizationNamespaceResource</c>, whose root table carries a nullable
+/// <c>Namespace</c> securable column plus a root EdOrg securable column, so GET-many filtering, GET-by-id
+/// denial, provider-exception decoding, prefix/parameter limits, and AND/OR composition all run against
+/// genuinely emitted SQL rather than a compiler fixture.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category("RelationalNamespace")]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Relational_Namespace_Read_Authorization_With_A_Synthetic_Namespace_Fixture
+{
+    private const long ClaimEducationOrganizationId =
+        RelationshipAuthorizationCrudTestSupport.ClaimEducationOrganizationId;
+    private const string ProjectEndpointName = RelationshipAuthorizationCrudTestSupport.ProjectEndpointName;
+    private const string ResourceName = RelationshipAuthorizationCrudTestSupport.NamespaceResourceName;
+    private const string AuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.AuthorizedNamespacePrefix;
+    private const string SecondAuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.SecondAuthorizedNamespacePrefix;
+    private const string UnauthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedNamespacePrefix;
+    private const int AuthorizedSchoolId = (int)RelationshipAuthorizationCrudTestSupport.AuthorizedSchoolId;
+    private const int UnauthorizedSchoolId = (int)
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedSchoolId;
+
+    /// <summary>The engine error number SQL Server raises for the compiler's intentional AUTH1 cast failure.</summary>
+    private const int ConversionFailedErrorNumber = 245;
+
+    private static readonly IReadOnlyList<string> _configuredPrefixes =
+        RelationshipAuthorizationCrudTestSupport.ConfiguredNamespacePrefixes;
+    private static readonly IReadOnlyList<string> _namespaceStrategy =
+        RelationshipAuthorizationCrudTestSupport.NamespaceBasedStrategyNames;
+    private static readonly IReadOnlyList<string> _namespaceAndEdOrgStrategies =
+        RelationshipAuthorizationCrudTestSupport.NamespaceBasedPlusEdOrgOnlyStrategyNames;
+
+    private static readonly QuerySchoolSeed[] _schoolSeeds =
+    [
+        new(
+            new DocumentUuid(Guid.Parse("a1a1a1a1-0000-0000-0000-000000000001")),
+            AuthorizedSchoolId,
+            "North"
+        ),
+        new(
+            new DocumentUuid(Guid.Parse("a1a1a1a1-0000-0000-0000-000000000002")),
+            UnauthorizedSchoolId,
+            "West"
+        ),
+    ];
+
+    private static readonly ClassPeriodSeed _classPeriodSeed = new(
+        new DocumentUuid(Guid.Parse("a2a2a2a2-0000-0000-0000-000000000001")),
+        AuthorizedSchoolId,
+        "P1"
+    );
+
+    // Seeded in this order, so dms.Document identity order — the GET-many sort order — matches the array
+    // order. Authorized-by-namespace rows are indexes 0, 2, and 5.
+    private static readonly AuthorizationNamespaceSeed[] _seeds =
+    [
+        NamespaceSeed(1, "first-matching-prefix", AuthorizedPrefix + "assessments", AuthorizedSchoolId),
+        NamespaceSeed(2, "second-nonmatching-prefix", UnauthorizedPrefix + "assessments", AuthorizedSchoolId),
+        NamespaceSeed(3, "third-second-prefix", SecondAuthorizedPrefix + "surveys", AuthorizedSchoolId),
+        NamespaceSeed(4, "fourth-null-namespace", null, AuthorizedSchoolId),
+        NamespaceSeed(5, "fifth-empty-namespace", string.Empty, AuthorizedSchoolId),
+        NamespaceSeed(
+            6,
+            "sixth-matching-unauthorized-edorg",
+            AuthorizedPrefix + "surveys",
+            UnauthorizedSchoolId
+        ),
+        NamespaceSeed(7, "seventh-stale-target", UnauthorizedPrefix + "stale", AuthorizedSchoolId),
+    ];
+
+    private static readonly AuthorizationNamespaceSeed _matchingSeed = _seeds[0];
+    private static readonly AuthorizationNamespaceSeed _mismatchingSeed = _seeds[1];
+    private static readonly AuthorizationNamespaceSeed _nullNamespaceSeed = _seeds[3];
+    private static readonly AuthorizationNamespaceSeed _emptyNamespaceSeed = _seeds[4];
+    private static readonly AuthorizationNamespaceSeed _staleTargetSeed = _seeds[6];
+
+    private readonly List<DbException> _observedProviderFailures = [];
+
+    private MssqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        // The observer only records the exception the production path already raised; the extractor still
+        // returns the default extraction, so no other test in this fixture changes behavior.
+        _context = new MssqlRelationalQueryAuthorizationTestContext(
+            providerFailureObserver: _observedProviderFailures.Add
+        );
+        await _context.InitializeAsync(
+            RelationshipAuthorizationCrudTestSupport.FixtureRelativePath,
+            strict: false,
+            replaceReadTargetLookup: false,
+            interceptReadTargetLookup: true
+        );
+        await _context.SeedSchoolDescriptorDataAsync();
+
+        foreach (var schoolSeed in _schoolSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateSchoolAsync(schoolSeed)
+            );
+        }
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateClassPeriodAsync(_classPeriodSeed)
+        );
+
+        foreach (var seed in _seeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateAuthorizationNamespaceAsync(seed)
+            );
+        }
+
+        await _context.InsertAuthEdgeAsync(ClaimEducationOrganizationId, AuthorizedSchoolId);
+        await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, UnauthorizedSchoolId);
+        await _context.DeleteAuthEdgeAsync(ClaimEducationOrganizationId, ClaimEducationOrganizationId);
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _context.ResetRecorder();
+        _observedProviderFailures.Clear();
+    }
+
+    [Test]
+    public async Task It_includes_matching_prefixes_and_excludes_nonmatching_null_and_empty_namespaces()
+    {
+        var result = await QueryAsync();
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        // Both configured prefixes contribute (seeds 1 and 6 match the first, seed 3 the second), while the
+        // nonmatching, null, and empty stored namespaces are filtered out of the page and the total count.
+        AssertReturnedDocuments(success, _seeds[0], _seeds[2], _seeds[5]);
+        success.TotalCount.Should().Be(3, "totalCount must count only namespace-authorized rows");
+    }
+
+    [Test]
+    public async Task It_filters_before_paging_so_the_page_window_lands_on_authorized_rows()
+    {
+        // Authorized rows in document order are seeds 1, 3, and 6. Skipping one authorized row yields seeds 3
+        // and 6. Paging before filtering would instead window rows 2 and 3 of the unfiltered set and return
+        // only seed 3, so this window fails unless authorization runs first.
+        var result = await QueryAsync(limit: 2, offset: 1);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+
+        AssertReturnedDocuments(success, _seeds[2], _seeds[5]);
+        success.TotalCount.Should().Be(3);
+    }
+
+    [Test]
+    public async Task It_authorizes_get_by_id_for_a_matching_prefix()
+    {
+        var result = await GetByIdAsync(_matchingSeed);
+
+        var success = result.Should().BeOfType<GetResult.GetSuccess>().Subject;
+        success.DocumentUuid.Should().Be(_matchingSeed.DocumentUuid);
+        success.EdfiDoc["namespace"]!.GetValue<string>().Should().Be(_matchingSeed.Namespace);
+        _context.AssertSingleDocumentHydration();
+        _context.AssertSingleDocumentMaterialized();
+    }
+
+    [Test]
+    public async Task It_returns_a_typed_mismatch_denial_from_a_real_sql_exception_without_hydrating()
+    {
+        var result = await GetByIdAsync(_mismatchingSeed);
+
+        AssertStoredNamespaceDenial(result, NamespaceAuthorizationFailureKind.NamespaceMismatch);
+        _context.AssertNoHydration();
+
+        // Provenance: the denial was decoded from an actual Microsoft.Data.SqlClient.SqlException raised by
+        // the production compiler's intentional AUTH1 cast, not from a stubbed DbException.
+        AssertDecodedFromRealSqlException("AUTH1 - ns1|0|m");
+    }
+
+    [TestCase(null, TestName = "It_returns_a_typed_stored_uninitialized_denial_for_a_null_namespace")]
+    [TestCase("", TestName = "It_returns_a_typed_stored_uninitialized_denial_for_an_empty_namespace")]
+    public async Task It_returns_a_typed_stored_uninitialized_denial(string? storedNamespace)
+    {
+        var seed = storedNamespace is null ? _nullNamespaceSeed : _emptyNamespaceSeed;
+
+        var result = await GetByIdAsync(seed);
+
+        AssertStoredNamespaceDenial(result, NamespaceAuthorizationFailureKind.StoredNamespaceUninitialized);
+        _context.AssertNoHydration();
+        AssertDecodedFromRealSqlException("AUTH1 - ns1|0|u");
+    }
+
+    [Test]
+    public async Task It_returns_not_found_when_the_target_is_deleted_between_lookup_and_authorization()
+    {
+        // The production target lookup resolves the row, then the row is deleted before the stored namespace
+        // check executes. The check's NOT EXISTS branch raises the stale AUTH1 kind, the read boundary
+        // re-resolves the target, and the vanished row surfaces as 404 rather than a namespace denial.
+        _context.AfterNextTargetLookup(async _ => await DeleteNamespaceRowAsync(_staleTargetSeed));
+
+        var result = await GetByIdAsync(_staleTargetSeed);
+
+        result
+            .Should()
+            .BeOfType<GetResult.GetFailureNotExists>(
+                "a target that vanished between lookup and authorization must follow the stale-target path"
+            );
+    }
+
+    [Test]
+    public async Task It_executes_a_supported_prefix_count_with_expanded_scalar_parameters()
+    {
+        var prefixes = CreateUniquePrefixes(
+            NamespacePrefixLimitExceededException.MssqlScalarParameterLimit - 1
+        );
+
+        var result = await QueryAsync(namespacePrefixes: prefixes);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        AssertReturnedDocuments(success, _seeds[0], _seeds[5]);
+        success.TotalCount.Should().Be(2);
+
+        var keyset = _context.AssertSingleQueryHydration();
+        var pageFilterParameters = keyset
+            .Plan.PageParametersInOrder.Where(static parameter =>
+                parameter.Role is QuerySqlParameterRole.Filter
+            )
+            .ToArray();
+
+        pageFilterParameters.Should().HaveCount(prefixes.Count);
+        pageFilterParameters[0].ParameterName.Should().Be("namespacePrefixes_0");
+        pageFilterParameters[^1].ParameterName.Should().Be($"namespacePrefixes_{prefixes.Count - 1}");
+        pageFilterParameters
+            .Select(static parameter => parameter.Binding.Kind)
+            .Should()
+            .OnlyContain(static kind => kind == QuerySqlParameterBindingKind.Scalar);
+        keyset.ParameterValues.Values.Should().Contain(AuthorizedPrefix + "%");
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_at_the_sql_server_prefix_cap()
+    {
+        var prefixes = CreateUniquePrefixes(NamespacePrefixLimitExceededException.MssqlScalarParameterLimit);
+
+        var result = await QueryAsync(namespacePrefixes: prefixes);
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .Equal(NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(prefixes.Count));
+        failure
+            .Diagnostics.Should()
+            .ContainSingle()
+            .Which.ProviderOrPlannerFailureKind.Should()
+            .Be("NamespaceAuthorization.PrefixCapExceeded");
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_returns_security_configuration_when_composed_authorization_parameters_exceed_the_command_limit()
+    {
+        // Each list is inside its own per-list cap, but composing them with the paging parameters exceeds
+        // SQL Server's per-command parameter ceiling, so the query must fail closed before executing.
+        const int PrefixCount = 1500;
+        const int ClaimCount = 599;
+        var prefixes = CreateUniquePrefixes(PrefixCount);
+        long[] claimEducationOrganizationIds =
+        [
+            .. Enumerable.Range(0, ClaimCount).Select(static index => 100000L + index),
+        ];
+
+        var result = await QueryAsync(
+            claimEducationOrganizationIds: claimEducationOrganizationIds,
+            strategyNames: _namespaceAndEdOrgStrategies,
+            namespacePrefixes: prefixes
+        );
+
+        var failure = result.Should().BeOfType<QueryResult.QueryFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .Equal(
+                NamespaceAuthorizationSecurityConfigurationMessages.CommandParameterCapExceeded(
+                    namespacePrefixCount: PrefixCount,
+                    claimEducationOrganizationIdCount: ClaimCount,
+                    nonAuthorizationParameterCount: AuthorizationParameterBudget.PaginationParameterCount
+                )
+            );
+        var diagnostic = failure.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic
+            .ProviderOrPlannerFailureKind.Should()
+            .Be("AuthorizationParameterBudget.CommandParameterCapExceeded");
+        diagnostic.ResourceFullName.Should().Be($"Authz.{ResourceName}");
+        _context.AssertNoHydration();
+    }
+
+    [Test]
+    public async Task It_ands_namespace_authorization_around_the_relationship_or_group()
+    {
+        // Seeds 1 and 3 satisfy both sides. Seed 6 matches a configured prefix but its EdOrg has no
+        // relationship, and seed 2 has an authorized EdOrg but a nonmatching prefix, so both are excluded —
+        // proving NamespaceBased is an AND condition around the relationship OR group rather than an
+        // alternative to it.
+        var result = await QueryAsync(
+            claimEducationOrganizationIds: [ClaimEducationOrganizationId],
+            strategyNames: _namespaceAndEdOrgStrategies
+        );
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        AssertReturnedDocuments(success, _seeds[0], _seeds[2]);
+        success.TotalCount.Should().Be(2);
+    }
+
+    private static AuthorizationNamespaceSeed NamespaceSeed(
+        int authorizationNamespaceId,
+        string name,
+        string? @namespace,
+        int schoolId
+    ) =>
+        new(
+            new DocumentUuid(Guid.Parse($"a3a3a3a3-0000-0000-0000-{authorizationNamespaceId:D12}")),
+            authorizationNamespaceId,
+            name,
+            @namespace,
+            schoolId,
+            authorizationNamespaceId == 1 ? [new ClassPeriodReferenceSeed("P1", AuthorizedSchoolId)] : []
+        );
+
+    /// <summary>
+    /// The authorized prefix plus filler prefixes, ordinal-distinct, so a test can drive an exact configured
+    /// prefix count while still matching the seeded rows.
+    /// </summary>
+    private static IReadOnlyList<string> CreateUniquePrefixes(int prefixCount) =>
+        [
+            AuthorizedPrefix,
+            .. Enumerable
+                .Range(0, prefixCount - 1)
+                .Select(static index => $"uri://filler{index:D5}.example/"),
+        ];
+
+    private async Task<QueryResult> QueryAsync(
+        int? limit = null,
+        int? offset = null,
+        IReadOnlyList<long>? claimEducationOrganizationIds = null,
+        IReadOnlyList<string>? strategyNames = null,
+        IReadOnlyList<string>? namespacePrefixes = null
+    ) =>
+        await _context.QueryAsync(
+            ProjectEndpointName,
+            ResourceName,
+            claimEducationOrganizationIds ?? [],
+            strategyNames ?? _namespaceStrategy,
+            limit: limit,
+            offset: offset,
+            namespacePrefixes: namespacePrefixes ?? _configuredPrefixes
+        );
+
+    private async Task<GetResult> GetByIdAsync(AuthorizationNamespaceSeed seed) =>
+        await _context.GetByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            seed.DocumentUuid,
+            [],
+            _namespaceStrategy,
+            namespacePrefixes: _configuredPrefixes
+        );
+
+    private static void AssertReturnedDocuments(
+        QueryResult.QuerySuccess success,
+        params AuthorizationNamespaceSeed[] expectedSeeds
+    ) =>
+        success
+            .EdfiDocs.Select(static document => document!["id"]!.GetValue<string>())
+            .Should()
+            .Equal(expectedSeeds.Select(static seed => seed.DocumentUuid.Value.ToString()));
+
+    /// <summary>
+    /// Asserts the typed outcome was decoded from one genuine <see cref="SqlException"/> carrying
+    /// <paramref name="expectedPayload"/>. The executor probes the extractor from more than one exception
+    /// filter, so the observer legitimately records the same exception instance repeatedly; requiring exactly
+    /// one distinct instance proves a single real engine failure drove the decision.
+    /// </summary>
+    private void AssertDecodedFromRealSqlException(string expectedPayload)
+    {
+        _observedProviderFailures
+            .Distinct()
+            .Should()
+            .ContainSingle("every exception filter must probe the one real provider exception");
+
+        var sqlException = _observedProviderFailures[0].Should().BeOfType<SqlException>().Subject;
+        sqlException
+            .Number.Should()
+            .Be(
+                ConversionFailedErrorNumber,
+                "the payload must arrive through SQL Server's conversion failure, which is how the production "
+                    + "compiler raises AUTH1"
+            );
+        sqlException.Message.Should().Contain(expectedPayload);
+    }
+
+    private static void AssertStoredNamespaceDenial(
+        GetResult result,
+        NamespaceAuthorizationFailureKind expectedFailureKind
+    )
+    {
+        var failure = result.Should().BeOfType<GetResult.GetFailureNamespaceNotAuthorized>().Subject;
+
+        failure.NamespaceFailure.FailureKind.Should().Be(expectedFailureKind);
+        failure.NamespaceFailure.ValueSource.Should().Be(NamespaceAuthorizationFailureValueSource.Stored);
+        failure.NamespaceFailure.EmittedAuth1Index.Should().Be(0);
+        failure
+            .NamespaceFailure.StrategyName.Should()
+            .Be(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+        failure.NamespaceFailure.ConfiguredNamespacePrefixes.Should().Equal(_configuredPrefixes);
+    }
+
+    /// <summary>
+    /// Removes every authoritative row for a seeded document in dependency order, so the deletion works
+    /// whether or not the generated foreign keys cascade.
+    /// </summary>
+    private async Task DeleteNamespaceRowAsync(AuthorizationNamespaceSeed seed)
+    {
+        await _context.Database.ExecuteNonQueryAsync(
+            """
+            DECLARE @documentId bigint = (
+                SELECT [DocumentId] FROM [dms].[Document] WHERE [DocumentUuid] = @documentUuid
+            );
+
+            DELETE FROM [authz].[AuthorizationNamespaceResourceClassPeriod]
+            WHERE [AuthorizationNamespaceResource_DocumentId] = @documentId;
+
+            DELETE FROM [authz].[AuthorizationNamespaceResource] WHERE [DocumentId] = @documentId;
+
+            DELETE FROM [dms].[ReferentialIdentity] WHERE [DocumentId] = @documentId;
+
+            DELETE FROM [dms].[Document] WHERE [DocumentId] = @documentId;
+            """,
+            new SqlParameter("@documentUuid", seed.DocumentUuid.Value)
+        );
+    }
+}
+
+/// <summary>
+/// Real-SQL-Server coverage for the namespace provider-failure mapper's fail-closed path. The request first
+/// raises a genuine <c>SqlException</c> through the production authorization SQL; only then does the test-only
+/// extractor seam rewrite the extracted payload to an unmappable <c>ns1|…</c> value, so the malformed-payload
+/// mapping is exercised without altering production SQL.
+/// </summary>
+/// <remarks>
+/// This fixture asserts the structured <c>Diagnostics</c> the wire response deliberately withholds; the
+/// sanitized ProblemDetails envelope itself is covered at the API integration boundary.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category("RelationalNamespace")]
+[Category(MssqlCiShards.Shard1)]
+public class Given_A_Mssql_Relational_Namespace_Authorization_With_An_Unmappable_Auth1_Payload
+{
+    private const string ProjectEndpointName = RelationshipAuthorizationCrudTestSupport.ProjectEndpointName;
+    private const string ResourceName = RelationshipAuthorizationCrudTestSupport.NamespaceResourceName;
+    private const int AuthorizedSchoolId = (int)RelationshipAuthorizationCrudTestSupport.AuthorizedSchoolId;
+
+    /// <summary>
+    /// A namespace payload whose emitted index exceeds the single planned stored check, so it decodes as a
+    /// namespace payload but cannot be mapped onto the plan.
+    /// </summary>
+    private const string UnmappableProviderMessage =
+        "Conversion failed when converting the varchar value 'AUTH1 - ns1|9|m' to data type int.";
+
+    private static readonly QuerySchoolSeed _schoolSeed = new(
+        new DocumentUuid(Guid.Parse("a4a4a4a4-0000-0000-0000-000000000001")),
+        AuthorizedSchoolId,
+        "North"
+    );
+
+    private static readonly AuthorizationNamespaceSeed _seed = new(
+        new DocumentUuid(Guid.Parse("a5a5a5a5-0000-0000-0000-000000000001")),
+        901,
+        "unmappable-auth1-payload",
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedNamespacePrefix + "assessments",
+        AuthorizedSchoolId,
+        []
+    );
+
+    private MssqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _context = new MssqlRelationalQueryAuthorizationTestContext(providerFailure =>
+            providerFailure with
+            {
+                Message = UnmappableProviderMessage,
+            }
+        );
+        await _context.InitializeAsync(
+            RelationshipAuthorizationCrudTestSupport.FixtureRelativePath,
+            strict: false,
+            replaceReadTargetLookup: false
+        );
+        await _context.SeedSchoolDescriptorDataAsync();
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateSchoolAsync(_schoolSeed)
+        );
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationNamespaceAsync(_seed)
+        );
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        _context.ResetRecorder();
+    }
+
+    [Test]
+    public async Task It_fails_closed_with_sanitized_security_configuration_diagnostics()
+    {
+        var result = await _context.GetByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            _seed.DocumentUuid,
+            [],
+            RelationshipAuthorizationCrudTestSupport.NamespaceBasedStrategyNames,
+            namespacePrefixes: RelationshipAuthorizationCrudTestSupport.ConfiguredNamespacePrefixes
+        );
+
+        var failure = result.Should().BeOfType<GetResult.GetFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .Equal(NamespaceAuthorizationSecurityConfigurationMessages.InvalidAuthorizationMetadata);
+        failure
+            .Errors.Should()
+            .NotContain(error =>
+                error.Contains("AUTH1", StringComparison.OrdinalIgnoreCase)
+                || error.Contains("Conversion failed", StringComparison.OrdinalIgnoreCase)
+                || error.Contains("varchar", StringComparison.OrdinalIgnoreCase)
+            );
+
+        var diagnostic = failure.Diagnostics.Should().ContainSingle().Subject;
+        diagnostic
+            .ProviderOrPlannerFailureKind.Should()
+            .Be("NamespaceAuthorization.Auth1.PayloadMappingFailed");
+        diagnostic
+            .ConfiguredStrategyNames.Should()
+            .Equal(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+        diagnostic.PhysicalPath.Should().Be($"authz.{ResourceName}.Namespace");
+        _context.AssertNoHydration();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceWriteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceWriteAuthorizationTests.cs
@@ -1,0 +1,674 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Backend.Plans;
+using EdFi.DataManagementService.Backend.Tests.Common;
+using EdFi.DataManagementService.Backend.Tests.Integration.Common;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Mssql.Tests.Integration;
+
+/// <summary>
+/// Real-SQL-Server coverage for NamespaceBased write authorization (DMS-1286): POST create, PUT,
+/// POST-as-update, and DELETE through the production MSSQL backend.
+/// </summary>
+/// <remarks>
+/// Every denial asserts three independent things. The typed failure carries the right kind and value source,
+/// which is what proves the stored check ran before the proposed one — a proposed failure is only reachable
+/// once the stored check has passed. The complete before/after
+/// <see cref="AuthorizationWriteSideEffectState"/> snapshot proves no authoritative row, referential identity,
+/// or tracking stamp moved. The no-DML command boundary proves the write session issued no persistence at all,
+/// which is what generalizes the guarantee to root, child, extension, identity, and tracking writes alike.
+/// The recorder is reset after arrangement in each test so only the act's commands are evaluated.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+[Category("Authorization")]
+[Category("DatabaseIntegration")]
+[Category("MssqlIntegration")]
+[Category("RelationalNamespace")]
+[Category(MssqlCiShards.Shard2)]
+public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synthetic_Namespace_Fixture
+{
+    private const string ProjectEndpointName = RelationshipAuthorizationCrudTestSupport.ProjectEndpointName;
+    private const string ResourceName = RelationshipAuthorizationCrudTestSupport.NamespaceResourceName;
+    private const string AuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.AuthorizedNamespacePrefix;
+    private const string SecondAuthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.SecondAuthorizedNamespacePrefix;
+    private const string UnauthorizedPrefix =
+        RelationshipAuthorizationCrudTestSupport.UnauthorizedNamespacePrefix;
+    private const int AuthorizedSchoolId = (int)RelationshipAuthorizationCrudTestSupport.AuthorizedSchoolId;
+    private const string StaleETag = "\"stale-etag\"";
+    private const string RootTableName = $"authz.{ResourceName}";
+
+    private static readonly IReadOnlyList<string> _configuredPrefixes =
+        RelationshipAuthorizationCrudTestSupport.ConfiguredNamespacePrefixes;
+    private static readonly IReadOnlyList<string> _namespaceStrategy =
+        RelationshipAuthorizationCrudTestSupport.NamespaceBasedStrategyNames;
+
+    private static readonly QuerySchoolSeed _schoolSeed = new(
+        new DocumentUuid(Guid.Parse("b1b1b1b1-0000-0000-0000-000000000001")),
+        AuthorizedSchoolId,
+        "North"
+    );
+
+    private static readonly ClassPeriodSeed[] _classPeriodSeeds =
+    [
+        new(new DocumentUuid(Guid.Parse("b2b2b2b2-0000-0000-0000-000000000001")), AuthorizedSchoolId, "P1"),
+        new(new DocumentUuid(Guid.Parse("b2b2b2b2-0000-0000-0000-000000000002")), AuthorizedSchoolId, "P2"),
+    ];
+
+    private static readonly ClassPeriodReferenceSeed[] _firstClassPeriod = [new("P1", AuthorizedSchoolId)];
+    private static readonly ClassPeriodReferenceSeed[] _secondClassPeriod = [new("P2", AuthorizedSchoolId)];
+
+    private MssqlRelationalQueryAuthorizationTestContext _context = null!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        if (!MssqlTestDatabaseHelper.IsConfigured())
+        {
+            Assert.Ignore(
+                "SQL Server integration tests require a MssqlAdmin connection string in appsettings.Test.json"
+            );
+        }
+
+        _context = new MssqlRelationalQueryAuthorizationTestContext();
+        await _context.InitializeAsync(
+            RelationshipAuthorizationCrudTestSupport.FixtureRelativePath,
+            strict: false,
+            replaceReadTargetLookup: false
+        );
+    }
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        await _context.Database.ResetAsync();
+        await _context.SeedSchoolDescriptorDataAsync();
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateSchoolAsync(_schoolSeed)
+        );
+
+        foreach (var classPeriodSeed in _classPeriodSeeds)
+        {
+            RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+                await _context.CreateClassPeriodAsync(classPeriodSeed)
+            );
+        }
+
+        _context.ResetRecorder();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
+    }
+
+    // ── POST create ─────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_post_create_and_inserts_document_root_and_child_rows()
+    {
+        var seed = NamespaceSeed(101, "create-authorized", AuthorizedPrefix + "assessments");
+
+        var result = await UpsertAsync(seed);
+
+        result.Should().BeOfType<UpsertResult.InsertSuccess>();
+        var state = await _context.ReadAuthorizationNamespaceSideEffectStateAsync(seed.DocumentUuid);
+        AssertRootRow(state, seed);
+        AssertChildRowCount(state, 1);
+        state.ReferentialIdentities.Should().ContainSingle();
+    }
+
+    [TestCase(
+        false,
+        NamespaceAuthorizationFailureKind.NamespaceMismatch,
+        TestName = "It_denies_post_create_with_a_mismatching_proposed_namespace_and_writes_nothing"
+    )]
+    [TestCase(
+        true,
+        NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+        TestName = "It_denies_post_create_with_a_missing_proposed_namespace_and_writes_nothing"
+    )]
+    public async Task It_denies_post_create_and_writes_nothing(
+        bool omitNamespace,
+        NamespaceAuthorizationFailureKind expectedFailureKind
+    )
+    {
+        var seed = NamespaceSeed(
+            102,
+            "create-denied",
+            omitNamespace ? null : UnauthorizedPrefix + "assessments"
+        );
+
+        var result = await UpsertAsync(seed);
+
+        AssertUpsertDenied(result, expectedFailureKind, NamespaceAuthorizationFailureValueSource.Proposed);
+        await AssertNoRowsExistAsync(seed);
+        _context.AssertNoPersistenceAfterNamespaceAuthorization();
+    }
+
+    // ── PUT ─────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_put_and_updates_the_existing_document()
+    {
+        var existingSeed = await SeedExistingAsync(201, "put-existing", AuthorizedPrefix + "assessments");
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-changed",
+            Namespace = SecondAuthorizedPrefix + "surveys",
+            ClassPeriods = _secondClassPeriod,
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid);
+
+        var success = result.Should().BeOfType<UpdateResult.UpdateSuccess>().Subject;
+        success.ExistingDocumentUuid.Should().Be(existingSeed.DocumentUuid);
+        var after = await ReadStateAsync(existingSeed);
+        after.Document.ContentVersion.Should().BeGreaterThan(before.Document.ContentVersion);
+        AssertRootRow(after, proposedSeed);
+    }
+
+    [Test]
+    public async Task It_denies_put_on_an_unauthorized_stored_namespace_even_when_the_proposed_namespace_matches()
+    {
+        var existingSeed = await SeedExistingAsync(202, "put-stored-denied", UnauthorizedPrefix + "stored");
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-stored-denied-change",
+            Namespace = AuthorizedPrefix + "assessments",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid);
+
+        // Stored is authorized first, so an authorized proposed value cannot rescue an unauthorized stored one.
+        AssertUpdateDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [TestCase(
+        false,
+        NamespaceAuthorizationFailureKind.NamespaceMismatch,
+        TestName = "It_denies_put_with_a_mismatching_proposed_namespace_after_stored_authorization_passes"
+    )]
+    [TestCase(
+        true,
+        NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+        TestName = "It_denies_put_with_a_missing_proposed_namespace_after_stored_authorization_passes"
+    )]
+    public async Task It_denies_put_on_the_proposed_namespace_after_stored_authorization_passes(
+        bool omitNamespace,
+        NamespaceAuthorizationFailureKind expectedFailureKind
+    )
+    {
+        var existingSeed = await SeedExistingAsync(
+            203,
+            "put-proposed-denied",
+            AuthorizedPrefix + "assessments"
+        );
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-proposed-denied-change",
+            Namespace = omitNamespace ? null : UnauthorizedPrefix + "proposed",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid);
+
+        // A proposed-value failure is only reachable once the stored check authorized, so the value source
+        // itself establishes the stored-then-proposed order.
+        AssertUpdateDenied(result, expectedFailureKind, NamespaceAuthorizationFailureValueSource.Proposed);
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [Test]
+    public async Task It_returns_403_before_a_stale_if_match_when_the_stored_namespace_is_unauthorized()
+    {
+        var existingSeed = await SeedExistingAsync(204, "put-collision", UnauthorizedPrefix + "collision");
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-collision-change",
+            Namespace = AuthorizedPrefix + "assessments",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid, ifMatch: StaleETag);
+
+        AssertUpdateDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_if_match_once_namespace_authorization_passes()
+    {
+        var existingSeed = await SeedExistingAsync(205, "put-precondition", AuthorizedPrefix + "assessments");
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-precondition-change",
+            Namespace = SecondAuthorizedPrefix + "surveys",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid, ifMatch: StaleETag);
+
+        result
+            .Should()
+            .BeOfType<UpdateResult.UpdateFailureETagMisMatch>(
+                "the precondition result must survive unchanged once authorization succeeds"
+            );
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    // ── POST-as-update ──────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_post_as_update_and_updates_the_existing_document()
+    {
+        var existingSeed = await SeedExistingAsync(301, "upsert-existing", AuthorizedPrefix + "assessments");
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000301")),
+            Name = "upsert-changed",
+            Namespace = SecondAuthorizedPrefix + "surveys",
+            ClassPeriods = _secondClassPeriod,
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed);
+
+        var success = result.Should().BeOfType<UpsertResult.UpdateSuccess>().Subject;
+        success.ExistingDocumentUuid.Should().Be(existingSeed.DocumentUuid);
+        var after = await ReadStateAsync(existingSeed);
+        after.Document.ContentVersion.Should().BeGreaterThan(before.Document.ContentVersion);
+        after.Document.DocumentUuid.Should().Be(existingSeed.DocumentUuid.Value);
+        AssertRootRow(after, candidateSeed);
+        (await _context.CountDocumentRowsAsync(candidateSeed.DocumentUuid))
+            .Should()
+            .Be(0, "the candidate uuid must not create a second document");
+    }
+
+    [Test]
+    public async Task It_denies_post_as_update_on_an_unauthorized_stored_namespace_even_when_the_proposed_namespace_matches()
+    {
+        var existingSeed = await SeedExistingAsync(
+            302,
+            "upsert-stored-denied",
+            UnauthorizedPrefix + "stored"
+        );
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000302")),
+            Name = "upsert-stored-denied-change",
+            Namespace = AuthorizedPrefix + "assessments",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed);
+
+        AssertUpsertDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+        (await _context.CountDocumentRowsAsync(candidateSeed.DocumentUuid)).Should().Be(0);
+    }
+
+    [TestCase(
+        false,
+        NamespaceAuthorizationFailureKind.NamespaceMismatch,
+        TestName = "It_denies_post_as_update_with_a_mismatching_proposed_namespace_after_stored_authorization_passes"
+    )]
+    [TestCase(
+        true,
+        NamespaceAuthorizationFailureKind.ProposedNamespaceMissing,
+        TestName = "It_denies_post_as_update_with_a_missing_proposed_namespace_after_stored_authorization_passes"
+    )]
+    public async Task It_denies_post_as_update_on_the_proposed_namespace_after_stored_authorization_passes(
+        bool omitNamespace,
+        NamespaceAuthorizationFailureKind expectedFailureKind
+    )
+    {
+        var existingSeed = await SeedExistingAsync(
+            303,
+            "upsert-proposed-denied",
+            AuthorizedPrefix + "assessments"
+        );
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000303")),
+            Name = "upsert-proposed-denied-change",
+            Namespace = omitNamespace ? null : UnauthorizedPrefix + "proposed",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed);
+
+        AssertUpsertDenied(result, expectedFailureKind, NamespaceAuthorizationFailureValueSource.Proposed);
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [Test]
+    public async Task It_returns_403_before_a_stale_post_as_update_if_match_when_the_proposed_namespace_is_unauthorized()
+    {
+        var existingSeed = await SeedExistingAsync(304, "upsert-collision", AuthorizedPrefix + "assessments");
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000304")),
+            Name = "upsert-collision-change",
+            Namespace = UnauthorizedPrefix + "proposed",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed, ifMatch: StaleETag);
+
+        AssertUpsertDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    // ── DELETE ──────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task It_authorizes_delete_and_removes_document_root_and_child_rows()
+    {
+        var seed = await SeedExistingAsync(401, "delete-authorized", AuthorizedPrefix + "assessments");
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(seed);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        await AssertNoRowsExistAsync(seed);
+    }
+
+    [Test]
+    public async Task It_returns_403_before_if_match_and_preserves_rows_when_both_would_fail()
+    {
+        var seed = await SeedExistingAsync(402, "delete-collision", UnauthorizedPrefix + "collision");
+        var before = await ReadStateAsync(seed);
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(seed, ifMatch: StaleETag);
+
+        AssertDeleteDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(seed, before);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_delete_if_match_once_namespace_authorization_passes()
+    {
+        var seed = await SeedExistingAsync(403, "delete-precondition", AuthorizedPrefix + "assessments");
+        var before = await ReadStateAsync(seed);
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(seed, ifMatch: StaleETag);
+
+        result.Should().BeOfType<DeleteResult.DeleteFailureETagMisMatch>();
+        await AssertStateUnchangedAsync(seed, before);
+    }
+
+    [Test]
+    public async Task It_locks_authorizes_then_deletes_within_one_guarded_session()
+    {
+        var seed = await SeedExistingAsync(404, "delete-ordering", AuthorizedPrefix + "assessments");
+        var getResult = await _context.GetByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            seed.DocumentUuid,
+            [],
+            _namespaceStrategy,
+            namespacePrefixes: _configuredPrefixes
+        );
+        var etag = getResult.Should().BeOfType<GetResult.GetSuccess>().Subject.EdfiDoc[
+            "_etag"
+        ]!.GetValue<string>();
+        _context.ResetRecorder();
+
+        var result = await DeleteAsync(seed, ifMatch: etag);
+
+        result.Should().BeOfType<DeleteResult.DeleteSuccess>();
+        _context.AssertDeleteWithIfMatchNamespaceOrdering();
+        await AssertNoRowsExistAsync(seed);
+    }
+
+    // ── Prefix cap on the write path ────────────────────────────────────
+
+    [Test]
+    public async Task It_returns_security_configuration_before_opening_a_write_session_at_the_prefix_cap()
+    {
+        var seed = NamespaceSeed(501, "create-prefix-cap", AuthorizedPrefix + "assessments");
+        IReadOnlyList<string> prefixes =
+        [
+            AuthorizedPrefix,
+            .. Enumerable
+                .Range(0, NamespacePrefixLimitExceededException.MssqlScalarParameterLimit - 1)
+                .Select(static index => $"uri://filler{index:D5}.example/"),
+        ];
+
+        var result = await UpsertAsync(seed, namespacePrefixes: prefixes);
+
+        var failure = result.Should().BeOfType<UpsertResult.UpsertFailureSecurityConfiguration>().Subject;
+        failure
+            .Errors.Should()
+            .Equal(NamespaceAuthorizationSecurityConfigurationMessages.PrefixCapExceeded(prefixes.Count));
+        await AssertNoRowsExistAsync(seed);
+
+        // The prefix cap is a planner terminal, so it must resolve before the write session issues anything.
+        _context.AssertNoWriteCommandsIssued();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static AuthorizationNamespaceSeed NamespaceSeed(
+        int authorizationNamespaceId,
+        string name,
+        string? @namespace
+    ) =>
+        new(
+            new DocumentUuid(Guid.Parse($"b3b3b3b3-0000-0000-0000-{authorizationNamespaceId:D12}")),
+            authorizationNamespaceId,
+            name,
+            @namespace,
+            AuthorizedSchoolId,
+            _firstClassPeriod
+        );
+
+    /// <summary>
+    /// Seeds an existing row through the production write path with no strategies configured, so any stored
+    /// namespace — authorized or not — can be established without first passing namespace authorization.
+    /// </summary>
+    private async Task<AuthorizationNamespaceSeed> SeedExistingAsync(
+        int authorizationNamespaceId,
+        string name,
+        string? @namespace
+    )
+    {
+        var seed = NamespaceSeed(authorizationNamespaceId, name, @namespace);
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateAuthorizationNamespaceAsync(seed)
+        );
+
+        return seed;
+    }
+
+    private async Task<UpsertResult> UpsertAsync(
+        AuthorizationNamespaceSeed seed,
+        string? ifMatch = null,
+        IReadOnlyList<string>? namespacePrefixes = null
+    ) =>
+        await _context.UpsertAuthorizationNamespaceAsync(
+            seed,
+            [],
+            _namespaceStrategy,
+            namespacePrefixes ?? _configuredPrefixes,
+            ifMatch
+        );
+
+    private async Task<UpdateResult> UpdateAsync(
+        AuthorizationNamespaceSeed seed,
+        DocumentUuid documentUuid,
+        string? ifMatch = null
+    ) =>
+        await _context.UpdateAuthorizationNamespaceByIdAsync(
+            seed,
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            _configuredPrefixes,
+            ifMatch
+        );
+
+    private async Task<DeleteResult> DeleteAsync(AuthorizationNamespaceSeed seed, string? ifMatch = null) =>
+        await _context.DeleteByIdAsync(
+            ProjectEndpointName,
+            ResourceName,
+            seed.DocumentUuid,
+            [],
+            _namespaceStrategy,
+            ifMatch,
+            namespacePrefixes: _configuredPrefixes
+        );
+
+    private async Task<AuthorizationWriteSideEffectState> ReadStateAsync(AuthorizationNamespaceSeed seed) =>
+        await _context.ReadAuthorizationNamespaceSideEffectStateAsync(seed.DocumentUuid);
+
+    /// <summary>
+    /// Every authoritative row and stamp for the target is byte-for-byte what it was before the denied
+    /// operation, and the write session issued no persistence command after authorization ran.
+    /// </summary>
+    private async Task AssertStateUnchangedAsync(
+        AuthorizationNamespaceSeed seed,
+        AuthorizationWriteSideEffectState before
+    )
+    {
+        var after = await ReadStateAsync(seed);
+
+        after.Should().BeEquivalentTo(before, static options => options.WithStrictOrdering());
+        _context.AssertNoPersistenceAfterNamespaceAuthorization();
+    }
+
+    private async Task AssertNoRowsExistAsync(AuthorizationNamespaceSeed seed)
+    {
+        (await _context.CountDocumentRowsAsync(seed.DocumentUuid)).Should().Be(0);
+        (await _context.CountResourceRootRowsAsync(ProjectEndpointName, ResourceName, seed.DocumentUuid))
+            .Should()
+            .Be(0);
+        (await _context.CountReferentialIdentityRowsForAuthorizationNamespaceAsync(seed)).Should().Be(0);
+    }
+
+    private static void AssertRootRow(
+        AuthorizationWriteSideEffectState state,
+        AuthorizationNamespaceSeed expectedSeed
+    )
+    {
+        var rootRow = state
+            .ResourceTables.Single(static table => table.TableName == RootTableName)
+            .Rows.Should()
+            .ContainSingle()
+            .Subject;
+
+        rootRow["AuthorizationNamespaceId"].Should().Be(expectedSeed.AuthorizationNamespaceId.ToString());
+        rootRow["Name"].Should().Be(expectedSeed.Name);
+        rootRow["Namespace"].Should().Be(expectedSeed.Namespace);
+    }
+
+    private static void AssertChildRowCount(AuthorizationWriteSideEffectState state, int expectedRowCount) =>
+        state
+            .ResourceTables.Single(static table => table.TableName == $"{RootTableName}ClassPeriod")
+            .Rows.Should()
+            .HaveCount(expectedRowCount);
+
+    private static void AssertUpsertDenied(
+        UpsertResult result,
+        NamespaceAuthorizationFailureKind expectedFailureKind,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    ) =>
+        AssertNamespaceFailure(
+            result
+                .Should()
+                .BeOfType<UpsertResult.UpsertFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            expectedFailureKind,
+            expectedValueSource
+        );
+
+    private static void AssertUpdateDenied(
+        UpdateResult result,
+        NamespaceAuthorizationFailureKind expectedFailureKind,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    ) =>
+        AssertNamespaceFailure(
+            result
+                .Should()
+                .BeOfType<UpdateResult.UpdateFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            expectedFailureKind,
+            expectedValueSource
+        );
+
+    private static void AssertDeleteDenied(
+        DeleteResult result,
+        NamespaceAuthorizationFailureKind expectedFailureKind,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    ) =>
+        AssertNamespaceFailure(
+            result
+                .Should()
+                .BeOfType<DeleteResult.DeleteFailureNamespaceNotAuthorized>()
+                .Subject.NamespaceFailure,
+            expectedFailureKind,
+            expectedValueSource
+        );
+
+    private static void AssertNamespaceFailure(
+        NamespaceAuthorizationFailure failure,
+        NamespaceAuthorizationFailureKind expectedFailureKind,
+        NamespaceAuthorizationFailureValueSource expectedValueSource
+    )
+    {
+        failure.FailureKind.Should().Be(expectedFailureKind);
+        failure.ValueSource.Should().Be(expectedValueSource);
+        failure.StrategyName.Should().Be(RelationshipAuthorizationCrudTestSupport.NamespaceBased);
+        failure.ConfiguredNamespacePrefixes.Should().Equal(_configuredPrefixes);
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceWriteAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalNamespaceWriteAuthorizationTests.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Globalization;
+using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Backend.Plans;
 using EdFi.DataManagementService.Backend.Tests.Common;
@@ -47,6 +49,12 @@ public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synth
     private const int AuthorizedSchoolId = (int)RelationshipAuthorizationCrudTestSupport.AuthorizedSchoolId;
     private const string StaleETag = "\"stale-etag\"";
     private const string RootTableName = $"authz.{ResourceName}";
+
+    /// <summary>
+    /// The extension table the fixture's <c>authzext</c> project generates for
+    /// <c>Ed-Fi.EducationContent</c>, whose single scalar column is <c>ExtensionValue</c>.
+    /// </summary>
+    private const string ExtensionTableName = "authzext.EducationContentExtension";
 
     private static readonly IReadOnlyList<string> _configuredPrefixes =
         RelationshipAuthorizationCrudTestSupport.ConfiguredNamespacePrefixes;
@@ -266,6 +274,33 @@ public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synth
     }
 
     [Test]
+    public async Task It_returns_403_before_a_stale_if_match_when_the_proposed_namespace_is_unauthorized()
+    {
+        // Companion to the stored-value collision above: the other reachable PUT denial must also beat 412.
+        var existingSeed = await SeedExistingAsync(
+            206,
+            "put-proposed-collision",
+            AuthorizedPrefix + "assessments"
+        );
+        var proposedSeed = existingSeed with
+        {
+            Name = "put-proposed-collision-change",
+            Namespace = UnauthorizedPrefix + "proposed",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpdateAsync(proposedSeed, existingSeed.DocumentUuid, ifMatch: StaleETag);
+
+        AssertUpdateDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [Test]
     public async Task It_returns_412_for_a_stale_if_match_once_namespace_authorization_passes()
     {
         var existingSeed = await SeedExistingAsync(205, "put-precondition", AuthorizedPrefix + "assessments");
@@ -285,6 +320,74 @@ public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synth
                 "the precondition result must survive unchanged once authorization succeeds"
             );
         await AssertStateUnchangedAsync(existingSeed, before);
+    }
+
+    [Test]
+    public async Task It_returns_403_before_a_stale_if_match_and_preserves_a_real_extension_row()
+    {
+        // The synthetic namespace resource has no extension table, so the conditional extension persistence
+        // path is only exercised with real _ext content. Ed-Fi.EducationContent is the lightest DS 5.2 resource
+        // with a concrete root Namespace column, and this fixture extends it with one optional scalar, which
+        // generates authzext.EducationContentExtension.
+        const string ContentIdentifier = "namespace-extension-coverage";
+        const string SeededExtensionValue = "seeded-extension-value";
+        var documentUuid = new DocumentUuid(Guid.Parse("b5b5b5b5-0000-0000-0000-000000000001"));
+
+        RelationalQueryAuthorizationAssertions.AssertInsertSuccess(
+            await _context.CreateEducationContentAsync(
+                CreateEducationContentBody(
+                    ContentIdentifier,
+                    AuthorizedPrefix + "content",
+                    SeededExtensionValue
+                ),
+                documentUuid
+            )
+        );
+        var before = await _context.ReadEducationContentSideEffectStateAsync(documentUuid);
+
+        // The extension row must exist and carry the seeded value before the request, so the unchanged-state
+        // comparison below cannot pass against an absent or empty extension table.
+        var extensionRowsBefore = before
+            .ResourceTables.Should()
+            .ContainSingle(table => table.TableName == ExtensionTableName)
+            .Subject.Rows;
+        extensionRowsBefore.Should().ContainSingle();
+        extensionRowsBefore[0]["ExtensionValue"].Should().Be(SeededExtensionValue);
+        long.Parse(extensionRowsBefore[0]["DocumentId"]!, CultureInfo.InvariantCulture)
+            .Should()
+            .Be(before.Document.DocumentId, "the extension row must belong to the seeded document");
+
+        _context.ResetRecorder();
+
+        var result = await _context.UpdateEducationContentByIdAsync(
+            CreateEducationContentBody(
+                ContentIdentifier,
+                UnauthorizedPrefix + "content",
+                "changed-extension-value"
+            ),
+            documentUuid,
+            [],
+            _namespaceStrategy,
+            _configuredPrefixes,
+            ifMatch: StaleETag
+        );
+
+        AssertUpdateDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Proposed
+        );
+
+        var after = await _context.ReadEducationContentSideEffectStateAsync(documentUuid);
+        after.Should().BeEquivalentTo(before, static options => options.WithStrictOrdering());
+        after
+            .ResourceTables.Single(static table => table.TableName == ExtensionTableName)
+            .Rows.Should()
+            .ContainSingle()
+            .Which["ExtensionValue"]
+            .Should()
+            .Be(SeededExtensionValue, "the denied write must not touch the extension row");
+        _context.AssertNoPersistenceAfterNamespaceAuthorization();
     }
 
     // ── POST-as-update ──────────────────────────────────────────────────
@@ -402,6 +505,62 @@ public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synth
         await AssertStateUnchangedAsync(existingSeed, before);
     }
 
+    [Test]
+    public async Task It_returns_403_before_a_stale_post_as_update_if_match_when_the_stored_namespace_is_unauthorized()
+    {
+        var existingSeed = await SeedExistingAsync(
+            305,
+            "upsert-stored-collision",
+            UnauthorizedPrefix + "stored"
+        );
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000305")),
+            Name = "upsert-stored-collision-change",
+            Namespace = AuthorizedPrefix + "assessments",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed, ifMatch: StaleETag);
+
+        AssertUpsertDenied(
+            result,
+            NamespaceAuthorizationFailureKind.NamespaceMismatch,
+            NamespaceAuthorizationFailureValueSource.Stored
+        );
+        await AssertStateUnchangedAsync(existingSeed, before);
+        (await _context.CountDocumentRowsAsync(candidateSeed.DocumentUuid)).Should().Be(0);
+    }
+
+    [Test]
+    public async Task It_returns_412_for_a_stale_post_as_update_if_match_once_namespace_authorization_passes()
+    {
+        var existingSeed = await SeedExistingAsync(
+            306,
+            "upsert-precondition",
+            AuthorizedPrefix + "assessments"
+        );
+        var candidateSeed = existingSeed with
+        {
+            DocumentUuid = new DocumentUuid(Guid.Parse("b4b4b4b4-0000-0000-0000-000000000306")),
+            Name = "upsert-precondition-change",
+            Namespace = SecondAuthorizedPrefix + "surveys",
+        };
+        var before = await ReadStateAsync(existingSeed);
+        _context.ResetRecorder();
+
+        var result = await UpsertAsync(candidateSeed, ifMatch: StaleETag);
+
+        result
+            .Should()
+            .BeOfType<UpsertResult.UpsertFailureETagMisMatch>(
+                "the precondition result must survive unchanged once both namespace checks pass"
+            );
+        await AssertStateUnchangedAsync(existingSeed, before);
+        (await _context.CountDocumentRowsAsync(candidateSeed.DocumentUuid)).Should().Be(0);
+    }
+
     // ── DELETE ──────────────────────────────────────────────────────────
 
     [Test]
@@ -497,6 +656,26 @@ public class Given_A_Mssql_Relational_Namespace_Write_Authorization_With_A_Synth
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// An EducationContent body carrying the fixture's one optional extension scalar under
+    /// <c>_ext.authzext</c>. Only the two schema-required fields plus a short description accompany it.
+    /// </summary>
+    private static JsonNode CreateEducationContentBody(
+        string contentIdentifier,
+        string @namespace,
+        string extensionValue
+    ) =>
+        new JsonObject
+        {
+            ["contentIdentifier"] = contentIdentifier,
+            ["namespace"] = @namespace,
+            ["shortDescription"] = "namespace extension coverage",
+            ["_ext"] = new JsonObject
+            {
+                ["authzext"] = new JsonObject { ["extensionValue"] = extensionValue },
+            },
+        };
 
     private static AuthorizationNamespaceSeed NamespaceSeed(
         int authorizationNamespaceId,

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
@@ -623,6 +623,73 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         );
     }
 
+    /// <summary>
+    /// Seeds an <c>Ed-Fi.EducationContent</c> row — the lightest DS 5.2 resource with a concrete root
+    /// <c>Namespace</c> column, and the one the fixture extends — through the production write path with no
+    /// authorization strategies, so any stored namespace and extension value can be established directly.
+    /// </summary>
+    public async Task<UpsertResult> CreateEducationContentAsync(
+        JsonNode requestBody,
+        DocumentUuid documentUuid
+    )
+    {
+        return await UpsertAsync(
+            "ed-fi",
+            "EducationContent",
+            requestBody,
+            documentUuid,
+            "seed-education-content"
+        );
+    }
+
+    public async Task<UpdateResult> UpdateEducationContentByIdAsync(
+        JsonNode requestBody,
+        DocumentUuid documentUuid,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> strategyNames,
+        IReadOnlyList<string>? namespacePrefixes = null,
+        string? ifMatch = null
+    )
+    {
+        return await UpdateAsync(
+            "ed-fi",
+            "EducationContent",
+            requestBody,
+            documentUuid,
+            "put-education-content",
+            claimEducationOrganizationIds,
+            strategyNames,
+            ifMatch,
+            namespacePrefixes: namespacePrefixes
+        );
+    }
+
+    /// <summary>
+    /// Snapshots every mapped <c>Ed-Fi.EducationContent</c> table, which includes the generated
+    /// <c>authzext.EducationContentExtension</c> row, so an extension value is inside the unchanged-state
+    /// comparison rather than outside it.
+    /// </summary>
+    public async Task<AuthorizationWriteSideEffectState> ReadEducationContentSideEffectStateAsync(
+        DocumentUuid documentUuid
+    )
+    {
+        var resourceKeyId = GetCompiledResourceKeyId("ed-fi", "EducationContent");
+        var document = await ReadDocumentStateAsync(documentUuid, resourceKeyId);
+
+        return new AuthorizationWriteSideEffectState(
+            Document: document,
+            ResourceTables: await ReadResourceTableStatesAsync(
+                "ed-fi",
+                "EducationContent",
+                document.DocumentId
+            ),
+            ReferentialIdentities: await ReadReferentialIdentityRowsForDocumentAsync(
+                document.DocumentId,
+                resourceKeyId
+            )
+        );
+    }
+
     public async Task<UpsertResult> CreateAuthorizationChildOnlyAsync(AuthorizationChildOnlySeed seed)
     {
         return await UpsertAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
@@ -170,6 +170,7 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         RelationshipAuthorizationProviderFailure,
         RelationshipAuthorizationProviderFailure
     >? _providerFailureTransform;
+    private readonly Action<DbException>? _providerFailureObserver;
     private static readonly BaseResourceInfo SchoolResource = new(
         new ProjectName("Ed-Fi"),
         new ResourceName("School"),
@@ -196,22 +197,48 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
 
     public MssqlGeneratedDdlTestDatabase Database { get; private set; } = null!;
 
+    /// <param name="providerFailureTransform">
+    /// Rewrites the extracted provider failure after a real engine exception has been raised, so a test can
+    /// drive malformed/unmappable AUTH1 payloads through the production mapper without changing production
+    /// SQL. Null leaves the default extraction in place.
+    /// </param>
+    /// <param name="providerFailureObserver">
+    /// Observes the actual <see cref="DbException"/> the production authorization path handed to the
+    /// extractor, so a test can assert real <c>Microsoft.Data.SqlClient.SqlException</c> provenance. Null
+    /// leaves the default extraction in place.
+    /// </param>
     public MssqlRelationalQueryAuthorizationTestContext(
         Func<
             RelationshipAuthorizationProviderFailure,
             RelationshipAuthorizationProviderFailure
-        >? providerFailureTransform = null
+        >? providerFailureTransform = null,
+        Action<DbException>? providerFailureObserver = null
     )
     {
         _providerFailureTransform = providerFailureTransform;
+        _providerFailureObserver = providerFailureObserver;
     }
 
+    /// <param name="interceptReadTargetLookup">
+    /// Runs the production GET-by-id target lookup and then invokes the one-shot
+    /// <see cref="AfterNextTargetLookup"/> callback, so a test can delete the resolved target in the window
+    /// between the unlocked lookup and the stored namespace check. Defaults to off.
+    /// </param>
     public async Task InitializeAsync(
         string fixtureRelativePath,
         bool strict,
-        bool replaceReadTargetLookup = true
+        bool replaceReadTargetLookup = true,
+        bool interceptReadTargetLookup = false
     )
     {
+        if (replaceReadTargetLookup && interceptReadTargetLookup)
+        {
+            throw new ArgumentException(
+                "The read target lookup cannot be both replaced with the throwing double and intercepted.",
+                nameof(interceptReadTargetLookup)
+            );
+        }
+
         _fixture = MssqlGeneratedDdlFixtureLoader.LoadFromRepositoryRelativePath(fixtureRelativePath, strict);
         IMssqlGeneratedDdlBaselineDatabase baseline = await MssqlBackendBaselineCache.CreateOrGetAsync(
             MssqlBackendBaselineCache.BuildFixtureSignature(fixtureRelativePath, strict),
@@ -219,7 +246,7 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         );
         _databaseLease = await baseline.AcquireRestoredDatabaseAsync();
         Database = _databaseLease.Database;
-        _serviceProvider = CreateServiceProvider(replaceReadTargetLookup);
+        _serviceProvider = CreateServiceProvider(replaceReadTargetLookup, interceptReadTargetLookup);
         _recorder = _serviceProvider.GetRequiredService<MssqlRelationalQueryExecutionRecorder>();
         _writeSessionRecorder =
             _serviceProvider.GetRequiredService<MssqlRelationalQueryAuthorizationWriteSessionRecorder>();
@@ -244,6 +271,39 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         _writeSessionRecorder.Reset();
     }
 
+    /// <summary>
+    /// Every command the production write session issued for the last operation, in issue order. Exposed so
+    /// the shared namespace command assertions can prove that a denial issued no persistence DML.
+    /// </summary>
+    public IReadOnlyList<MssqlRelationalQueryAuthorizationRecordedCommand> RecordedWriteCommands =>
+        _writeSessionRecorder.Commands;
+
+    /// <summary>
+    /// Asserts that namespace authorization ran and that no persistence DML followed it. See
+    /// <see cref="MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization"/>.
+    /// </summary>
+    public void AssertNoPersistenceAfterNamespaceAuthorization() =>
+        MssqlNamespaceAuthorizationCommandAssertions.AssertNoPersistenceAfterNamespaceAuthorization(
+            RecordedWriteCommands
+        );
+
+    /// <summary>
+    /// Asserts that the operation opened no write session command at all, which is how a planner-terminal
+    /// denial (for example the SQL Server namespace prefix cap) must fail closed.
+    /// </summary>
+    public void AssertNoWriteCommandsIssued() =>
+        MssqlNamespaceAuthorizationCommandAssertions.AssertNoCommandsIssued(RecordedWriteCommands);
+
+    /// <summary>
+    /// Runs <paramref name="afterTargetLookupAsync"/> once, immediately after the production GET-by-id target
+    /// lookup resolves and before the stored namespace check executes. Requires
+    /// <c>interceptReadTargetLookup: true</c> on <see cref="InitializeAsync"/>.
+    /// </summary>
+    public void AfterNextTargetLookup(Func<CancellationToken, Task> afterTargetLookupAsync)
+    {
+        _recorder.AfterNextTargetLookupAsync = afterTargetLookupAsync;
+    }
+
     public void AssertDeleteWithIfMatchSharedGuardedSession()
     {
         var commands = _writeSessionRecorder.Commands;
@@ -256,6 +316,30 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         // state-hydration read.
         var lockIndex = FindRequiredCommandIndex(commands, IsMssqlDocumentLockCommand);
         var authorizationIndex = FindRequiredCommandIndex(commands, IsMssqlRelationshipAuthorizationCommand);
+        var deleteIndex = FindRequiredCommandIndex(commands, IsMssqlDocumentDeleteCommand);
+
+        lockIndex.Should().BeLessThan(authorizationIndex);
+        authorizationIndex.Should().BeLessThan(deleteIndex);
+
+        commands.Count(command => IsMssqlDocumentLockCommand(command.CommandText)).Should().Be(1);
+    }
+
+    /// <summary>
+    /// Namespace twin of <see cref="AssertDeleteWithIfMatchSharedGuardedSession"/>: the target is locked
+    /// once, the stored namespace check runs against that locked row, and the delete follows — all inside
+    /// one guarded session, so authorization precedes both the If-Match result and the deletion.
+    /// </summary>
+    public void AssertDeleteWithIfMatchNamespaceOrdering()
+    {
+        var commands = _writeSessionRecorder.Commands;
+
+        commands.Select(static command => command.SessionId).Distinct().Should().ContainSingle();
+
+        var lockIndex = FindRequiredCommandIndex(commands, IsMssqlDocumentLockCommand);
+        var authorizationIndex = FindRequiredCommandIndex(
+            commands,
+            MssqlNamespaceAuthorizationCommandAssertions.IsNamespaceAuthorizationCommand
+        );
         var deleteIndex = FindRequiredCommandIndex(commands, IsMssqlDocumentDeleteCommand);
 
         lockIndex.Should().BeLessThan(authorizationIndex);
@@ -416,6 +500,69 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             strategyNames,
             ifMatch,
             backendProfileWriteContext
+        );
+    }
+
+    /// <summary>
+    /// Seeds an <c>AuthorizationNamespaceResource</c> row through the production write path with no
+    /// authorization strategies configured, so any stored namespace value — including null and empty — can
+    /// be established without first passing namespace authorization.
+    /// </summary>
+    public async Task<UpsertResult> CreateAuthorizationNamespaceAsync(AuthorizationNamespaceSeed seed)
+    {
+        return await UpsertAsync(
+            "authz",
+            RelationshipAuthorizationCrudTestSupport.NamespaceResourceName,
+            RelationalQueryAuthorizationRequestBodies.CreateAuthorizationNamespaceRequestBody(seed),
+            seed.DocumentUuid,
+            $"seed-auth-namespace-{seed.AuthorizationNamespaceId}"
+        );
+    }
+
+    public async Task<UpsertResult> UpsertAuthorizationNamespaceAsync(
+        AuthorizationNamespaceSeed seed,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> strategyNames,
+        IReadOnlyList<string>? namespacePrefixes = null,
+        string? ifMatch = null,
+        JsonNode? requestBody = null
+    )
+    {
+        return await UpsertAsync(
+            "authz",
+            RelationshipAuthorizationCrudTestSupport.NamespaceResourceName,
+            requestBody
+                ?? RelationalQueryAuthorizationRequestBodies.CreateAuthorizationNamespaceRequestBody(seed),
+            seed.DocumentUuid,
+            $"post-auth-namespace-{seed.AuthorizationNamespaceId}",
+            claimEducationOrganizationIds,
+            strategyNames,
+            ifMatch,
+            namespacePrefixes: namespacePrefixes
+        );
+    }
+
+    public async Task<UpdateResult> UpdateAuthorizationNamespaceByIdAsync(
+        AuthorizationNamespaceSeed seed,
+        DocumentUuid documentUuid,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> strategyNames,
+        IReadOnlyList<string>? namespacePrefixes = null,
+        string? ifMatch = null,
+        JsonNode? requestBody = null
+    )
+    {
+        return await UpdateAsync(
+            "authz",
+            RelationshipAuthorizationCrudTestSupport.NamespaceResourceName,
+            requestBody
+                ?? RelationalQueryAuthorizationRequestBodies.CreateAuthorizationNamespaceRequestBody(seed),
+            documentUuid,
+            $"put-auth-namespace-{seed.AuthorizationNamespaceId}",
+            claimEducationOrganizationIds,
+            strategyNames,
+            ifMatch,
+            namespacePrefixes: namespacePrefixes
         );
     }
 
@@ -1061,7 +1208,8 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         bool totalCount = true,
         IReadOnlyList<QueryElement>? queryElements = null,
         Func<MappingSet, MappingSet>? mappingSetTransform = null,
-        ChangeVersionRange? changeVersionRange = null
+        ChangeVersionRange? changeVersionRange = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         ResetRecorder();
@@ -1073,7 +1221,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
 
         var request = new RelationalQueryRequest(
             ResourceInfo: resourceHandle.ResourceInfo,
-            AuthorizationContext: new RelationalAuthorizationContext(claimEducationOrganizationIds),
+            AuthorizationContext: new RelationalAuthorizationContext(
+                claimEducationOrganizationIds,
+                namespacePrefixes ?? []
+            ),
             MappingSet: mappingSet,
             QueryElements: queryElements is null ? [] : [.. queryElements],
             AuthorizationStrategyEvaluators:
@@ -1106,7 +1257,8 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         IReadOnlyList<long> claimEducationOrganizationIds,
         IReadOnlyList<string> strategyNames,
         string? traceId = null,
-        Func<MappingSet, MappingSet>? mappingSetTransform = null
+        Func<MappingSet, MappingSet>? mappingSetTransform = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         ResetRecorder();
@@ -1131,7 +1283,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             TraceId: new TraceId(traceId ?? $"{resourceName}-authorization-get-by-id")
         )
         {
-            AuthorizationContext = new RelationalAuthorizationContext(claimEducationOrganizationIds),
+            AuthorizationContext = new RelationalAuthorizationContext(
+                claimEducationOrganizationIds,
+                namespacePrefixes ?? []
+            ),
         };
 
         return await scope
@@ -1146,7 +1301,8 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         IReadOnlyList<long> claimEducationOrganizationIds,
         IReadOnlyList<string> strategyNames,
         string? ifMatch = null,
-        string? traceId = null
+        string? traceId = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         ResetRecorder();
@@ -1163,7 +1319,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             MappingSet: MappingSet
         )
         {
-            AuthorizationContext = new RelationalAuthorizationContext(claimEducationOrganizationIds),
+            AuthorizationContext = new RelationalAuthorizationContext(
+                claimEducationOrganizationIds,
+                namespacePrefixes ?? []
+            ),
             AuthorizationStrategyEvaluators =
             [
                 .. strategyNames.Select(static strategyName => new AuthorizationStrategyEvaluator(
@@ -1268,6 +1427,57 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
                 document.DocumentId,
                 resourceKeyId
             )
+        );
+    }
+
+    public async Task<AuthorizationWriteSideEffectState> ReadAuthorizationNamespaceSideEffectStateAsync(
+        DocumentUuid documentUuid
+    )
+    {
+        var resourceKeyId = GetCompiledResourceKeyId(
+            "authz",
+            RelationshipAuthorizationCrudTestSupport.NamespaceResourceName
+        );
+        var document = await ReadDocumentStateAsync(documentUuid, resourceKeyId);
+
+        return new AuthorizationWriteSideEffectState(
+            Document: document,
+            ResourceTables: await ReadResourceTableStatesAsync(
+                "authz",
+                RelationshipAuthorizationCrudTestSupport.NamespaceResourceName,
+                document.DocumentId
+            ),
+            ReferentialIdentities: await ReadReferentialIdentityRowsForDocumentAsync(
+                document.DocumentId,
+                resourceKeyId
+            )
+        );
+    }
+
+    public async Task<long> CountReferentialIdentityRowsForAuthorizationNamespaceAsync(
+        AuthorizationNamespaceSeed seed
+    )
+    {
+        var resourceHandle = GetResourceHandle(
+            "authz",
+            RelationshipAuthorizationCrudTestSupport.NamespaceResourceName
+        );
+        var referentialId = RelationalDocumentInfoTestHelper
+            .CreateDocumentInfo(
+                RelationalQueryAuthorizationRequestBodies.CreateAuthorizationNamespaceRequestBody(seed),
+                resourceHandle.ResourceInfo,
+                resourceHandle.ResourceSchema,
+                MappingSet
+            )
+            .ReferentialId;
+
+        return await Database.ExecuteScalarAsync<long>(
+            """
+            SELECT COUNT_BIG(*)
+            FROM [dms].[ReferentialIdentity]
+            WHERE [ReferentialId] = @referentialId;
+            """,
+            new SqlParameter("@referentialId", referentialId.Value)
         );
     }
 
@@ -1529,7 +1739,8 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         IReadOnlyList<long>? claimEducationOrganizationIds = null,
         IReadOnlyList<string>? strategyNames = null,
         string? ifMatch = null,
-        BackendProfileWriteContext? backendProfileWriteContext = null
+        BackendProfileWriteContext? backendProfileWriteContext = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         var resourceHandle = GetResourceHandle(projectEndpointName, resourceName);
@@ -1553,7 +1764,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             BackendProfileWriteContext: backendProfileWriteContext
         )
         {
-            AuthorizationContext = new RelationalAuthorizationContext(claimEducationOrganizationIds ?? []),
+            AuthorizationContext = new RelationalAuthorizationContext(
+                claimEducationOrganizationIds ?? [],
+                namespacePrefixes ?? []
+            ),
             AuthorizationStrategyEvaluators =
             [
                 .. (strategyNames ?? []).Select(static strategyName => new AuthorizationStrategyEvaluator(
@@ -1578,7 +1792,8 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         IReadOnlyList<long>? claimEducationOrganizationIds = null,
         IReadOnlyList<string>? strategyNames = null,
         string? ifMatch = null,
-        BackendProfileWriteContext? backendProfileWriteContext = null
+        BackendProfileWriteContext? backendProfileWriteContext = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         var resourceHandle = GetResourceHandle(projectEndpointName, resourceName);
@@ -1602,7 +1817,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             BackendProfileWriteContext: backendProfileWriteContext
         )
         {
-            AuthorizationContext = new RelationalAuthorizationContext(claimEducationOrganizationIds ?? []),
+            AuthorizationContext = new RelationalAuthorizationContext(
+                claimEducationOrganizationIds ?? [],
+                namespacePrefixes ?? []
+            ),
             AuthorizationStrategyEvaluators =
             [
                 .. (strategyNames ?? []).Select(static strategyName => new AuthorizationStrategyEvaluator(
@@ -1842,7 +2060,10 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         return resourceHandle;
     }
 
-    private ServiceProvider CreateServiceProvider(bool replaceReadTargetLookup)
+    private ServiceProvider CreateServiceProvider(
+        bool replaceReadTargetLookup,
+        bool interceptReadTargetLookup
+    )
     {
         ServiceCollection services = [];
 
@@ -1865,12 +2086,13 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
             ServiceDescriptor.Scoped<IRelationalReadMaterializer, RecordingRelationalReadMaterializer>()
         );
 
-        if (_providerFailureTransform is not null)
+        if (_providerFailureTransform is not null || _providerFailureObserver is not null)
         {
             services.Replace(
                 ServiceDescriptor.Scoped<IRelationshipAuthorizationProviderFailureExtractor>(
                     _ => new TransformingMssqlRelationshipAuthorizationProviderFailureExtractor(
-                        _providerFailureTransform
+                        _providerFailureTransform,
+                        _providerFailureObserver
                     )
                 )
             );
@@ -1882,6 +2104,15 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
                 ServiceDescriptor.Scoped<
                     IRelationalReadTargetLookupService,
                     ThrowingRelationalReadTargetLookupService
+                >()
+            );
+        }
+        else if (interceptReadTargetLookup)
+        {
+            services.Replace(
+                ServiceDescriptor.Scoped<
+                    IRelationalReadTargetLookupService,
+                    InterceptingRelationalReadTargetLookupService
                 >()
             );
         }
@@ -2234,15 +2465,25 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         ResourceInfo ResourceInfo
     );
 
+    /// <summary>
+    /// Test-only extractor seam. It observes the real provider exception the production authorization path
+    /// raised (so a test can assert genuine <c>SqlException</c> provenance) and optionally rewrites the
+    /// extracted payload (so a test can drive malformed/unmappable AUTH1 data through the production mapper).
+    /// With both hooks null this type is never registered, so the default extraction stays in place.
+    /// </summary>
     private sealed class TransformingMssqlRelationshipAuthorizationProviderFailureExtractor(
-        Func<RelationshipAuthorizationProviderFailure, RelationshipAuthorizationProviderFailure> transform
+        Func<RelationshipAuthorizationProviderFailure, RelationshipAuthorizationProviderFailure>? transform,
+        Action<DbException>? observer
     ) : IRelationshipAuthorizationProviderFailureExtractor
     {
         public RelationshipAuthorizationProviderFailure Extract(DbException exception)
         {
             ArgumentNullException.ThrowIfNull(exception);
 
-            return transform(new RelationshipAuthorizationProviderFailure(null, exception.Message));
+            observer?.Invoke(exception);
+            var providerFailure = new RelationshipAuthorizationProviderFailure(null, exception.Message);
+
+            return transform is null ? providerFailure : transform(providerFailure);
         }
     }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
@@ -566,6 +566,63 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
         );
     }
 
+    /// <summary>
+    /// Issues a descriptor POST through <c>RelationalDocumentStoreRepository.UpsertDocument</c>, which routes
+    /// descriptor resources into the production <c>DescriptorWriteHandler</c> and carries the authorization
+    /// context with it — so the test exercises the real routing seam rather than calling the handler directly.
+    /// </summary>
+    public async Task<UpsertResult> UpsertDescriptorAsync(
+        string projectEndpointName,
+        string resourceName,
+        JsonNode requestBody,
+        DocumentUuid documentUuid,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> strategyNames,
+        IReadOnlyList<string>? namespacePrefixes = null,
+        string? ifMatch = null
+    )
+    {
+        return await UpsertAsync(
+            projectEndpointName,
+            resourceName,
+            requestBody,
+            documentUuid,
+            $"post-descriptor-{resourceName}",
+            claimEducationOrganizationIds,
+            strategyNames,
+            ifMatch,
+            namespacePrefixes: namespacePrefixes
+        );
+    }
+
+    /// <summary>
+    /// Issues a descriptor PUT through <c>RelationalDocumentStoreRepository.UpdateDocumentById</c>, which routes
+    /// descriptor resources into the production <c>DescriptorWriteHandler</c>.
+    /// </summary>
+    public async Task<UpdateResult> UpdateDescriptorByIdAsync(
+        string projectEndpointName,
+        string resourceName,
+        JsonNode requestBody,
+        DocumentUuid documentUuid,
+        IReadOnlyList<long> claimEducationOrganizationIds,
+        IReadOnlyList<string> strategyNames,
+        IReadOnlyList<string>? namespacePrefixes = null,
+        string? ifMatch = null
+    )
+    {
+        return await UpdateAsync(
+            projectEndpointName,
+            resourceName,
+            requestBody,
+            documentUuid,
+            $"put-descriptor-{resourceName}",
+            claimEducationOrganizationIds,
+            strategyNames,
+            ifMatch,
+            namespacePrefixes: namespacePrefixes
+        );
+    }
+
     public async Task<UpsertResult> CreateAuthorizationChildOnlyAsync(AuthorizationChildOnlySeed seed)
     {
         return await UpsertAsync(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
@@ -34,6 +34,14 @@ internal sealed class MssqlRelationalQueryExecutionRecorder
     public List<PageKeysetSpec> HydrationKeysets { get; } = [];
     public List<long> PageMaterializedDocumentIds { get; } = [];
     public Func<CancellationToken, Task>? BeforeNextHydrationAsync { get; set; }
+
+    /// <summary>
+    /// One-shot callback invoked immediately after the production GET-by-id target lookup resolves, used to
+    /// open the window a stored authorization check must tolerate (for example a target deleted between the
+    /// unlocked lookup and the check). Only observed when a fixture opts into
+    /// <see cref="InterceptingRelationalReadTargetLookupService"/>.
+    /// </summary>
+    public Func<CancellationToken, Task>? AfterNextTargetLookupAsync { get; set; }
     public int SingleDocumentMaterializationCallCount { get; private set; }
     public int PageMaterializationCallCount { get; private set; }
 
@@ -69,6 +77,19 @@ internal sealed class MssqlRelationalQueryExecutionRecorder
 
         BeforeNextHydrationAsync = null;
         await beforeHydrationAsync(cancellationToken);
+    }
+
+    public async Task InvokeAfterTargetLookupAsync(CancellationToken cancellationToken)
+    {
+        var afterTargetLookupAsync = AfterNextTargetLookupAsync;
+
+        if (afterTargetLookupAsync is null)
+        {
+            return;
+        }
+
+        AfterNextTargetLookupAsync = null;
+        await afterTargetLookupAsync(cancellationToken);
     }
 }
 
@@ -157,6 +178,40 @@ internal sealed class ThrowingRelationalReadTargetLookupService : IRelationalRea
         throw new AssertionException(
             "Relational query execution should not route through get-by-id read target lookup."
         );
+    }
+}
+
+/// <summary>
+/// Runs the production GET-by-id target lookup and then invokes the recorder's one-shot
+/// <see cref="MssqlRelationalQueryExecutionRecorder.AfterNextTargetLookupAsync"/> callback, so a test can
+/// mutate or delete the resolved target in the window between the unlocked lookup and the stored
+/// authorization check. With no callback set it behaves exactly like the production service.
+/// </summary>
+internal sealed class InterceptingRelationalReadTargetLookupService(
+    IRelationalCommandExecutor commandExecutor,
+    MssqlRelationalQueryExecutionRecorder recorder
+) : IRelationalReadTargetLookupService
+{
+    private readonly RelationalReadTargetLookupService _inner = new(
+        commandExecutor ?? throw new ArgumentNullException(nameof(commandExecutor))
+    );
+    private readonly MssqlRelationalQueryExecutionRecorder _recorder =
+        recorder ?? throw new ArgumentNullException(nameof(recorder));
+
+    public async Task<RelationalReadTargetLookupResult> ResolveForGetByIdAsync(
+        MappingSet mappingSet,
+        QualifiedResourceName resource,
+        DocumentUuid documentUuid,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var lookupResult = await _inner
+            .ResolveForGetByIdAsync(mappingSet, resource, documentUuid, cancellationToken)
+            .ConfigureAwait(false);
+
+        await _recorder.InvokeAfterTargetLookupAsync(cancellationToken);
+
+        return lookupResult;
     }
 }
 

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationalQueryAuthorizationTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationalQueryAuthorizationTestSupport.cs
@@ -43,6 +43,21 @@ internal sealed record AuthorizationNullableSeed(
     int? NullableSchoolId = null
 );
 
+/// <summary>
+/// Seed for the synthetic <c>AuthorizationNamespaceResource</c>, whose root table carries both a nullable
+/// <c>Namespace</c> securable column and an EdOrg securable column. A <see langword="null"/>
+/// <paramref name="Namespace"/> omits the property from the request body, which is how a write exercises
+/// the missing-proposed-namespace failure and how a stored row is seeded with an uninitialized namespace.
+/// </summary>
+internal sealed record AuthorizationNamespaceSeed(
+    DocumentUuid DocumentUuid,
+    int AuthorizationNamespaceId,
+    string Name,
+    string? Namespace,
+    int SchoolId,
+    IReadOnlyList<ClassPeriodReferenceSeed> ClassPeriods
+);
+
 internal sealed record StudentSeed(
     DocumentUuid DocumentUuid,
     string StudentUniqueId,
@@ -226,6 +241,43 @@ internal static class RelationalQueryAuthorizationRequestBodies
             ["name"] = seed.Name,
             ["classPeriods"] = classPeriods,
         };
+    }
+
+    public static JsonNode CreateAuthorizationNamespaceRequestBody(AuthorizationNamespaceSeed seed)
+    {
+        JsonArray classPeriods = [];
+
+        foreach (var classPeriod in seed.ClassPeriods)
+        {
+            classPeriods.Add(
+                new JsonObject
+                {
+                    ["classPeriodReference"] = new JsonObject
+                    {
+                        ["classPeriodName"] = classPeriod.ClassPeriodName,
+                        ["schoolId"] = (long)classPeriod.SchoolId,
+                    },
+                }
+            );
+        }
+
+        JsonObject requestBody = new()
+        {
+            ["authorizationNamespaceId"] = seed.AuthorizationNamespaceId,
+            ["name"] = seed.Name,
+            ["schoolReference"] = new JsonObject { ["schoolId"] = (long)seed.SchoolId },
+            ["classPeriods"] = classPeriods,
+        };
+
+        // Namespace is optional on this resource, so a null seed value omits the property entirely
+        // (the missing-proposed-namespace case) while an empty string is written through as an
+        // uninitialized stored value.
+        if (seed.Namespace is not null)
+        {
+            requestBody["namespace"] = seed.Namespace;
+        }
+
+        return requestBody;
     }
 
     public static JsonNode CreateAuthorizationNullableRequestBody(AuthorizationNullableSeed seed)

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Core.External.Security;
+
 namespace EdFi.DataManagementService.Backend.Tests.Common;
 
 public sealed record RelationshipAuthorizationCrudScenario(
@@ -22,10 +24,23 @@ public static class RelationshipAuthorizationCrudTestSupport
     public const string StudentAcademicRecordResourceName = "AuthorizationStudentAcademicRecordResource";
     public const string StudentSchoolResourceName = "AuthorizationStudentSchoolResource";
 
+    /// <summary>
+    /// The synthetic resource whose root table carries a nullable <c>Namespace</c> securable column plus a
+    /// root EdOrg securable column, so one resource covers NamespaceBased-only and composed
+    /// NamespaceBased/relationship scenarios.
+    /// </summary>
+    public const string NamespaceResourceName = "AuthorizationNamespaceResource";
+
     public const long ClaimEducationOrganizationId = 900;
     public const long AuthorizedSchoolId = 100;
     public const long SecondAuthorizedSchoolId = 200;
     public const long UnauthorizedSchoolId = 300;
+
+    // Prefixes differ by more than case so assertions never depend on the dialect's Namespace column
+    // collation (SQL Server's default LIKE is case-insensitive, PostgreSQL's is case-sensitive).
+    public const string AuthorizedNamespacePrefix = "uri://ns1.org/";
+    public const string SecondAuthorizedNamespacePrefix = "uri://ns2.org/";
+    public const string UnauthorizedNamespacePrefix = "uri://other.example/";
 
     public const string RelationshipsWithEdOrgsOnly = "RelationshipsWithEdOrgsOnly";
     public const string RelationshipsWithEdOrgsOnlyInverted = "RelationshipsWithEdOrgsOnlyInverted";
@@ -36,6 +51,7 @@ public static class RelationshipAuthorizationCrudTestSupport
         "RelationshipsWithStudentsOnlyThroughResponsibility";
     public const string NoFurtherAuthorizationRequired = "NoFurtherAuthorizationRequired";
     public const string OwnershipBased = "OwnershipBased";
+    public const string NamespaceBased = AuthorizationStrategyNameConstants.NamespaceBased;
 
     public static IReadOnlyList<string> EdOrgOnlyStrategyNames { get; } = [RelationshipsWithEdOrgsOnly];
 
@@ -63,6 +79,17 @@ public static class RelationshipAuthorizationCrudTestSupport
 
     public static IReadOnlyList<string> EdOrgOnlyPlusKnownUnsupportedStrategyNames { get; } =
     [RelationshipsWithEdOrgsOnly, OwnershipBased];
+
+    public static IReadOnlyList<string> NamespaceBasedStrategyNames { get; } = [NamespaceBased];
+
+    /// <summary>
+    /// NamespaceBased AND-composed around the relationship OR group, in the order the planner splits them.
+    /// </summary>
+    public static IReadOnlyList<string> NamespaceBasedPlusEdOrgOnlyStrategyNames { get; } =
+    [NamespaceBased, RelationshipsWithEdOrgsOnly];
+
+    public static IReadOnlyList<string> ConfiguredNamespacePrefixes { get; } =
+    [AuthorizedNamespacePrefix, SecondAuthorizedNamespacePrefix];
 
     public static RelationshipAuthorizationCrudScenario SupportedEdOrgOnlyScenario { get; } =
         new("supported-edorg-only", RootAndChildEdOrgResourceName, EdOrgOnlyStrategyNames);

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Common/RelationshipAuthorizationCrudTestSupport.cs
@@ -83,10 +83,19 @@ public static class RelationshipAuthorizationCrudTestSupport
     public static IReadOnlyList<string> NamespaceBasedStrategyNames { get; } = [NamespaceBased];
 
     /// <summary>
-    /// NamespaceBased AND-composed around the relationship OR group, in the order the planner splits them.
+    /// NamespaceBased AND-composed with a single relationship strategy. This is <c>Namespace AND R1</c>, not an
+    /// OR group; use <see cref="NamespaceBasedPlusEdOrgNormalOrInvertedStrategyNames"/> to compose around two
+    /// independently satisfiable relationship strategies.
     /// </summary>
     public static IReadOnlyList<string> NamespaceBasedPlusEdOrgOnlyStrategyNames { get; } =
     [NamespaceBased, RelationshipsWithEdOrgsOnly];
+
+    /// <summary>
+    /// NamespaceBased AND-composed around a genuine relationship OR group: the normal and inverted EdOrg
+    /// strategies are independently satisfiable, so a row may satisfy either branch alone.
+    /// </summary>
+    public static IReadOnlyList<string> NamespaceBasedPlusEdOrgNormalOrInvertedStrategyNames { get; } =
+    [NamespaceBased, RelationshipsWithEdOrgsOnly, RelationshipsWithEdOrgsOnlyInverted];
 
     public static IReadOnlyList<string> ConfiguredNamespacePrefixes { get; } =
     [AuthorizedNamespacePrefix, SecondAuthorizedNamespacePrefix];

--- a/src/dms/backend/Fixtures/synthetic/authorization-query/fixture.json
+++ b/src/dms/backend/Fixtures/synthetic/authorization-query/fixture.json
@@ -1,7 +1,8 @@
 {
   "apiSchemaFiles": [
     "repo:src/dms/backend/Fixtures/authoritative/ds-5.2/inputs/ds-5.2-api-schema-authoritative.json",
-    "authorization-query-extension.json"
+    "authorization-query-extension.json",
+    "authorization-education-content-extension.json"
   ],
   "dialects": ["pgsql", "mssql"],
   "emitDdlManifest": true

--- a/src/dms/backend/Fixtures/synthetic/authorization-query/inputs/authorization-education-content-extension.json
+++ b/src/dms/backend/Fixtures/synthetic/authorization-query/inputs/authorization-education-content-extension.json
@@ -1,0 +1,48 @@
+{
+  "apiSchemaVersion": "1.0.0",
+  "projectSchema": {
+    "abstractResources": {},
+    "caseInsensitiveEndpointNameMapping": {},
+    "description": "Synthetic extension project adding one optional scalar to Ed-Fi.EducationContent, so namespace denial tests can prove a real extension-table row is preserved. EducationContent is the lightest DS 5.2 resource with a concrete root Namespace column: its schema requires only contentIdentifier and namespace.",
+    "educationOrganizationHierarchy": {},
+    "educationOrganizationTypes": [],
+    "isExtensionProject": true,
+    "projectEndpointName": "authzext",
+    "projectName": "AuthzExt",
+    "projectVersion": "1.0.0",
+    "resourceNameMapping": {},
+    "resourceSchemas": {
+      "educationContentExtensions": {
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [],
+        "documentPathsMapping": {},
+        "equalityConstraints": [],
+        "identityJsonPaths": [],
+        "isDescriptor": false,
+        "isResourceExtension": true,
+        "isSchoolYearEnumeration": false,
+        "isSubclass": false,
+        "jsonSchemaForInsert": {
+          "properties": {
+            "_ext": {
+              "properties": {
+                "authzext": {
+                  "properties": {
+                    "extensionValue": {
+                      "maxLength": 60,
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "resourceName": "EducationContent"
+      }
+    }
+  }
+}

--- a/src/dms/backend/Fixtures/synthetic/authorization-query/inputs/authorization-query-extension.json
+++ b/src/dms/backend/Fixtures/synthetic/authorization-query/inputs/authorization-query-extension.json
@@ -5,6 +5,7 @@
     "caseInsensitiveEndpointNameMapping": {
       "authorizationandresources": "authorizationAndResources",
       "authorizationchildonlyresources": "authorizationChildOnlyResources",
+      "authorizationnamespaceresources": "authorizationNamespaceResources",
       "authorizationnullableresources": "authorizationNullableResources",
       "authorizationrootchildresources": "authorizationRootChildResources",
       "authorizationstudentacademicrecordresources": "authorizationStudentAcademicRecordResources",
@@ -22,6 +23,7 @@
     "resourceNameMapping": {
       "AuthorizationAndResource": "authorizationAndResources",
       "AuthorizationChildOnlyResource": "authorizationChildOnlyResources",
+      "AuthorizationNamespaceResource": "authorizationNamespaceResources",
       "AuthorizationNullableResource": "authorizationNullableResources",
       "AuthorizationRootChildResource": "authorizationRootChildResources",
       "AuthorizationStudentAcademicRecordResource": "authorizationStudentAcademicRecordResources",
@@ -597,6 +599,198 @@
             }
           ],
           "Namespace": [],
+          "Staff": [],
+          "Student": []
+        }
+      },
+      "authorizationNamespaceResources": {
+        "allowIdentityUpdates": false,
+        "arrayUniquenessConstraints": [
+          {
+            "paths": [
+              "$.classPeriods[*].classPeriodReference.classPeriodName",
+              "$.classPeriods[*].classPeriodReference.schoolId"
+            ]
+          }
+        ],
+        "authorizationPathways": [],
+        "booleanJsonPaths": [],
+        "commonExtensionOverrides": [],
+        "dateJsonPaths": [],
+        "dateTimeJsonPaths": [],
+        "decimalPropertyValidationInfos": [],
+        "documentPathsMapping": {
+          "AuthorizationNamespaceId": {
+            "isPartOfIdentity": true,
+            "isReference": false,
+            "isRequired": true,
+            "path": "$.authorizationNamespaceId",
+            "type": "number"
+          },
+          "ClassPeriod": {
+            "isDescriptor": false,
+            "isPartOfIdentity": false,
+            "isReference": true,
+            "isRequired": false,
+            "projectName": "Ed-Fi",
+            "referenceJsonPaths": [
+              {
+                "identityJsonPath": "$.classPeriodName",
+                "referenceJsonPath": "$.classPeriods[*].classPeriodReference.classPeriodName",
+                "type": "string"
+              },
+              {
+                "identityJsonPath": "$.schoolReference.schoolId",
+                "referenceJsonPath": "$.classPeriods[*].classPeriodReference.schoolId",
+                "type": "number"
+              }
+            ],
+            "resourceName": "ClassPeriod"
+          },
+          "Name": {
+            "isPartOfIdentity": false,
+            "isReference": false,
+            "isRequired": true,
+            "path": "$.name",
+            "type": "string"
+          },
+          "Namespace": {
+            "isPartOfIdentity": false,
+            "isReference": false,
+            "isRequired": false,
+            "path": "$.namespace",
+            "type": "string"
+          },
+          "School": {
+            "isDescriptor": false,
+            "isPartOfIdentity": false,
+            "isReference": true,
+            "isRequired": true,
+            "projectName": "Ed-Fi",
+            "referenceJsonPaths": [
+              {
+                "identityJsonPath": "$.schoolId",
+                "referenceJsonPath": "$.schoolReference.schoolId",
+                "type": "number"
+              }
+            ],
+            "resourceName": "School"
+          }
+        },
+        "domains": [],
+        "equalityConstraints": [],
+        "identityJsonPaths": ["$.authorizationNamespaceId"],
+        "isDescriptor": false,
+        "isResourceExtension": false,
+        "isSchoolYearEnumeration": false,
+        "isSubclass": false,
+        "jsonSchemaForInsert": {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "additionalProperties": false,
+          "description": "Synthetic authorization resource with an optional root Namespace securable element.",
+          "properties": {
+            "authorizationNamespaceId": {
+              "format": "int32",
+              "type": "integer"
+            },
+            "classPeriods": {
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "classPeriodReference": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "classPeriodName": {
+                        "maxLength": 60,
+                        "type": "string"
+                      },
+                      "schoolId": {
+                        "format": "int64",
+                        "type": "integer"
+                      }
+                    },
+                    "required": ["classPeriodName", "schoolId"],
+                    "type": "object"
+                  }
+                },
+                "required": ["classPeriodReference"],
+                "type": "object"
+              },
+              "minItems": 0,
+              "type": "array",
+              "uniqueItems": false
+            },
+            "name": {
+              "maxLength": 75,
+              "type": "string"
+            },
+            "namespace": {
+              "maxLength": 255,
+              "type": "string"
+            },
+            "schoolReference": {
+              "additionalProperties": false,
+              "properties": {
+                "schoolId": {
+                  "format": "int64",
+                  "type": "integer"
+                }
+              },
+              "required": ["schoolId"],
+              "type": "object"
+            }
+          },
+          "required": ["authorizationNamespaceId", "name", "schoolReference"],
+          "title": "Authz.AuthorizationNamespaceResource",
+          "type": "object"
+        },
+        "numericJsonPaths": [
+          "$.authorizationNamespaceId",
+          "$.classPeriods[*].classPeriodReference.schoolId",
+          "$.schoolReference.schoolId"
+        ],
+        "queryFieldMapping": {
+          "authorizationNamespaceId": [
+            {
+              "path": "$.authorizationNamespaceId",
+              "type": "number"
+            }
+          ],
+          "id": [
+            {
+              "path": "$.id",
+              "type": "string"
+            }
+          ],
+          "name": [
+            {
+              "path": "$.name",
+              "type": "string"
+            }
+          ],
+          "namespace": [
+            {
+              "path": "$.namespace",
+              "type": "string"
+            }
+          ],
+          "schoolId": [
+            {
+              "path": "$.schoolReference.schoolId",
+              "type": "number"
+            }
+          ]
+        },
+        "resourceName": "AuthorizationNamespaceResource",
+        "securableElements": {
+          "Contact": [],
+          "EducationOrganization": [
+            {
+              "jsonPath": "$.schoolReference.schoolId",
+              "metaEdName": "SchoolId"
+            }
+          ],
+          "Namespace": ["$.namespace"],
           "Staff": [],
           "Student": []
         }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationHarness.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationHarness.cs
@@ -22,13 +22,15 @@ public sealed class ApiIntegrationHarness : IAsyncDisposable
         HttpClient httpClient,
         DbConnection dbConnection,
         FixtureContext fixture,
-        ApiIntegrationQueryRecorder? queryRecorder = null
+        ApiIntegrationQueryRecorder? queryRecorder = null,
+        ApiIntegrationProviderFailureRecorder? providerFailureRecorder = null
     )
     {
         HttpClient = httpClient;
         DbConnection = dbConnection;
         Fixture = fixture;
         QueryRecorder = queryRecorder;
+        ProviderFailureRecorder = providerFailureRecorder;
 
         HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
@@ -40,6 +42,12 @@ public sealed class ApiIntegrationHarness : IAsyncDisposable
     public DbConnection DbConnection { get; }
     public FixtureContext Fixture { get; }
     public ApiIntegrationQueryRecorder? QueryRecorder { get; }
+
+    /// <summary>
+    /// Provider exceptions the production authorization path raised, recorded only when the test class supplies
+    /// a <c>ProviderFailureTransform</c>. Null otherwise.
+    /// </summary>
+    public ApiIntegrationProviderFailureRecorder? ProviderFailureRecorder { get; }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/ApiIntegrationTestBase.cs
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Data.Common;
+using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Core.Security;
 using EdFi.DataManagementService.Tests.Integration.Doubles;
 using EdFi.DataManagementService.Tests.Integration.Fixtures;
@@ -30,6 +31,7 @@ public abstract class ApiIntegrationTestBase
     private FixtureContext? _fixtureContext;
     private string? _startupStatusFilePath;
     private ApiIntegrationQueryRecorder? _queryRecorder;
+    private ApiIntegrationProviderFailureRecorder? _providerFailureRecorder;
 
     protected ApiIntegrationHarness Harness { get; private set; } = null!;
 
@@ -52,6 +54,21 @@ public abstract class ApiIntegrationTestBase
     /// EducationOrganizationIds returned from the fake JWT validation service.
     /// </summary>
     protected virtual IReadOnlyList<long> ClientEducationOrganizationIds => [];
+
+    /// <summary>
+    /// Namespace prefixes returned from the fake JWT validation service, for NamespaceBased scenarios.
+    /// </summary>
+    protected virtual IReadOnlyList<string> ClientNamespacePrefixes => [];
+
+    /// <summary>
+    /// When set, replaces the authorization provider-failure extractor with a recording double that rewrites
+    /// the extracted payload after the production authorization path raised a real provider exception. Used by
+    /// malformed-AUTH1-payload scenarios; null leaves the production extraction in place.
+    /// </summary>
+    protected virtual Func<
+        RelationshipAuthorizationProviderFailure,
+        RelationshipAuthorizationProviderFailure
+    >? ProviderFailureTransform => null;
 
     /// <summary>
     /// Captures compiled page keysets passed into the document hydrator for assertions
@@ -88,11 +105,17 @@ public abstract class ApiIntegrationTestBase
         _leasedConnectionString = await LeaseDatabaseAsync(_fixtureContext);
         _startupStatusFilePath = Path.Combine(Path.GetTempPath(), $"api-int-startup-{Guid.NewGuid():N}.json");
         _queryRecorder = CaptureQueryPlans ? new ApiIntegrationQueryRecorder() : null;
+        var providerFailureTransform = ProviderFailureTransform;
+        _providerFailureRecorder = providerFailureTransform is null
+            ? null
+            : new ApiIntegrationProviderFailureRecorder();
 
         var fixtureContext = _fixtureContext;
         var leasedConnectionString = _leasedConnectionString;
         var startupStatusFilePath = _startupStatusFilePath;
         var queryRecorder = _queryRecorder;
+        var providerFailureRecorder = _providerFailureRecorder;
+        var clientNamespacePrefixes = ClientNamespacePrefixes;
 
         _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
         {
@@ -122,7 +145,10 @@ public abstract class ApiIntegrationTestBase
                     fixtureContext,
                     leasedConnectionString,
                     CreateClaimSetProvider(fixtureContext),
-                    ClientEducationOrganizationIds
+                    ClientEducationOrganizationIds,
+                    clientNamespacePrefixes,
+                    providerFailureTransform,
+                    providerFailureRecorder
                 );
 
                 if (queryRecorder is not null)
@@ -139,7 +165,8 @@ public abstract class ApiIntegrationTestBase
             httpClient,
             _assertionConnection,
             _fixtureContext,
-            _queryRecorder
+            _queryRecorder,
+            _providerFailureRecorder
         );
     }
 
@@ -174,6 +201,7 @@ public abstract class ApiIntegrationTestBase
 
         _fixtureContext = null;
         _queryRecorder = null;
+        _providerFailureRecorder = null;
 
         if (_startupStatusFilePath is not null && File.Exists(_startupStatusFilePath))
         {

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/ExternalDoublesRegistration.cs
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using EdFi.DataManagementService.Backend;
 using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.Security;
@@ -23,12 +24,30 @@ namespace EdFi.DataManagementService.Tests.Integration.Doubles;
 /// </summary>
 internal static class ExternalDoublesRegistration
 {
+    /// <param name="clientNamespacePrefixes">
+    /// Namespace prefixes the fake JWT carries for NamespaceBased scenarios. Empty by default.
+    /// </param>
+    /// <param name="providerFailureTransform">
+    /// When supplied, replaces the authorization provider-failure extractor with a recording double that
+    /// rewrites the extracted payload after the real provider exception was raised. Null leaves the production
+    /// extraction in place, which is the historical behavior for every other scenario.
+    /// </param>
+    /// <param name="providerFailureRecorder">
+    /// Collects the real provider exceptions observed while <paramref name="providerFailureTransform"/> is
+    /// active, so a scenario can assert genuine <c>SqlException</c> provenance.
+    /// </param>
     public static void RegisterAll(
         IServiceCollection services,
         FixtureContext fixture,
         string leasedConnectionString,
         IClaimSetProvider claimSetProvider,
-        IReadOnlyList<long> clientEducationOrganizationIds
+        IReadOnlyList<long> clientEducationOrganizationIds,
+        IReadOnlyList<string>? clientNamespacePrefixes = null,
+        Func<
+            RelationshipAuthorizationProviderFailure,
+            RelationshipAuthorizationProviderFailure
+        >? providerFailureTransform = null,
+        ApiIntegrationProviderFailureRecorder? providerFailureRecorder = null
     )
     {
         services.RemoveAll<IJwtValidationService>();
@@ -43,9 +62,25 @@ internal static class ExternalDoublesRegistration
             FakeJwtValidationService.Allowing(
                 ExternalDoublesConstants.SmokeToken,
                 ExternalDoublesConstants.SmokeClientId,
-                clientEducationOrganizationIds
+                clientEducationOrganizationIds,
+                clientNamespacePrefixes
             )
         );
+
+        if (providerFailureTransform is not null && providerFailureRecorder is not null)
+        {
+            // The backend registers the production extractor with TryAdd before ConfigureServices runs, so the
+            // existing registration has to be removed rather than merely attempted.
+            services.RemoveAll<IRelationshipAuthorizationProviderFailureExtractor>();
+            services.AddSingleton(providerFailureRecorder);
+            services.AddScoped<IRelationshipAuthorizationProviderFailureExtractor>(
+                serviceProvider => new RecordingProviderFailureExtractor(
+                    serviceProvider.GetRequiredService<ApiIntegrationProviderFailureRecorder>(),
+                    providerFailureTransform
+                )
+            );
+        }
+
         services.AddSingleton(FakeOidcConfigurationManager.Stable());
         services.AddSingleton(claimSetProvider);
         services.AddSingleton<IApplicationContextProvider>(FakeApplicationContextProvider.Stable());

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeJwtValidationService.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/FakeJwtValidationService.cs
@@ -17,10 +17,15 @@ namespace EdFi.DataManagementService.Tests.Integration.Doubles;
 /// </summary>
 internal static class FakeJwtValidationService
 {
+    /// <param name="namespacePrefixes">
+    /// Namespace prefixes carried on the returned <see cref="ClientAuthorizations"/> for NamespaceBased
+    /// authorization scenarios. Defaults to none, which is the historical behavior.
+    /// </param>
     public static IJwtValidationService Allowing(
         string tokenId,
         string clientId,
-        IReadOnlyList<long>? educationOrganizationIds = null
+        IReadOnlyList<long>? educationOrganizationIds = null,
+        IReadOnlyList<string>? namespacePrefixes = null
     )
     {
         var fake = A.Fake<IJwtValidationService>();
@@ -32,7 +37,9 @@ internal static class FakeJwtValidationService
             educationOrganizationIds is null
                 ? []
                 : [.. educationOrganizationIds.Select(static id => new EducationOrganizationId(id))],
-            [],
+            namespacePrefixes is null
+                ? []
+                : [.. namespacePrefixes.Select(static prefix => new NamespacePrefix(prefix))],
             [new DataStoreId(ExternalDoublesConstants.StableDataStoreId)]
         );
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/RecordingProviderFailureExtractor.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Doubles/RecordingProviderFailureExtractor.cs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Data.Common;
+using EdFi.DataManagementService.Backend;
+
+namespace EdFi.DataManagementService.Tests.Integration.Doubles;
+
+/// <summary>
+/// Records the provider exceptions the production authorization path raised during a test, so a scenario can
+/// assert that a wire response was decoded from a genuine <c>Microsoft.Data.SqlClient.SqlException</c>.
+/// </summary>
+/// <remarks>
+/// The authorization executor probes the extractor from more than one exception filter, so the same exception
+/// instance is normally recorded several times; assert on the distinct set.
+/// </remarks>
+public sealed class ApiIntegrationProviderFailureRecorder
+{
+    private readonly object _sync = new();
+    private readonly List<DbException> _providerFailures = [];
+
+    public IReadOnlyList<DbException> ProviderFailures
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return [.. _providerFailures];
+            }
+        }
+    }
+
+    public void Record(DbException exception)
+    {
+        lock (_sync)
+        {
+            _providerFailures.Add(exception);
+        }
+    }
+}
+
+/// <summary>
+/// Test-only extractor seam for the in-process API host. It records the real provider exception the production
+/// authorization path raised and optionally rewrites the extracted payload, so a scenario can drive a
+/// malformed or unmappable AUTH1 payload through the production mapper without altering production SQL.
+/// </summary>
+/// <remarks>
+/// Registered only when a test class supplies a transform, so the default extraction stays in place for every
+/// other API integration test.
+/// </remarks>
+internal sealed class RecordingProviderFailureExtractor(
+    ApiIntegrationProviderFailureRecorder recorder,
+    Func<RelationshipAuthorizationProviderFailure, RelationshipAuthorizationProviderFailure> transform
+) : IRelationshipAuthorizationProviderFailureExtractor
+{
+    private readonly ApiIntegrationProviderFailureRecorder _recorder =
+        recorder ?? throw new ArgumentNullException(nameof(recorder));
+    private readonly Func<
+        RelationshipAuthorizationProviderFailure,
+        RelationshipAuthorizationProviderFailure
+    > _transform = transform ?? throw new ArgumentNullException(nameof(transform));
+
+    public RelationshipAuthorizationProviderFailure Extract(DbException exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        _recorder.Record(exception);
+
+        return _transform(new RelationshipAuthorizationProviderFailure(null, exception.Message));
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/NamespaceAuthorizationProblemDetailsScenario.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Scenarios/NamespaceAuthorizationProblemDetailsScenario.cs
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Net;
+using System.Text;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Backend;
+using EdFi.DataManagementService.Core.External.Security;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Doubles;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+
+namespace EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+/// <summary>
+/// Public-boundary coverage for NamespaceBased authorization: the exact ProblemDetails wire contracts from
+/// <c>auth.md</c> §2.10–§2.12, the 403-over-412 collision ordering, and the sanitized 500 envelope a malformed
+/// AUTH1 payload must produce. The provider-integration matrix lives in the backend suites; this scenario owns
+/// only what those cannot observe — the served response body and the real JWT/claim-set prefix plumbing.
+/// </summary>
+internal static class NamespaceAuthorizationProblemDetailsScenario
+{
+    public const string AuthorizedPrefix = "uri://ns1.org/";
+    public const string SecondAuthorizedPrefix = "uri://ns2.org/";
+    private const string UnauthorizedNamespace = "uri://other.example/assessments";
+
+    /// <summary>Configured prefixes as the failure formatter renders them: deduplicated and ordinal-sorted.</summary>
+    public static IReadOnlyList<string> ConfiguredPrefixes { get; } =
+    [AuthorizedPrefix, SecondAuthorizedPrefix];
+
+    private const string NamespaceResourcesEndpoint = "/data/authz/authorizationNamespaceResources";
+    private const string SchoolsEndpoint = "/data/ed-fi/schools";
+    private const string EducationOrganizationCategoryDescriptorsEndpoint =
+        "/data/ed-fi/educationOrganizationCategoryDescriptors";
+    private const string GradeLevelDescriptorsEndpoint = "/data/ed-fi/gradeLevelDescriptors";
+
+    private const int SchoolId = 100;
+
+    private const string MismatchType =
+        "urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-mismatch";
+    private const string StoredUninitializedType =
+        "urn:ed-fi:api:security:authorization:namespace:invalid-data:namespace-uninitialized";
+    private const string ProposedRequiredType =
+        "urn:ed-fi:api:security:authorization:namespace:access-denied:namespace-required";
+    private const string SecurityConfigurationType = "urn:ed-fi:api:system:configuration:security";
+
+    private static readonly string[] _noFurtherAuthorizationRequiredStrategy =
+    [
+        AuthorizationStrategyNameConstants.NoFurtherAuthorizationRequired,
+    ];
+
+    private static readonly string[] _namespaceBasedStrategy =
+    [
+        AuthorizationStrategyNameConstants.NamespaceBased,
+    ];
+
+    /// <summary>
+    /// Rewrites the extracted AUTH1 payload to a namespace payload whose emitted index exceeds the planned
+    /// checks, so it decodes as a namespace payload but cannot be mapped onto the plan. Applied only after the
+    /// production authorization SQL has already raised a real provider exception.
+    /// </summary>
+    public static RelationshipAuthorizationProviderFailure ToUnmappablePayload(
+        RelationshipAuthorizationProviderFailure providerFailure
+    ) =>
+        providerFailure with
+        {
+            Message =
+                "Conversion failed when converting the varchar value 'AUTH1 - ns1|9|m' to data type int.",
+        };
+
+    /// <summary>
+    /// Reads, updates, and deletes use NamespaceBased while creates stay unauthorized-by-default, so a stored
+    /// row with any namespace — including an omitted one — can be seeded before the denial is exercised.
+    /// </summary>
+    public static IClaimSetProvider CreateReadUpdateDeleteClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            create: _noFurtherAuthorizationRequiredStrategy,
+            read: _namespaceBasedStrategy,
+            update: _namespaceBasedStrategy,
+            delete: _namespaceBasedStrategy
+        );
+
+    public static IClaimSetProvider CreateCreateClaimSetProvider(FixtureContext fixture) =>
+        CreateClaimSetProvider(
+            fixture,
+            create: _namespaceBasedStrategy,
+            read: _noFurtherAuthorizationRequiredStrategy,
+            update: _noFurtherAuthorizationRequiredStrategy,
+            delete: _noFurtherAuthorizationRequiredStrategy
+        );
+
+    public static async Task It_returns_namespace_mismatch_problem_details_for_get_by_id(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+        var locationPath = await CreateNamespaceResourceAsync(harness, 101, UnauthorizedNamespace);
+
+        using var response = await harness.HttpClient.GetAsync(locationPath);
+
+        // §2.12 against stored data, so the detail includes the word "existing" and lists the caller's
+        // prefixes in the order the formatter renders them.
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            MismatchType,
+            "Authorization Denied",
+            "Access to the requested data could not be authorized. The existing 'Namespace' value of the data "
+                + $"does not start with any of the caller's associated namespace prefixes ('{AuthorizedPrefix}', "
+                + $"'{SecondAuthorizedPrefix}').",
+            expectedErrors: []
+        );
+    }
+
+    public static async Task It_returns_stored_uninitialized_problem_details_for_get_by_id(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+        var locationPath = await CreateNamespaceResourceAsync(harness, 102, storedNamespace: null);
+
+        using var response = await harness.HttpClient.GetAsync(locationPath);
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            StoredUninitializedType,
+            "Authorization Denied",
+            "Access to the requested data could not be authorized. The existing 'Namespace' value has not been "
+                + "assigned but is required for authorization purposes.",
+            expectedErrors:
+            [
+                "The existing resource item is inaccessible to clients using the 'NamespaceBased' authorization "
+                    + "strategy because the 'Namespace' value has not been assigned.",
+            ]
+        );
+    }
+
+    public static async Task It_returns_proposed_namespace_required_problem_details_for_post_create(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+
+        // The synthetic resource's namespace is optional, so an omitted value passes JSON schema validation and
+        // reaches namespace authorization rather than being intercepted as a validation error.
+        using var response = await PostJsonAsync(
+            harness,
+            NamespaceResourcesEndpoint,
+            CreateNamespaceResourceBody(103, storedNamespace: null)
+        );
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            ProposedRequiredType,
+            "Authorization Denied",
+            "Access to the requested data could not be authorized. The 'Namespace' value has not been assigned "
+                + "but is required for authorization purposes.",
+            expectedErrors: []
+        );
+    }
+
+    public static async Task It_returns_proposed_namespace_mismatch_problem_details_for_post_create(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+
+        using var response = await PostJsonAsync(
+            harness,
+            NamespaceResourcesEndpoint,
+            CreateNamespaceResourceBody(104, UnauthorizedNamespace)
+        );
+
+        // §2.12 against proposed data omits "existing", which is what distinguishes it from the stored-value
+        // mismatch above.
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            MismatchType,
+            "Authorization Denied",
+            "Access to the requested data could not be authorized. The 'Namespace' value of the data does not "
+                + $"start with any of the caller's associated namespace prefixes ('{AuthorizedPrefix}', "
+                + $"'{SecondAuthorizedPrefix}').",
+            expectedErrors: []
+        );
+    }
+
+    public static async Task It_returns_403_rather_than_412_for_an_unauthorized_delete_with_a_stale_if_match(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+        var locationPath = await CreateNamespaceResourceAsync(harness, 105, UnauthorizedNamespace);
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, locationPath);
+        request.Headers.TryAddWithoutValidation("If-Match", "\"stale-etag\"");
+        using var response = await harness.HttpClient.SendAsync(request);
+
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.Forbidden,
+            MismatchType,
+            "Authorization Denied",
+            "Access to the requested data could not be authorized. The existing 'Namespace' value of the data "
+                + $"does not start with any of the caller's associated namespace prefixes ('{AuthorizedPrefix}', "
+                + $"'{SecondAuthorizedPrefix}').",
+            expectedErrors: []
+        );
+
+        // The target must survive the denied delete.
+        using var getResponse = await harness.HttpClient.GetAsync(locationPath);
+        getResponse.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    public static async Task It_returns_412_for_a_stale_delete_if_match_once_namespace_authorization_passes(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+        var locationPath = await CreateNamespaceResourceAsync(harness, 106, AuthorizedPrefix + "assessments");
+
+        using var request = new HttpRequestMessage(HttpMethod.Delete, locationPath);
+        request.Headers.TryAddWithoutValidation("If-Match", "\"stale-etag\"");
+        using var response = await harness.HttpClient.SendAsync(request);
+
+        var body = await response.Content.ReadAsStringAsync();
+        response
+            .StatusCode.Should()
+            .Be(
+                HttpStatusCode.PreconditionFailed,
+                $"the precondition result must survive once authorization succeeds, but got: {body}"
+            );
+    }
+
+    public static async Task It_returns_a_sanitized_security_configuration_500_for_an_unmappable_payload(
+        ApiIntegrationHarness harness
+    )
+    {
+        await SeedReferenceDataAsync(harness);
+        var locationPath = await CreateNamespaceResourceAsync(harness, 107, UnauthorizedNamespace);
+
+        using var response = await harness.HttpClient.GetAsync(locationPath);
+
+        // The canonical DMS-1099 envelope, in full.
+        await AssertProblemDetailsAsync(
+            response,
+            HttpStatusCode.InternalServerError,
+            SecurityConfigurationType,
+            "Security Configuration Error",
+            "A security configuration problem was detected. The request cannot be authorized.",
+            expectedErrors:
+            [
+                "The namespace authorization failure payload returned by the authorization provider is invalid "
+                    + "and cannot be mapped to the configured namespace authorization plan.",
+            ]
+        );
+
+        // The payload was rewritten only after SQL Server itself raised the conversion failure that the
+        // production compiler's AUTH1 cast provokes, so the sanitized response is proved to come from a real
+        // provider exception rather than a stubbed one.
+        var providerFailures =
+            harness.ProviderFailureRecorder?.ProviderFailures
+            ?? throw new InvalidOperationException(
+                "The provider failure recorder must be enabled for this scenario."
+            );
+        providerFailures
+            .Distinct()
+            .Should()
+            .ContainSingle("every exception filter must probe the one real provider exception");
+        var sqlException = providerFailures[0].Should().BeOfType<SqlException>().Subject;
+        sqlException.Number.Should().Be(245);
+        sqlException.Message.Should().Contain("AUTH1 - ns1|0|m");
+    }
+
+    private static IClaimSetProvider CreateClaimSetProvider(
+        FixtureContext fixture,
+        IReadOnlyList<string> create,
+        IReadOnlyList<string> read,
+        IReadOnlyList<string> update,
+        IReadOnlyList<string> delete
+    ) =>
+        new ConfigurableClaimSetProvider(
+            fixture,
+            (resource, action) =>
+                !string.Equals(
+                    resource.ResourceName,
+                    "AuthorizationNamespaceResource",
+                    StringComparison.Ordinal
+                )
+                    ? _noFurtherAuthorizationRequiredStrategy
+                    : action switch
+                    {
+                        "Create" => create,
+                        "Read" => read,
+                        "Update" => update,
+                        "Delete" => delete,
+                        _ => _noFurtherAuthorizationRequiredStrategy,
+                    }
+        );
+
+    private static async Task SeedReferenceDataAsync(ApiIntegrationHarness harness)
+    {
+        await CreateDescriptorAsync(
+            harness,
+            EducationOrganizationCategoryDescriptorsEndpoint,
+            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor",
+            "School"
+        );
+        await CreateDescriptorAsync(
+            harness,
+            GradeLevelDescriptorsEndpoint,
+            "uri://ed-fi.org/GradeLevelDescriptor",
+            "Tenth grade"
+        );
+        await CreateSchoolAsync(harness);
+    }
+
+    private static async Task CreateDescriptorAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        string @namespace,
+        string codeValue
+    )
+    {
+        using var response = await PostJsonAsync(
+            harness,
+            endpoint,
+            new JsonObject
+            {
+                ["codeValue"] = codeValue,
+                ["description"] = codeValue,
+                ["namespace"] = @namespace,
+                ["shortDescription"] = codeValue,
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, await response.Content.ReadAsStringAsync());
+    }
+
+    private static async Task CreateSchoolAsync(ApiIntegrationHarness harness)
+    {
+        using var response = await PostJsonAsync(
+            harness,
+            SchoolsEndpoint,
+            new JsonObject
+            {
+                ["schoolId"] = SchoolId,
+                ["nameOfInstitution"] = "North School",
+                ["educationOrganizationCategories"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["educationOrganizationCategoryDescriptor"] =
+                            "uri://ed-fi.org/EducationOrganizationCategoryDescriptor#School",
+                    }
+                ),
+                ["gradeLevels"] = new JsonArray(
+                    new JsonObject
+                    {
+                        ["gradeLevelDescriptor"] = "uri://ed-fi.org/GradeLevelDescriptor#Tenth grade",
+                    }
+                ),
+            }
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, await response.Content.ReadAsStringAsync());
+    }
+
+    private static async Task<string> CreateNamespaceResourceAsync(
+        ApiIntegrationHarness harness,
+        int authorizationNamespaceId,
+        string? storedNamespace
+    )
+    {
+        using var response = await PostJsonAsync(
+            harness,
+            NamespaceResourcesEndpoint,
+            CreateNamespaceResourceBody(authorizationNamespaceId, storedNamespace)
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, await response.Content.ReadAsStringAsync());
+        response.Headers.Location.Should().NotBeNull();
+
+        return response.Headers.Location!.IsAbsoluteUri
+            ? response.Headers.Location.AbsolutePath
+            : response.Headers.Location.OriginalString;
+    }
+
+    private static JsonObject CreateNamespaceResourceBody(
+        int authorizationNamespaceId,
+        string? storedNamespace
+    )
+    {
+        JsonObject body = new()
+        {
+            ["authorizationNamespaceId"] = authorizationNamespaceId,
+            ["name"] = $"namespace-problem-details-{authorizationNamespaceId}",
+            ["schoolReference"] = new JsonObject { ["schoolId"] = SchoolId },
+            ["classPeriods"] = new JsonArray(),
+        };
+
+        if (storedNamespace is not null)
+        {
+            body["namespace"] = storedNamespace;
+        }
+
+        return body;
+    }
+
+    private static async Task<HttpResponseMessage> PostJsonAsync(
+        ApiIntegrationHarness harness,
+        string endpoint,
+        JsonObject body
+    )
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(body.ToJsonString(), Encoding.UTF8, "application/json"),
+        };
+
+        return await harness.HttpClient.SendAsync(request);
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        HttpStatusCode expectedStatusCode,
+        string expectedType,
+        string expectedTitle,
+        string expectedDetail,
+        IReadOnlyList<string> expectedErrors
+    )
+    {
+        var body = await response.Content.ReadAsStringAsync();
+
+        response.StatusCode.Should().Be(expectedStatusCode, body);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/problem+json");
+
+        var problem = JsonNode.Parse(body)!.AsObject();
+        problem["type"]!.GetValue<string>().Should().Be(expectedType);
+        problem["title"]!.GetValue<string>().Should().Be(expectedTitle);
+        problem["status"]!.GetValue<int>().Should().Be((int)expectedStatusCode);
+        problem["detail"]!.GetValue<string>().Should().Be(expectedDetail);
+        problem["correlationId"]!.GetValue<string>().Should().NotBeNullOrWhiteSpace();
+        problem["validationErrors"]!.AsObject().Count.Should().Be(0);
+        problem["errors"]!
+            .AsArray()
+            .Select(static error => error!.GetValue<string>())
+            .Should()
+            .Equal(expectedErrors);
+
+        AssertNoProviderDetailLeaked(body);
+    }
+
+    /// <summary>
+    /// The served body must never carry provider or SQL internals, whether the response was produced from a
+    /// decoded AUTH1 payload or from the sanitized security-configuration fallback.
+    /// </summary>
+    private static void AssertNoProviderDetailLeaked(string body)
+    {
+        string[] forbiddenFragments =
+        [
+            "AUTH1",
+            "ns1|",
+            "Conversion failed",
+            "varchar",
+            "SqlException",
+            "Microsoft.Data.SqlClient",
+            "CAST(",
+            "SELECT ",
+            "dms.",
+            "authz.",
+            "   at ",
+        ];
+
+        foreach (var fragment in forbiddenFragments)
+        {
+            body.Should()
+                .NotContain(fragment, $"the served response must not leak provider detail '{fragment}'");
+        }
+    }
+}

--- a/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_NamespaceAuthorizationProblemDetails.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.Integration/Tests/Mssql/Given_Mssql_NamespaceAuthorizationProblemDetails.cs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend;
+using EdFi.DataManagementService.Core.Security;
+using EdFi.DataManagementService.Tests.Integration.Fixtures;
+using EdFi.DataManagementService.Tests.Integration.Mssql;
+using EdFi.DataManagementService.Tests.Integration.Scenarios;
+
+namespace EdFi.DataManagementService.Tests.Integration.Tests.Mssql;
+
+/// <summary>
+/// NamespaceBased ProblemDetails at the public HTTP boundary against SQL Server, for stored-value denials and
+/// the DELETE authorization-before-precondition ordering.
+/// </summary>
+public sealed class Given_Mssql_NamespaceAuthorizationProblemDetails_For_Read_And_Delete
+    : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    protected override bool BypassAuthorization => false;
+
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        NamespaceAuthorizationProblemDetailsScenario.ConfiguredPrefixes;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        NamespaceAuthorizationProblemDetailsScenario.CreateReadUpdateDeleteClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_namespace_mismatch_problem_details_for_get_by_id() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_namespace_mismatch_problem_details_for_get_by_id(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_stored_uninitialized_problem_details_for_get_by_id() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_stored_uninitialized_problem_details_for_get_by_id(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_403_rather_than_412_for_an_unauthorized_delete_with_a_stale_if_match() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_403_rather_than_412_for_an_unauthorized_delete_with_a_stale_if_match(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_412_for_a_stale_delete_if_match_once_namespace_authorization_passes() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_412_for_a_stale_delete_if_match_once_namespace_authorization_passes(
+            Harness
+        );
+}
+
+/// <summary>
+/// NamespaceBased ProblemDetails for proposed values on POST create, where the omitted-namespace case proves a
+/// missing proposed value reaches authorization through the real pipeline rather than being intercepted by JSON
+/// schema validation.
+/// </summary>
+public sealed class Given_Mssql_NamespaceAuthorizationProblemDetails_For_Create : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    protected override bool BypassAuthorization => false;
+
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        NamespaceAuthorizationProblemDetailsScenario.ConfiguredPrefixes;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        NamespaceAuthorizationProblemDetailsScenario.CreateCreateClaimSetProvider(fixture);
+
+    [Test]
+    public Task It_returns_proposed_namespace_required_problem_details_for_post_create() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_proposed_namespace_required_problem_details_for_post_create(
+            Harness
+        );
+
+    [Test]
+    public Task It_returns_proposed_namespace_mismatch_problem_details_for_post_create() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_proposed_namespace_mismatch_problem_details_for_post_create(
+            Harness
+        );
+}
+
+/// <summary>
+/// The sanitized 500 a malformed AUTH1 payload must produce at the wire boundary. The request raises a genuine
+/// SQL Server exception through the production authorization SQL; only the extracted payload is rewritten, by
+/// the opt-in test seam.
+/// </summary>
+public sealed class Given_Mssql_NamespaceAuthorizationProblemDetails_For_An_Unmappable_Auth1_Payload
+    : MssqlApiIntegrationTestBase
+{
+    protected override FixtureKey Fixture => FixtureKey.AuthorizationQuery;
+
+    protected override bool BypassAuthorization => false;
+
+    protected override IReadOnlyList<string> ClientNamespacePrefixes =>
+        NamespaceAuthorizationProblemDetailsScenario.ConfiguredPrefixes;
+
+    protected override IClaimSetProvider CreateClaimSetProvider(FixtureContext fixture) =>
+        NamespaceAuthorizationProblemDetailsScenario.CreateReadUpdateDeleteClaimSetProvider(fixture);
+
+    protected override Func<
+        RelationshipAuthorizationProviderFailure,
+        RelationshipAuthorizationProviderFailure
+    >? ProviderFailureTransform => NamespaceAuthorizationProblemDetailsScenario.ToUnmappablePayload;
+
+    [Test]
+    public Task It_returns_a_sanitized_security_configuration_500_for_an_unmappable_payload() =>
+        NamespaceAuthorizationProblemDetailsScenario.It_returns_a_sanitized_security_configuration_500_for_an_unmappable_payload(
+            Harness
+        );
+}


### PR DESCRIPTION
## What

Adds real-SQL-Server integration coverage for NamespaceBased CRUD authorization through the production MSSQL backend, closing DMS-1286.

## Why

DMS-1057 implemented NamespaceBased authorization for both engines, but shared compiler and unit coverage cannot certify the MSSQL provider boundary: provider exception decoding, authorization/mutation ordering, SQL Server parameter limits, and rollback safety. Per the design ([`06-mssql-namespace-authorization-coverage.md`](reference/design/backend-redesign/epics/17-mssql-gap-closure/06-mssql-namespace-authorization-coverage.md)), this story validates that boundary against a real engine and fixes only defects required to preserve the existing contract.

No defect was found, so this PR changes no production code. 60 tests, 17 files, all tests/fixtures/test-harness.

## Changes

Fixture

- Adds `Authz.AuthorizationNamespaceResource` to the shared `authorization-query` synthetic extension. Its root table carries an optional (nullable) `Namespace` securable column plus a root EducationOrganization securable column and a ClassPeriod child collection, so one resource covers NamespaceBased-only and composed NamespaceBased/relationship scenarios, null and empty stored namespaces, a missing proposed namespace, and child-row state snapshots. No authoritative resource can express a nullable root namespace, since `namespace` is required on all of them.
- `AuthorizationRootChildResource` is untouched, preserving its fail-closed "no usable root Namespace column" coverage.

Backend test harness (all additions opt-in, defaults preserve existing behavior)

- Namespace prefixes threaded through the MSSQL authorization context's query, get-by-id, delete, upsert, and update helpers, plus seed/upsert/update/snapshot/referential-identity helpers for the new resource and thin descriptor POST/PUT wrappers.
- A provider-failure observer on the existing extractor seam, so a test can assert genuine `SqlException` provenance alongside the existing payload transform.
- A one-shot read-target-lookup interceptor that runs the production lookup and then opens the window a stored namespace check must tolerate.
- `MssqlNamespaceAuthorizationCommandAssertions`: the generic no-mutation proof. Because `SessionRelationalCommandExecutor.ForSession` routes every write-session command through `IRelationalWriteSession.CreateCommand` and no bulk-copy path exists, the absence of persistence DML establishes that no document, root, child, extension, referential identity, or tracking row changed. The boundary is the final namespace authorization command and, within it, the last namespace marker, so co-batching is tolerated without masking bad ordering. Nine database-free tests cover the ordering cases.

Backend coverage against real SQL Server

- Reads: matching prefixes included and nonmatching, null, and empty excluded from both page and `totalCount`; a page window that lands on the wrong rows unless authorization filters before paging; typed mismatch and stored-uninitialized denials with no hydration; a target deleted between the unlocked lookup and the check resolving to 404 rather than a namespace denial; 1,999 prefixes executing with one scalar parameter each, 2,000 failing closed at the prefix cap, and 1,500 prefixes composed with 599 claim education organization ids failing closed at SQL Server's per-command ceiling; NamespaceBased proved to AND around the relationship OR group.
- Writes: POST create, PUT, POST-as-update, and DELETE. Each denial asserts the typed failure's value source (a proposed failure is only reachable once the stored check passed), a complete before/after authoritative state snapshot compared with strict ordering, and the no-DML boundary. Authorization before `If-Match` is proved as a pair on each surface: with the same stale etag, an unauthorized namespace returns 403 while an authorized one returns 412. DELETE additionally asserts lock, then authorization, then delete inside one guarded session.
- Descriptors: issued through `RelationalDocumentStoreRepository` so the routing into `DescriptorReadHandler`/`DescriptorWriteHandler` is exercised rather than bypassed. Covers GET-by-id, GET-many filtering, POST create, PUT, POST-as-update, and DELETE, comparing both authoritative rows including the descriptor's own tracking columns and probing descriptor absence independently of `dms.Document`.
- Provider failures: a real mismatch raises a genuine `SqlException` (error 245) carrying `AUTH1 - ns1|...`; the existing test-only extractor seam then rewrites the extracted payload to an unmappable value, and the request fails closed with the canonical security-configuration message and diagnostics.

API test harness and coverage

- `FakeJwtValidationService` gains optional namespace prefixes, surfaced through `ExternalDoublesRegistration` and a `ClientNamespacePrefixes` hook defaulting to none.
- A `ProviderFailureTransform` hook, null by default, replaces the authorization provider-failure extractor with a recording double. The production extractor is registered with `TryAdd` before `ConfigureServices` runs, so the existing registration is removed rather than merely attempted.
- Seven MSSQL API tests assert the exact `auth.md` 2.10, 2.11, and 2.12 wire contracts (including the `existing` wording that separates stored from proposed mismatch), 403-before-412 on DELETE paired with 412 once authorization passes, a missing proposed namespace reaching authorization rather than JSON schema validation, and the complete canonical 500 envelope for a malformed AUTH1 payload. Every body is checked to leak no AUTH1 marker, payload, conversion text, provider or exception type name, SQL fragment, schema-qualified table name, or stack frame.

Production invariants documented rather than asserted, because production makes them unreachable

- A missing descriptor `namespace` cannot reach authorization: it is required on every Ed-Fi descriptor, so JSON schema validation is that boundary and `DescriptorWriteBodyExtractor` treats its absence as an internal pipeline bug. The authorization path for a missing proposed value is covered on the ordinary-resource suite.
- A proposed-value denial on descriptor POST-as-update is structurally unreachable, because a descriptor's identity is its uri, `namespace#codeValue`, so a POST carrying a different namespace addresses a different descriptor and takes the create path.

Non-goals honored

- No production, workflow, E2E, parity-catalog, or PostgreSQL-specific changes. No namespace-prefix TVP. No new PostgreSQL tests: existing PostgreSQL behavior is the regression baseline and both complete API lanes plus the PostgreSQL authorization suite were run unchanged. New fixtures reuse existing CI shard categories, so no workflow change is needed.

## Verification

Run locally against SQL Server 2025 and PostgreSQL 16 containers:

- MSSQL backend authorization suite: 151 passed
- Complete MSSQL API integration lane: 82 passed (75 before this branch)
- Complete PostgreSQL API integration lane: 71 passed, unchanged
- PostgreSQL backend authorization suite: 99 passed
- Shard guardrails, parity-catalog resolution, DDL and namespace unit suites: passed
- `dotnet csharpier check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
