### PR TITLE
[DMS-1383] Cursor Contract Primitives

### DIFF
--- a/eng/azure-vm/compose/docker-compose.yml
+++ b/eng/azure-vm/compose/docker-compose.yml
@@ -42,6 +42,7 @@ x-dms-common-env: &dms-common-env
   OtlpLogging__DeploymentEnvironment: "${OTLP_LOGGING_DEPLOYMENT_ENVIRONMENT:-}"
   AppSettings__MaskRequestBodyInLogs: "true"
   AppSettings__MaximumPageSize: "500"
+  AppSettings__DefaultPartitionCount: "${DEFAULT_PARTITION_COUNT:-10}"
   RateLimit__PermitLimit: "${DMS_RATE_LIMIT_PERMIT_LIMIT:-20000}"
   RateLimit__QueueLimit: "${DMS_RATE_LIMIT_QUEUE_LIMIT:-0}"
   RateLimit__Window: "${DMS_RATE_LIMIT_WINDOW:-10}"

--- a/eng/docker-compose/local-dms.yml
+++ b/eng/docker-compose/local-dms.yml
@@ -24,6 +24,7 @@ services:
       # Mask incoming HTTP POST and PUT request body structures in DEBUG logging
       AppSettings__MaskRequestBodyInLogs: ${MASK_REQUEST_BODY_IN_LOGS:-true}
       AppSettings__MaximumPageSize: ${MAXIMUM_PAGE_SIZE:-500}
+      AppSettings__DefaultPartitionCount: ${DEFAULT_PARTITION_COUNT:-10}
       # Segment of the url to use as base for all request. The default path base is deliberately blank on the following line
       AppSettings__PathBase: ${PATH_BASE:-}
       AppSettings__ReverseProxy__UseForwardedHeaders: ${USE_REVERSE_PROXY_HEADERS:-false}

--- a/eng/docker-compose/published-dms.yml
+++ b/eng/docker-compose/published-dms.yml
@@ -19,6 +19,7 @@ services:
       # Mask incoming HTTP POST and PUT request body structures in DEBUG logging
       AppSettings__MaskRequestBodyInLogs: ${MASK_REQUEST_BODY_IN_LOGS:-true}
       AppSettings__MaximumPageSize: ${MAXIMUM_PAGE_SIZE:-500}
+      AppSettings__DefaultPartitionCount: ${DEFAULT_PARTITION_COUNT:-10}
       # Segment of the url to use as base for all request. The default path base is deliberately blank on the following line
       AppSettings__PathBase: ${PATH_BASE:-}
       AppSettings__ReverseProxy__UseForwardedHeaders: ${USE_REVERSE_PROXY_HEADERS:-false}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/HydrationContracts.cs
@@ -98,6 +98,19 @@ public sealed record HydratedPage(
     /// reconstitution.
     /// </summary>
     public HydratedDocumentReferenceLookup? DocumentReferenceLookup { get; init; }
+
+    /// <summary>
+    /// The maximum <c>DocumentId</c> in the selected page keyset, or <see langword="null"/> when page
+    /// selection was skipped or selected no keys — including authorization, preprocessing, and planner
+    /// early-empty paths, and zero-size pages.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately independent of the hydrated body: every selected row may be deleted before
+    /// hydration completes, so this can be non-null while the body is empty. A body-derived boundary
+    /// would stall a cursor walk on the last surviving document, or stop it entirely on an empty body.
+    /// Populated by hydration execution in a later story.
+    /// </remarks>
+    public long? HighestSelectedDocumentId { get; init; }
 }
 
 /// <summary>

--- a/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.External/RelationalQueryRequestContracts.cs
@@ -92,9 +92,10 @@ public interface IQueryRequest : IRequestWithMappingSet
     AuthorizationStrategyEvaluator[] AuthorizationStrategyEvaluators { get; }
 
     /// <summary>
-    /// The pagination parameters for this query.
+    /// The paging mode and its inputs for this query: traditional limit/offset, or cursor over an
+    /// inclusive DocumentId range.
     /// </summary>
-    PaginationParameters PaginationParameters { get; }
+    CollectionPaging Paging { get; }
 
     /// <summary>
     /// The request TraceId.

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlAbstractEducationOrganizationReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlAbstractEducationOrganizationReferenceLinkInjectionIntegrationTests.cs
@@ -340,11 +340,13 @@ public class Given_A_Mssql_Course_With_Abstract_EducationOrganization_Reference
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-29b-query-course")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlAuthorizationLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlAuthorizationLinkInjectionIntegrationTests.cs
@@ -352,11 +352,13 @@ public class Given_A_Mssql_AcademicWeek_Read_With_Different_Caller_Authorization
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-32-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionAlignedExtensionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlCollectionAlignedExtensionReferenceLinkInjectionIntegrationTests.cs
@@ -310,11 +310,13 @@ public class Given_A_Mssql_ParentResource_With_Collection_Aligned_Extension_Spon
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-29d-query-parentresource")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlDescriptorReadQueryFilterTests.cs
@@ -522,11 +522,13 @@ public class Given_A_Mssql_DescriptorRead_Query_Request
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlExtensionChildCollectionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlExtensionChildCollectionReferenceLinkInjectionIntegrationTests.cs
@@ -360,11 +360,13 @@ public class Given_A_Mssql_School_With_Extension_Child_Collection_Bus_Reference
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-29e-query-school")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlLinkInjectionIntegrationTests.cs
@@ -345,11 +345,13 @@ public class Given_A_Mssql_AcademicWeek_To_School_Reference_With_Link_Injection
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-link-injection-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNestedCollectionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlNestedCollectionReferenceLinkInjectionIntegrationTests.cs
@@ -420,11 +420,13 @@ public class Given_A_Mssql_BellSchedule_With_Nested_Collection_ClassPeriod_Refer
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-29c-query-bellschedule")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlOrphanedReferenceLinkSuppressionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlOrphanedReferenceLinkSuppressionIntegrationTests.cs
@@ -335,11 +335,13 @@ public class Given_A_Mssql_AcademicWeek_With_Orphaned_School_Reference
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-30-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlProfileIfMatchEtagTests.cs
@@ -157,11 +157,13 @@ file static class MssqlProfileIfMatchEtagTestSupport
             MappingSet: mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: MaximumPageSize,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: MaximumPageSize,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ReadableProfileProjectionContext: readableProfileProjectionContext

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryAuthorizationTests.cs
@@ -1359,11 +1359,13 @@ internal sealed class MssqlRelationalQueryAuthorizationTestContext : IAsyncDispo
                     FilterOperator.And
                 )),
             ],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId($"{resourceName}-authorization-query"),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlRelationalQueryExecutionTests.cs
@@ -652,11 +652,13 @@ public class Given_A_Mssql_Relational_Query_With_The_Authoritative_Sample_School
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlResourceLinksFlagIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Mssql.Tests.Integration/MssqlResourceLinksFlagIntegrationTests.cs
@@ -396,11 +396,13 @@ public class Given_A_Mssql_AcademicWeek_When_The_ResourceLinks_Flag_Is_Flipped_A
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("mssql-31-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlAbstractEducationOrganizationReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlAbstractEducationOrganizationReferenceLinkInjectionIntegrationTests.cs
@@ -340,11 +340,13 @@ public class Given_A_Postgresql_Course_With_Abstract_EducationOrganization_Refer
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-29b-query-course")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlAuthorizationLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlAuthorizationLinkInjectionIntegrationTests.cs
@@ -357,11 +357,13 @@ public class Given_A_Postgresql_AcademicWeek_Read_With_Different_Caller_Authoriz
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-32-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCollectionAlignedExtensionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlCollectionAlignedExtensionReferenceLinkInjectionIntegrationTests.cs
@@ -301,11 +301,13 @@ public class Given_A_Postgresql_ParentResource_With_Collection_Aligned_Extension
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-29d-query-parentresource")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlDescriptorReadQueryFilterTests.cs
@@ -510,11 +510,13 @@ public class Given_A_Postgresql_DescriptorRead_Query_Request
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlExtensionChildCollectionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlExtensionChildCollectionReferenceLinkInjectionIntegrationTests.cs
@@ -357,11 +357,13 @@ public class Given_A_Postgresql_School_With_Extension_Child_Collection_Bus_Refer
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-29e-query-school")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlLinkInjectionIntegrationTests.cs
@@ -337,11 +337,13 @@ public class Given_A_Postgresql_AcademicWeek_To_School_Reference_With_Link_Injec
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-link-injection-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNestedCollectionReferenceLinkInjectionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlNestedCollectionReferenceLinkInjectionIntegrationTests.cs
@@ -415,11 +415,13 @@ public class Given_A_Postgresql_BellSchedule_With_Nested_Collection_ClassPeriod_
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-29c-query-bellschedule")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlOrphanedReferenceLinkSuppressionIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlOrphanedReferenceLinkSuppressionIntegrationTests.cs
@@ -340,11 +340,13 @@ public class Given_A_Postgresql_AcademicWeek_With_Orphaned_School_Reference
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-30-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlProfileIfMatchEtagTests.cs
@@ -158,11 +158,13 @@ file static class PostgresqlProfileIfMatchEtagTestSupport
             MappingSet: mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: MaximumPageSize,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: MaximumPageSize,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ReadableProfileProjectionContext: readableProfileProjectionContext

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryAuthorizationTests.cs
@@ -963,11 +963,13 @@ internal sealed class PostgresqlRelationalQueryAuthorizationTestContext : IAsync
                     FilterOperator.And
                 )),
             ],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId($"{resourceName}-authorization-query"),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlRelationalQueryExecutionTests.cs
@@ -687,11 +687,13 @@ public class Given_A_Postgresql_Relational_Query_With_The_Authoritative_Ds52_Sch
             MappingSet: _mappingSet,
             QueryElements: queryElements,
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: limit,
-                Offset: offset,
-                TotalCount: totalCount,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: limit,
+                    Offset: offset,
+                    TotalCount: totalCount,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId(traceId),
             ChangeVersionRange: changeVersionRange

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlResourceLinksFlagIntegrationTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Postgresql.Tests.Integration/PostgresqlResourceLinksFlagIntegrationTests.cs
@@ -394,11 +394,13 @@ public class Given_A_Postgresql_AcademicWeek_When_The_ResourceLinks_Flag_Is_Flip
             MappingSet: _mappingSet,
             QueryElements: [],
             AuthorizationStrategyEvaluators: [],
-            PaginationParameters: new PaginationParameters(
-                Limit: 25,
-                Offset: 0,
-                TotalCount: false,
-                MaximumPageSize: MaximumPageSize
+            Paging: new CollectionPaging.Traditional(
+                new PaginationParameters(
+                    Limit: 25,
+                    Offset: 0,
+                    TotalCount: false,
+                    MaximumPageSize: MaximumPageSize
+                )
             ),
             TraceId: new TraceId("pg-31-query-academicweek")
         );

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/HydrationContractsTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/HydrationContractsTests.cs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Backend.External;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Backend.Tests.Unit;
+
+/// <summary>
+/// The hydrated page carries the maximum DocumentId of the selected page keyset alongside, and
+/// independent of, the hydrated body. Hydration execution populates it in a later story.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_A_Hydrated_Page
+{
+    private HydratedPage _page = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _page = new HydratedPage(TotalCount: null, DocumentMetadata: [], [], []);
+    }
+
+    [Test]
+    public void It_has_no_selected_keyset_boundary_by_default()
+    {
+        _page.HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public void It_accepts_a_selected_keyset_boundary()
+    {
+        HydratedPage withBoundary = _page with { HighestSelectedDocumentId = 2509 };
+
+        withBoundary.HighestSelectedDocumentId.Should().Be(2509);
+    }
+
+    [Test]
+    public void It_keeps_the_selected_keyset_boundary_independent_of_the_hydrated_body()
+    {
+        HydratedPage withBoundary = _page with { HighestSelectedDocumentId = 2509 };
+
+        withBoundary.DocumentMetadata.Should().BeEmpty();
+        withBoundary.HighestSelectedDocumentId.Should().Be(2509);
+    }
+
+    [Test]
+    public void It_carries_the_boundary_as_a_nullable_long()
+    {
+        typeof(HydratedPage)
+            .GetProperty(nameof(HydratedPage.HighestSelectedDocumentId))!
+            .PropertyType.Should()
+            .Be<long?>();
+    }
+}

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -2926,6 +2926,139 @@ public class Given_RelationalDocumentStoreRepositoryTests
             .MustNotHaveHappened();
     }
 
+    [Test]
+    public async Task It_carries_the_hydrated_selected_keyset_boundary_into_the_query_success()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("beefbeef-1111-2222-3333-cdcdcdcdcdcd"));
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(mappingSet, [], totalCount: false);
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 91L),
+            (345L, "Lincoln High")
+        ) with
+        {
+            HighestSelectedDocumentId = 2509L,
+        };
+
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([
+                new MaterializedDocument(
+                    hydratedPage.DocumentMetadata[0],
+                    JsonNode.Parse($$"""{"id":"{{documentUuid.Value}}"}""")!
+                ),
+            ]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+        success.EdfiDocs.Should().ContainSingle();
+    }
+
+    // The boundary comes from the selected keyset, not the hydrated body, so it must survive a page
+    // whose every selected row was deleted before hydration completed. A body-derived boundary would
+    // stop a cursor walk here instead of advancing past the deleted rows.
+    [Test]
+    public async Task It_carries_the_hydrated_boundary_into_the_query_success_with_an_empty_body()
+    {
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(mappingSet, [], totalCount: false);
+        var hydratedPage = new HydratedPage(null, [], [new HydratedTableRows(readPlan.Model.Root, [])], [])
+        {
+            HighestSelectedDocumentId = 2509L,
+        };
+
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().Be(2509L);
+        success.EdfiDocs.Should().BeEmpty();
+    }
+
+    [Test]
+    public async Task It_leaves_the_query_success_boundary_null_when_hydration_reports_none()
+    {
+        var documentUuid = new DocumentUuid(Guid.Parse("beefbeef-4444-5555-6666-cdcdcdcdcdcd"));
+        var mappingSet = CreateQuerySupportedMappingSet(
+            _schoolResourceInfo,
+            CreateSupportedQueryField(
+                "name",
+                "$.name",
+                "string",
+                new RelationalQueryFieldTarget.RootColumn(new DbColumnName("Name"))
+            )
+        );
+        var readPlan = mappingSet.ReadPlansByResource[new QualifiedResourceName("Ed-Fi", "School")];
+        var queryRequest = CreateQueryRequest(mappingSet, [], totalCount: false);
+        var hydratedPage = CreateHydratedPage(
+            readPlan,
+            CreateDocumentMetadataRow(documentUuid, 345L, 91L),
+            (345L, "Lincoln High")
+        );
+
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    readPlan,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
+            .Returns(hydratedPage);
+        A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
+            .Returns([
+                new MaterializedDocument(
+                    hydratedPage.DocumentMetadata[0],
+                    JsonNode.Parse($$"""{"id":"{{documentUuid.Value}}"}""")!
+                ),
+            ]);
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        var success = result.Should().BeOfType<QueryResult.QuerySuccess>().Subject;
+        success.HighestSelectedDocumentId.Should().BeNull();
+    }
+
     [TestCase("1.5")]
     [TestCase("2147483648")]
     public async Task It_returns_an_empty_query_success_when_integer_number_filter_values_cannot_match(

--- a/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend.Tests.Unit/RelationalDocumentStoreRepositoryTests.cs
@@ -2653,7 +2653,9 @@ public class Given_RelationalDocumentStoreRepositoryTests
         capturedRequest.MappingSet.Should().BeSameAs(mappingSet);
         capturedRequest.Resource.Should().Be(new QualifiedResourceName("Ed-Fi", "SchoolTypeDescriptor"));
         capturedRequest.QueryElements.Should().BeSameAs(queryElements);
-        capturedRequest.PaginationParameters.Should().Be(queryRequest.PaginationParameters);
+        capturedRequest
+            .PaginationParameters.Should()
+            .Be(((CollectionPaging.Traditional)queryRequest.Paging).Parameters);
         capturedRequest.AuthorizationStrategyEvaluators.Should().BeSameAs(authorizationStrategyEvaluators);
         capturedRequest.ReadableProfileProjectionContext.Should().BeSameAs(projectionContext);
         capturedRequest.TraceId.Value.Should().Be("query-trace");
@@ -2675,6 +2677,46 @@ public class Given_RelationalDocumentStoreRepositoryTests
         A.CallTo(() => _readMaterializer.MaterializePage(A<RelationalReadPageMaterializationRequest>._))
             .MustNotHaveHappened();
         A.CallTo(() => _readMaterializer.Materialize(A<RelationalReadMaterializationRequest>._))
+            .MustNotHaveHappened();
+    }
+
+    [Test]
+    public async Task It_declines_a_cursor_paged_query_until_cursor_page_selection_is_implemented()
+    {
+        var queryRequest = A.Fake<IQueryRequest>();
+        A.CallTo(() => queryRequest.Paging)
+            .Returns(new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100)));
+
+        var result = await _sut.QueryDocuments(queryRequest);
+
+        result
+            .Should()
+            .BeOfType<QueryResult.QueryFailureNotImplemented>()
+            .Which.FailureMessage.Should()
+            .Be("Cursor paging is not yet supported for relational queries.");
+    }
+
+    [Test]
+    public async Task It_declines_a_cursor_paged_query_before_resolving_any_read_dependency()
+    {
+        var queryRequest = A.Fake<IQueryRequest>();
+        A.CallTo(() => queryRequest.Paging)
+            .Returns(new CollectionPaging.Cursor(CursorRange.From(1), new PageSize(25)));
+
+        await _sut.QueryDocuments(queryRequest);
+
+        A.CallTo(() =>
+                _descriptorReadHandler.HandleQueryAsync(A<DescriptorQueryRequest>._, A<CancellationToken>._)
+            )
+            .MustNotHaveHappened();
+        A.CallTo(() =>
+                _documentHydrator.HydrateAsync(
+                    A<ResourceReadPlan>._,
+                    A<PageKeysetSpec>._,
+                    A<HydrationExecutionOptions>._,
+                    A<CancellationToken>._
+                )
+            )
             .MustNotHaveHappened();
     }
 
@@ -11241,9 +11283,16 @@ public class Given_RelationalDocumentStoreRepositoryTests
                 new RelationalAuthorizationContext(claimEducationOrganizationIds, namespacePrefixes ?? [])
             );
         A.CallTo(() => queryRequest.AuthorizationStrategyEvaluators).Returns(authorizationStrategyEvaluators);
-        A.CallTo(() => queryRequest.PaginationParameters)
+        A.CallTo(() => queryRequest.Paging)
             .Returns(
-                new PaginationParameters(Limit: 25, Offset: 0, TotalCount: totalCount, MaximumPageSize: 500)
+                new CollectionPaging.Traditional(
+                    new PaginationParameters(
+                        Limit: 25,
+                        Offset: 0,
+                        TotalCount: totalCount,
+                        MaximumPageSize: 500
+                    )
+                )
             );
         A.CallTo(() => queryRequest.TraceId).Returns(new TraceId("query-trace"));
         A.CallTo(() => queryRequest.ReadableProfileProjectionContext)

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -1001,6 +1001,15 @@ public sealed class RelationalDocumentStoreRepository(
     public async Task<QueryResult> QueryDocuments(IQueryRequest queryRequest)
     {
         ArgumentNullException.ThrowIfNull(queryRequest);
+
+        if (queryRequest.Paging is not CollectionPaging.Traditional traditionalPaging)
+        {
+            // Cursor page selection arrives with the shared candidate planner and cursor execution.
+            return new QueryResult.QueryFailureNotImplemented(
+                "Cursor paging is not yet supported for relational queries."
+            );
+        }
+
         var mappingSet = queryRequest.MappingSet;
         var resource = RelationalWriteSupport.ToQualifiedResourceName(queryRequest.ResourceInfo);
 
@@ -1017,7 +1026,7 @@ public sealed class RelationalDocumentStoreRepository(
                         mappingSet,
                         resource,
                         queryRequest.QueryElements,
-                        queryRequest.PaginationParameters,
+                        traditionalPaging.Parameters,
                         queryRequest.AuthorizationStrategyEvaluators,
                         queryRequest.ReadableProfileProjectionContext,
                         queryRequest.TraceId,
@@ -1060,7 +1069,7 @@ public sealed class RelationalDocumentStoreRepository(
             resource,
             configuredAuthorizationStrategies,
             queryRequest.AuthorizationContext,
-            queryRequest.PaginationParameters.TotalCount
+            queryRequest.Paging.IncludesTotalCount
         );
 
         PageDocumentIdAuthorizationSpec? pageQueryAuthorization;
@@ -1101,7 +1110,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         if (preprocessingResult.Outcome is RelationalQueryPreprocessingOutcome.EmptyPage)
         {
-            return new QueryResult.QuerySuccess([], queryRequest.PaginationParameters.TotalCount ? 0 : null);
+            return new QueryResult.QuerySuccess([], queryRequest.Paging.IncludesTotalCount ? 0 : null);
         }
 
         ResourceReadPlan readPlan;
@@ -1133,7 +1142,7 @@ public sealed class RelationalDocumentStoreRepository(
                 !planner.TryPlan(
                     readPlan.Model.Root,
                     preprocessingResult,
-                    queryRequest.PaginationParameters,
+                    traditionalPaging.Parameters,
                     out plannedQuery,
                     out _,
                     authorization: pageQueryAuthorization,
@@ -1141,10 +1150,7 @@ public sealed class RelationalDocumentStoreRepository(
                 ) || plannedQuery is null
             )
             {
-                return new QueryResult.QuerySuccess(
-                    [],
-                    queryRequest.PaginationParameters.TotalCount ? 0 : null
-                );
+                return new QueryResult.QuerySuccess([], queryRequest.Paging.IncludesTotalCount ? 0 : null);
             }
         }
         catch (NotSupportedException ex)
@@ -3953,7 +3959,7 @@ public sealed class RelationalDocumentStoreRepository(
 
         return new QueryResult.QuerySuccess(
             edfiDocs,
-            relationalQueryRequest.PaginationParameters.TotalCount
+            relationalQueryRequest.Paging.IncludesTotalCount
                 ? RelationalReadGuardrails.ConvertTotalCountOrThrow(
                     resource,
                     hydratedPage.TotalCount,

--- a/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
+++ b/src/dms/backend/EdFi.DataManagementService.Backend/RelationalDocumentStoreRepository.cs
@@ -3957,6 +3957,8 @@ public sealed class RelationalDocumentStoreRepository(
             edfiDocs.Add(projectedOrUnchangedDocument);
         }
 
+        // The selected-keyset boundary passes through unchanged, including when the body above came back
+        // empty: it describes what page selection chose, not what survived to hydration.
         return new QueryResult.QuerySuccess(
             edfiDocs,
             relationalQueryRequest.Paging.IncludesTotalCount
@@ -3965,7 +3967,8 @@ public sealed class RelationalDocumentStoreRepository(
                     hydratedPage.TotalCount,
                     "query hydration"
                 )
-                : null
+                : null,
+            hydratedPage.HighestSelectedDocumentId
         );
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/PartitionResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/PartitionResult.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.External.Backend;
+
+/// <summary>
+/// A partition-boundary result from a partition handler.
+/// </summary>
+/// <remarks>
+/// Provider-neutral by construction: it carries typed inclusive DocumentId ranges only, never token
+/// text and no provider syntax. Core encodes each range as a page token at the HTTP contract boundary.
+/// </remarks>
+public abstract record PartitionResult
+{
+    /// <summary>
+    /// Successful partition boundaries, ascending. An empty list means no accessible candidates.
+    /// </summary>
+    /// <param name="Ranges">
+    /// The inclusive DocumentId ranges a client can walk independently. Every range but the last is
+    /// bounded above, so a later insert cannot move into a completed partition.
+    /// </param>
+    public sealed record PartitionSuccess(IReadOnlyList<CursorRange> Ranges) : PartitionResult;
+
+    private PartitionResult() { }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Backend/QueryResult.cs
@@ -16,7 +16,14 @@ public record QueryResult
     /// </summary>
     /// <param name="EdfiDocs">The documents returned from the query</param>
     /// <param name="TotalCount">The total number of documents returned</param>
-    public record QuerySuccess(JsonArray EdfiDocs, int? TotalCount) : QueryResult();
+    /// <param name="HighestSelectedDocumentId">
+    /// The maximum DocumentId in the selected page keyset, or null when page selection was skipped or
+    /// selected no keys, including early-empty paths and zero-size pages. Independent of
+    /// <paramref name="EdfiDocs"/>: it can be non-null while the body is empty, because every selected
+    /// row may be deleted before hydration completes. Populated by cursor execution in a later story.
+    /// </param>
+    public record QuerySuccess(JsonArray EdfiDocs, int? TotalCount, long? HighestSelectedDocumentId = null)
+        : QueryResult();
 
     /// <summary>
     /// A known failure from the query handler, likely invalid query terms that

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Model/CollectionPaging.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Model/CollectionPaging.cs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Model;
+
+/// <summary>
+/// How a live collection query pages: traditional limit/offset, or cursor over an inclusive
+/// DocumentId range.
+/// </summary>
+/// <remarks>
+/// An explicit choice rather than nullable combinations, so a cursor request without a range and a
+/// traditional request with a page size are both unrepresentable. Change Query endpoints keep using
+/// <see cref="PaginationParameters"/> directly and do not page by cursor.
+/// </remarks>
+public abstract record CollectionPaging
+{
+    private CollectionPaging() { }
+
+    /// <summary>
+    /// Whether this query asked for a total count. Only traditional paging can: cursor paging never
+    /// requests or compiles a total count.
+    /// </summary>
+    public abstract bool IncludesTotalCount { get; }
+
+    /// <summary>
+    /// Traditional limit / offset / totalCount paging.
+    /// </summary>
+    /// <param name="Parameters">The client-supplied traditional paging inputs.</param>
+    public sealed record Traditional(PaginationParameters Parameters) : CollectionPaging
+    {
+        public override bool IncludesTotalCount => Parameters.TotalCount;
+    }
+
+    /// <summary>
+    /// Cursor paging over an inclusive DocumentId range.
+    /// </summary>
+    /// <param name="Range">The inclusive DocumentId window to select from.</param>
+    /// <param name="PageSize">The number of items the page may select.</param>
+    public sealed record Cursor(CursorRange Range, PageSize PageSize) : CollectionPaging
+    {
+        public override bool IncludesTotalCount => false;
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Model/CursorRange.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Model/CursorRange.cs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Model;
+
+/// <summary>
+/// An inclusive DocumentId window for cursor page selection. Bounds are signed long-width to match
+/// the relational bigint DocumentId identity.
+/// </summary>
+/// <remarks>
+/// Negative bounds, and a minimum greater than the maximum, are valid match-nothing ranges rather
+/// than errors. An inverted range is how a bounded partition reaches its terminal empty page after
+/// returning the item at its upper bound.
+/// </remarks>
+public sealed record CursorRange(long InclusiveMinimum, long InclusiveMaximum)
+{
+    /// <summary>
+    /// A range starting at the given inclusive minimum and unbounded above.
+    /// </summary>
+    public static CursorRange From(long inclusiveMinimum) => new(inclusiveMinimum, long.MaxValue);
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Model/PageSize.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Model/PageSize.cs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.External.Model;
+
+/// <summary>
+/// The number of items a cursor page may select. Zero is a valid size that returns an empty page and
+/// intentionally cannot advance a cursor walk.
+/// </summary>
+/// <remarks>
+/// Only the negative case is unrepresentable here. Validating a page size against the configured
+/// maximum, and reporting that failure to the client, belongs to request validation.
+/// </remarks>
+public readonly record struct PageSize
+{
+    public PageSize(int value)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(value);
+        Value = value;
+    }
+
+    /// <summary>
+    /// The page size. Zero for a default-constructed value, which is itself a valid empty page.
+    /// </summary>
+    public int Value { get; }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/PartitionResultTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/PartitionResultTests.cs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Backend;
+
+/// <summary>
+/// Partition boundaries cross the backend seam as typed ranges. Token text is created only at Core's
+/// HTTP contract boundary, so these shapes must have nowhere to carry it.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_A_Partition_Success_Result
+{
+    private PartitionResult.PartitionSuccess _result = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _result = new PartitionResult.PartitionSuccess([
+            new CursorRange(1, 2500),
+            new CursorRange(2501, long.MaxValue),
+        ]);
+    }
+
+    [Test]
+    public void It_carries_the_typed_ranges_in_order()
+    {
+        _result.Ranges.Should().Equal(new CursorRange(1, 2500), new CursorRange(2501, long.MaxValue));
+    }
+
+    [Test]
+    public void It_is_a_partition_result()
+    {
+        _result.Should().BeAssignableTo<PartitionResult>();
+    }
+
+    [Test]
+    public void It_exposes_ranges_as_a_read_only_list_of_cursor_ranges()
+    {
+        typeof(PartitionResult.PartitionSuccess)
+            .GetProperty(nameof(PartitionResult.PartitionSuccess.Ranges))!
+            .PropertyType.Should()
+            .Be<IReadOnlyList<CursorRange>>();
+    }
+
+    [Test]
+    public void It_represents_no_accessible_candidates_as_an_empty_range_list()
+    {
+        new PartitionResult.PartitionSuccess([]).Ranges.Should().BeEmpty();
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_The_Cursor_Paging_And_Partition_Contracts
+{
+    /// <summary>
+    /// The contracts DMS-1383 owns. Deliberately not the whole result hierarchy: a later partition
+    /// failure diagnostic may legitimately carry strings.
+    /// </summary>
+    private static readonly Type[] _ownedContracts =
+    [
+        typeof(CursorRange),
+        typeof(PageSize),
+        typeof(CollectionPaging),
+        typeof(CollectionPaging.Traditional),
+        typeof(CollectionPaging.Cursor),
+        typeof(PartitionResult.PartitionSuccess),
+    ];
+
+    [TestCaseSource(nameof(_ownedContracts))]
+    public void It_exposes_no_token_text(Type contract)
+    {
+        contract
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Should()
+            .NotContain(property => property.PropertyType == typeof(string));
+    }
+
+    [Test]
+    public void It_closes_the_partition_result_hierarchy()
+    {
+        typeof(PartitionResult)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+            .Should()
+            .BeEmpty();
+
+        // Asserts the closure property rather than the arm count, so a later story can add a failure
+        // alternative without this test failing for the wrong reason.
+        typeof(PartitionResult)
+            .Assembly.GetTypes()
+            .Where(type => typeof(PartitionResult).IsAssignableFrom(type) && type != typeof(PartitionResult))
+            .Should()
+            .Contain(typeof(PartitionResult.PartitionSuccess))
+            .And.OnlyContain(type => type.IsSealed && type.DeclaringType == typeof(PartitionResult));
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryRequestPagingContractTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryRequestPagingContractTests.cs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using EdFi.DataManagementService.Backend.External;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Backend;
+
+/// <summary>
+/// Live GET-many queries page through the typed paging choice, so a backend can never receive a
+/// paging mode the request did not select.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Relational_Query_Request_Contract
+{
+    private PropertyInfo[] _properties = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _properties = typeof(IQueryRequest).GetProperties(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.FlattenHierarchy
+        );
+    }
+
+    [Test]
+    public void It_exposes_the_typed_collection_paging_choice()
+    {
+        _properties
+            .Should()
+            .Contain(property =>
+                property.Name == nameof(IQueryRequest.Paging)
+                && property.PropertyType == typeof(CollectionPaging)
+            );
+    }
+
+    [Test]
+    public void It_no_longer_exposes_traditional_pagination_parameters_directly()
+    {
+        _properties.Should().NotContain(property => property.PropertyType == typeof(PaginationParameters));
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryResultBoundaryTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/QueryResultBoundaryTests.cs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Backend;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Backend;
+
+/// <summary>
+/// The selected-keyset boundary is a value in its own right, not something inferred from the response
+/// body. An empty body cannot distinguish a skipped or empty selection from concurrent deletion after
+/// selection, which is why the two are independent.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_A_Query_Success_Result
+{
+    [Test]
+    public void It_has_no_selected_keyset_boundary_by_default()
+    {
+        new QueryResult.QuerySuccess([], 0).HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public void It_allows_documents_without_a_selected_keyset_boundary()
+    {
+        QueryResult.QuerySuccess success = new([JsonValue.Create(1)], null);
+
+        success.EdfiDocs.Should().HaveCount(1);
+        success.HighestSelectedDocumentId.Should().BeNull();
+    }
+
+    [Test]
+    public void It_allows_a_selected_keyset_boundary_with_an_empty_body()
+    {
+        QueryResult.QuerySuccess success = new([], null, 2509);
+
+        success.EdfiDocs.Should().BeEmpty();
+        success.HighestSelectedDocumentId.Should().Be(2509);
+    }
+
+    [Test]
+    public void It_carries_the_boundary_as_a_nullable_long()
+    {
+        typeof(QueryResult.QuerySuccess)
+            .GetProperty(nameof(QueryResult.QuerySuccess.HighestSelectedDocumentId))!
+            .PropertyType.Should()
+            .Be<long?>();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/TrackedChangeQueryRequestPagingContractTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Backend/TrackedChangeQueryRequestPagingContractTests.cs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using EdFi.DataManagementService.Core.Backend;
+using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Backend;
+
+/// <summary>
+/// Change Query endpoints page traditionally only. These assertions keep cursor paging off the
+/// tracked-change request contracts, so /deletes and /keyChanges neither acquire cursor behavior nor
+/// reserve cursor parameter names.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class TrackedChangeQueryRequestPagingContractTests
+{
+    private static readonly Type[] _trackedChangeRequestContracts =
+    [
+        typeof(ITrackedChangeQueryRequest),
+        typeof(TrackedChangeQueryRequest),
+        typeof(RelationalTrackedChangeQueryRequest),
+    ];
+
+    private static readonly Type[] _cursorPagingContracts =
+    [
+        typeof(CollectionPaging),
+        typeof(CursorRange),
+        typeof(PageSize),
+    ];
+
+    private static IEnumerable<PropertyInfo> PropertiesOf(Type contract) =>
+        contract.GetProperties(
+            BindingFlags.Instance
+                | BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.FlattenHierarchy
+        );
+
+    [TestCaseSource(nameof(_trackedChangeRequestContracts))]
+    public void It_exposes_traditional_pagination_parameters(Type contract)
+    {
+        PropertiesOf(contract)
+            .Should()
+            .Contain(property =>
+                property.Name == nameof(ITrackedChangeQueryRequest.PaginationParameters)
+                && property.PropertyType == typeof(PaginationParameters)
+            );
+    }
+
+    [TestCaseSource(nameof(_trackedChangeRequestContracts))]
+    public void It_exposes_no_cursor_paging_contract(Type contract)
+    {
+        PropertiesOf(contract)
+            .Should()
+            .NotContain(property =>
+                _cursorPagingContracts.Any(cursorContract =>
+                    cursorContract.IsAssignableFrom(property.PropertyType)
+                )
+            );
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/AppSettingsValidatorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Configuration/AppSettingsValidatorTests.cs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Configuration;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Configuration;
+
+[TestFixture]
+[Parallelizable]
+public class Given_The_App_Settings_Validator
+{
+    private static AppSettings ValidSettings() =>
+        new()
+        {
+            AllowIdentityUpdateOverrides = string.Empty,
+            MaximumPageSize = 500,
+            DefaultPartitionCount = AppSettings.DefaultPartitionCountDefault,
+        };
+
+    private static ValidateOptionsResult Validate(AppSettings settings) =>
+        new AppSettingsValidator().Validate(Options.DefaultName, settings);
+
+    [Test]
+    public void It_accepts_valid_settings()
+    {
+        Validate(ValidSettings()).Succeeded.Should().BeTrue();
+    }
+
+    [TestCase(0)]
+    [TestCase(-1)]
+    public void It_rejects_a_nonpositive_maximum_page_size(int maximumPageSize)
+    {
+        AppSettings settings = ValidSettings();
+        settings.MaximumPageSize = maximumPageSize;
+
+        ValidateOptionsResult result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().ContainSingle().Which.Should().Contain(nameof(AppSettings.MaximumPageSize));
+    }
+
+    [TestCase(0)]
+    [TestCase(201)]
+    [TestCase(-1)]
+    public void It_rejects_a_partition_count_outside_the_supported_range(int defaultPartitionCount)
+    {
+        AppSettings settings = ValidSettings();
+        settings.DefaultPartitionCount = defaultPartitionCount;
+
+        ValidateOptionsResult result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result
+            .Failures.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(nameof(AppSettings.DefaultPartitionCount));
+    }
+
+    [TestCase(1)]
+    [TestCase(10)]
+    [TestCase(200)]
+    public void It_accepts_a_partition_count_within_the_inclusive_range(int defaultPartitionCount)
+    {
+        AppSettings settings = ValidSettings();
+        settings.DefaultPartitionCount = defaultPartitionCount;
+
+        Validate(settings).Succeeded.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_reports_every_failure_rather_than_stopping_at_the_first()
+    {
+        AppSettings settings = ValidSettings();
+        settings.MaximumPageSize = 0;
+        settings.DefaultPartitionCount = 201;
+
+        ValidateOptionsResult result = Validate(settings);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().HaveCount(2);
+    }
+
+    [Test]
+    public void It_exposes_the_supported_partition_count_bounds()
+    {
+        AppSettingsValidator.MinimumDefaultPartitionCount.Should().Be(1);
+        AppSettingsValidator.MaximumDefaultPartitionCount.Should().Be(200);
+    }
+
+    [Test]
+    public void It_rejects_a_null_options_argument()
+    {
+        Action act = () => new AppSettingsValidator().Validate(Options.DefaultName, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_Default_App_Settings
+{
+    [Test]
+    public void It_defaults_the_partition_count_to_ten()
+    {
+        new AppSettings { AllowIdentityUpdateOverrides = string.Empty }
+            .DefaultPartitionCount.Should()
+            .Be(10);
+    }
+
+    [Test]
+    public void It_shares_one_literal_between_the_property_default_and_the_constant()
+    {
+        new AppSettings { AllowIdentityUpdateOverrides = string.Empty }
+            .DefaultPartitionCount.Should()
+            .Be(AppSettings.DefaultPartitionCountDefault);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Handler/QueryRequestHandlerTests.cs
@@ -809,7 +809,11 @@ public class QueryRequestHandlerTests
                 .Equal("uri://sample-a.org", "uri://sample-b.org");
             _repository.CapturedRequest.ResourceInfo.Should().BeSameAs(_requestInfo.ResourceInfo);
             _repository.CapturedRequest.QueryElements.Should().BeSameAs(_queryElements);
-            _repository.CapturedRequest.PaginationParameters.Should().BeSameAs(_paginationParameters);
+            _repository
+                .CapturedRequest.Paging.Should()
+                .BeOfType<CollectionPaging.Traditional>()
+                .Which.Parameters.Should()
+                .BeSameAs(_paginationParameters);
             _repository
                 .CapturedRequest.AuthorizationStrategyEvaluators.Should()
                 .BeSameAs(_authorizationStrategyEvaluators);

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/CollectionPagingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/CollectionPagingTests.cs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Reflection;
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Model;
+
+[TestFixture]
+[Parallelizable]
+public class CollectionPagingTests
+{
+    private static PaginationParameters TraditionalParameters(bool totalCount) =>
+        new(Limit: 25, Offset: 0, TotalCount: totalCount, MaximumPageSize: 500);
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Traditional_Paging : CollectionPagingTests
+    {
+        private CollectionPaging.Traditional _paging = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _paging = new CollectionPaging.Traditional(TraditionalParameters(totalCount: false));
+        }
+
+        [Test]
+        public void It_carries_the_pagination_parameters_unchanged()
+        {
+            _paging.Parameters.Should().Be(TraditionalParameters(totalCount: false));
+        }
+
+        [Test]
+        public void It_is_a_collection_paging_alternative()
+        {
+            _paging.Should().BeAssignableTo<CollectionPaging>();
+        }
+
+        [Test]
+        public void It_compares_equal_to_the_same_traditional_paging()
+        {
+            _paging.Should().Be(new CollectionPaging.Traditional(TraditionalParameters(totalCount: false)));
+        }
+
+        [Test]
+        public void It_does_not_include_a_total_count_when_none_was_requested()
+        {
+            _paging.IncludesTotalCount.Should().BeFalse();
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Cursor_Paging : CollectionPagingTests
+    {
+        private CollectionPaging.Cursor _paging = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _paging = new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100));
+        }
+
+        [Test]
+        public void It_carries_the_typed_cursor_range()
+        {
+            _paging.Range.Should().Be(new CursorRange(10, 2509));
+        }
+
+        [Test]
+        public void It_carries_the_page_size()
+        {
+            _paging.PageSize.Should().Be(new PageSize(100));
+        }
+
+        [Test]
+        public void It_is_a_collection_paging_alternative()
+        {
+            _paging.Should().BeAssignableTo<CollectionPaging>();
+        }
+
+        [Test]
+        public void It_compares_equal_to_the_same_cursor_paging()
+        {
+            _paging.Should().Be(new CollectionPaging.Cursor(new CursorRange(10, 2509), new PageSize(100)));
+        }
+
+        [Test]
+        public void It_never_includes_a_total_count()
+        {
+            _paging.IncludesTotalCount.Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void It_includes_a_total_count_only_for_a_traditional_request_that_asked_for_one()
+    {
+        CollectionPaging paging = new CollectionPaging.Traditional(TraditionalParameters(totalCount: true));
+
+        paging.IncludesTotalCount.Should().BeTrue();
+    }
+
+    [Test]
+    public void It_declares_no_public_constructor_on_the_choice_itself()
+    {
+        typeof(CollectionPaging)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.Public)
+            .Should()
+            .BeEmpty();
+    }
+
+    [Test]
+    public void It_offers_only_nested_sealed_alternatives()
+    {
+        IEnumerable<Type> alternatives = typeof(CollectionPaging)
+            .Assembly.GetTypes()
+            .Where(type =>
+                typeof(CollectionPaging).IsAssignableFrom(type) && type != typeof(CollectionPaging)
+            );
+
+        alternatives
+            .Should()
+            .HaveCount(2)
+            .And.OnlyContain(type => type.IsSealed && type.DeclaringType == typeof(CollectionPaging));
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/CursorRangeTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/CursorRangeTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Model;
+
+[TestFixture]
+[Parallelizable]
+public class CursorRangeTests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Range_With_Both_Bounds_Supplied : CursorRangeTests
+    {
+        private CursorRange _range = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _range = new CursorRange(InclusiveMinimum: 10, InclusiveMaximum: 2509);
+        }
+
+        [Test]
+        public void It_carries_the_inclusive_minimum()
+        {
+            _range.InclusiveMinimum.Should().Be(10);
+        }
+
+        [Test]
+        public void It_carries_the_inclusive_maximum()
+        {
+            _range.InclusiveMaximum.Should().Be(2509);
+        }
+
+        [Test]
+        public void It_compares_equal_to_a_range_with_the_same_bounds()
+        {
+            _range.Should().Be(new CursorRange(10, 2509));
+        }
+
+        [Test]
+        public void It_compares_unequal_to_a_range_with_different_bounds()
+        {
+            _range.Should().NotBe(new CursorRange(10, 2510));
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_A_Range_Created_From_A_Minimum_Only : CursorRangeTests
+    {
+        private CursorRange _range = null!;
+
+        [SetUp]
+        public void Setup()
+        {
+            _range = CursorRange.From(inclusiveMinimum: 501);
+        }
+
+        [Test]
+        public void It_retains_the_supplied_minimum()
+        {
+            _range.InclusiveMinimum.Should().Be(501);
+        }
+
+        [Test]
+        public void It_is_unbounded_above()
+        {
+            _range.InclusiveMaximum.Should().Be(long.MaxValue);
+        }
+    }
+
+    [Test]
+    public void It_accepts_negative_bounds()
+    {
+        CursorRange range = new(-20, -5);
+
+        range.InclusiveMinimum.Should().Be(-20);
+        range.InclusiveMaximum.Should().Be(-5);
+    }
+
+    [Test]
+    public void It_accepts_an_inverted_match_nothing_range()
+    {
+        CursorRange range = new(2510, 2509);
+
+        range.InclusiveMinimum.Should().Be(2510);
+        range.InclusiveMaximum.Should().Be(2509);
+    }
+
+    [Test]
+    public void It_accepts_the_full_signed_range()
+    {
+        CursorRange range = new(long.MinValue, long.MaxValue);
+
+        range.InclusiveMinimum.Should().Be(long.MinValue);
+        range.InclusiveMaximum.Should().Be(long.MaxValue);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/PageSizeTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Model/PageSizeTests.cs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.External.Model;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Model;
+
+[TestFixture]
+[Parallelizable]
+public class PageSizeTests
+{
+    [Test]
+    public void It_accepts_a_zero_page_size()
+    {
+        PageSize pageSize = new(0);
+
+        pageSize.Value.Should().Be(0);
+    }
+
+    [Test]
+    public void It_accepts_a_positive_page_size()
+    {
+        PageSize pageSize = new(500);
+
+        pageSize.Value.Should().Be(500);
+    }
+
+    [Test]
+    public void It_rejects_a_negative_page_size()
+    {
+        Action act = () => _ = new PageSize(-1);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Test]
+    public void It_compares_equal_to_a_page_size_with_the_same_value()
+    {
+        new PageSize(25).Should().Be(new PageSize(25));
+    }
+
+    [Test]
+    public void It_compares_unequal_to_a_page_size_with_a_different_value()
+    {
+        new PageSize(25).Should().NotBe(new PageSize(26));
+    }
+
+    [Test]
+    public void It_treats_the_default_value_as_a_zero_page_size()
+    {
+        default(PageSize).Value.Should().Be(0);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/CursorPagingLimitsTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/CursorPagingLimitsTests.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Paging;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Paging;
+
+/// <summary>
+/// A partition is never smaller than five maximum-sized pages, so a small collection is not sliced
+/// into partitions that cost more to coordinate than to read.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Minimum_Partition_Size
+{
+    [Test]
+    public void It_is_five_maximum_sized_pages()
+    {
+        CursorPagingLimits.MinimumPartitionSize(500).Should().Be(2500);
+    }
+
+    [Test]
+    public void It_scales_with_the_smallest_usable_page_size()
+    {
+        CursorPagingLimits.MinimumPartitionSize(1).Should().Be(5);
+    }
+
+    [Test]
+    public void It_widens_before_multiplying_so_a_large_page_size_cannot_wrap()
+    {
+        CursorPagingLimits.MinimumPartitionSize(int.MaxValue).Should().Be(10_737_418_235);
+    }
+
+    [Test]
+    public void It_uses_the_documented_page_multiplier()
+    {
+        CursorPagingLimits.MinimumPartitionPageMultiplier.Should().Be(5);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/PageTokenCodecTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/PageTokenCodecTests.cs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Buffers.Text;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using EdFi.DataManagementService.Core.External.Model;
+using EdFi.DataManagementService.Core.Paging;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Paging;
+
+/// <summary>
+/// The page token is the only client-visible form of a cursor range, so its grammar is pinned in both
+/// directions: what the encoder emits, and the exact set of inputs the decoder accepts.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Page_Token_Codec
+{
+    /// <summary>Encodes arbitrary payload text the way a well-formed token encodes its range.</summary>
+    private static string TokenFor(string payload) =>
+        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+
+    /// <summary>Reads the payload text back out of a token, to assert the wire format itself.</summary>
+    private static string PayloadOf(string token) =>
+        Encoding.UTF8.GetString(Base64Url.DecodeFromChars(token));
+
+    private static string Padded(string token) => token + new string('=', (4 - (token.Length % 4)) % 4);
+
+    [Test]
+    public void It_is_not_visible_outside_Core()
+    {
+        typeof(PageTokenCodec).IsPublic.Should().BeFalse();
+    }
+
+    [Test]
+    public void It_is_not_reachable_from_backend_production_code()
+    {
+        typeof(PageTokenCodec)
+            .Assembly.GetCustomAttributes<InternalsVisibleToAttribute>()
+            .Select(static attribute => attribute.AssemblyName)
+            .Should()
+            .NotContain("EdFi.DataManagementService.Backend");
+    }
+
+    [Test]
+    public void It_encodes_both_bounds_as_invariant_signed_decimals_joined_by_one_comma()
+    {
+        PayloadOf(PageTokenCodec.Encode(new CursorRange(10, 2509))).Should().Be("10,2509");
+    }
+
+    [Test]
+    public void It_encodes_negative_bounds_with_a_leading_minus()
+    {
+        PayloadOf(PageTokenCodec.Encode(new CursorRange(-20, -5))).Should().Be("-20,-5");
+    }
+
+    [Test]
+    public void It_never_emits_the_empty_maximum_form()
+    {
+        PayloadOf(PageTokenCodec.Encode(CursorRange.From(5))).Should().Be("5,9223372036854775807");
+    }
+
+    [Test]
+    public void It_emits_canonical_unpadded_base64url()
+    {
+        string token = PageTokenCodec.Encode(new CursorRange(10, 2509));
+
+        token.Should().NotContain("+").And.NotContain("/").And.NotContain("=");
+    }
+
+    [TestCase(0L, 0L)]
+    [TestCase(1L, 500L)]
+    [TestCase(-5L, -1L)]
+    [TestCase(2510L, 2509L)]
+    [TestCase(long.MinValue, long.MaxValue)]
+    public void It_round_trips_a_range(long inclusiveMinimum, long inclusiveMaximum)
+    {
+        CursorRange range = new(inclusiveMinimum, inclusiveMaximum);
+
+        PageTokenCodec.TryDecode(PageTokenCodec.Encode(range), out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(range);
+    }
+
+    [Test]
+    public void It_accepts_a_correctly_padded_token()
+    {
+        string unpadded = PageTokenCodec.Encode(new CursorRange(10, 2509));
+
+        PageTokenCodec.TryDecode(Padded(unpadded), out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(10, 2509));
+    }
+
+    [Test]
+    public void It_decodes_an_empty_maximum_as_unbounded_above()
+    {
+        PageTokenCodec.TryDecode(TokenFor("5,"), out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(5, long.MaxValue));
+    }
+
+    [Test]
+    public void It_accepts_the_signed_extremes()
+    {
+        PageTokenCodec
+            .TryDecode(TokenFor("-9223372036854775808,9223372036854775807"), out CursorRange? decoded)
+            .Should()
+            .BeTrue();
+        decoded.Should().Be(new CursorRange(long.MinValue, long.MaxValue));
+    }
+
+    [TestCase("-20,-5", -20L, -5L, TestName = "It_accepts_negative_bounds")]
+    [TestCase("2510,2509", 2510L, 2509L, TestName = "It_accepts_an_inverted_match_nothing_range")]
+    public void It_accepts_a_valid_payload(string payload, long expectedMinimum, long expectedMaximum)
+    {
+        PageTokenCodec.TryDecode(TokenFor(payload), out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(expectedMinimum, expectedMaximum));
+    }
+
+    [TestCase(null, TestName = "It_rejects_a_null_token")]
+    [TestCase("", TestName = "It_rejects_an_empty_token")]
+    [TestCase("=", TestName = "It_rejects_padding_only")]
+    [TestCase("MTAs+jUwOQ", TestName = "It_rejects_the_plus_character")]
+    [TestCase("MTAs/jUwOQ", TestName = "It_rejects_the_slash_character")]
+    [TestCase("MTAsM", TestName = "It_rejects_an_impossible_base64url_length")]
+    // A permissive base64 reader skips whitespace; the token grammar does not allow it anywhere.
+    [TestCase("MTAs MjUwOQ", TestName = "It_rejects_embedded_whitespace")]
+    [TestCase(" MTAsMjUwOQ", TestName = "It_rejects_leading_whitespace_in_the_token")]
+    [TestCase("MTAsMjUwOQ ", TestName = "It_rejects_trailing_whitespace_in_the_token")]
+    [TestCase("MTAsMjUw\nOQ", TestName = "It_rejects_an_embedded_newline")]
+    public void It_rejects_a_malformed_token(string? pageToken)
+    {
+        PageTokenCodec.TryDecode(pageToken!, out CursorRange? decoded).Should().BeFalse();
+        decoded.Should().BeNull();
+    }
+
+    [Test]
+    public void It_rejects_internal_padding()
+    {
+        string token = PageTokenCodec.Encode(new CursorRange(10, 2509));
+        string withInternalPadding = token[..2] + "=" + token[2..];
+
+        PageTokenCodec.TryDecode(withInternalPadding, out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_rejects_more_padding_than_required()
+    {
+        string token = PageTokenCodec.Encode(new CursorRange(10, 2509));
+
+        PageTokenCodec.TryDecode(Padded(token) + "=", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_rejects_incomplete_padding()
+    {
+        string token = TokenFor("100,200");
+        token.Length.Should().Be(10, "this payload encodes to a length requiring two padding characters");
+
+        PageTokenCodec.TryDecode(token + "=", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_rejects_padding_that_is_not_required()
+    {
+        string token = TokenFor("1,2");
+        token.Length.Should().Be(4, "this payload encodes to a length requiring no padding");
+
+        PageTokenCodec.TryDecode(token + "=", out _).Should().BeFalse();
+    }
+
+    [Test]
+    public void It_rejects_invalid_utf8_payload_bytes()
+    {
+        string token = Base64Url.EncodeToString([0xFF, 0xFE]);
+
+        PageTokenCodec.TryDecode(token, out _).Should().BeFalse();
+    }
+
+    [TestCase("10", TestName = "It_rejects_a_single_field")]
+    [TestCase("10,20,30", TestName = "It_rejects_three_fields")]
+    [TestCase("10,20,30,40", TestName = "It_rejects_four_fields")]
+    [TestCase(",20", TestName = "It_rejects_an_empty_minimum")]
+    [TestCase(",", TestName = "It_rejects_two_empty_fields")]
+    [TestCase(" 10,20", TestName = "It_rejects_leading_whitespace")]
+    [TestCase("10 ,20", TestName = "It_rejects_trailing_whitespace_in_the_minimum")]
+    [TestCase("10, 20", TestName = "It_rejects_leading_whitespace_in_the_maximum")]
+    [TestCase("10,20 ", TestName = "It_rejects_trailing_whitespace")]
+    [TestCase("+10,20", TestName = "It_rejects_a_leading_plus_in_the_minimum")]
+    [TestCase("10,+20", TestName = "It_rejects_a_leading_plus_in_the_maximum")]
+    [TestCase("-,20", TestName = "It_rejects_a_bare_minus")]
+    [TestCase("1a,20", TestName = "It_rejects_a_non_digit_in_the_minimum")]
+    [TestCase("10,2b", TestName = "It_rejects_a_non_digit_in_the_maximum")]
+    [TestCase("1.0,20", TestName = "It_rejects_a_decimal_point")]
+    [TestCase("9223372036854775808,1", TestName = "It_rejects_a_minimum_above_Int64")]
+    [TestCase("-9223372036854775809,1", TestName = "It_rejects_a_minimum_below_Int64")]
+    [TestCase("1,9223372036854775808", TestName = "It_rejects_a_maximum_above_Int64")]
+    public void It_rejects_a_malformed_payload(string payload)
+    {
+        PageTokenCodec.TryDecode(TokenFor(payload), out CursorRange? decoded).Should().BeFalse();
+        decoded.Should().BeNull();
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Selected_Page_Below_The_Maximum_Document_Id
+{
+    private bool _created;
+    private string? _nextPageToken;
+
+    [SetUp]
+    public void Setup()
+    {
+        _created = PageTokenCodec.TryCreateNextPageToken(
+            highestSelectedDocumentId: 100,
+            maximumDocumentId: 2509,
+            out _nextPageToken
+        );
+    }
+
+    [Test]
+    public void It_creates_a_next_page_token()
+    {
+        _created.Should().BeTrue();
+        _nextPageToken.Should().NotBeNullOrEmpty();
+    }
+
+    [Test]
+    public void It_advances_past_the_highest_selected_document_and_retains_the_maximum()
+    {
+        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(101, 2509));
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Selected_Page_At_A_Bounded_Partition_Upper_Bound
+{
+    private string? _nextPageToken;
+
+    [SetUp]
+    public void Setup()
+    {
+        PageTokenCodec.TryCreateNextPageToken(
+            highestSelectedDocumentId: 2509,
+            maximumDocumentId: 2509,
+            out _nextPageToken
+        );
+    }
+
+    [Test]
+    public void It_creates_an_inverted_range_that_ends_the_partition_walk()
+    {
+        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(2510, 2509));
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Selected_Page_Entered_From_An_Unbounded_Walk
+{
+    private string? _nextPageToken;
+
+    [SetUp]
+    public void Setup()
+    {
+        PageTokenCodec.TryCreateNextPageToken(
+            highestSelectedDocumentId: 100,
+            maximumDocumentId: long.MaxValue,
+            out _nextPageToken
+        );
+    }
+
+    [Test]
+    public void It_stays_unbounded_above()
+    {
+        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        decoded.Should().Be(new CursorRange(101, long.MaxValue));
+    }
+}
+
+[TestFixture]
+[Parallelizable]
+public class Given_A_Selected_Page_At_The_Largest_Document_Id
+{
+    private bool _created;
+    private string? _nextPageToken;
+
+    [SetUp]
+    public void Setup()
+    {
+        _created = PageTokenCodec.TryCreateNextPageToken(
+            highestSelectedDocumentId: long.MaxValue,
+            maximumDocumentId: long.MaxValue,
+            out _nextPageToken
+        );
+    }
+
+    [Test]
+    public void It_declines_to_create_a_next_page_token_rather_than_overflowing()
+    {
+        _created.Should().BeFalse();
+    }
+
+    [Test]
+    public void It_produces_no_token()
+    {
+        _nextPageToken.Should().BeNull();
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/PageTokenCodecTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Paging/PageTokenCodecTests.cs
@@ -134,7 +134,7 @@ public class Given_The_Page_Token_Codec
     [TestCase("MTAsMjUw\nOQ", TestName = "It_rejects_an_embedded_newline")]
     public void It_rejects_a_malformed_token(string? pageToken)
     {
-        PageTokenCodec.TryDecode(pageToken!, out CursorRange? decoded).Should().BeFalse();
+        PageTokenCodec.TryDecode(pageToken, out CursorRange? decoded).Should().BeFalse();
         decoded.Should().BeNull();
     }
 
@@ -233,7 +233,7 @@ public class Given_A_Selected_Page_Below_The_Maximum_Document_Id
     [Test]
     public void It_advances_past_the_highest_selected_document_and_retains_the_maximum()
     {
-        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        PageTokenCodec.TryDecode(_nextPageToken, out CursorRange? decoded).Should().BeTrue();
         decoded.Should().Be(new CursorRange(101, 2509));
     }
 }
@@ -257,7 +257,7 @@ public class Given_A_Selected_Page_At_A_Bounded_Partition_Upper_Bound
     [Test]
     public void It_creates_an_inverted_range_that_ends_the_partition_walk()
     {
-        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        PageTokenCodec.TryDecode(_nextPageToken, out CursorRange? decoded).Should().BeTrue();
         decoded.Should().Be(new CursorRange(2510, 2509));
     }
 }
@@ -281,7 +281,7 @@ public class Given_A_Selected_Page_Entered_From_An_Unbounded_Walk
     [Test]
     public void It_stays_unbounded_above()
     {
-        PageTokenCodec.TryDecode(_nextPageToken!, out CursorRange? decoded).Should().BeTrue();
+        PageTokenCodec.TryDecode(_nextPageToken, out CursorRange? decoded).Should().BeTrue();
         decoded.Should().Be(new CursorRange(101, long.MaxValue));
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Backend/QueryRequest.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Backend/QueryRequest.cs
@@ -24,7 +24,7 @@ namespace EdFi.DataManagementService.Core.Backend;
 /// <param name="AuthorizationStrategyEvaluators">
 /// Collection of authorization strategy filters, each specifying collection of filters and filter operator.
 /// </param>
-/// <param name="PaginationParameters">The pagination parameters for this query.</param>
+/// <param name="Paging">The paging mode and its inputs for this query.</param>
 /// <param name="TraceId">The request TraceId.</param>
 /// <param name="ReadableProfileProjectionContext">
 /// Optional readable-profile projection inputs when a readable profile applies to the request.
@@ -39,7 +39,7 @@ internal sealed record RelationalQueryRequest(
     MappingSet MappingSet,
     QueryElement[] QueryElements,
     AuthorizationStrategyEvaluator[] AuthorizationStrategyEvaluators,
-    PaginationParameters PaginationParameters,
+    CollectionPaging Paging,
     TraceId TraceId,
     ReadableProfileProjectionContext? ReadableProfileProjectionContext = null,
     ChangeVersionRange? ChangeVersionRange = null,

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettings.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettings.cs
@@ -8,6 +8,11 @@ namespace EdFi.DataManagementService.Core.Configuration;
 public class AppSettings
 {
     /// <summary>
+    /// The default desired partition count applied when a /partitions request omits its count.
+    /// </summary>
+    public const int DefaultPartitionCountDefault = 10;
+
+    /// <summary>
     /// Bypasses schema-guided request value type coercion.
     /// </summary>
     public bool BypassTypeCoercion { get; set; }
@@ -27,6 +32,12 @@ public class AppSettings
     /// Indicates the maximum number of items that should be returned in the results
     /// </summary>
     public int MaximumPageSize { get; set; }
+
+    /// <summary>
+    /// The desired partition count applied when a /partitions request omits its count.
+    /// Environment override: <c>AppSettings__DefaultPartitionCount</c>.
+    /// </summary>
+    public int DefaultPartitionCount { get; set; } = DefaultPartitionCountDefault;
 
     /// <summary>
     /// If true, loads manifest-backed ApiSchema workspace content from ApiSchemaPath.

--- a/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettingsValidator.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Configuration/AppSettingsValidator.cs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using Microsoft.Extensions.Options;
+
+namespace EdFi.DataManagementService.Core.Configuration;
+
+/// <summary>
+/// Validates the paging-related <see cref="AppSettings"/> values that later request handling and
+/// partition sizing depend on.
+/// </summary>
+/// <remarks>
+/// Every failure is reported rather than stopping at the first, so an operator correcting a
+/// misconfigured deployment sees all of it in one startup attempt.
+/// </remarks>
+public sealed class AppSettingsValidator : IValidateOptions<AppSettings>
+{
+    /// <summary>The smallest partition count a client may request or configure.</summary>
+    public const int MinimumDefaultPartitionCount = 1;
+
+    /// <summary>The largest partition count a client may request or configure.</summary>
+    public const int MaximumDefaultPartitionCount = 200;
+
+    public ValidateOptionsResult Validate(string? name, AppSettings options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        List<string> failures = [];
+
+        if (options.MaximumPageSize <= 0)
+        {
+            failures.Add($"AppSettings value {nameof(AppSettings.MaximumPageSize)} must be greater than 0");
+        }
+
+        if (
+            options.DefaultPartitionCount < MinimumDefaultPartitionCount
+            || options.DefaultPartitionCount > MaximumDefaultPartitionCount
+        )
+        {
+            failures.Add(
+                $"AppSettings value {nameof(AppSettings.DefaultPartitionCount)} must be between {MinimumDefaultPartitionCount} and {MaximumDefaultPartitionCount}"
+            );
+        }
+
+        return failures.Count == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/DmsCoreServiceExtensions.cs
@@ -148,7 +148,8 @@ public static class DmsCoreServiceExtensions
                         ),
                         QueryResult.QuerySuccess querySuccess => new QueryResult.QuerySuccess(
                             new JsonArray("REDACTED"),
-                            querySuccess.TotalCount
+                            querySuccess.TotalCount,
+                            querySuccess.HighestSelectedDocumentId
                         ),
                         _ => result,
                     };

--- a/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Handler/QueryRequestHandler.cs
@@ -6,6 +6,7 @@
 using EdFi.DataManagementService.Backend.External;
 using EdFi.DataManagementService.Core.Backend;
 using EdFi.DataManagementService.Core.External.Backend;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
@@ -120,7 +121,7 @@ internal class QueryRequestHandler(ILogger _logger, ResiliencePipeline _resilien
             MappingSet: mappingSet,
             QueryElements: requestInfo.QueryElements,
             AuthorizationStrategyEvaluators: requestInfo.AuthorizationStrategyEvaluators,
-            PaginationParameters: requestInfo.PaginationParameters,
+            Paging: new CollectionPaging.Traditional(requestInfo.PaginationParameters),
             TraceId: requestInfo.FrontendRequest.TraceId,
             ReadableProfileProjectionContext: CreateReadableProfileProjectionContext(requestInfo),
             ChangeVersionRange: requestInfo.ChangeVersionRange,

--- a/src/dms/core/EdFi.DataManagementService.Core/Paging/CursorPagingLimits.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Paging/CursorPagingLimits.cs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+namespace EdFi.DataManagementService.Core.Paging;
+
+/// <summary>
+/// Sizing limits derived from the configured maximum page size.
+/// </summary>
+internal static class CursorPagingLimits
+{
+    /// <summary>
+    /// A partition is at least this many maximum-sized pages, so a small collection is not sliced into
+    /// partitions that cost more to coordinate than to read.
+    /// </summary>
+    internal const int MinimumPartitionPageMultiplier = 5;
+
+    /// <summary>
+    /// The minimum partition size in candidate rows.
+    /// </summary>
+    /// <remarks>
+    /// The cast precedes the multiplication so the product is computed in 64-bit width. Multiplying in
+    /// 32-bit width would wrap negative at a large configured page size, which would defeat the
+    /// max(computed, minimum) guard and produce absurd partition counts. The checked context pins that
+    /// required arithmetic shape.
+    /// </remarks>
+    internal static long MinimumPartitionSize(int maximumPageSize) =>
+        checked((long)maximumPageSize * MinimumPartitionPageMultiplier);
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Paging/PageTokenCodec.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Paging/PageTokenCodec.cs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using EdFi.DataManagementService.Core.External.Model;
+
+namespace EdFi.DataManagementService.Core.Paging;
+
+/// <summary>
+/// Transport encoding for a <see cref="CursorRange"/>. A page token is opaque to clients and carries
+/// nothing but the inclusive bounds.
+/// </summary>
+/// <remarks>
+/// Internal to Core on purpose: token text belongs at the HTTP contract boundary, and backend
+/// contracts, planners, and SQL compilers receive typed ranges only. A compiler that could see token
+/// text would be one refactor away from making an authorization decision from client-supplied text.
+/// Decoding grants no authority and makes no authorization decision. Reporting a rejected token to the
+/// client belongs to request validation, so <see cref="TryDecode"/> returns a bool rather than a
+/// message or an exception.
+/// </remarks>
+internal static class PageTokenCodec
+{
+    private const char PaddingCharacter = '=';
+    private const char FieldSeparator = ',';
+    private const int FieldCount = 2;
+
+    /// <summary>
+    /// Rejects invalid byte sequences instead of substituting replacement characters, so a token that
+    /// was never produced by the encoder cannot decode to a different range than it names.
+    /// </summary>
+    private static readonly UTF8Encoding _strictUtf8 = new(
+        encoderShouldEmitUTF8Identifier: false,
+        throwOnInvalidBytes: true
+    );
+
+    /// <summary>
+    /// Encodes both inclusive bounds as invariant signed decimals joined by one comma, UTF-8 encoded,
+    /// in canonical unpadded base64url. Both fields are always emitted.
+    /// </summary>
+    internal static string Encode(CursorRange range)
+    {
+        ArgumentNullException.ThrowIfNull(range);
+
+        string payload =
+            range.InclusiveMinimum.ToString(CultureInfo.InvariantCulture)
+            + FieldSeparator
+            + range.InclusiveMaximum.ToString(CultureInfo.InvariantCulture);
+
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+    }
+
+    /// <summary>
+    /// Decodes a client-supplied page token, accepting correctly padded or unpadded base64url.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately stricter than a permissive base64 reader: accepting forms the encoder never emits
+    /// would create an undocumented input surface that a later change could not safely narrow. An
+    /// empty maximum is the one accepted form the encoder does not produce, so a client or tool can
+    /// express a range that is unbounded above.
+    /// </remarks>
+    internal static bool TryDecode(string pageToken, out CursorRange? range)
+    {
+        range = null;
+
+        if (string.IsNullOrEmpty(pageToken))
+        {
+            return false;
+        }
+
+        int paddingLength = 0;
+        while (
+            paddingLength < pageToken.Length
+            && pageToken[pageToken.Length - 1 - paddingLength] == PaddingCharacter
+        )
+        {
+            paddingLength++;
+        }
+
+        int unpaddedLength = pageToken.Length - paddingLength;
+
+        if (unpaddedLength == 0)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < unpaddedLength; index++)
+        {
+            char character = pageToken[index];
+
+            // Also rejects '+', '/', whitespace, and any padding before the trailing run.
+            if (!char.IsAsciiLetterOrDigit(character) && character != '-' && character != '_')
+            {
+                return false;
+            }
+        }
+
+        int lengthRemainder = unpaddedLength % 4;
+
+        if (lengthRemainder == 1)
+        {
+            return false;
+        }
+
+        int requiredPaddingLength = lengthRemainder == 0 ? 0 : 4 - lengthRemainder;
+
+        if (paddingLength != 0 && paddingLength != requiredPaddingLength)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> unpadded = pageToken.AsSpan(0, unpaddedLength);
+        byte[] payloadBytes = new byte[Base64Url.GetMaxDecodedLength(unpaddedLength)];
+
+        if (!Base64Url.TryDecodeFromChars(unpadded, payloadBytes, out int payloadLength))
+        {
+            return false;
+        }
+
+        string payload;
+
+        try
+        {
+            payload = _strictUtf8.GetString(payloadBytes, 0, payloadLength);
+        }
+        catch (DecoderFallbackException)
+        {
+            return false;
+        }
+
+        string[] fields = payload.Split(FieldSeparator);
+
+        if (fields.Length != FieldCount)
+        {
+            return false;
+        }
+
+        if (!TryParseBound(fields[0], out long inclusiveMinimum))
+        {
+            return false;
+        }
+
+        long inclusiveMaximum;
+
+        if (fields[1].Length == 0)
+        {
+            inclusiveMaximum = long.MaxValue;
+        }
+        else if (!TryParseBound(fields[1], out inclusiveMaximum))
+        {
+            return false;
+        }
+
+        range = new CursorRange(inclusiveMinimum, inclusiveMaximum);
+        return true;
+    }
+
+    /// <summary>
+    /// Creates the token for the page after a non-empty selected keyset, retaining the request's
+    /// maximum bound so a partition walk stays inside its slice.
+    /// </summary>
+    /// <remarks>
+    /// Returns false at <see cref="long.MaxValue"/>: advancing would overflow, so no next token exists
+    /// and the caller omits it. Callers whose request carried no maximum bound pass
+    /// <see cref="long.MaxValue"/>, which keeps a walk entered from a traditional response unbounded
+    /// above.
+    /// </remarks>
+    internal static bool TryCreateNextPageToken(
+        long highestSelectedDocumentId,
+        long maximumDocumentId,
+        out string? nextPageToken
+    )
+    {
+        if (highestSelectedDocumentId == long.MaxValue)
+        {
+            nextPageToken = null;
+            return false;
+        }
+
+        nextPageToken = Encode(new CursorRange(highestSelectedDocumentId + 1, maximumDocumentId));
+        return true;
+    }
+
+    /// <summary>
+    /// Parses one decimal bound, which must match <c>-?[0-9]+</c> exactly and fit <see cref="long"/>.
+    /// </summary>
+    private static bool TryParseBound(string field, out long bound)
+    {
+        bound = 0;
+
+        if (field.Length == 0)
+        {
+            return false;
+        }
+
+        int firstDigitIndex = field[0] == '-' ? 1 : 0;
+
+        if (field.Length == firstDigitIndex)
+        {
+            return false;
+        }
+
+        for (int index = firstDigitIndex; index < field.Length; index++)
+        {
+            // Rejects whitespace, a leading '+', grouping separators, and any other non-digit.
+            if (!char.IsAsciiDigit(field[index]))
+            {
+                return false;
+            }
+        }
+
+        // Only the Int64 range check remains once the grammar above has passed.
+        return long.TryParse(field, NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out bound);
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Paging/PageTokenCodec.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Paging/PageTokenCodec.cs
@@ -54,7 +54,9 @@ internal static class PageTokenCodec
     }
 
     /// <summary>
-    /// Decodes a client-supplied page token, accepting correctly padded or unpadded base64url.
+    /// Decodes a client-supplied page token, accepting correctly padded or unpadded base64url. A null
+    /// or empty token is rejected like any other malformed input, so callers can hand over an absent
+    /// query-string value without a null check of their own.
     /// </summary>
     /// <remarks>
     /// Deliberately stricter than a permissive base64 reader: accepting forms the encoder never emits
@@ -62,7 +64,7 @@ internal static class PageTokenCodec
     /// empty maximum is the one accepted form the encoder does not produce, so a client or tool can
     /// express a range that is unbounded above.
     /// </remarks>
-    internal static bool TryDecode(string pageToken, out CursorRange? range)
+    internal static bool TryDecode(string? pageToken, out CursorRange? range)
     {
         range = null;
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/CoreAppSettingsBindingTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/CoreAppSettingsBindingTests.cs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using NUnit.Framework;
+using CoreAppSettings = EdFi.DataManagementService.Core.Configuration.AppSettings;
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit;
+
+[TestFixture]
+[Parallelizable]
+public class CoreAppSettingsBindingTests
+{
+    [Test]
+    public void It_binds_the_partition_count_from_the_app_settings_section()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["AppSettings:MaximumPageSize"] = "250",
+                    ["AppSettings:DefaultPartitionCount"] = "25",
+                }
+            )
+            .Build();
+
+        CoreAppSettings settings = new() { AllowIdentityUpdateOverrides = string.Empty };
+        configuration.GetSection("AppSettings").Bind(settings);
+
+        settings.MaximumPageSize.Should().Be(250);
+        settings.DefaultPartitionCount.Should().Be(25);
+    }
+
+    [Test]
+    public void It_keeps_the_property_default_when_the_section_omits_the_partition_count()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?> { ["AppSettings:MaximumPageSize"] = "500" }
+            )
+            .Build();
+
+        CoreAppSettings settings = new() { AllowIdentityUpdateOverrides = string.Empty };
+        configuration.GetSection("AppSettings").Bind(settings);
+
+        settings.DefaultPartitionCount.Should().Be(CoreAppSettings.DefaultPartitionCountDefault);
+    }
+
+    [Test]
+    public void It_binds_the_shipped_configured_defaults()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory)
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        CoreAppSettings settings = new() { AllowIdentityUpdateOverrides = string.Empty };
+        configuration.GetSection("AppSettings").Bind(settings);
+
+        settings.MaximumPageSize.Should().Be(500);
+        settings.DefaultPartitionCount.Should().Be(10);
+    }
+}
+
+/// <summary>
+/// The documented environment override must reach the bound options. Non-parallel and restoring the
+/// exact prior process value, because the variable name is process-wide.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class Given_A_Partition_Count_Environment_Override
+{
+    private const string VariableName = "AppSettings__DefaultPartitionCount";
+
+    [Test]
+    public void It_overrides_the_configuration_section_value()
+    {
+        string? priorValue = Environment.GetEnvironmentVariable(VariableName);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(VariableName, "42");
+
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                    new Dictionary<string, string?> { ["AppSettings:DefaultPartitionCount"] = "10" }
+                )
+                .AddEnvironmentVariables()
+                .Build();
+
+            CoreAppSettings settings = new() { AllowIdentityUpdateOverrides = string.Empty };
+            configuration.GetSection("AppSettings").Bind(settings);
+
+            settings.DefaultPartitionCount.Should().Be(42);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(VariableName, priorValue);
+        }
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/CoreAppSettingsStartupValidationTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/CoreAppSettingsStartupValidationTests.cs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using CoreAppSettings = EdFi.DataManagementService.Core.Configuration.AppSettings;
+
+namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit;
+
+/// <summary>
+/// Proves the Core AppSettings paging values are validated when the application starts, through the
+/// real application entry point.
+/// </summary>
+/// <remarks>
+/// The eager resolve in Program.cs records the failure against the ConfigureEndpoints phase, so an
+/// operator gets an accurate status file rather than one reading Completed on a process that is about
+/// to die. Host start then still fails, because eager options validation refuses to bring a host up on
+/// invalid values. That is why these cases assert the recorded failure rather than a short-circuited
+/// HTTP 500 response: the 500 path is reachable only for options that are not eagerly validated.
+/// </remarks>
+[TestFixture]
+[NonParallelizable]
+public class CoreAppSettingsStartupValidationTests
+{
+    private WebApplicationFactory<Program>? _factory;
+    private string _statusDirectory = null!;
+    private string _statusFilePath = null!;
+
+    private void CreateFactoryWith(string settingKey, string settingValue)
+    {
+        _statusDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        _statusFilePath = Path.Combine(_statusDirectory, "dms-startup-status.json");
+
+        _factory = new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            builder.ConfigureAppConfiguration(
+                (_, configuration) =>
+                    configuration.AddInMemoryCollection(
+                        new Dictionary<string, string?>
+                        {
+                            ["AppSettings:StartupStatusFilePath"] = _statusFilePath,
+                            [settingKey] = settingValue,
+                        }
+                    )
+            );
+            builder.ConfigureServices(TestMockHelper.AddEssentialMocks);
+        });
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        _factory?.Dispose();
+
+        if (Directory.Exists(_statusDirectory))
+        {
+            Directory.Delete(_statusDirectory, recursive: true);
+        }
+    }
+
+    [TestCase(
+        "AppSettings:DefaultPartitionCount",
+        "201",
+        nameof(CoreAppSettings.DefaultPartitionCount),
+        TestName = "It_fails_startup_for_a_partition_count_above_the_supported_range"
+    )]
+    [TestCase(
+        "AppSettings:MaximumPageSize",
+        "0",
+        nameof(CoreAppSettings.MaximumPageSize),
+        TestName = "It_fails_startup_for_a_nonpositive_maximum_page_size"
+    )]
+    public async Task It_records_the_failed_startup_and_refuses_to_start(
+        string settingKey,
+        string settingValue,
+        string expectedSettingName
+    )
+    {
+        CreateFactoryWith(settingKey, settingValue);
+
+        Action startHost = () => _factory!.CreateClient();
+        startHost.Should().Throw<OptionsValidationException>();
+
+        File.Exists(_statusFilePath).Should().BeTrue();
+        var startupStatus = JsonNode.Parse(await File.ReadAllTextAsync(_statusFilePath))!.AsObject();
+
+        startupStatus["State"]!.GetValue<string>().Should().Be("Failed");
+        startupStatus["Phase"]!.GetValue<string>().Should().Be(DmsStartupPhases.ConfigureEndpoints);
+        startupStatus["ErrorType"]!.GetValue<string>().Should().Be(nameof(OptionsValidationException));
+        startupStatus["ErrorMessage"]!.GetValue<string>().Should().Contain(expectedSettingName);
+    }
+}
+
+/// <summary>
+/// Complements the host-start coverage above with a direct assertion on the eager validator's
+/// failures, which the startup-status path reports only as a message.
+/// </summary>
+[TestFixture]
+[Parallelizable]
+public class Given_The_Core_App_Settings_Startup_Validator
+{
+    private static ServiceProvider CreateServices(Dictionary<string, string?> configuration)
+    {
+        var builder = WebApplication.CreateBuilder(new WebApplicationOptions { EnvironmentName = "Test" });
+
+        builder.Configuration.Sources.Clear();
+        builder.Configuration.AddInMemoryCollection(
+            new Dictionary<string, string?>(configuration)
+            {
+                ["AppSettings:Datastore"] = "postgresql",
+                ["ConfigurationServiceSettings:BaseUrl"] = "https://example.org",
+                ["ConfigurationServiceSettings:ClientId"] = "client-id",
+                ["ConfigurationServiceSettings:ClientSecret"] = "client-secret",
+                ["ConfigurationServiceSettings:Scope"] = "scope",
+                ["ConfigurationServiceSettings:EncryptionKey"] =
+                    "TestEncryptionKey123456789012345678901234567890",
+            }
+        );
+
+        builder.AddServices();
+
+        return builder.Services.BuildServiceProvider();
+    }
+
+    [Test]
+    public void It_reports_the_partition_count_failure_from_the_startup_validator()
+    {
+        using ServiceProvider serviceProvider = CreateServices(
+            new Dictionary<string, string?>
+            {
+                ["AppSettings:MaximumPageSize"] = "500",
+                ["AppSettings:DefaultPartitionCount"] = "201",
+            }
+        );
+
+        Action validate = () => serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        validate
+            .Should()
+            .Throw<OptionsValidationException>()
+            .Which.Failures.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(nameof(CoreAppSettings.DefaultPartitionCount));
+    }
+
+    [Test]
+    public void It_reports_the_maximum_page_size_failure_from_the_startup_validator()
+    {
+        using ServiceProvider serviceProvider = CreateServices(
+            new Dictionary<string, string?>
+            {
+                ["AppSettings:MaximumPageSize"] = "0",
+                ["AppSettings:DefaultPartitionCount"] = "10",
+            }
+        );
+
+        Action validate = () => serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        validate
+            .Should()
+            .Throw<OptionsValidationException>()
+            .Which.Failures.Should()
+            .ContainSingle()
+            .Which.Should()
+            .Contain(nameof(CoreAppSettings.MaximumPageSize));
+    }
+
+    [Test]
+    public void It_passes_for_the_shipped_default_values()
+    {
+        using ServiceProvider serviceProvider = CreateServices(
+            new Dictionary<string, string?>
+            {
+                ["AppSettings:MaximumPageSize"] = "500",
+                ["AppSettings:DefaultPartitionCount"] = "10",
+            }
+        );
+
+        Action validate = () => serviceProvider.GetRequiredService<IStartupValidator>().Validate();
+
+        validate.Should().NotThrow();
+    }
+}

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/WebApplicationBuilderExtensionsTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/WebApplicationBuilderExtensionsTests.cs
@@ -38,6 +38,10 @@ public class WebApplicationBuilderExtensionsTests
         {
             ["AppSettings:Datastore"] = datastore,
             ["AppSettings:MaskRequestBodyInLogs"] = "false",
+            // This helper is the valid baseline; focused tests override a single setting when they
+            // intend it to be invalid.
+            ["AppSettings:MaximumPageSize"] = "500",
+            ["AppSettings:DefaultPartitionCount"] = "10",
             ["ConfigurationServiceSettings:BaseUrl"] = "https://example.org",
             ["ConfigurationServiceSettings:ClientId"] = "client-id",
             ["ConfigurationServiceSettings:ClientSecret"] = "client-secret",

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -23,6 +23,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Serilog;
 using CoreAppSettings = EdFi.DataManagementService.Core.Configuration.AppSettings;
+using CoreAppSettingsValidator = EdFi.DataManagementService.Core.Configuration.AppSettingsValidator;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Infrastructure;
 
@@ -55,8 +56,10 @@ public static class WebApplicationBuilderExtensions
             .Configure<Frontend.AspNetCore.Configuration.AppSettings>(
                 webAppBuilder.Configuration.GetSection("AppSettings")
             )
-            .Configure<CoreAppSettings>(webAppBuilder.Configuration.GetSection("AppSettings"))
-            .Configure<ReverseProxySettings>(
+            .AddOptions<CoreAppSettings>()
+            .Bind(webAppBuilder.Configuration.GetSection("AppSettings"))
+            .ValidateOnStart()
+            .Services.Configure<ReverseProxySettings>(
                 webAppBuilder.Configuration.GetSection("AppSettings:ReverseProxy")
             )
             .Configure<ConfigurationServiceSettings>(
@@ -73,8 +76,9 @@ public static class WebApplicationBuilderExtensions
             .AddSingleton<StartupPhaseExecutor>()
             .AddSingleton<
                 IValidateOptions<Frontend.AspNetCore.Configuration.AppSettings>,
-                AppSettingsValidator
+                Frontend.AspNetCore.Configuration.AppSettingsValidator
             >()
+            .AddSingleton<IValidateOptions<CoreAppSettings>, CoreAppSettingsValidator>()
             .AddSingleton<
                 IValidateOptions<ConfigurationServiceSettings>,
                 ConfigurationServiceSettingsValidator

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Program.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Options;
 using AppSettings = EdFi.DataManagementService.Frontend.AspNetCore.Configuration.AppSettings;
+using CoreAppSettings = EdFi.DataManagementService.Core.Configuration.AppSettings;
 using ResponseCompressionDefaults = Microsoft.AspNetCore.ResponseCompression.ResponseCompressionDefaults;
 
 // Disable reload to work around .NET file watcher bug on Linux. See:
@@ -272,6 +273,10 @@ OptionsValidationException? ReportInvalidConfiguration(WebApplication app)
     {
         // Accessing IOptions<T> forces validation
         _ = app.Services.GetRequiredService<IOptions<AppSettings>>().Value;
+        // Core AppSettings is validated at startup by ValidateOnStart. Resolving it here as well is
+        // what routes a failure into the graceful path below instead of surfacing later, during host
+        // start, past every guard in this file.
+        _ = app.Services.GetRequiredService<IOptions<CoreAppSettings>>().Value;
         _ = app.Services.GetRequiredService<IOptions<ConfigurationServiceSettings>>().Value;
         _ = app.Services.GetRequiredService<IOptions<MappingSetProviderOptions>>().Value;
         _ = app.Services.GetRequiredService<IOptions<ReverseProxySettings>>().Value;

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.json
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/appsettings.json
@@ -7,6 +7,7 @@
     "BypassTypeCoercion": false,
     "CorrelationIdHeader": "",
     "Datastore": "postgresql",
+    "DefaultPartitionCount": 10,
     "DomainsExcludedFromOpenApi": "",
     "EnableClaimsetReload": false,
     "EnableManagementEndpoints": false,


### PR DESCRIPTION
## Summary

Establishes the provider-neutral typed paging, range, token, result-boundary, and configuration
vocabulary that the rest of the partitioned cursor paging epic (DMS-1348) builds on, so every later
story shares one contract before validation, routing, planning, or execution work begins.

Contracts, codec, and configuration only. Traditional `limit`/`offset` behavior is unchanged: no
page-selection SQL, parameter role, planner signature, or golden is touched, and `/deletes` and
`/keyChanges` neither acquire cursor behavior nor reserve cursor parameter names.

Implements [DMS-1383](https://edfi.atlassian.net/browse/DMS-1383). Normative design:
`reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md` and
`reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00a-cursor-contract-primitives.md`,
both landed on `main` via #1148.

## What this adds

**Typed paging vocabulary** (`Core.External/Model`)

- `CursorRange(long InclusiveMinimum, long InclusiveMaximum)` with `From(min)` for unbounded above.
  Negative bounds and inverted ranges are valid match-nothing ranges, not errors — an inverted range
  is how a bounded partition reaches its terminal empty page.
- `PageSize`, a value type that makes negative sizes unrepresentable. Zero is valid and intentionally
  cannot advance a cursor walk.
- `CollectionPaging`, a closed choice of `Traditional(PaginationParameters)` and
  `Cursor(CursorRange, PageSize)`, so "cursor request with a null range" and "traditional request with
  a page size" cannot be constructed. `IncludesTotalCount` is overridden per alternative because only
  traditional paging can request a count.

`PaginationParameters` is unchanged and still serves traditional and tracked-change paging.

**Request-contract threading**

`IQueryRequest` now exposes `CollectionPaging Paging` instead of `PaginationParameters`.
`RelationalQueryRequest` carries the choice and `QueryRequestHandler` adapts the already-parsed
parameters with `CollectionPaging.Traditional`. `RelationalDocumentStoreRepository` unwraps the
traditional alternative once, up front, and passes the same `PaginationParameters` to the existing
planners untouched.

The cursor alternative returns `QueryFailureNotImplemented` — a deliberate temporary seam, pinned by
two tests so that DMS-1385/DMS-1386 must remove it consciously. It is unreachable today because
nothing constructs a cursor request until token parsing exists, and it produces HTTP 501 rather than
the wrong data a silent traditional fallback would return.

**Page token codec** (`Core/Paging/PageTokenCodec.cs`, internal to Core)

Encodes both inclusive bounds as invariant signed decimals joined by one comma, UTF-8, canonical
unpadded base64url. The decoder validates the whole grammar before handing bytes to the framework,
because a permissive base64 reader silently skips whitespace: it rejects `+` and `/`, internal
padding, excess or incomplete padding, an impossible length, invalid UTF-8, anything other than
exactly two fields, and any bound not matching `-?[0-9]+` or not fitting `Int64`. An empty maximum
decodes as `Int64.MaxValue`; the encoder never emits that form.

`TryCreateNextPageToken` advances past the highest selected id and retains the request's maximum, so a
partition walk stays inside its slice, and declines at `Int64.MaxValue` rather than overflowing.

The codec is `internal` to Core, and `EdFi.DataManagementService.Backend` is deliberately absent from
Core's `InternalsVisibleTo` list, so planners and SQL compilers cannot reference token text at all.
Two tests pin that boundary.

**Result shapes**

Nullable `HighestSelectedDocumentId` on `HydratedPage` and `QuerySuccess`, deliberately independent of
the hydrated body: every selected row may be deleted before hydration completes, so a body-derived
boundary would stall a walk on the last surviving document. Plus a closed
`PartitionResult`/`PartitionSuccess(IReadOnlyList<CursorRange>)` carrying typed ranges only.

Shapes only — nothing populates or reads them. Hydration/execution propagation is DMS-1386, and the
partition pipeline is DMS-1387.

**Configuration and startup validation**

- `AppSettings:DefaultPartitionCount` with both a property default and a configured default of `10`,
  the `AppSettings__DefaultPartitionCount` environment override, and matching entries in
  `eng/docker-compose/local-dms.yml` and `published-dms.yml`.
- A Core-owned validator requiring `MaximumPageSize > 0` and `DefaultPartitionCount` within an
  inclusive `1..200`, reporting both failures together, wired with
  `AddOptions/Bind/ValidateOnStart` so it runs at startup rather than at first options access.
- `CursorPagingLimits.MinimumPartitionSize` as `checked((long)maximumPageSize * 5)`. The cast precedes
  the multiplication because the real hazard is 32-bit wrap at a large page size, which would defeat
  the `max(computed, minimum)` guard.

### Startup failure is two-stage, and that is intended

`Program.cs` also resolves `IOptions<CoreAppSettings>.Value` eagerly inside
`ReportInvalidConfiguration`. Without it, a `ValidateOnStart` failure surfaces during host start —
after every guard in that file — and takes the process down while the startup status file still reads
`Completed`, the outcome the existing comment there argues is worse than a stranded `Starting`.

With it, an invalid value produces an accurate operator record (`State=Failed`,
`Phase=ConfigureEndpoints`, `ErrorType=OptionsValidationException`, offending setting named) and *then*
host start still refuses to come up. Both stages are asserted. Note that the graceful HTTP 500
short-circuit is not reachable for an eagerly validated option, unlike the frontend `AppSettings`,
which is validated without `ValidateOnStart`.

## Out of scope

Deferred to the stories that own them, and verified absent from this diff:

- **DMS-1384** — cursor/partition validation, precedence phases, error messages, the ProblemDetails
  shell, operation-scoped rejection, typed path classification, parameter canonicalization
- **DMS-1385 / DMS-1387** — candidate planning, cursor and partition SQL, provider execution, the
  partition pipeline and `IPartitionQueryHandler`, starting-id-to-range conversion
- **DMS-1386** — selected-keyset propagation, `RETURNING`/`OUTPUT`, `Next-Page-Token` emission
- **DMS-1388** — OpenAPI and client publication

No persisted state, schema migration, index, feature toggle, token signing/encryption/expiration, or
authorization binding. Token parsing grants no authority and makes no authorization decision.

## Testing

- Full `src/dms` solution build: **0 warnings, 0 errors**
- `Core.Tests.Unit` — 3088 passed / 1 skipped
- `Backend.Tests.Unit` — 2253 passed
- `Backend.Plans.Tests.Unit` — 1734 passed
- `Frontend.AspNetCore.Tests.Unit` — 325 passed / 2 skipped

Coverage highlights: the complete codec grammar including round trips, both signed extremes, padded
and unpadded input, every rejection form, and terminal advancement; contract tests proving
tracked-change requests expose no cursor type and the owned contracts declare no token text;
independence of the selected-keyset boundary from the response body in both directions; the validator
matrix; the environment override with exact prior-value save/restore; and host-start validation
through the real `Program` entry point.

No Docker E2E or provider integration run: nothing here touches SQL, hydration execution, routing, or
request handling. The 24 provider integration test files in this diff changed by exactly one
constructor argument each — 2 lines per file, no test logic or fixture data — which the warning-free
solution build verifies.

## Notes for reviewers

- `IQueryRequest.PaginationParameters` → `Paging` ripples into 24 PostgreSQL and SQL Server
  integration test files that construct the Core-internal `RelationalQueryRequest` directly through
  `InternalsVisibleTo`. Those edits are mechanical wrappers preserving the original values.
- Known cosmetic items, none affecting behavior: some early test fixtures do not use the preferred
  `Given_` prefix; the closure tests inspect only public base constructors; the final commit body has a
  duplicated word ("Validator coverage coverage") that squash-on-merge will drop; and the new
  `Program.cs` comment says "instead of surfacing later" where "before" would be accurate, since the
  failure also surfaces later and refuses host start.
- The branch is two commits behind `main`. Four changed configuration/compose files overlap the
  upstream OTLP log-export work; a read-only merge simulation produced no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DMS-1383]: https://edfi.atlassian.net/browse/DMS-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ