### PR TITLE
[DMS-1281] Return Ed-Fi problem-details body for unsupported HTTP methods (e.g., PATCH) on data endpoints

### DIFF
--- a/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
@@ -53,6 +53,15 @@ public interface IApiService
     Task<IFrontendResponse> GetTrackedChanges(FrontendRequest frontendRequest);
 
     /// <summary>
+    /// DMS entry point for a data-route request whose HTTP method is not one of the supported
+    /// verbs. Core determines the response, so a request for an unknown project namespace or
+    /// resource still answers 404 rather than 405.
+    /// </summary>
+    /// <param name="frontendRequest">The request to be processed</param>
+    /// <param name="requestMethodName">The actual HTTP method name of the request, e.g. "PATCH"</param>
+    Task<IFrontendResponse> MethodNotAllowed(FrontendRequest frontendRequest, string requestMethodName);
+
+    /// <summary>
     /// DMS entry point for data model information from ApiSchema.json
     /// </summary>
     IList<IDataModelInfo> GetDataModelInfo();

--- a/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.External/Interface/IApiService.cs
@@ -62,6 +62,20 @@ public interface IApiService
     Task<IFrontendResponse> MethodNotAllowed(FrontendRequest frontendRequest, string requestMethodName);
 
     /// <summary>
+    /// DMS entry point for a tracked-change route request (/deletes, /keyChanges) whose HTTP
+    /// method is not one of the supported verbs. Separate from MethodNotAllowed because the two
+    /// paths parse differently: a tracked-change path carries an operation suffix where a data
+    /// path carries a document id. Core determines the response here too, so authentication,
+    /// tenant validation and resource existence all precede the 405.
+    /// </summary>
+    /// <param name="frontendRequest">The request to be processed</param>
+    /// <param name="requestMethodName">The actual HTTP method name of the request, e.g. "PATCH"</param>
+    Task<IFrontendResponse> MethodNotAllowedForTrackedChange(
+        FrontendRequest frontendRequest,
+        string requestMethodName
+    );
+
+    /// <summary>
     /// DMS entry point for data model information from ApiSchema.json
     /// </summary>
     IList<IDataModelInfo> GetDataModelInfo();

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -5,7 +5,6 @@
 
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Frontend;
-using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
@@ -22,9 +21,9 @@ public class MethodNotAllowedMiddlewareTests
 {
     private const string TraceId = "method-not-allowed-trace-id";
 
-    private static IPipelineStep Middleware()
+    private static IPipelineStep Middleware(bool isTrackedChangeRoute = false)
     {
-        return new MethodNotAllowedMiddleware(NullLogger.Instance);
+        return new MethodNotAllowedMiddleware(NullLogger.Instance, isTrackedChangeRoute);
     }
 
     private static PathComponents PathComponents(bool hasDocumentUuidSegment)
@@ -155,34 +154,35 @@ public class MethodNotAllowedMiddlewareTests
     [Parallelizable]
     public class Given_An_Unsupported_Method_On_A_Tracked_Change_Route : MethodNotAllowedMiddlewareTests
     {
-        /// <summary>
-        /// Mirrors what ParseTrackedChangePathMiddleware leaves behind for a /deletes or
-        /// /keyChanges request: the operation set, and no document uuid segment.
-        /// </summary>
-        private static RequestInfo TrackedChangeRequestInfoFor(
-            string unsupportedMethodName,
-            ChangeQueryEndpointOperation operation
-        )
+        [Test]
+        public async Task It_returns_405_allowing_get_only()
         {
-            RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, hasDocumentUuidSegment: false);
-            requestInfo.ChangeQueryOperation = operation;
-            return requestInfo;
-        }
+            // ParseTrackedChangePathMiddleware leaves no document uuid segment behind, exactly as
+            // ParsePathMiddleware does for a collection route, which is why the pipeline tells this
+            // step which route family it terminates rather than the step reading it off the request.
+            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
 
-        [TestCase(ChangeQueryEndpointOperation.Deletes)]
-        [TestCase(ChangeQueryEndpointOperation.KeyChanges)]
-        public async Task It_returns_405_allowing_get_only(ChangeQueryEndpointOperation operation)
-        {
-            RequestInfo requestInfo = TrackedChangeRequestInfoFor("PATCH", operation);
-
-            await Middleware().Execute(requestInfo, NullNext);
+            await Middleware(isTrackedChangeRoute: true).Execute(requestInfo, NullNext);
 
             requestInfo.FrontendResponse.StatusCode.Should().Be(405);
-            // A tracked-change path leaves HasDocumentUuidSegment false, so without the
-            // ChangeQueryOperation check this would advertise the collection methods.
             requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET");
             requestInfo.FrontendResponse.ContentType.Should().Be("application/json; charset=utf-8");
             AssertMethodNotAllowedProblemDetails(requestInfo.FrontendResponse, "PATCH");
+        }
+
+        /// <summary>
+        /// The regression guard for the discriminator: the identical request answered by the
+        /// data-route pipeline must advertise the collection methods, so a terminal wired into the
+        /// wrong pipeline cannot go unnoticed.
+        /// </summary>
+        [Test]
+        public async Task It_advertises_the_collection_methods_when_wired_into_the_data_pipeline()
+        {
+            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+
+            await Middleware(isTrackedChangeRoute: false).Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, POST");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -26,22 +26,19 @@ public class MethodNotAllowedMiddlewareTests
         return new MethodNotAllowedMiddleware(NullLogger.Instance, isTrackedChangeRoute);
     }
 
-    private static PathComponents PathComponents(bool hasDocumentUuidSegment)
+    private static PathComponents PathComponents(ResourcePathOperation operation)
     {
-        return new(
-            ProjectEndpointName: new("ed-fi"),
-            EndpointName: new("schools"),
-            DocumentUuid: hasDocumentUuidSegment ? new(Guid.NewGuid()) : No.DocumentUuid,
-            HasDocumentUuidSegment: hasDocumentUuidSegment
-        );
+        return new(ProjectEndpointName: new("ed-fi"), EndpointName: new("schools"), Operation: operation);
     }
 
-    private static RequestInfo RequestInfoFor(string unsupportedMethodName, bool hasDocumentUuidSegment)
+    private static ResourcePathOperation CollectionRoute() => ResourcePathOperation.Collection.Instance;
+
+    private static RequestInfo RequestInfoFor(string unsupportedMethodName, ResourcePathOperation operation)
     {
         RequestInfo requestInfo = No.RequestInfo(TraceId);
         requestInfo.Method = RequestMethod.UNSUPPORTED;
         requestInfo.UnsupportedMethodName = unsupportedMethodName;
-        requestInfo.PathComponents = PathComponents(hasDocumentUuidSegment);
+        requestInfo.PathComponents = PathComponents(operation);
         return requestInfo;
     }
 
@@ -74,7 +71,7 @@ public class MethodNotAllowedMiddlewareTests
     [Parallelizable]
     public class Given_An_Unsupported_Method_On_A_Collection_Route : MethodNotAllowedMiddlewareTests
     {
-        private readonly RequestInfo _requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+        private readonly RequestInfo _requestInfo = RequestInfoFor("PATCH", CollectionRoute());
 
         [SetUp]
         public async Task Setup()
@@ -117,7 +114,10 @@ public class MethodNotAllowedMiddlewareTests
     [Parallelizable]
     public class Given_An_Unsupported_Method_On_An_Item_Route : MethodNotAllowedMiddlewareTests
     {
-        private readonly RequestInfo _requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: true);
+        private readonly RequestInfo _requestInfo = RequestInfoFor(
+            "PATCH",
+            new ResourcePathOperation.ById(new(Guid.NewGuid()))
+        );
 
         [SetUp]
         public async Task Setup()
@@ -157,14 +157,15 @@ public class MethodNotAllowedMiddlewareTests
         [Test]
         public async Task It_returns_405_allowing_get_only()
         {
-            // ParseTrackedChangePathMiddleware leaves no document uuid segment behind, exactly as
-            // ParsePathMiddleware does for a collection route, which is why the pipeline tells this
-            // step which route family it terminates rather than the step reading it off the request.
+            // ParseTrackedChangePathMiddleware classifies its path as the Collection operation,
+            // exactly as ParsePathMiddleware does for a collection route, which is why the pipeline
+            // tells this step which route family it terminates rather than the step reading it off
+            // the request.
             //
             // These tests supply that flag themselves, so none of them can show it being wired
             // correctly. That is pinned in PipelineOrderingTests, which exercises the terminal each
             // pipeline factory actually constructed.
-            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+            RequestInfo requestInfo = RequestInfoFor("PATCH", CollectionRoute());
 
             await Middleware(isTrackedChangeRoute: true).Execute(requestInfo, NullNext);
 
@@ -187,7 +188,7 @@ public class MethodNotAllowedMiddlewareTests
         [TestCase("HEAD")]
         public async Task It_names_the_method_of_the_request_in_the_errors(string unsupportedMethodName)
         {
-            RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, hasDocumentUuidSegment: false);
+            RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, CollectionRoute());
 
             await Middleware().Execute(requestInfo, NullNext);
 
@@ -203,7 +204,7 @@ public class MethodNotAllowedMiddlewareTests
         [Test]
         public async Task It_does_not_invoke_the_next_step()
         {
-            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+            RequestInfo requestInfo = RequestInfoFor("PATCH", CollectionRoute());
             bool nextWasInvoked = false;
 
             await Middleware()

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.Middleware;
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
+
+namespace EdFi.DataManagementService.Core.Tests.Unit.Middleware;
+
+[TestFixture]
+[Parallelizable]
+public class MethodNotAllowedMiddlewareTests
+{
+    private const string TraceId = "method-not-allowed-trace-id";
+
+    private static IPipelineStep Middleware()
+    {
+        return new MethodNotAllowedMiddleware(NullLogger.Instance);
+    }
+
+    private static PathComponents PathComponents(bool hasDocumentUuidSegment)
+    {
+        return new(
+            ProjectEndpointName: new("ed-fi"),
+            EndpointName: new("schools"),
+            DocumentUuid: hasDocumentUuidSegment ? new(Guid.NewGuid()) : No.DocumentUuid,
+            HasDocumentUuidSegment: hasDocumentUuidSegment
+        );
+    }
+
+    private static RequestInfo RequestInfoFor(string unsupportedMethodName, bool hasDocumentUuidSegment)
+    {
+        RequestInfo requestInfo = No.RequestInfo(TraceId);
+        requestInfo.Method = RequestMethod.UNSUPPORTED;
+        requestInfo.UnsupportedMethodName = unsupportedMethodName;
+        requestInfo.PathComponents = PathComponents(hasDocumentUuidSegment);
+        return requestInfo;
+    }
+
+    /// <summary>
+    /// Asserts the Ed-Fi method-not-allowed problem-details contract member by member. The
+    /// frontend's tracked-change terminal produces the same body from the same factory, and its
+    /// test asserts these same members so the two 405 producers cannot drift.
+    /// </summary>
+    private static void AssertMethodNotAllowedProblemDetails(
+        IFrontendResponse response,
+        string expectedMethodName
+    )
+    {
+        response.Body.Should().NotBeNull();
+        JsonNode body = response.Body!;
+
+        body["detail"]!.GetValue<string>().Should().Be("The request construction was invalid.");
+        body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:method-not-allowed");
+        body["title"]!.GetValue<string>().Should().Be("Method Not Allowed");
+        body["status"]!.GetValue<int>().Should().Be(405);
+        body["validationErrors"]!.AsObject().Should().BeEmpty();
+        body["errors"]!
+            .AsArray()
+            .Select(error => error!.GetValue<string>())
+            .Should()
+            .Equal($"The endpoint of the request does not support the '{expectedMethodName}' method.");
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Unsupported_Method_On_A_Collection_Route : MethodNotAllowedMiddlewareTests
+    {
+        private readonly RequestInfo _requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_returns_status_405()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(405);
+        }
+
+        [Test]
+        public void It_returns_an_allow_header_of_the_collection_methods()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, POST");
+        }
+
+        [Test]
+        public void It_returns_json_content_type()
+        {
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/json; charset=utf-8");
+        }
+
+        [Test]
+        public void It_returns_the_ed_fi_method_not_allowed_body()
+        {
+            AssertMethodNotAllowedProblemDetails(_requestInfo.FrontendResponse, "PATCH");
+        }
+
+        [Test]
+        public void It_returns_the_correlation_id_of_the_request()
+        {
+            _requestInfo.FrontendResponse.Body!["correlationId"]!.GetValue<string>().Should().Be(TraceId);
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Unsupported_Method_On_An_Item_Route : MethodNotAllowedMiddlewareTests
+    {
+        private readonly RequestInfo _requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: true);
+
+        [SetUp]
+        public async Task Setup()
+        {
+            await Middleware().Execute(_requestInfo, NullNext);
+        }
+
+        [Test]
+        public void It_returns_status_405()
+        {
+            _requestInfo.FrontendResponse.StatusCode.Should().Be(405);
+        }
+
+        [Test]
+        public void It_returns_an_allow_header_of_the_item_methods()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, PUT, DELETE");
+        }
+
+        [Test]
+        public void It_returns_json_content_type()
+        {
+            _requestInfo.FrontendResponse.ContentType.Should().Be("application/json; charset=utf-8");
+        }
+
+        [Test]
+        public void It_returns_the_ed_fi_method_not_allowed_body()
+        {
+            AssertMethodNotAllowedProblemDetails(_requestInfo.FrontendResponse, "PATCH");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_Any_Unsupported_Method : MethodNotAllowedMiddlewareTests
+    {
+        [TestCase("PATCH")]
+        [TestCase("OPTIONS")]
+        [TestCase("TRACE")]
+        [TestCase("FOO")]
+        public async Task It_names_the_method_of_the_request_in_the_errors(string unsupportedMethodName)
+        {
+            RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, hasDocumentUuidSegment: false);
+
+            await Middleware().Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(405);
+            AssertMethodNotAllowedProblemDetails(requestInfo.FrontendResponse, unsupportedMethodName);
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_The_Step_Is_Terminal : MethodNotAllowedMiddlewareTests
+    {
+        [Test]
+        public async Task It_does_not_invoke_the_next_step()
+        {
+            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
+            bool nextWasInvoked = false;
+
+            await Middleware()
+                .Execute(
+                    requestInfo,
+                    () =>
+                    {
+                        nextWasInvoked = true;
+                        return Task.CompletedTask;
+                    }
+                );
+
+            nextWasInvoked.Should().BeFalse();
+        }
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Core.Middleware;
 using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
@@ -147,6 +148,41 @@ public class MethodNotAllowedMiddlewareTests
         public void It_returns_the_ed_fi_method_not_allowed_body()
         {
             AssertMethodNotAllowedProblemDetails(_requestInfo.FrontendResponse, "PATCH");
+        }
+    }
+
+    [TestFixture]
+    [Parallelizable]
+    public class Given_An_Unsupported_Method_On_A_Tracked_Change_Route : MethodNotAllowedMiddlewareTests
+    {
+        /// <summary>
+        /// Mirrors what ParseTrackedChangePathMiddleware leaves behind for a /deletes or
+        /// /keyChanges request: the operation set, and no document uuid segment.
+        /// </summary>
+        private static RequestInfo TrackedChangeRequestInfoFor(
+            string unsupportedMethodName,
+            ChangeQueryEndpointOperation operation
+        )
+        {
+            RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, hasDocumentUuidSegment: false);
+            requestInfo.ChangeQueryOperation = operation;
+            return requestInfo;
+        }
+
+        [TestCase(ChangeQueryEndpointOperation.Deletes)]
+        [TestCase(ChangeQueryEndpointOperation.KeyChanges)]
+        public async Task It_returns_405_allowing_get_only(ChangeQueryEndpointOperation operation)
+        {
+            RequestInfo requestInfo = TrackedChangeRequestInfoFor("PATCH", operation);
+
+            await Middleware().Execute(requestInfo, NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(405);
+            // A tracked-change path leaves HasDocumentUuidSegment false, so without the
+            // ChangeQueryOperation check this would advertise the collection methods.
+            requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET");
+            requestInfo.FrontendResponse.ContentType.Should().Be("application/json; charset=utf-8");
+            AssertMethodNotAllowedProblemDetails(requestInfo.FrontendResponse, "PATCH");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -46,9 +46,9 @@ public class MethodNotAllowedMiddlewareTests
     }
 
     /// <summary>
-    /// Asserts the Ed-Fi method-not-allowed problem-details contract member by member. The
-    /// frontend's tracked-change terminal produces the same body from the same factory, and its
-    /// test asserts these same members so the two 405 producers cannot drift.
+    /// Asserts the Ed-Fi method-not-allowed problem-details contract member by member. This
+    /// middleware is the sole producer of that body: both frontend terminals hand the request to
+    /// Core and carry its response out through ToResult, so this is where the contract is pinned.
     /// </summary>
     private static void AssertMethodNotAllowedProblemDetails(
         IFrontendResponse response,
@@ -160,6 +160,10 @@ public class MethodNotAllowedMiddlewareTests
             // ParseTrackedChangePathMiddleware leaves no document uuid segment behind, exactly as
             // ParsePathMiddleware does for a collection route, which is why the pipeline tells this
             // step which route family it terminates rather than the step reading it off the request.
+            //
+            // These tests supply that flag themselves, so none of them can show it being wired
+            // correctly. That is pinned in PipelineOrderingTests, which exercises the terminal each
+            // pipeline factory actually constructed.
             RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
 
             await Middleware(isTrackedChangeRoute: true).Execute(requestInfo, NullNext);
@@ -168,21 +172,6 @@ public class MethodNotAllowedMiddlewareTests
             requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET");
             requestInfo.FrontendResponse.ContentType.Should().Be("application/json; charset=utf-8");
             AssertMethodNotAllowedProblemDetails(requestInfo.FrontendResponse, "PATCH");
-        }
-
-        /// <summary>
-        /// The regression guard for the discriminator: the identical request answered by the
-        /// data-route pipeline must advertise the collection methods, so a terminal wired into the
-        /// wrong pipeline cannot go unnoticed.
-        /// </summary>
-        [Test]
-        public async Task It_advertises_the_collection_methods_when_wired_into_the_data_pipeline()
-        {
-            RequestInfo requestInfo = RequestInfoFor("PATCH", hasDocumentUuidSegment: false);
-
-            await Middleware(isTrackedChangeRoute: false).Execute(requestInfo, NullNext);
-
-            requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, POST");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/MethodNotAllowedMiddlewareTests.cs
@@ -194,6 +194,8 @@ public class MethodNotAllowedMiddlewareTests
         [TestCase("OPTIONS")]
         [TestCase("TRACE")]
         [TestCase("FOO")]
+        // HEAD is rejected rather than served, matching ODS/API, so it reaches this step too.
+        [TestCase("HEAD")]
         public async Task It_names_the_method_of_the_request_in_the_errors(string unsupportedMethodName)
         {
             RequestInfo requestInfo = RequestInfoFor(unsupportedMethodName, hasDocumentUuidSegment: false);

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/RequestResponseLoggingMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/RequestResponseLoggingMiddlewareTests.cs
@@ -63,6 +63,48 @@ public class Given_RequestResponseLoggingMiddleware
     }
 
     [Test]
+    public async Task It_logs_the_real_verb_of_an_unsupported_method_request()
+    {
+        var requestInfo = No.RequestInfo("core-trace-id");
+        requestInfo.FrontendRequest = requestInfo.FrontendRequest with { Path = "/ed-fi/schools" };
+        requestInfo.Method = RequestMethod.UNSUPPORTED;
+        requestInfo.UnsupportedMethodName = "PATCH";
+        requestInfo.FrontendResponse = new FrontendResponse(405, Body: null, Headers: []);
+
+        await _middleware.Execute(requestInfo, TestHelper.NullNext);
+
+        // Operators search logs by HTTP verb, so the enum member name must never reach the log.
+        var record = _logger.Records.Single(log => log.EventId.Name == "HttpRequestCompleted");
+        record.Properties.Should().Contain("Method", "PATCH");
+        record.Properties.Should().NotContain("Method", "UNSUPPORTED");
+        var scope = record.ActiveScopes.Single();
+        scope.Should().Contain("Method", "PATCH");
+        _logger
+            .Records.Should()
+            .ContainSingle(log =>
+                log.Level == LogLevel.Debug
+                && log.Message == "Core pipeline started: PATCH /ed-fi/schools - TraceId: core-trace-id"
+            );
+    }
+
+    [Test]
+    public async Task It_sanitizes_the_client_supplied_method_name_of_an_unsupported_method_request()
+    {
+        var requestInfo = No.RequestInfo("core-trace-id");
+        requestInfo.FrontendRequest = requestInfo.FrontendRequest with { Path = "/ed-fi/schools" };
+        requestInfo.Method = RequestMethod.UNSUPPORTED;
+        requestInfo.UnsupportedMethodName = "PAT\r\nCH{unsafe}";
+        requestInfo.FrontendResponse = new FrontendResponse(405, Body: null, Headers: []);
+
+        await _middleware.Execute(requestInfo, TestHelper.NullNext);
+
+        // The method name is client-supplied on this path, so it must keep flowing through
+        // LoggingSanitizer rather than around it.
+        var record = _logger.Records.Single(log => log.EventId.Name == "HttpRequestCompleted");
+        record.Properties.Should().Contain("Method", "PATCHunsafe");
+    }
+
+    [Test]
     public async Task It_logs_request_start_as_debug_breadcrumb_only()
     {
         var requestInfo = No.RequestInfo("core-trace-id");

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateRouteSemanticsMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateRouteSemanticsMiddlewareTests.cs
@@ -70,6 +70,13 @@ public class ValidateRouteSemanticsMiddlewareTests
                     "Resource items can only be updated using PUT. To 'upsert' an item in the resource collection using POST, remove the 'id' from the route."
                 );
         }
+
+        [Test]
+        public void It_returns_an_allow_header_of_the_item_methods()
+        {
+            // Both method-not-allowed producers carry Allow, not just the unsupported-verb one.
+            _requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, PUT, DELETE");
+        }
     }
 
     [TestFixture]
@@ -109,6 +116,12 @@ public class ValidateRouteSemanticsMiddlewareTests
                     "Resource collections cannot be replaced. To 'upsert' an item in the collection, use POST. To update a specific item, use PUT and include the 'id' in the route."
                 );
         }
+
+        [Test]
+        public void It_returns_an_allow_header_of_the_collection_methods()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, POST");
+        }
     }
 
     [TestFixture]
@@ -147,6 +160,12 @@ public class ValidateRouteSemanticsMiddlewareTests
                 .Contain(
                     "Resource collections cannot be deleted. To delete a specific item, use DELETE and include the 'id' in the route."
                 );
+        }
+
+        [Test]
+        public void It_returns_an_allow_header_of_the_collection_methods()
+        {
+            _requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET, POST");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateRouteSemanticsMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateRouteSemanticsMiddlewareTests.cs
@@ -226,6 +226,27 @@ public class ValidateRouteSemanticsMiddlewareTests
                     "Resource items can only be updated using PUT. To 'upsert' an item in the resource collection using POST, remove the 'id' from the route."
                 );
         }
+
+        [Test]
+        public async Task It_returns_an_allow_header_of_get_only()
+        {
+            // A partitions route is read-only, so none of the rejected write methods may appear in
+            // the set offered back. Naming the collection's set here would advertise the POST the
+            // arm above rejects. Cased in the body rather than by TestCase because RequestMethod is
+            // internal and so cannot be a parameter of a public test method.
+            foreach (
+                RequestMethod method in new[] { RequestMethod.DELETE, RequestMethod.PUT, RequestMethod.POST }
+            )
+            {
+                RequestInfo requestInfo = No.RequestInfo();
+                requestInfo.Method = method;
+                requestInfo.PathComponents = PathComponents(ResourcePathOperation.Partitions.Instance);
+
+                await Middleware().Execute(requestInfo, NullNext);
+
+                requestInfo.FrontendResponse.Headers.Should().Contain("Allow", "GET");
+            }
+        }
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -679,4 +679,117 @@ public class PipelineOrderingTests
                 );
         }
     }
+
+    /// <summary>
+    /// The two pipelines that answer an unsupported HTTP method. They are near-identical by design and
+    /// differ in exactly one step - the path parser - which no other test can see: the terminal's own
+    /// unit tests build PathComponents by hand, and the frontend routing tests fake IApiService, so
+    /// neither ever runs a parse step.
+    ///
+    /// The registrations below are deliberately smaller than every fixture above. Neither pipeline
+    /// reaches a backend, so the fingerprint, resource-key-seed and mapping-set services are absent and
+    /// resolution would fail outright if a future change put those steps back.
+    /// </summary>
+    [TestFixture]
+    [Parallelizable]
+    public class Given_The_Method_Not_Allowed_Pipelines : PipelineOrderingTests
+    {
+        private const string DataRoutePipeline = "CreateMethodNotAllowedPipeline";
+        private const string TrackedChangePipeline = "CreateTrackedChangeMethodNotAllowedPipeline";
+
+        private static List<Type> GetMethodNotAllowedPipelineStepTypes(string factoryMethodName)
+        {
+            var services = new ServiceCollection();
+
+            services.AddTransient<JwtAuthenticationMiddleware>();
+            services.AddTransient<IJwtValidationService>(_ => A.Fake<IJwtValidationService>());
+            services.AddTransient<ILogger<JwtAuthenticationMiddleware>>(_ =>
+                NullLogger<JwtAuthenticationMiddleware>.Instance
+            );
+
+            services.AddTransient<ResolveDataStoreMiddleware>();
+            services.AddSingleton<IDataStoreProvider>(A.Fake<IDataStoreProvider>());
+            services.AddTransient<ILogger<ResolveDataStoreMiddleware>>(_ =>
+                NullLogger<ResolveDataStoreMiddleware>.Instance
+            );
+
+            var appSettingsOptions = Options.Create(
+                new AppSettings { AllowIdentityUpdateOverrides = "", MaskRequestBodyInLogs = false }
+            );
+            services.AddSingleton(appSettingsOptions);
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            var apiService = new ApiService(
+                A.Fake<IApiSchemaProvider>(),
+                A.Fake<IEffectiveApiSchemaProvider>(),
+                A.Fake<IClaimSetProvider>(),
+                A.Fake<IDocumentValidator>(),
+                A.Fake<IMatchingDocumentUuidsValidator>(),
+                A.Fake<IEqualityConstraintValidator>(),
+                A.Fake<IDecimalValidator>(),
+                NullLogger<ApiService>.Instance,
+                NullLoggerFactory.Instance,
+                appSettingsOptions,
+                ResiliencePipeline.Empty,
+                A.Fake<ResourceLoadOrderCalculator>(),
+                serviceProvider,
+                A.Fake<IServiceScopeFactory>(),
+                A.Fake<CachedClaimSetProvider>(),
+                A.Fake<IResourceDependencyGraphMLFactory>(),
+                A.Fake<IProfileService>()
+            );
+
+            return GetStepTypes(apiService, factoryMethodName);
+        }
+
+        [Test]
+        public void It_parses_the_data_path_in_the_data_route_pipeline()
+        {
+            // ParseTrackedChangePathMiddleware here instead would miss /ed-fi/schools, because its
+            // regex requires a third segment, turning every collection-route 405 into a 404.
+            GetMethodNotAllowedPipelineStepTypes(DataRoutePipeline)
+                .Should()
+                .Contain(typeof(ParsePathMiddleware));
+        }
+
+        [Test]
+        public void It_parses_the_operation_suffix_in_the_tracked_change_pipeline()
+        {
+            // ParsePathMiddleware here instead would read "deletes" as a document id and reject it as
+            // a malformed uuid, turning every tracked-change 405 into a 400.
+            GetMethodNotAllowedPipelineStepTypes(TrackedChangePipeline)
+                .Should()
+                .Contain(typeof(ParseTrackedChangePathMiddleware));
+        }
+
+        [TestCase(DataRoutePipeline)]
+        [TestCase(TrackedChangePipeline)]
+        public void It_answers_405_only_after_the_endpoint_is_known_to_exist(string factoryMethodName)
+        {
+            var stepTypes = GetMethodNotAllowedPipelineStepTypes(factoryMethodName);
+            var validateEndpointIndex = stepTypes.IndexOf(typeof(ValidateEndpointMiddleware));
+            var terminalIndex = stepTypes.IndexOf(typeof(MethodNotAllowedMiddleware));
+
+            validateEndpointIndex.Should().BeGreaterThanOrEqualTo(0);
+            terminalIndex
+                .Should()
+                .BeGreaterThan(
+                    validateEndpointIndex,
+                    "an unknown project namespace or resource must answer 404 rather than 405, matching ODS/API's existence-then-method ordering"
+                );
+        }
+
+        [TestCase(DataRoutePipeline)]
+        [TestCase(TrackedChangePipeline)]
+        public void It_contains_ResolveDataStoreMiddleware(string factoryMethodName)
+        {
+            GetMethodNotAllowedPipelineStepTypes(factoryMethodName)
+                .Should()
+                .Contain(
+                    typeof(ResolveDataStoreMiddleware),
+                    "an unsupported method must not answer 405 where the equivalent supported request answers 403 or 404 for want of an authorized or matching instance"
+                );
+        }
+    }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -9,6 +9,7 @@ using EdFi.DataManagementService.Core.Configuration;
 using EdFi.DataManagementService.Core.External.Backend;
 using EdFi.DataManagementService.Core.Handler;
 using EdFi.DataManagementService.Core.Middleware;
+using EdFi.DataManagementService.Core.Model;
 using EdFi.DataManagementService.Core.Pipeline;
 using EdFi.DataManagementService.Core.Profile;
 using EdFi.DataManagementService.Core.ResourceLoadOrder;
@@ -29,7 +30,12 @@ namespace EdFi.DataManagementService.Core.Tests.Unit.Pipeline;
 [Parallelizable]
 public class PipelineOrderingTests
 {
-    private static List<Type> GetStepTypes(ApiService apiService, string factoryMethodName)
+    /// <summary>
+    /// The steps a pipeline factory actually built, as constructed instances. Most fixtures here
+    /// only compare step types, but a step configured by a constructor argument can only be checked
+    /// by exercising the instance the factory produced.
+    /// </summary>
+    private static List<IPipelineStep> GetSteps(ApiService apiService, string factoryMethodName)
     {
         var method = typeof(ApiService).GetMethod(
             factoryMethodName,
@@ -44,8 +50,12 @@ public class PipelineOrderingTests
 
         field.Should().NotBeNull("PipelineProvider should store its steps for execution");
 
-        var steps = (List<IPipelineStep>)field!.GetValue(pipeline)!;
-        return steps.Select(step => step.GetType()).ToList();
+        return (List<IPipelineStep>)field!.GetValue(pipeline)!;
+    }
+
+    private static List<Type> GetStepTypes(ApiService apiService, string factoryMethodName)
+    {
+        return GetSteps(apiService, factoryMethodName).Select(step => step.GetType()).ToList();
     }
 
     [TestFixture]
@@ -697,7 +707,7 @@ public class PipelineOrderingTests
         private const string DataRoutePipeline = "CreateMethodNotAllowedPipeline";
         private const string TrackedChangePipeline = "CreateTrackedChangeMethodNotAllowedPipeline";
 
-        private static List<Type> GetMethodNotAllowedPipelineStepTypes(string factoryMethodName)
+        private static ApiService BuildApiService()
         {
             var services = new ServiceCollection();
 
@@ -740,7 +750,12 @@ public class PipelineOrderingTests
                 A.Fake<IProfileService>()
             );
 
-            return GetStepTypes(apiService, factoryMethodName);
+            return apiService;
+        }
+
+        private static List<Type> GetMethodNotAllowedPipelineStepTypes(string factoryMethodName)
+        {
+            return GetStepTypes(BuildApiService(), factoryMethodName);
         }
 
         [Test]
@@ -790,6 +805,41 @@ public class PipelineOrderingTests
                     typeof(ResolveDataStoreMiddleware),
                     "an unsupported method must not answer 405 where the equivalent supported request answers 403 or 404 for want of an authorized or matching instance"
                 );
+        }
+
+        /// <summary>
+        /// The regression guard for the route-family discriminator. MethodNotAllowedMiddleware takes
+        /// which family it terminates as a constructor argument, so no assertion over step types can
+        /// see it wired, and the middleware's own tests pass the flag in themselves. This runs the
+        /// terminal each factory actually built and reads the Allow header back off it, which is the
+        /// only place a pipeline constructed with the wrong flag shows up.
+        /// </summary>
+        [TestCase(DataRoutePipeline, "GET, POST")]
+        [TestCase(TrackedChangePipeline, "GET")]
+        public async Task It_builds_the_terminal_for_its_own_route_family(
+            string factoryMethodName,
+            string expectedAllow
+        )
+        {
+            IPipelineStep terminal = GetSteps(BuildApiService(), factoryMethodName)
+                .Single(step => step is MethodNotAllowedMiddleware);
+
+            // Both parse steps leave HasDocumentUuidSegment false, which is why the terminal cannot
+            // read the route family off the request and has to be told at construction.
+            RequestInfo requestInfo = No.RequestInfo("method-not-allowed-wiring-trace-id");
+            requestInfo.Method = RequestMethod.UNSUPPORTED;
+            requestInfo.UnsupportedMethodName = "PATCH";
+            requestInfo.PathComponents = new(
+                ProjectEndpointName: new("ed-fi"),
+                EndpointName: new("schools"),
+                DocumentUuid: No.DocumentUuid,
+                HasDocumentUuidSegment: false
+            );
+
+            await terminal.Execute(requestInfo, TestHelper.NullNext);
+
+            requestInfo.FrontendResponse.StatusCode.Should().Be(405);
+            requestInfo.FrontendResponse.Headers.Should().Contain("Allow", expectedAllow);
         }
     }
 }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Pipeline/PipelineOrderingTests.cs
@@ -824,16 +824,15 @@ public class PipelineOrderingTests
             IPipelineStep terminal = GetSteps(BuildApiService(), factoryMethodName)
                 .Single(step => step is MethodNotAllowedMiddleware);
 
-            // Both parse steps leave HasDocumentUuidSegment false, which is why the terminal cannot
-            // read the route family off the request and has to be told at construction.
+            // Both parse steps classify their path as the Collection operation, which is why the
+            // terminal cannot read the route family off the request and has to be told at construction.
             RequestInfo requestInfo = No.RequestInfo("method-not-allowed-wiring-trace-id");
             requestInfo.Method = RequestMethod.UNSUPPORTED;
             requestInfo.UnsupportedMethodName = "PATCH";
             requestInfo.PathComponents = new(
                 ProjectEndpointName: new("ed-fi"),
                 EndpointName: new("schools"),
-                DocumentUuid: No.DocumentUuid,
-                HasDocumentUuidSegment: false
+                Operation: ResourcePathOperation.Collection.Instance
             );
 
             await terminal.Execute(requestInfo, TestHelper.NullNext);

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -90,6 +90,11 @@ internal class ApiService : IApiService
     private readonly Lazy<PipelineProvider> _getTrackedChangesSteps;
 
     /// <summary>
+    /// The pipeline steps to satisfy a data-route request made with an unsupported HTTP method
+    /// </summary>
+    private readonly Lazy<PipelineProvider> _methodNotAllowedSteps;
+
+    /// <summary>
     /// The OpenAPI specification derived from core and extension ApiSchemas
     /// </summary>
     private readonly Lazy<JsonNode> _resourceOpenApiSpecification;
@@ -153,6 +158,7 @@ internal class ApiService : IApiService
             CreateGetAvailableChangeVersionsPipeline
         );
         _getTrackedChangesSteps = new Lazy<PipelineProvider>(CreateGetTrackedChangesPipeline);
+        _methodNotAllowedSteps = new Lazy<PipelineProvider>(CreateMethodNotAllowedPipeline);
         _resourceOpenApiSpecification = new Lazy<JsonNode>(CreateResourceOpenApiSpecification);
         _descriptorOpenApiSpecification = new Lazy<JsonNode>(CreateDescriptorOpenApiSpecification);
         _changeQueriesOpenApiSpecification = new Lazy<JsonNode?>(CreateChangeQueriesOpenApiSpecification);
@@ -403,6 +409,30 @@ internal class ApiService : IApiService
         return new PipelineProvider(steps);
     }
 
+    private PipelineProvider CreateMethodNotAllowedPipeline()
+    {
+        // Deliberately not GetRoutedResourceInitialSteps(): the fingerprint, resource-key-seed and
+        // mapping-set steps exist for data access, and this request never reaches a backend.
+        // ResolveDataStoreMiddleware (inside the common steps) stays, so an unsupported method
+        // cannot answer 405 where the equivalent supported request would answer 403/404 because no
+        // authorized or matching instance exists.
+        //
+        // The step order is the point: ParsePathMiddleware answers 404 on a malformed path shape,
+        // ValidateEndpointMiddleware answers 404 on an unknown project namespace or resource, and
+        // only then does the terminal answer 405. That reproduces ODS/API's existence-then-method
+        // ordering.
+        var steps = GetCommonInitialSteps();
+        steps.AddRange([
+            new ParsePathMiddleware(_logger),
+            new ApiSchemaValidationMiddleware(_apiSchemaProvider, _logger),
+            new ProvideApiSchemaMiddleware(_effectiveApiSchemaProvider, _logger),
+            new ValidateEndpointMiddleware(_logger),
+            new MethodNotAllowedMiddleware(_logger),
+        ]);
+
+        return new PipelineProvider(steps);
+    }
+
     /// <summary>
     /// Parses the excluded domains configuration setting into an array of domain names
     /// </summary>
@@ -571,6 +601,23 @@ internal class ApiService : IApiService
         await using var scope = _serviceScopeFactory.CreateAsyncScope();
         RequestInfo requestInfo = new(frontendRequest, RequestMethod.GET, scope.ServiceProvider);
         await _getTrackedChangesSteps.Value.Run(requestInfo);
+        return requestInfo.FrontendResponse;
+    }
+
+    /// <summary>
+    /// DMS entry point for a data-route request made with an unsupported HTTP method
+    /// </summary>
+    public async Task<IFrontendResponse> MethodNotAllowed(
+        FrontendRequest frontendRequest,
+        string requestMethodName
+    )
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        RequestInfo requestInfo = new(frontendRequest, RequestMethod.UNSUPPORTED, scope.ServiceProvider)
+        {
+            UnsupportedMethodName = requestMethodName,
+        };
+        await _methodNotAllowedSteps.Value.Run(requestInfo);
         return requestInfo.FrontendResponse;
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -95,6 +95,12 @@ internal class ApiService : IApiService
     private readonly Lazy<PipelineProvider> _methodNotAllowedSteps;
 
     /// <summary>
+    /// The pipeline steps to satisfy a tracked-change route request made with an unsupported
+    /// HTTP method
+    /// </summary>
+    private readonly Lazy<PipelineProvider> _trackedChangeMethodNotAllowedSteps;
+
+    /// <summary>
     /// The OpenAPI specification derived from core and extension ApiSchemas
     /// </summary>
     private readonly Lazy<JsonNode> _resourceOpenApiSpecification;
@@ -159,6 +165,9 @@ internal class ApiService : IApiService
         );
         _getTrackedChangesSteps = new Lazy<PipelineProvider>(CreateGetTrackedChangesPipeline);
         _methodNotAllowedSteps = new Lazy<PipelineProvider>(CreateMethodNotAllowedPipeline);
+        _trackedChangeMethodNotAllowedSteps = new Lazy<PipelineProvider>(
+            CreateTrackedChangeMethodNotAllowedPipeline
+        );
         _resourceOpenApiSpecification = new Lazy<JsonNode>(CreateResourceOpenApiSpecification);
         _descriptorOpenApiSpecification = new Lazy<JsonNode>(CreateDescriptorOpenApiSpecification);
         _changeQueriesOpenApiSpecification = new Lazy<JsonNode?>(CreateChangeQueriesOpenApiSpecification);
@@ -433,6 +442,27 @@ internal class ApiService : IApiService
         return new PipelineProvider(steps);
     }
 
+    private PipelineProvider CreateTrackedChangeMethodNotAllowedPipeline()
+    {
+        // The tracked-change twin of CreateMethodNotAllowedPipeline. It differs only in the path
+        // step: ParseTrackedChangePathMiddleware reads the /deletes or /keyChanges suffix as an
+        // operation, where ParsePathMiddleware would read it as a document id and reject it as a
+        // malformed UUID. Everything else - and the reason for coming through Core at all - is the
+        // same: the common steps authenticate and validate the tenant, and ValidateEndpointMiddleware
+        // answers 404 for an unknown project namespace or resource, so the terminal's 405 is reached
+        // only once the endpoint is known to exist.
+        var steps = GetCommonInitialSteps();
+        steps.AddRange([
+            new ParseTrackedChangePathMiddleware(_logger),
+            new ApiSchemaValidationMiddleware(_apiSchemaProvider, _logger),
+            new ProvideApiSchemaMiddleware(_effectiveApiSchemaProvider, _logger),
+            new ValidateEndpointMiddleware(_logger),
+            new MethodNotAllowedMiddleware(_logger),
+        ]);
+
+        return new PipelineProvider(steps);
+    }
+
     /// <summary>
     /// Parses the excluded domains configuration setting into an array of domain names
     /// </summary>
@@ -618,6 +648,23 @@ internal class ApiService : IApiService
             UnsupportedMethodName = requestMethodName,
         };
         await _methodNotAllowedSteps.Value.Run(requestInfo);
+        return requestInfo.FrontendResponse;
+    }
+
+    /// <summary>
+    /// DMS entry point for a tracked-change route request made with an unsupported HTTP method
+    /// </summary>
+    public async Task<IFrontendResponse> MethodNotAllowedForTrackedChange(
+        FrontendRequest frontendRequest,
+        string requestMethodName
+    )
+    {
+        await using var scope = _serviceScopeFactory.CreateAsyncScope();
+        RequestInfo requestInfo = new(frontendRequest, RequestMethod.UNSUPPORTED, scope.ServiceProvider)
+        {
+            UnsupportedMethodName = requestMethodName,
+        };
+        await _trackedChangeMethodNotAllowedSteps.Value.Run(requestInfo);
         return requestInfo.FrontendResponse;
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/ApiService.cs
@@ -436,7 +436,7 @@ internal class ApiService : IApiService
             new ApiSchemaValidationMiddleware(_apiSchemaProvider, _logger),
             new ProvideApiSchemaMiddleware(_effectiveApiSchemaProvider, _logger),
             new ValidateEndpointMiddleware(_logger),
-            new MethodNotAllowedMiddleware(_logger),
+            new MethodNotAllowedMiddleware(_logger, _isTrackedChangeRoute: false),
         ]);
 
         return new PipelineProvider(steps);
@@ -457,7 +457,7 @@ internal class ApiService : IApiService
             new ApiSchemaValidationMiddleware(_apiSchemaProvider, _logger),
             new ProvideApiSchemaMiddleware(_effectiveApiSchemaProvider, _logger),
             new ValidateEndpointMiddleware(_logger),
-            new MethodNotAllowedMiddleware(_logger),
+            new MethodNotAllowedMiddleware(_logger, _isTrackedChangeRoute: true),
         ]);
 
         return new PipelineProvider(steps);

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
@@ -19,8 +19,8 @@ namespace EdFi.DataManagementService.Core.Middleware;
 /// <param name="_isTrackedChangeRoute">
 /// True in the tracked-change pipeline (/deletes, /keyChanges), false in the data-route pipeline.
 /// ApiService fixes this when it builds the two pipelines, because the request cannot be asked:
-/// both parse steps leave HasDocumentUuidSegment false, so that flag alone cannot tell a
-/// tracked-change route from a data collection route.
+/// both parse steps classify their path as the Collection operation, so the operation alone cannot
+/// tell a tracked-change route from a data collection route.
 /// </param>
 internal class MethodNotAllowedMiddleware(ILogger _logger, bool _isTrackedChangeRoute) : IPipelineStep
 {
@@ -38,11 +38,9 @@ internal class MethodNotAllowedMiddleware(ILogger _logger, bool _isTrackedChange
             requestInfo.FrontendRequest.TraceId.Value
         );
 
-        string dataRouteMethods = requestInfo.PathComponents.HasDocumentUuidSegment
-            ? ValidateRouteSemanticsMiddleware.ItemMethods
-            : ValidateRouteSemanticsMiddleware.CollectionMethods;
-
-        string allowed = _isTrackedChangeRoute ? TrackedChangeMethods : dataRouteMethods;
+        string allowed = _isTrackedChangeRoute
+            ? TrackedChangeMethods
+            : ValidateRouteSemanticsMiddleware.AllowedMethodsFor(requestInfo.PathComponents.Operation);
 
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: 405,

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
@@ -19,15 +19,9 @@ namespace EdFi.DataManagementService.Core.Middleware;
 internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
 {
     /// <summary>
-    /// The authority for these sets is ValidateRouteSemanticsMiddleware: collection routes
-    /// reject PUT and DELETE, item routes reject POST.
-    /// </summary>
-    private const string CollectionMethods = "GET, POST";
-
-    private const string ItemMethods = "GET, PUT, DELETE";
-
-    /// <summary>
-    /// Tracked-change routes are read-only: TrackedChangesEndpointModule maps GET alone.
+    /// Tracked-change routes are read-only: TrackedChangesEndpointModule maps GET alone. The
+    /// data-route sets come from ValidateRouteSemanticsMiddleware, which is their authority
+    /// because its rejection table is what makes them true.
     /// </summary>
     private const string TrackedChangeMethods = "GET";
 
@@ -47,16 +41,14 @@ internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
         ) switch
         {
             (true, _) => TrackedChangeMethods,
-            (false, true) => ItemMethods,
-            (false, false) => CollectionMethods,
+            (false, true) => ValidateRouteSemanticsMiddleware.ItemMethods,
+            (false, false) => ValidateRouteSemanticsMiddleware.CollectionMethods,
         };
 
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: 405,
             Body: FailureResponse.ForMethodNotAllowed(
-                [
-                    $"The endpoint of the request does not support the '{requestInfo.UnsupportedMethodName}' method.",
-                ],
+                [$"The endpoint of the request does not support the '{requestInfo.MethodName}' method."],
                 requestInfo.FrontendRequest.TraceId
             ),
             Headers: new Dictionary<string, string> { ["Allow"] = allowed },

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
@@ -16,7 +16,13 @@ namespace EdFi.DataManagementService.Core.Middleware;
 /// project namespace or resource still answers 404 rather than 405, matching ODS/API's
 /// existence-then-method ordering.
 /// </summary>
-internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
+/// <param name="_isTrackedChangeRoute">
+/// True in the tracked-change pipeline (/deletes, /keyChanges), false in the data-route pipeline.
+/// ApiService fixes this when it builds the two pipelines, because the request cannot be asked:
+/// both parse steps leave HasDocumentUuidSegment false, so that flag alone cannot tell a
+/// tracked-change route from a data collection route.
+/// </param>
+internal class MethodNotAllowedMiddleware(ILogger _logger, bool _isTrackedChangeRoute) : IPipelineStep
 {
     /// <summary>
     /// Tracked-change routes are read-only: TrackedChangesEndpointModule maps GET alone. The
@@ -32,18 +38,11 @@ internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
             requestInfo.FrontendRequest.TraceId.Value
         );
 
-        // ChangeQueryOperation is set only by ParseTrackedChangePathMiddleware, so it is what
-        // distinguishes a /deletes or /keyChanges route from a data route here. Both parse steps
-        // leave HasDocumentUuidSegment false, so that flag alone cannot tell them apart.
-        string allowed = (
-            requestInfo.ChangeQueryOperation is not null,
-            requestInfo.PathComponents.HasDocumentUuidSegment
-        ) switch
-        {
-            (true, _) => TrackedChangeMethods,
-            (false, true) => ValidateRouteSemanticsMiddleware.ItemMethods,
-            (false, false) => ValidateRouteSemanticsMiddleware.CollectionMethods,
-        };
+        string dataRouteMethods = requestInfo.PathComponents.HasDocumentUuidSegment
+            ? ValidateRouteSemanticsMiddleware.ItemMethods
+            : ValidateRouteSemanticsMiddleware.CollectionMethods;
+
+        string allowed = _isTrackedChangeRoute ? TrackedChangeMethods : dataRouteMethods;
 
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: 405,

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using EdFi.DataManagementService.Core.Model;
+using EdFi.DataManagementService.Core.Pipeline;
+using EdFi.DataManagementService.Core.Response;
+using Microsoft.Extensions.Logging;
+
+namespace EdFi.DataManagementService.Core.Middleware;
+
+/// <summary>
+/// Terminal step for a data-route request whose HTTP method is not one of the supported verbs.
+/// Reached only after the path has been parsed and the resource resolved, so that an unknown
+/// project namespace or resource still answers 404 rather than 405, matching ODS/API's
+/// existence-then-method ordering.
+/// </summary>
+internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
+{
+    /// <summary>
+    /// The authority for these sets is ValidateRouteSemanticsMiddleware: collection routes
+    /// reject PUT and DELETE, item routes reject POST.
+    /// </summary>
+    private const string CollectionMethods = "GET, POST";
+
+    private const string ItemMethods = "GET, PUT, DELETE";
+
+    public Task Execute(RequestInfo requestInfo, Func<Task> next)
+    {
+        _logger.LogDebug(
+            "Entering MethodNotAllowedMiddleware - {TraceId}",
+            requestInfo.FrontendRequest.TraceId.Value
+        );
+
+        string allowed = requestInfo.PathComponents.HasDocumentUuidSegment ? ItemMethods : CollectionMethods;
+
+        requestInfo.FrontendResponse = new FrontendResponse(
+            StatusCode: 405,
+            Body: FailureResponse.ForMethodNotAllowed(
+                [
+                    $"The endpoint of the request does not support the '{requestInfo.UnsupportedMethodName}' method.",
+                ],
+                requestInfo.FrontendRequest.TraceId
+            ),
+            Headers: new Dictionary<string, string> { ["Allow"] = allowed },
+            ContentType: "application/json; charset=utf-8"
+        );
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/MethodNotAllowedMiddleware.cs
@@ -26,6 +26,11 @@ internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
 
     private const string ItemMethods = "GET, PUT, DELETE";
 
+    /// <summary>
+    /// Tracked-change routes are read-only: TrackedChangesEndpointModule maps GET alone.
+    /// </summary>
+    private const string TrackedChangeMethods = "GET";
+
     public Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         _logger.LogDebug(
@@ -33,7 +38,18 @@ internal class MethodNotAllowedMiddleware(ILogger _logger) : IPipelineStep
             requestInfo.FrontendRequest.TraceId.Value
         );
 
-        string allowed = requestInfo.PathComponents.HasDocumentUuidSegment ? ItemMethods : CollectionMethods;
+        // ChangeQueryOperation is set only by ParseTrackedChangePathMiddleware, so it is what
+        // distinguishes a /deletes or /keyChanges route from a data route here. Both parse steps
+        // leave HasDocumentUuidSegment false, so that flag alone cannot tell them apart.
+        string allowed = (
+            requestInfo.ChangeQueryOperation is not null,
+            requestInfo.PathComponents.HasDocumentUuidSegment
+        ) switch
+        {
+            (true, _) => TrackedChangeMethods,
+            (false, true) => ItemMethods,
+            (false, false) => CollectionMethods,
+        };
 
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: 405,

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/RequestResponseLoggingMiddleware.cs
@@ -25,7 +25,16 @@ internal class RequestResponseLoggingMiddleware(ILogger _logger) : IPipelineStep
     {
         var traceId = requestInfo.FrontendRequest.TraceId.Value;
         var stopwatch = Stopwatch.StartNew();
-        string method = LoggingSanitizer.SanitizeForLogging(requestInfo.Method.ToString());
+        // An unsupported-method request carries its real verb on UnsupportedMethodName; logging
+        // requestInfo.Method would emit the literal "UNSUPPORTED" and operators searching for
+        // PATCH would find nothing. The name is client-supplied either way, so it must keep
+        // flowing through LoggingSanitizer.
+        string methodName =
+            requestInfo.Method == RequestMethod.UNSUPPORTED
+            && requestInfo.UnsupportedMethodName is { } unsupportedMethodName
+                ? unsupportedMethodName
+                : requestInfo.Method.ToString();
+        string method = LoggingSanitizer.SanitizeForLogging(methodName);
         string path = LoggingSanitizer.SanitizeForLogging(requestInfo.FrontendRequest.Path);
         string sanitizedTraceId = LoggingSanitizer.SanitizeForLogging(traceId);
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/RequestResponseLoggingMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/RequestResponseLoggingMiddleware.cs
@@ -25,16 +25,9 @@ internal class RequestResponseLoggingMiddleware(ILogger _logger) : IPipelineStep
     {
         var traceId = requestInfo.FrontendRequest.TraceId.Value;
         var stopwatch = Stopwatch.StartNew();
-        // An unsupported-method request carries its real verb on UnsupportedMethodName; logging
-        // requestInfo.Method would emit the literal "UNSUPPORTED" and operators searching for
-        // PATCH would find nothing. The name is client-supplied either way, so it must keep
-        // flowing through LoggingSanitizer.
-        string methodName =
-            requestInfo.Method == RequestMethod.UNSUPPORTED
-            && requestInfo.UnsupportedMethodName is { } unsupportedMethodName
-                ? unsupportedMethodName
-                : requestInfo.Method.ToString();
-        string method = LoggingSanitizer.SanitizeForLogging(methodName);
+        // RequestInfo.MethodName resolves the real verb of an unsupported-method request. It is
+        // client-supplied on that path, so it must keep flowing through LoggingSanitizer.
+        string method = LoggingSanitizer.SanitizeForLogging(requestInfo.MethodName);
         string path = LoggingSanitizer.SanitizeForLogging(requestInfo.FrontendRequest.Path);
         string sanitizedTraceId = LoggingSanitizer.SanitizeForLogging(traceId);
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ResourceActionAuthorizationMiddleware.cs
@@ -215,7 +215,19 @@ internal class ResourceActionAuthorizationMiddleware(IClaimSetProvider _claimSet
             return ReadChangesActionName;
         }
 
-        return _methodToActionNameMapping[requestInfo.Method];
+        // The mapping covers the four verbs that carry out a resource action. RequestMethod also
+        // has UNSUPPORTED, which has no action and belongs to a pipeline that terminates at
+        // MethodNotAllowedMiddleware well before this step - so reaching here with it means a
+        // pipeline was misassembled, and saying so beats a bare KeyNotFoundException.
+        if (!_methodToActionNameMapping.TryGetValue(requestInfo.Method, out string? actionName))
+        {
+            throw new InvalidOperationException(
+                $"No resource action is defined for request method '{requestInfo.Method}'. "
+                    + "ResourceActionAuthorizationMiddleware only runs in pipelines whose method is GET, POST, PUT or DELETE."
+            );
+        }
+
+        return actionName;
     }
 
     /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateRouteSemanticsMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateRouteSemanticsMiddleware.cs
@@ -16,6 +16,16 @@ namespace EdFi.DataManagementService.Core.Middleware;
 /// </summary>
 internal class ValidateRouteSemanticsMiddleware(ILogger _logger) : IPipelineStep
 {
+    /// <summary>
+    /// The method sets this middleware enforces, expressed for the Allow response header. They
+    /// live here because the rejection table below is what makes them true, and
+    /// MethodNotAllowedMiddleware advertises the same sets for a wholly unsupported verb -
+    /// referencing these keeps the two 405 producers in agreement by construction.
+    /// </summary>
+    internal const string CollectionMethods = "GET, POST";
+
+    internal const string ItemMethods = "GET, PUT, DELETE";
+
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         _logger.LogDebug(
@@ -53,7 +63,18 @@ internal class ValidateRouteSemanticsMiddleware(ILogger _logger) : IPipelineStep
         requestInfo.FrontendResponse = new FrontendResponse(
             StatusCode: 405,
             Body: FailureResponse.ForMethodNotAllowed([error], requestInfo.FrontendRequest.TraceId),
-            Headers: [],
+            // RFC 9110 section 15.5.6 requires Allow on a 405. Sent here as well as from
+            // MethodNotAllowedMiddleware so both urn:ed-fi:api:method-not-allowed responses carry
+            // it, rather than only the one for a wholly unsupported verb. The profile-scoped 405
+            // in CachedProfileService is a different contract
+            // (urn:ed-fi:api:profile:method-usage) whose allowed set depends on the profile's
+            // read/write content types, and is deliberately left alone.
+            Headers: new Dictionary<string, string>
+            {
+                ["Allow"] = requestInfo.PathComponents.HasDocumentUuidSegment
+                    ? ItemMethods
+                    : CollectionMethods,
+            },
             ContentType: "application/json; charset=utf-8"
         );
     }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateRouteSemanticsMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateRouteSemanticsMiddleware.cs
@@ -26,6 +26,34 @@ internal class ValidateRouteSemanticsMiddleware(ILogger _logger) : IPipelineStep
 
     internal const string ItemMethods = "GET, PUT, DELETE";
 
+    /// <summary>
+    /// The partitions operation is a read-only sibling of the GET-many endpoint, so the write
+    /// methods this middleware rejects on it leave GET as the whole Allow set. Advertised even
+    /// though no partitions pipeline exists yet and ParsePathMiddleware answers the GET itself as
+    /// an invalid identifier: the header has to name the methods the route will serve, and naming
+    /// the collection's set instead would advertise the very POST being rejected.
+    /// </summary>
+    internal const string PartitionsMethods = "GET";
+
+    /// <summary>
+    /// The Allow set for an operation, for both this middleware and MethodNotAllowedMiddleware.
+    /// </summary>
+    /// <remarks>
+    /// Exhaustive rather than an item-or-else choice, so an operation added to the hierarchy has to
+    /// name its own set instead of silently inheriting the collection's.
+    /// </remarks>
+    internal static string AllowedMethodsFor(ResourcePathOperation operation) =>
+        operation switch
+        {
+            ResourcePathOperation.ById => ItemMethods,
+            ResourcePathOperation.Collection => CollectionMethods,
+            ResourcePathOperation.Partitions => PartitionsMethods,
+            _ => throw new InvalidOperationException(
+                $"Unhandled resource path operation '{operation.GetType().Name}'. A new operation "
+                    + "must name the methods it allows."
+            ),
+        };
+
     public async Task Execute(RequestInfo requestInfo, Func<Task> next)
     {
         _logger.LogDebug(
@@ -71,9 +99,7 @@ internal class ValidateRouteSemanticsMiddleware(ILogger _logger) : IPipelineStep
             // read/write content types, and is deliberately left alone.
             Headers: new Dictionary<string, string>
             {
-                ["Allow"] = requestInfo.PathComponents.HasDocumentUuidSegment
-                    ? ItemMethods
-                    : CollectionMethods,
+                ["Allow"] = AllowedMethodsFor(requestInfo.PathComponents.Operation),
             },
             ContentType: "application/json; charset=utf-8"
         );

--- a/src/dms/core/EdFi.DataManagementService.Core/Model/RequestMethod.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Model/RequestMethod.cs
@@ -11,4 +11,10 @@ internal enum RequestMethod
     GET,
     PUT,
     DELETE,
+
+    /// <summary>
+    /// A request whose HTTP method is not one of the supported verbs above. The actual
+    /// method name is carried on RequestInfo.UnsupportedMethodName.
+    /// </summary>
+    UNSUPPORTED,
 }

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -42,6 +42,13 @@ internal class RequestInfo(
     }
 
     /// <summary>
+    /// The actual HTTP method name of a request whose method is not one of the supported
+    /// verbs, e.g. "PATCH". Set only when Method is RequestMethod.UNSUPPORTED, and used
+    /// both for the 405 error message and for request logging.
+    /// </summary>
+    public string? UnsupportedMethodName { get; set; }
+
+    /// <summary>
     /// The important parts of the request URL path in object form
     /// </summary>
     public PathComponents PathComponents { get; set; } = No.PathComponents;

--- a/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Pipeline/RequestInfo.cs
@@ -43,10 +43,19 @@ internal class RequestInfo(
 
     /// <summary>
     /// The actual HTTP method name of a request whose method is not one of the supported
-    /// verbs, e.g. "PATCH". Set only when Method is RequestMethod.UNSUPPORTED, and used
-    /// both for the 405 error message and for request logging.
+    /// verbs, e.g. "PATCH". Set only when Method is RequestMethod.UNSUPPORTED.
+    /// Read it through <see cref="MethodName"/> rather than directly.
     /// </summary>
     public string? UnsupportedMethodName { get; set; }
+
+    /// <summary>
+    /// The HTTP verb to attribute this request to, for the 405 error message and for request
+    /// logging. An unsupported-method request carries its real verb on UnsupportedMethodName;
+    /// using Method there would surface the literal "UNSUPPORTED", so operators searching logs
+    /// for PATCH would find nothing and the 405 body would name the wrong method. Single
+    /// accessor so the two readers cannot disagree about whether the name can be absent.
+    /// </summary>
+    public string MethodName => UnsupportedMethodName ?? Method.ToString();
 
     /// <summary>
     /// The important parts of the request URL path in object form

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -3,8 +3,18 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Net;
+using System.Net.Http;
+using System.Text.Json.Nodes;
+using EdFi.DataManagementService.Core.External.Frontend;
+using EdFi.DataManagementService.Core.External.Interface;
 using EdFi.DataManagementService.Frontend.AspNetCore.Modules;
+using FakeItEasy;
 using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit.Modules;
@@ -131,6 +141,365 @@ public class CoreEndpointModuleTests
             {
                 _result.Should().Be("/{tenant}/{districtId}/{schoolYear}/data/{**dmsPath}");
             }
+        }
+    }
+
+    private const string ItemUuid = "0192ac2c-8f7f-7c2a-9c1d-3f4b5a6c7d8e";
+
+    private static IFrontendResponse FakeCoreMethodNotAllowedResponse()
+    {
+        JsonObject body = new() { ["source"] = "core" };
+
+        var response = A.Fake<IFrontendResponse>();
+        A.CallTo(() => response.StatusCode).Returns(405);
+        A.CallTo(() => response.Body).Returns(body);
+        A.CallTo(() => response.Headers).Returns(new Dictionary<string, string> { ["Allow"] = "GET, POST" });
+        A.CallTo(() => response.ContentType).Returns("application/json; charset=utf-8");
+        return response;
+    }
+
+    private static IFrontendResponse FakeCoreOkResponse()
+    {
+        JsonObject body = new() { ["source"] = "core" };
+
+        var response = A.Fake<IFrontendResponse>();
+        A.CallTo(() => response.StatusCode).Returns(200);
+        A.CallTo(() => response.Body).Returns(body);
+        A.CallTo(() => response.Headers).Returns(new Dictionary<string, string>());
+        A.CallTo(() => response.ContentType).Returns("application/json");
+        return response;
+    }
+
+    /// <summary>
+    /// A fake whose every request entry point answers 200, so a test can assert which entry point
+    /// the router selected without any of them failing for want of a configured response.
+    /// </summary>
+    private static IApiService FakeApiServiceAnsweringEveryVerb()
+    {
+        var apiService = A.Fake<IApiService>();
+        A.CallTo(() => apiService.Get(A<FrontendRequest>._)).Returns(Task.FromResult(FakeCoreOkResponse()));
+        A.CallTo(() => apiService.Upsert(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeCoreOkResponse()));
+        A.CallTo(() => apiService.UpdateById(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeCoreOkResponse()));
+        A.CallTo(() => apiService.DeleteById(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeCoreOkResponse()));
+        A.CallTo(() => apiService.GetTrackedChanges(A<FrontendRequest>._))
+            .Returns(Task.FromResult(FakeCoreOkResponse()));
+        A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+            .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse()));
+        return apiService;
+    }
+
+    private static WebApplicationFactory<Program> CreateFactory(
+        IApiService apiService,
+        Dictionary<string, string?>? configuration = null
+    )
+    {
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(builder =>
+        {
+            builder.UseEnvironment("Test");
+            if (configuration is not null)
+            {
+                builder.ConfigureAppConfiguration(
+                    (context, configurationBuilder) =>
+                        configurationBuilder.AddInMemoryCollection(configuration)
+                );
+            }
+            builder.ConfigureServices(collection =>
+            {
+                TestMockHelper.AddEssentialMocks(collection);
+                collection.AddTransient(x => apiService);
+            });
+        });
+    }
+
+    /// <summary>
+    /// Exercises the real Program.cs route table with a faked IApiService, so these tests prove how
+    /// the request is routed rather than what the response body says - the fake, not Core, supplies
+    /// the response here.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_A_Data_Route_Request_With_An_Unsupported_Method
+    {
+        [TestCase("/data/ed-fi/schools", "/ed-fi/schools", TestName = "Collection route")]
+        [TestCase($"/data/ed-fi/schools/{ItemUuid}", $"/ed-fi/schools/{ItemUuid}", TestName = "Item route")]
+        public async Task It_hands_the_request_to_core_with_the_real_method_name(
+            string requestUrl,
+            string expectedDmsPath
+        )
+        {
+            var apiService = A.Fake<IApiService>();
+            FrontendRequest? capturedRequest = null;
+            string? capturedMethodName = null;
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .Invokes(
+                    (FrontendRequest request, string methodName) =>
+                    {
+                        capturedRequest = request;
+                        capturedMethodName = methodName;
+                    }
+                )
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse()));
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Patch, requestUrl);
+
+            await client.SendAsync(request);
+
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustHaveHappenedOnceExactly();
+            capturedRequest.Should().NotBeNull();
+            capturedRequest!.Path.Should().Be(expectedDmsPath);
+            capturedMethodName.Should().Be("PATCH");
+        }
+
+        [Test]
+        public async Task It_returns_the_core_response_allow_header_and_body_unmodified()
+        {
+            var apiService = A.Fake<IApiService>();
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse()));
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Patch, "/data/ed-fi/schools");
+
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // ToResult is what carries Core's headers and content type to the wire; Core, not the
+            // frontend, is the single authority for the Allow value.
+            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            // Allow is a well-known header, so HttpClient parses the single "GET, POST" line Core
+            // set into separate tokens; rejoining them recovers the value that went over the wire.
+            string.Join(", ", response.Content.Headers.GetValues("Allow")).Should().Be("GET, POST");
+            response.Content.Headers.ContentType!.ToString().Should().Be("application/json; charset=utf-8");
+            JsonNode.Parse(content)!["source"]!.GetValue<string>().Should().Be("core");
+        }
+    }
+
+    /// <summary>
+    /// The regression guard for the terminal added to CoreEndpointModule: adding a method-less
+    /// endpoint on the verb endpoints' own route template must not divert any supported verb.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_A_Data_Route_Request_With_A_Supported_Method
+    {
+        [TestCase("GET", "/data/ed-fi/schools")]
+        [TestCase("POST", "/data/ed-fi/schools")]
+        [TestCase("PUT", "/data/ed-fi/schools")]
+        [TestCase("DELETE", "/data/ed-fi/schools")]
+        [TestCase("GET", $"/data/ed-fi/schools/{ItemUuid}")]
+        [TestCase("PUT", $"/data/ed-fi/schools/{ItemUuid}")]
+        [TestCase("DELETE", $"/data/ed-fi/schools/{ItemUuid}")]
+        public async Task It_still_reaches_its_original_api_service_method(string verb, string requestUrl)
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(new HttpMethod(verb), requestUrl);
+
+            var response = await client.SendAsync(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            AssertVerbReachedItsHandler(apiService, verb);
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
+        }
+    }
+
+    /// <summary>
+    /// The regression guard for the terminals added to TrackedChangesEndpointModule, and the
+    /// highest-value test in this set. Those terminals sit on literal templates that outrank the
+    /// data catch-all on precedence, so at Order 0 they intercept POST, PUT and DELETE on these
+    /// routes - verbs that today fall through to the catch-all verb endpoints and into Core.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_A_Tracked_Change_Route_Request_With_A_Supported_Method
+    {
+        [TestCase("deletes", "GET")]
+        [TestCase("deletes", "POST")]
+        [TestCase("deletes", "PUT")]
+        [TestCase("deletes", "DELETE")]
+        [TestCase("keyChanges", "GET")]
+        [TestCase("keyChanges", "POST")]
+        [TestCase("keyChanges", "PUT")]
+        [TestCase("keyChanges", "DELETE")]
+        public async Task It_still_reaches_its_original_api_service_method(
+            string trackedChangeSegment,
+            string verb
+        )
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(
+                new HttpMethod(verb),
+                $"/data/ed-fi/schools/{trackedChangeSegment}"
+            );
+
+            var response = await client.SendAsync(request);
+
+            // A 405 here means a tracked terminal answered a verb it must not own.
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            if (verb == "GET")
+            {
+                A.CallTo(() => apiService.GetTrackedChanges(A<FrontendRequest>._))
+                    .MustHaveHappenedOnceExactly();
+            }
+            else
+            {
+                AssertVerbReachedItsHandler(apiService, verb);
+                A.CallTo(() => apiService.GetTrackedChanges(A<FrontendRequest>._)).MustNotHaveHappened();
+            }
+        }
+    }
+
+    /// <summary>
+    /// These routes are newly returning 405 where they returned 404, so the response is a new wire
+    /// contract. Unlike the tests above this asserts the real wire response, because here the
+    /// frontend - not a faked Core - authors the body. The asserted members are deliberately the
+    /// same ones the Core terminal's own unit test asserts, so the two 405 producers cannot drift.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_A_Tracked_Change_Route_Request_With_An_Unsupported_Method
+    {
+        private const string CorrelationIdHeader = "correlationid";
+        private const string SentCorrelationId = "tracked-change-correlation-id";
+
+        [TestCase("deletes")]
+        [TestCase("keyChanges")]
+        public async Task It_answers_405_with_the_same_ed_fi_body_the_core_terminal_produces(
+            string trackedChangeSegment
+        )
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            // CorrelationIdHeader is empty by default, which would make ExtractTraceIdFrom fall back
+            // to TraceIdentifier and leave the correlationId assertion below unable to tell the two
+            // apart. Configuring the header is what gives that assertion its meaning.
+            await using var factory = CreateFactory(
+                apiService,
+                new Dictionary<string, string?> { ["AppSettings:CorrelationIdHeader"] = CorrelationIdHeader }
+            );
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Patch,
+                $"/data/ed-fi/schools/{trackedChangeSegment}"
+            );
+            request.Headers.Add(CorrelationIdHeader, SentCorrelationId);
+
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+            JsonNode body = JsonNode.Parse(content)!;
+
+            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            response.Content.Headers.GetValues("Allow").Should().Equal("GET");
+            response.Content.Headers.ContentType!.ToString().Should().Be("application/json; charset=utf-8");
+
+            body["detail"]!.GetValue<string>().Should().Be("The request construction was invalid.");
+            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:method-not-allowed");
+            body["title"]!.GetValue<string>().Should().Be("Method Not Allowed");
+            body["status"]!.GetValue<int>().Should().Be(405);
+            body["validationErrors"]!.AsObject().Should().BeEmpty();
+            body["errors"]!
+                .AsArray()
+                .Select(error => error!.GetValue<string>())
+                .Should()
+                .Equal("The endpoint of the request does not support the 'PATCH' method.");
+            body["correlationId"]!.GetValue<string>().Should().Be(SentCorrelationId);
+
+            // The terminal answers locally; it must not reach Core at all.
+            A.CallTo(apiService).MustNotHaveHappened();
+        }
+    }
+
+    [TestFixture]
+    [NonParallelizable]
+    public class Given_Other_Unmapped_Requests
+    {
+        [Test]
+        public async Task It_answers_head_on_a_data_route_from_the_method_not_allowed_terminal()
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Head, "/data/ed-fi/schools");
+
+            var response = await client.SendAsync(request);
+
+            // Status and Allow only, deliberately: TestServer does not implement Kestrel's HEAD
+            // body suppression, so any wire-body assertion here would describe the test host rather
+            // than the product.
+            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            string.Join(", ", response.Content.Headers.GetValues("Allow")).Should().Be("GET, POST");
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustHaveHappenedOnceExactly();
+        }
+
+        [Test]
+        public async Task It_still_answers_a_non_data_path_from_the_fallback()
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+
+            var response = await client.GetAsync("/nope");
+
+            response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
+        }
+
+        [Test]
+        public async Task It_still_answers_a_cors_preflight_before_reaching_the_terminal()
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Options, "/data/ed-fi/schools");
+            request.Headers.Add("Origin", "http://localhost:8082");
+            request.Headers.Add("Access-Control-Request-Method", "GET");
+
+            var response = await client.SendAsync(request);
+
+            // A plain OPTIONS now reaches the terminal and answers 405, but the CORS middleware
+            // short-circuits a preflight ahead of endpoint execution.
+            response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
+        }
+    }
+
+    private static void AssertVerbReachedItsHandler(IApiService apiService, string verb)
+    {
+        switch (verb)
+        {
+            case "GET":
+                A.CallTo(() => apiService.Get(A<FrontendRequest>._)).MustHaveHappenedOnceExactly();
+                break;
+            case "POST":
+                A.CallTo(() => apiService.Upsert(A<FrontendRequest>._)).MustHaveHappenedOnceExactly();
+                break;
+            case "PUT":
+                A.CallTo(() => apiService.UpdateById(A<FrontendRequest>._)).MustHaveHappenedOnceExactly();
+                break;
+            case "DELETE":
+                A.CallTo(() => apiService.DeleteById(A<FrontendRequest>._)).MustHaveHappenedOnceExactly();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(verb), verb, "Unhandled verb");
         }
     }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -146,14 +146,14 @@ public class CoreEndpointModuleTests
 
     private const string ItemUuid = "0192ac2c-8f7f-7c2a-9c1d-3f4b5a6c7d8e";
 
-    private static IFrontendResponse FakeCoreMethodNotAllowedResponse()
+    private static IFrontendResponse FakeCoreMethodNotAllowedResponse(string allow = "GET, POST")
     {
         JsonObject body = new() { ["source"] = "core" };
 
         var response = A.Fake<IFrontendResponse>();
         A.CallTo(() => response.StatusCode).Returns(405);
         A.CallTo(() => response.Body).Returns(body);
-        A.CallTo(() => response.Headers).Returns(new Dictionary<string, string> { ["Allow"] = "GET, POST" });
+        A.CallTo(() => response.Headers).Returns(new Dictionary<string, string> { ["Allow"] = allow });
         A.CallTo(() => response.ContentType).Returns("application/json; charset=utf-8");
         return response;
     }
@@ -188,6 +188,8 @@ public class CoreEndpointModuleTests
             .Returns(Task.FromResult(FakeCoreOkResponse()));
         A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
             .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse()));
+        A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+            .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse(allow: "GET")));
         return apiService;
     }
 
@@ -359,66 +361,121 @@ public class CoreEndpointModuleTests
                 AssertVerbReachedItsHandler(apiService, verb);
                 A.CallTo(() => apiService.GetTrackedChanges(A<FrontendRequest>._)).MustNotHaveHappened();
             }
+
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
         }
     }
 
     /// <summary>
-    /// These routes are newly returning 405 where they returned 404, so the response is a new wire
-    /// contract. Unlike the tests above this asserts the real wire response, because here the
-    /// frontend - not a faked Core - authors the body. The asserted members are deliberately the
-    /// same ones the Core terminal's own unit test asserts, so the two 405 producers cannot drift.
+    /// Like the data-route terminal, these hand the request to Core rather than answering locally,
+    /// so authentication, tenant validation and resource existence precede the 405. That makes this
+    /// a routing test: the response body comes from the fake, and the Core terminal's own unit test
+    /// owns the Ed-Fi problem-details contract.
     /// </summary>
     [TestFixture]
     [NonParallelizable]
     public class Given_A_Tracked_Change_Route_Request_With_An_Unsupported_Method
     {
-        private const string CorrelationIdHeader = "correlationid";
-        private const string SentCorrelationId = "tracked-change-correlation-id";
+        /// <summary>
+        /// Stands in for what JwtAuthenticationMiddleware produces at the head of the Core
+        /// pipeline, so a routing test can prove the frontend surfaces it instead of answering
+        /// 405 itself.
+        /// </summary>
+        private static IFrontendResponse FakeCoreUnauthorizedResponse()
+        {
+            var response = A.Fake<IFrontendResponse>();
+            A.CallTo(() => response.StatusCode).Returns(401);
+            A.CallTo(() => response.Body).Returns(new JsonObject { ["source"] = "core" });
+            A.CallTo(() => response.Headers).Returns(new Dictionary<string, string>());
+            A.CallTo(() => response.ContentType).Returns("application/json");
+            return response;
+        }
 
         [TestCase("deletes")]
         [TestCase("keyChanges")]
-        public async Task It_answers_405_with_the_same_ed_fi_body_the_core_terminal_produces(
+        public async Task It_hands_the_request_to_core_with_the_operation_suffix_and_method_name(
             string trackedChangeSegment
         )
         {
-            var apiService = FakeApiServiceAnsweringEveryVerb();
+            var apiService = A.Fake<IApiService>();
+            FrontendRequest? capturedRequest = null;
+            string? capturedMethodName = null;
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .Invokes(
+                    (FrontendRequest request, string methodName) =>
+                    {
+                        capturedRequest = request;
+                        capturedMethodName = methodName;
+                    }
+                )
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse(allow: "GET")));
 
-            // CorrelationIdHeader is empty by default, which would make ExtractTraceIdFrom fall back
-            // to TraceIdentifier and leave the correlationId assertion below unable to tell the two
-            // apart. Configuring the header is what gives that assertion its meaning.
-            await using var factory = CreateFactory(
-                apiService,
-                new Dictionary<string, string?> { ["AppSettings:CorrelationIdHeader"] = CorrelationIdHeader }
-            );
+            await using var factory = CreateFactory(apiService);
             using var client = factory.CreateClient();
             using var request = new HttpRequestMessage(
                 HttpMethod.Patch,
                 $"/data/ed-fi/schools/{trackedChangeSegment}"
             );
-            request.Headers.Add(CorrelationIdHeader, SentCorrelationId);
+
+            await client.SendAsync(request);
+
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .MustHaveHappenedOnceExactly();
+            capturedRequest.Should().NotBeNull();
+            // The suffix has to survive into the path, because ParseTrackedChangePathMiddleware
+            // parses the operation back out of it.
+            capturedRequest!.Path.Should().Be($"/ed-fi/schools/{trackedChangeSegment}");
+            capturedMethodName.Should().Be("PATCH");
+        }
+
+        [Test]
+        public async Task It_returns_the_core_response_allow_header_and_body_unmodified()
+        {
+            var apiService = A.Fake<IApiService>();
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse(allow: "GET")));
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Patch, "/data/ed-fi/schools/deletes");
 
             var response = await client.SendAsync(request);
             var content = await response.Content.ReadAsStringAsync();
-            JsonNode body = JsonNode.Parse(content)!;
 
+            // Core, not the frontend, is the single authority for the Allow value here too.
             response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
             response.Content.Headers.GetValues("Allow").Should().Equal("GET");
             response.Content.Headers.ContentType!.ToString().Should().Be("application/json; charset=utf-8");
+            JsonNode.Parse(content)!["source"]!.GetValue<string>().Should().Be("core");
+        }
 
-            body["detail"]!.GetValue<string>().Should().Be("The request construction was invalid.");
-            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:method-not-allowed");
-            body["title"]!.GetValue<string>().Should().Be("Method Not Allowed");
-            body["status"]!.GetValue<int>().Should().Be(405);
-            body["validationErrors"]!.AsObject().Should().BeEmpty();
-            body["errors"]!
-                .AsArray()
-                .Select(error => error!.GetValue<string>())
-                .Should()
-                .Equal("The endpoint of the request does not support the 'PATCH' method.");
-            body["correlationId"]!.GetValue<string>().Should().Be(SentCorrelationId);
+        /// <summary>
+        /// The regression guard for the defect this routing replaced: answering in the frontend
+        /// skipped JwtAuthenticationMiddleware, so an unauthenticated caller received a 405 where
+        /// every other data path requires a token. Nothing but reaching Core can restore that.
+        /// </summary>
+        [TestCase("deletes")]
+        [TestCase("keyChanges")]
+        public async Task It_lets_core_answer_rather_than_responding_before_authentication(
+            string trackedChangeSegment
+        )
+        {
+            var apiService = A.Fake<IApiService>();
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .Returns(Task.FromResult(FakeCoreUnauthorizedResponse()));
 
-            // The terminal answers locally; it must not reach Core at all.
-            A.CallTo(apiService).MustNotHaveHappened();
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Patch,
+                $"/data/ed-fi/schools/{trackedChangeSegment}"
+            );
+
+            var response = await client.SendAsync(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            response.Content.Headers.Contains("Allow").Should().BeFalse();
         }
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -8,7 +8,6 @@ using System.Net.Http;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Interface;
-using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Modules;
 using FakeItEasy;
 using FluentAssertions;
@@ -489,16 +488,25 @@ public class CoreEndpointModuleTests
     public class Given_Other_Unmapped_Requests
     {
         /// <summary>
-        /// HEAD reaches the GET handler rather than the method-not-allowed terminal. Left to the
-        /// terminal it would answer 405 while listing GET in its own Allow header, and RFC 9110
-        /// section 9.1 requires HEAD wherever GET is supported.
+        /// HEAD falls through to the method-not-allowed terminal rather than being answered by the
+        /// GET handler. RFC 9110 section 9.1 would have a general-purpose server support HEAD
+        /// wherever GET is supported, but ODS/API declares no HttpHead action and pins the
+        /// resulting 405 with an integration test, and this endpoint exists for ODS/API
+        /// compatibility. Mapping HEAD onto GET here would answer 200 where ODS/API answers 405.
         /// </summary>
         [TestCase("/data/ed-fi/schools", TestName = "Collection route")]
         [TestCase($"/data/ed-fi/schools/{ItemUuid}", TestName = "Item route")]
         [TestCase("/data/ed-fi/schools/deletes", TestName = "Tracked change route")]
-        public async Task It_answers_head_from_the_get_handler(string requestUrl)
+        public async Task It_answers_head_from_the_method_not_allowed_terminal(string requestUrl)
         {
             var apiService = FakeApiServiceAnsweringEveryVerb();
+            List<string> terminalMethodNames = [];
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .Invokes((FrontendRequest _, string methodName) => terminalMethodNames.Add(methodName))
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse()));
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .Invokes((FrontendRequest _, string methodName) => terminalMethodNames.Add(methodName))
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse(allow: "GET")));
 
             await using var factory = CreateFactory(apiService);
             using var client = factory.CreateClient();
@@ -506,42 +514,12 @@ public class CoreEndpointModuleTests
 
             var response = await client.SendAsync(request);
 
-            // Status only, deliberately: TestServer does not implement Kestrel's HEAD body
-            // suppression, so any wire-body assertion here would describe the test host rather
-            // than the product.
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
-            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
-                .MustNotHaveHappened();
-            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
-                .MustNotHaveHappened();
-        }
-
-        /// <summary>
-        /// The etag served for a resource embeds the negotiated content coding (see VariantKey), so
-        /// a HEAD that negotiated identity where GET negotiated a compressed coding would return an
-        /// etag the client's follow-up conditional GET could never match.
-        /// </summary>
-        [Test]
-        public async Task It_negotiates_the_same_content_coding_for_head_as_for_get()
-        {
-            var apiService = A.Fake<IApiService>();
-            List<ResponseContentCoding> negotiated = [];
-            A.CallTo(() => apiService.Get(A<FrontendRequest>._))
-                .Invokes((FrontendRequest request) => negotiated.Add(request.ResponseContentCoding))
-                .Returns(Task.FromResult(FakeCoreOkResponse()));
-
-            await using var factory = CreateFactory(apiService);
-            using var client = factory.CreateClient();
-
-            foreach (var method in new[] { HttpMethod.Get, HttpMethod.Head })
-            {
-                using var request = new HttpRequestMessage(method, $"/data/ed-fi/schools/{ItemUuid}");
-                request.Headers.Add("Accept-Encoding", "gzip");
-                await client.SendAsync(request);
-            }
-
-            negotiated.Should().HaveCount(2);
-            negotiated[1].Should().Be(negotiated[0]);
+            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            // Core names the verb in the 405 body, the same way ODS/API does from
+            // context.Request.Method, so the real verb has to survive the hand-off.
+            terminalMethodNames.Should().Equal("HEAD");
+            A.CallTo(() => apiService.Get(A<FrontendRequest>._)).MustNotHaveHappened();
+            A.CallTo(() => apiService.GetTrackedChanges(A<FrontendRequest>._)).MustNotHaveHappened();
         }
 
         [Test]

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -297,6 +297,10 @@ public class CoreEndpointModuleTests
         [TestCase("PUT", "/data/ed-fi/schools")]
         [TestCase("DELETE", "/data/ed-fi/schools")]
         [TestCase("GET", $"/data/ed-fi/schools/{ItemUuid}")]
+        // POST on an item route must still reach Upsert so ValidateRouteSemanticsMiddleware can
+        // emit its own distinct 405 message. If the terminal ever intercepted it the status would
+        // still be 405 and only that message would change, which no other test here would catch.
+        [TestCase("POST", $"/data/ed-fi/schools/{ItemUuid}")]
         [TestCase("PUT", $"/data/ed-fi/schools/{ItemUuid}")]
         [TestCase("DELETE", $"/data/ed-fi/schools/{ItemUuid}")]
         public async Task It_still_reaches_its_original_api_service_method(string verb, string requestUrl)

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Modules;
 using FakeItEasy;
 using FluentAssertions;
@@ -480,6 +481,60 @@ public class CoreEndpointModuleTests
 
             response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             response.Content.Headers.Contains("Allow").Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Under a tenant and route-qualifier prefix both terminals sit at Order 1, so nothing but
+        /// route precedence keeps the literal tracked-change template ahead of the data catch-all.
+        /// If that ever inverts the status stays 405 and only the Allow value degrades from "GET" to
+        /// the collection methods, which no other assertion here would notice. The prefix segments
+        /// are asserted too because the Core pipeline validates the tenant and resolves the data
+        /// store before reaching the terminal.
+        /// </summary>
+        [TestCase("deletes")]
+        [TestCase("keyChanges")]
+        public async Task It_reaches_the_tracked_change_terminal_under_a_tenant_and_qualifier_prefix(
+            string trackedChangeSegment
+        )
+        {
+            var apiService = FakeApiServiceAnsweringEveryVerb();
+            FrontendRequest? capturedRequest = null;
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .Invokes((FrontendRequest request, string _) => capturedRequest = request)
+                .Returns(Task.FromResult(FakeCoreMethodNotAllowedResponse(allow: "GET")));
+
+            await using var factory = CreateFactory(
+                apiService,
+                new Dictionary<string, string?>
+                {
+                    ["AppSettings:MultiTenancy"] = "true",
+                    ["AppSettings:RouteQualifierSegments"] = "districtId,schoolYear",
+                }
+            );
+            using var client = factory.CreateClient();
+            using var request = new HttpRequestMessage(
+                HttpMethod.Patch,
+                $"/tenant1/255902/2026/data/ed-fi/schools/{trackedChangeSegment}"
+            );
+
+            var response = await client.SendAsync(request);
+
+            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
+            response.Content.Headers.GetValues("Allow").Should().Equal("GET");
+            // The data-route terminal shares Order 1 and would answer with the collection methods.
+            A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
+            capturedRequest.Should().NotBeNull();
+            capturedRequest!.Path.Should().Be($"/ed-fi/schools/{trackedChangeSegment}");
+            capturedRequest.Tenant.Should().Be("tenant1");
+            capturedRequest
+                .RouteQualifiers[new RouteQualifierName("districtId")]
+                .Should()
+                .Be(new RouteQualifierValue("255902"));
+            capturedRequest
+                .RouteQualifiers[new RouteQualifierName("schoolYear")]
+                .Should()
+                .Be(new RouteQualifierValue("2026"));
         }
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore.Tests.Unit/Modules/CoreEndpointModuleTests.cs
@@ -8,6 +8,7 @@ using System.Net.Http;
 using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Frontend;
 using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.External.Model;
 using EdFi.DataManagementService.Frontend.AspNetCore.Modules;
 using FakeItEasy;
 using FluentAssertions;
@@ -483,24 +484,60 @@ public class CoreEndpointModuleTests
     [NonParallelizable]
     public class Given_Other_Unmapped_Requests
     {
-        [Test]
-        public async Task It_answers_head_on_a_data_route_from_the_method_not_allowed_terminal()
+        /// <summary>
+        /// HEAD reaches the GET handler rather than the method-not-allowed terminal. Left to the
+        /// terminal it would answer 405 while listing GET in its own Allow header, and RFC 9110
+        /// section 9.1 requires HEAD wherever GET is supported.
+        /// </summary>
+        [TestCase("/data/ed-fi/schools", TestName = "Collection route")]
+        [TestCase($"/data/ed-fi/schools/{ItemUuid}", TestName = "Item route")]
+        [TestCase("/data/ed-fi/schools/deletes", TestName = "Tracked change route")]
+        public async Task It_answers_head_from_the_get_handler(string requestUrl)
         {
             var apiService = FakeApiServiceAnsweringEveryVerb();
 
             await using var factory = CreateFactory(apiService);
             using var client = factory.CreateClient();
-            using var request = new HttpRequestMessage(HttpMethod.Head, "/data/ed-fi/schools");
+            using var request = new HttpRequestMessage(HttpMethod.Head, requestUrl);
 
             var response = await client.SendAsync(request);
 
-            // Status and Allow only, deliberately: TestServer does not implement Kestrel's HEAD
-            // body suppression, so any wire-body assertion here would describe the test host rather
+            // Status only, deliberately: TestServer does not implement Kestrel's HEAD body
+            // suppression, so any wire-body assertion here would describe the test host rather
             // than the product.
-            response.StatusCode.Should().Be(HttpStatusCode.MethodNotAllowed);
-            string.Join(", ", response.Content.Headers.GetValues("Allow")).Should().Be("GET, POST");
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
             A.CallTo(() => apiService.MethodNotAllowed(A<FrontendRequest>._, A<string>._))
-                .MustHaveHappenedOnceExactly();
+                .MustNotHaveHappened();
+            A.CallTo(() => apiService.MethodNotAllowedForTrackedChange(A<FrontendRequest>._, A<string>._))
+                .MustNotHaveHappened();
+        }
+
+        /// <summary>
+        /// The etag served for a resource embeds the negotiated content coding (see VariantKey), so
+        /// a HEAD that negotiated identity where GET negotiated a compressed coding would return an
+        /// etag the client's follow-up conditional GET could never match.
+        /// </summary>
+        [Test]
+        public async Task It_negotiates_the_same_content_coding_for_head_as_for_get()
+        {
+            var apiService = A.Fake<IApiService>();
+            List<ResponseContentCoding> negotiated = [];
+            A.CallTo(() => apiService.Get(A<FrontendRequest>._))
+                .Invokes((FrontendRequest request) => negotiated.Add(request.ResponseContentCoding))
+                .Returns(Task.FromResult(FakeCoreOkResponse()));
+
+            await using var factory = CreateFactory(apiService);
+            using var client = factory.CreateClient();
+
+            foreach (var method in new[] { HttpMethod.Get, HttpMethod.Head })
+            {
+                using var request = new HttpRequestMessage(method, $"/data/ed-fi/schools/{ItemUuid}");
+                request.Headers.Add("Accept-Encoding", "gzip");
+                await client.SendAsync(request);
+            }
+
+            negotiated.Should().HaveCount(2);
+            negotiated[1].Should().Be(negotiated[0]);
         }
 
         [Test]

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -963,4 +963,33 @@ public static class AspNetCoreFrontend
             dmsPath
         );
     }
+
+    /// <summary>
+    /// ASP.NET Core entry point for tracked-change route requests (/deletes, /keyChanges) whose
+    /// HTTP method is not one of the supported verbs. Goes through Core for the same reason the
+    /// data-route entry point does: authentication, tenant validation and resource existence must
+    /// all precede the 405.
+    /// </summary>
+    public static async Task<IResult> MethodNotAllowedForTrackedChange(
+        HttpContext httpContext,
+        IApiService apiService,
+        string dmsPath,
+        IOptions<AppSettings> appSettings
+    )
+    {
+        return ToResult(
+            await apiService.MethodNotAllowedForTrackedChange(
+                await FromRequest(
+                    httpContext.Request,
+                    dmsPath,
+                    appSettings,
+                    includeBody: false,
+                    includeForm: false
+                ),
+                httpContext.Request.Method
+            ),
+            httpContext,
+            dmsPath
+        );
+    }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -935,4 +935,32 @@ public static class AspNetCoreFrontend
             dmsPath
         );
     }
+
+    /// <summary>
+    /// ASP.NET Core entry point for data-route requests whose HTTP method is not one of the
+    /// supported verbs. Core decides between 404 (unknown resource) and 405 (unsupported method),
+    /// and ToResult carries Core's Allow header and content type to the response.
+    /// </summary>
+    public static async Task<IResult> MethodNotAllowed(
+        HttpContext httpContext,
+        IApiService apiService,
+        string dmsPath,
+        IOptions<AppSettings> appSettings
+    )
+    {
+        return ToResult(
+            await apiService.MethodNotAllowed(
+                await FromRequest(
+                    httpContext.Request,
+                    dmsPath,
+                    appSettings,
+                    includeBody: false,
+                    includeForm: false
+                ),
+                httpContext.Request.Method
+            ),
+            httpContext,
+            dmsPath
+        );
+    }
 }

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -617,11 +617,21 @@ public static class AspNetCoreFrontend
             ParsedBody: jsonBody.ParsedBody,
             BodyParseErrorMessage: jsonBody.ParseErrorMessage,
             DuplicatePropertyPath: jsonBody.DuplicatePropertyPath,
-            ResponseContentCoding: HttpMethods.IsGet(httpRequest.Method)
+            ResponseContentCoding: IsGetOrHead(httpRequest)
                 ? ResolveResponseContentCoding(httpRequest.HttpContext)
                 : ResponseContentCoding.Identity
         );
     }
+
+    /// <summary>
+    /// HEAD must be answered with the same headers GET would have produced (RFC 9110 section
+    /// 9.3.2), so it negotiates the same representation. This is load-bearing rather than tidy:
+    /// the selected content coding participates in the served etag (see VariantKey), so a HEAD
+    /// that resolved identity where GET resolved gzip would hand the client an etag its follow-up
+    /// conditional GET could never match.
+    /// </summary>
+    private static bool IsGetOrHead(HttpRequest request) =>
+        HttpMethods.IsGet(request.Method) || HttpMethods.IsHead(request.Method);
 
     /// <summary>
     /// Uses the same registered provider as ASP.NET Core response compression to select the content
@@ -717,7 +727,7 @@ public static class AspNetCoreFrontend
         // middleware. Declare both request selectors at the serving boundary so caches never reuse a
         // representation across incompatible Accept or Accept-Encoding values.
         if (
-            HttpMethods.IsGet(httpContext.Request.Method)
+            IsGetOrHead(httpContext.Request)
             && frontendResponse.StatusCode is StatusCodes.Status200OK or StatusCodes.Status304NotModified
         )
         {

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/AspNetCoreFrontend.cs
@@ -617,21 +617,11 @@ public static class AspNetCoreFrontend
             ParsedBody: jsonBody.ParsedBody,
             BodyParseErrorMessage: jsonBody.ParseErrorMessage,
             DuplicatePropertyPath: jsonBody.DuplicatePropertyPath,
-            ResponseContentCoding: IsGetOrHead(httpRequest)
+            ResponseContentCoding: HttpMethods.IsGet(httpRequest.Method)
                 ? ResolveResponseContentCoding(httpRequest.HttpContext)
                 : ResponseContentCoding.Identity
         );
     }
-
-    /// <summary>
-    /// HEAD must be answered with the same headers GET would have produced (RFC 9110 section
-    /// 9.3.2), so it negotiates the same representation. This is load-bearing rather than tidy:
-    /// the selected content coding participates in the served etag (see VariantKey), so a HEAD
-    /// that resolved identity where GET resolved gzip would hand the client an etag its follow-up
-    /// conditional GET could never match.
-    /// </summary>
-    private static bool IsGetOrHead(HttpRequest request) =>
-        HttpMethods.IsGet(request.Method) || HttpMethods.IsHead(request.Method);
 
     /// <summary>
     /// Uses the same registered provider as ASP.NET Core response compression to select the content
@@ -727,7 +717,7 @@ public static class AspNetCoreFrontend
         // middleware. Declare both request selectors at the serving boundary so caches never reuse a
         // representation across incompatible Accept or Accept-Encoding values.
         if (
-            IsGetOrHead(httpContext.Request)
+            HttpMethods.IsGet(httpContext.Request.Method)
             && frontendResponse.StatusCode is StatusCodes.Status200OK or StatusCodes.Status304NotModified
         )
         {

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
@@ -23,6 +23,17 @@ public class CoreEndpointModule(IOptions<AppSettings> appSettings) : IEndpointMo
         endpoints.MapGet(routePattern, Get);
         endpoints.MapPut(routePattern, UpdateById);
         endpoints.MapDelete(routePattern, DeleteById);
+
+        // Terminal for data-route requests whose method is not one of the four above. Core decides
+        // 404-vs-405 (unknown resource vs unsupported method), matching ODS/API's ordering.
+        //
+        // This shares the verb endpoints' exact route template, so Order and precedence both tie and
+        // EndpointComparer falls through to HttpMethodMatcherPolicy's metadata comparer, which ranks
+        // method-constrained endpoints ahead of method-less ones. The four verbs therefore win on
+        // their own merits and this terminal picks up everything else. WithOrder(1) is defensive,
+        // not load-bearing: it keeps the terminal demoted if the template is ever narrowed. Any
+        // order below MapFallback's int.MaxValue works.
+        endpoints.Map(routePattern, MethodNotAllowed).WithOrder(1);
     }
 
     /// <summary>

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
@@ -20,16 +20,19 @@ public class CoreEndpointModule(IOptions<AppSettings> appSettings) : IEndpointMo
         );
 
         endpoints.MapPost(routePattern, Upsert);
-        // HEAD is GET without the response body (RFC 9110 section 9.3.2), and section 9.1 requires
-        // general-purpose servers to support both. Mapped on the GET endpoint rather than left to
-        // the terminal below, which would otherwise answer HEAD with a 405 whose own Allow header
-        // lists GET. Kestrel suppresses the body.
-        endpoints.MapMethods(routePattern, [HttpMethods.Get, HttpMethods.Head], Get);
+        endpoints.MapGet(routePattern, Get);
         endpoints.MapPut(routePattern, UpdateById);
         endpoints.MapDelete(routePattern, DeleteById);
 
         // Terminal for data-route requests whose method is none of the verbs above. Core decides
         // 404-vs-405 (unknown resource vs unsupported method), matching ODS/API's ordering.
+        //
+        // HEAD deliberately falls through to here rather than being mapped onto the GET endpoint.
+        // RFC 9110 section 9.1 would have general-purpose servers support HEAD wherever GET is
+        // supported, but ODS/API does not: it declares no HttpHead action and pins the resulting
+        // 405 with an integration test (GetAll_405_Tests/when_http_method_is_head_should_return_405).
+        // This endpoint exists for ODS/API compatibility, so HEAD answers 405 here too, and the
+        // Allow sets in Core list only the verbs above.
         //
         // This shares the verb endpoints' exact route template, so precedence ties, and were this
         // terminal left at Order 0 the Order would tie too - EndpointComparer would then fall

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
@@ -28,15 +28,16 @@ public class CoreEndpointModule(IOptions<AppSettings> appSettings) : IEndpointMo
         endpoints.MapPut(routePattern, UpdateById);
         endpoints.MapDelete(routePattern, DeleteById);
 
-        // Terminal for data-route requests whose method is not one of the four above. Core decides
+        // Terminal for data-route requests whose method is none of the verbs above. Core decides
         // 404-vs-405 (unknown resource vs unsupported method), matching ODS/API's ordering.
         //
-        // This shares the verb endpoints' exact route template, so Order and precedence both tie and
-        // EndpointComparer falls through to HttpMethodMatcherPolicy's metadata comparer, which ranks
-        // method-constrained endpoints ahead of method-less ones. The four verbs therefore win on
-        // their own merits and this terminal picks up everything else. WithOrder(1) is defensive,
-        // not load-bearing: it keeps the terminal demoted if the template is ever narrowed. Any
-        // order below MapFallback's int.MaxValue works.
+        // This shares the verb endpoints' exact route template, so precedence ties, and were this
+        // terminal left at Order 0 the Order would tie too - EndpointComparer would then fall
+        // through to HttpMethodMatcherPolicy's metadata comparer, which ranks method-constrained
+        // endpoints ahead of method-less ones, and the verbs would still win on their own merits.
+        // WithOrder(1) is therefore defensive rather than load-bearing here: it keeps the terminal
+        // demoted if the template is ever narrowed. Any order below MapFallback's int.MaxValue
+        // works. Contrast TrackedChangesEndpointModule, where the order IS load-bearing.
         endpoints.Map(routePattern, MethodNotAllowed).WithOrder(1);
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/CoreEndpointModule.cs
@@ -20,7 +20,11 @@ public class CoreEndpointModule(IOptions<AppSettings> appSettings) : IEndpointMo
         );
 
         endpoints.MapPost(routePattern, Upsert);
-        endpoints.MapGet(routePattern, Get);
+        // HEAD is GET without the response body (RFC 9110 section 9.3.2), and section 9.1 requires
+        // general-purpose servers to support both. Mapped on the GET endpoint rather than left to
+        // the terminal below, which would otherwise answer HEAD with a 405 whose own Allow header
+        // lists GET. Kestrel suppresses the body.
+        endpoints.MapMethods(routePattern, [HttpMethods.Get, HttpMethods.Head], Get);
         endpoints.MapPut(routePattern, UpdateById);
         endpoints.MapDelete(routePattern, DeleteById);
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
@@ -17,16 +17,11 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         string[] routeQualifierSegments = appSettings.Value.GetRouteQualifierSegmentsArray();
         bool multiTenancy = appSettings.Value.MultiTenancy;
 
-        // GET and HEAD together, for the reason given in CoreEndpointModule: HEAD is GET without
-        // the body, so leaving it to the terminals below would answer it 405 with Allow: GET.
-        endpoints.MapMethods(
-            BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"),
-            [HttpMethods.Get, HttpMethods.Head],
-            GetDeletes
-        );
-        endpoints.MapMethods(
+        // GET alone, for the reason given in CoreEndpointModule: ODS/API answers HEAD with a 405,
+        // so HEAD falls through to the terminals below rather than being mapped here.
+        endpoints.MapGet(BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"), GetDeletes);
+        endpoints.MapGet(
             BuildRoutePattern(routeQualifierSegments, multiTenancy, "keyChanges"),
-            [HttpMethods.Get, HttpMethods.Head],
             GetKeyChanges
         );
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
@@ -17,9 +17,16 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         string[] routeQualifierSegments = appSettings.Value.GetRouteQualifierSegmentsArray();
         bool multiTenancy = appSettings.Value.MultiTenancy;
 
-        endpoints.MapGet(BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"), GetDeletes);
-        endpoints.MapGet(
+        // GET and HEAD together, for the reason given in CoreEndpointModule: HEAD is GET without
+        // the body, so leaving it to the terminals below would answer it 405 with Allow: GET.
+        endpoints.MapMethods(
+            BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"),
+            [HttpMethods.Get, HttpMethods.Head],
+            GetDeletes
+        );
+        endpoints.MapMethods(
             BuildRoutePattern(routeQualifierSegments, multiTenancy, "keyChanges"),
+            [HttpMethods.Get, HttpMethods.Head],
             GetKeyChanges
         );
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
@@ -3,7 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Interface;
+using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
 using Microsoft.Extensions.Options;
 using static EdFi.DataManagementService.Frontend.AspNetCore.AspNetCoreFrontend;
@@ -21,6 +25,60 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         endpoints.MapGet(
             BuildRoutePattern(routeQualifierSegments, multiTenancy, "keyChanges"),
             GetKeyChanges
+        );
+
+        // Terminals for tracked-change routes reached with an unsupported method.
+        //
+        // Here WithOrder(1) IS load-bearing, unlike the terminal in CoreEndpointModule. These
+        // templates are literal and therefore more specific than /data/{**dmsPath}, and
+        // EndpointComparer sorts Order -> precedence -> policy comparers, so precedence is consulted
+        // before the HTTP-method comparer. At Order 0 these terminals intercept POST, PUT and DELETE
+        // on /deletes and /keyChanges, which today fall through to the catch-all verb endpoints and
+        // into Core. Order 1 demotes them below the Order-0 verb endpoints so only genuinely
+        // unmapped verbs reach them.
+        endpoints
+            .Map(
+                BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"),
+                MethodNotAllowedForTrackedChange
+            )
+            .WithOrder(1);
+        endpoints
+            .Map(
+                BuildRoutePattern(routeQualifierSegments, multiTenancy, "keyChanges"),
+                MethodNotAllowedForTrackedChange
+            )
+            .WithOrder(1);
+    }
+
+    /// <summary>
+    /// Answers 405 for a tracked-change route reached with an unsupported method. Answered here
+    /// rather than in Core because ParsePathMiddleware parses the deletes/keyChanges suffix as the
+    /// document id segment and rejects it as a malformed UUID with a 400, and
+    /// ParseTrackedChangePathMiddleware 404s any other suffix so it cannot sit in a shared pipeline.
+    ///
+    /// The body, content type and correlation id are deliberately identical to what
+    /// MethodNotAllowedMiddleware emits, from the same FailureResponse factory; only the Allow value
+    /// differs. ToResult cannot be reused here because it is private and takes IFrontendResponse,
+    /// whose only implementation is internal to Core, so the Results.Content call below reproduces
+    /// ToResult's own tail.
+    /// </summary>
+    private static IResult MethodNotAllowedForTrackedChange(
+        HttpContext httpContext,
+        IOptions<AppSettings> appSettings
+    )
+    {
+        httpContext.Response.Headers.Append("Allow", "GET");
+
+        JsonNode body = FailureResponse.ForMethodNotAllowed(
+            [$"The endpoint of the request does not support the '{httpContext.Request.Method}' method."],
+            ExtractTraceIdFrom(httpContext.Request, appSettings)
+        );
+
+        return Results.Content(
+            statusCode: StatusCodes.Status405MethodNotAllowed,
+            content: JsonSerializer.Serialize(body, SharedSerializerOptions),
+            contentType: "application/json; charset=utf-8",
+            contentEncoding: Encoding.UTF8
         );
     }
 

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
@@ -36,6 +36,12 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         // on /deletes and /keyChanges, which today fall through to the catch-all verb endpoints and
         // into Core. Order 1 demotes them below the Order-0 verb endpoints so only genuinely
         // unmapped verbs reach them.
+        //
+        // A deliberate consequence: POST, PUT and DELETE on these routes still reach the data
+        // pipeline, where ParsePathMiddleware reads the /deletes or /keyChanges suffix as a document
+        // id and rejects it as a malformed uuid with a 400. The Allow: GET these terminals emit
+        // therefore states what this terminal accepts, not what the whole URL accepts. Dropping the
+        // WithOrder(1) calls would make those three verbs answer 405 here as well.
         endpoints
             .Map(
                 BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"),

--- a/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
+++ b/src/dms/frontend/EdFi.DataManagementService.Frontend.AspNetCore/Modules/TrackedChangesEndpointModule.cs
@@ -3,11 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Nodes;
 using EdFi.DataManagementService.Core.External.Interface;
-using EdFi.DataManagementService.Core.Response;
 using EdFi.DataManagementService.Frontend.AspNetCore.Configuration;
 using Microsoft.Extensions.Options;
 using static EdFi.DataManagementService.Frontend.AspNetCore.AspNetCoreFrontend;
@@ -27,7 +23,9 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
             GetKeyChanges
         );
 
-        // Terminals for tracked-change routes reached with an unsupported method.
+        // Terminals for tracked-change routes reached with an unsupported method. They hand the
+        // request to Core rather than answering here, so that authentication, tenant validation and
+        // resource existence all run first - the same ordering the data-route terminal gets.
         //
         // Here WithOrder(1) IS load-bearing, unlike the terminal in CoreEndpointModule. These
         // templates are literal and therefore more specific than /data/{**dmsPath}, and
@@ -39,47 +37,15 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         endpoints
             .Map(
                 BuildRoutePattern(routeQualifierSegments, multiTenancy, "deletes"),
-                MethodNotAllowedForTrackedChange
+                MethodNotAllowedForDeletes
             )
             .WithOrder(1);
         endpoints
             .Map(
                 BuildRoutePattern(routeQualifierSegments, multiTenancy, "keyChanges"),
-                MethodNotAllowedForTrackedChange
+                MethodNotAllowedForKeyChanges
             )
             .WithOrder(1);
-    }
-
-    /// <summary>
-    /// Answers 405 for a tracked-change route reached with an unsupported method. Answered here
-    /// rather than in Core because ParsePathMiddleware parses the deletes/keyChanges suffix as the
-    /// document id segment and rejects it as a malformed UUID with a 400, and
-    /// ParseTrackedChangePathMiddleware 404s any other suffix so it cannot sit in a shared pipeline.
-    ///
-    /// The body, content type and correlation id are deliberately identical to what
-    /// MethodNotAllowedMiddleware emits, from the same FailureResponse factory; only the Allow value
-    /// differs. ToResult cannot be reused here because it is private and takes IFrontendResponse,
-    /// whose only implementation is internal to Core, so the Results.Content call below reproduces
-    /// ToResult's own tail.
-    /// </summary>
-    private static IResult MethodNotAllowedForTrackedChange(
-        HttpContext httpContext,
-        IOptions<AppSettings> appSettings
-    )
-    {
-        httpContext.Response.Headers.Append("Allow", "GET");
-
-        JsonNode body = FailureResponse.ForMethodNotAllowed(
-            [$"The endpoint of the request does not support the '{httpContext.Request.Method}' method."],
-            ExtractTraceIdFrom(httpContext.Request, appSettings)
-        );
-
-        return Results.Content(
-            statusCode: StatusCodes.Status405MethodNotAllowed,
-            content: JsonSerializer.Serialize(body, SharedSerializerOptions),
-            contentType: "application/json; charset=utf-8",
-            contentEncoding: Encoding.UTF8
-        );
     }
 
     internal static string BuildRoutePattern(
@@ -116,6 +82,36 @@ public class TrackedChangesEndpointModule(IOptions<AppSettings> appSettings) : I
         IOptions<AppSettings> appSettings
     ) =>
         GetTrackedChanges(
+            httpContext,
+            apiService,
+            $"{projectNamespace}/{endpointName}/keyChanges",
+            appSettings
+        );
+
+    // These rebuild the dmsPath from the route's literal suffix exactly as GetDeletes and
+    // GetKeyChanges do, because Core parses the operation back out of the path.
+    private static Task<IResult> MethodNotAllowedForDeletes(
+        HttpContext httpContext,
+        IApiService apiService,
+        string projectNamespace,
+        string endpointName,
+        IOptions<AppSettings> appSettings
+    ) =>
+        MethodNotAllowedForTrackedChange(
+            httpContext,
+            apiService,
+            $"{projectNamespace}/{endpointName}/deletes",
+            appSettings
+        );
+
+    private static Task<IResult> MethodNotAllowedForKeyChanges(
+        HttpContext httpContext,
+        IApiService apiService,
+        string projectNamespace,
+        string endpointName,
+        IOptions<AppSettings> appSettings
+    ) =>
+        MethodNotAllowedForTrackedChange(
             httpContext,
             apiService,
             $"{projectNamespace}/{endpointName}/keyChanges",

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -316,6 +316,7 @@ Feature: Validation of the structure of the URLs
               And the response headers include
                   """
                     {
+                        "Allow": "GET, PUT, DELETE",
                         "Content-Type": "application/json; charset=utf-8"
                     }
                   """
@@ -358,6 +359,7 @@ Feature: Validation of the structure of the URLs
               And the response headers include
                   """
                     {
+                        "Allow": "GET, POST",
                         "Content-Type": "application/json; charset=utf-8"
                     }
                   """
@@ -384,6 +386,7 @@ Feature: Validation of the structure of the URLs
               And the response headers include
                   """
                     {
+                        "Allow": "GET, POST",
                         "Content-Type": "application/json; charset=utf-8"
                     }
                   """
@@ -814,3 +817,25 @@ Feature: Validation of the structure of the URLs
                   | Key    | Value |
                   | Accept | */*   |
              Then it should respond with 200
+
+        # The unknown-project-namespace branch of endpoint validation, the sibling of scenario 25's
+        # unknown-resource branch.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 32 Ensure clients get 404 for an unsupported method on an unknown project namespace
+             When an "PATCH" request is made to "/notaschema/notaresource" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -849,8 +849,9 @@ Feature: Validation of the structure of the URLs
 
         # ODS/API parity: OPTIONS is not a supported method on a data route either, so it earns the
         # same problem-details 405 as any other unsupported verb. A CORS preflight is different - it
-        # carries Origin and Access-Control-Request-Method and is answered by the CORS middleware
-        # before routing, which OwaspCriticalPaths scenario 12 covers.
+        # carries Origin and Access-Control-Request-Method, and the CORS middleware answers it once
+        # the route has matched but before the endpoint runs, so it never reaches the terminal this
+        # scenario exercises. OwaspCriticalPaths scenario 12 covers that path.
         @DMS-1281
         @e2e-ci-shard-4
         Scenario: 33 Ensure clients get 405 for an OPTIONS request on a resource collection

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -634,3 +634,89 @@ Feature: Validation of the structure of the URLs
                         "Content-Type": "application/problem+json"
                     }
                   """
+
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 23 Ensure clients get 405 for an unsupported method on a resource collection
+             When an "PATCH" request is made to "/ed-fi/schools" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 405
+              And the response body is
+                  """
+                  {
+                      "detail": "The request construction was invalid.",
+                      "type": "urn:ed-fi:api:method-not-allowed",
+                      "title": "Method Not Allowed",
+                      "status": 405,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": [
+                          "The endpoint of the request does not support the 'PATCH' method."
+                      ]
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET, POST",
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
+                  """
+
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 24 Ensure clients get 405 for an unsupported method on a resource item
+             When an "PATCH" request is made to "/ed-fi/schools/00000000-0000-4000-a000-000000000000" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 405
+              And the response body is
+                  """
+                  {
+                      "detail": "The request construction was invalid.",
+                      "type": "urn:ed-fi:api:method-not-allowed",
+                      "title": "Method Not Allowed",
+                      "status": 405,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": [
+                          "The endpoint of the request does not support the 'PATCH' method."
+                      ]
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET, PUT, DELETE",
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
+                  """
+
+        # ODS/API parity: an unsupported method on a resource that does not exist is a 404, not a
+        # 405, because existence is resolved before the method is rejected.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 25 Ensure clients get 404 for an unsupported method on an unknown Ed-Fi resource
+             When an "PATCH" request is made to "/ed-fi/notaresource" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Content-Type": "application/problem+json"
+                    }
+                  """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -879,3 +879,31 @@ Feature: Validation of the structure of the URLs
                         "Content-Type": "application/json; charset=utf-8"
                     }
                   """
+
+        # The path is parsed before the method is judged, so a malformed id is answered with the
+        # same 400 that scenario 14 pins for a GET - not the 405 of scenario 24. This is the third
+        # and last outcome the terminal can produce, alongside the 405s above and the 404s of
+        # scenarios 25, 29 and 32.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 34 Ensure clients get 400 for an unsupported method on a malformed resource id
+             When an "PATCH" request is made to "/ed-fi/schools/ffc0a272" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 400
+              And the response body is
+                  """
+                  {
+                      "detail": "Data validation failed. See 'validationErrors' for details.",
+                      "type": "urn:ed-fi:api:bad-request:data-validation-failed",
+                      "title": "Data Validation Failed",
+                      "status": 400,
+                      "correlationId": null,
+                      "validationErrors": {
+                        "$.id": [
+                            "The value 'ffc0a272' is not valid."
+                        ]
+                      },
+                      "errors": []
+                  }
+                  """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -720,3 +720,97 @@ Feature: Validation of the structure of the URLs
                         "Content-Type": "application/problem+json"
                     }
                   """
+
+        # An unsupported method is routed into the DMS core rather than answered at the routing
+        # layer, so authentication runs ahead of the method check. Without a token the response is
+        # 401, never the 405 below. This is the ODS/API ordering: authentication, then existence,
+        # then method.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 26 Ensure an unsupported method without a token is rejected as unauthorized
+             When an unauthenticated "PATCH" request is made to "/ed-fi/schools"
+             Then it should respond with 401
+
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 27 Ensure clients get 405 for an unsupported method on a deletes route
+             When an "PATCH" request is made to "/ed-fi/schools/deletes" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 405
+              And the response body is
+                  """
+                  {
+                      "detail": "The request construction was invalid.",
+                      "type": "urn:ed-fi:api:method-not-allowed",
+                      "title": "Method Not Allowed",
+                      "status": 405,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": [
+                          "The endpoint of the request does not support the 'PATCH' method."
+                      ]
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET",
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
+                  """
+
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 28 Ensure clients get 405 for an unsupported method on a keyChanges route
+             When an "PATCH" request is made to "/ed-fi/schools/keyChanges" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 405
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET",
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
+                  """
+
+        # The same existence-before-method ordering as scenario 25, on a tracked-change route.
+        # These routes resolve the resource in the core pipeline, so an unknown resource is a 404.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 29 Ensure clients get 404 for an unsupported method on an unknown resource's deletes route
+             When an "PATCH" request is made to "/ed-fi/notaresource/deletes" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 404
+              And the response body is
+                  """
+                  {
+                      "detail": "The specified data could not be found.",
+                      "type": "urn:ed-fi:api:not-found",
+                      "title": "Not Found",
+                      "status": 404,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": []
+                  }
+                  """
+
+        # Tracked-change routes are answered by the same core pipeline as the data routes, so they
+        # inherit the same authentication ordering as scenario 26.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 30 Ensure an unsupported method on a tracked-change route without a token is rejected as unauthorized
+             When an unauthenticated "PATCH" request is made to "/ed-fi/schools/deletes"
+             Then it should respond with 401
+
+        # HEAD is GET without a response body, so it is answered by the GET endpoint rather than
+        # rejected as an unsupported method.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 31 Ensure HEAD is supported wherever GET is supported
+             When an "HEAD" request is made to "/ed-fi/schools" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 200

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/General/URLValidation.feature
@@ -808,15 +808,22 @@ Feature: Validation of the structure of the URLs
              When an unauthenticated "PATCH" request is made to "/ed-fi/schools/deletes"
              Then it should respond with 401
 
-        # HEAD is GET without a response body, so it is answered by the GET endpoint rather than
-        # rejected as an unsupported method.
+        # ODS/API parity: HEAD is not a supported method on a data route, so it is rejected like any
+        # other unsupported verb rather than answered by the GET endpoint. A HEAD response carries no
+        # body, so only the status and the Allow header are asserted.
         @DMS-1281
         @e2e-ci-shard-4
-        Scenario: 31 Ensure HEAD is supported wherever GET is supported
+        Scenario: 31 Ensure clients get 405 for a HEAD request on a resource collection
              When an "HEAD" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
                   | Accept | */*   |
-             Then it should respond with 200
+             Then it should respond with 405
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET, POST"
+                    }
+                  """
 
         # The unknown-project-namespace branch of endpoint validation, the sibling of scenario 25's
         # unknown-resource branch.
@@ -838,4 +845,37 @@ Feature: Validation of the structure of the URLs
                       "validationErrors": {},
                       "errors": []
                   }
+                  """
+
+        # ODS/API parity: OPTIONS is not a supported method on a data route either, so it earns the
+        # same problem-details 405 as any other unsupported verb. A CORS preflight is different - it
+        # carries Origin and Access-Control-Request-Method and is answered by the CORS middleware
+        # before routing, which OwaspCriticalPaths scenario 12 covers.
+        @DMS-1281
+        @e2e-ci-shard-4
+        Scenario: 33 Ensure clients get 405 for an OPTIONS request on a resource collection
+             When an "OPTIONS" request is made to "/ed-fi/schools" with headers
+                  | Key    | Value |
+                  | Accept | */*   |
+             Then it should respond with 405
+              And the response body is
+                  """
+                  {
+                      "detail": "The request construction was invalid.",
+                      "type": "urn:ed-fi:api:method-not-allowed",
+                      "title": "Method Not Allowed",
+                      "status": 405,
+                      "correlationId": null,
+                      "validationErrors": {},
+                      "errors": [
+                          "The endpoint of the request does not support the 'OPTIONS' method."
+                      ]
+                  }
+                  """
+              And the response headers include
+                  """
+                    {
+                        "Allow": "GET, POST",
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
                   """

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -203,8 +203,9 @@ Feature: OWASP critical attack path protections
              Then it should respond with 200 or 204
               And the response header "Access-Control-Allow-Origin" is not present
 
-        # Note: the bearer token is included by the step helper; TRACE rejection (404/405) is
-        # enforced at the routing layer regardless of auth state.
+        # Note: the bearer token is included by the step helper, so this verifies AUTHENTICATED TRACE
+        # rejection. TRACE enters Core, where JWT authentication runs before the method-not-allowed
+        # terminal, so an unauthenticated TRACE would be 401 rather than 404/405.
         @e2e-ci-shard-3
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/Security/OwaspCriticalPaths.feature
@@ -205,13 +205,13 @@ Feature: OWASP critical attack path protections
 
         # Note: the bearer token is included by the step helper, so this verifies AUTHENTICATED TRACE
         # rejection. TRACE enters Core, where JWT authentication runs before the method-not-allowed
-        # terminal, so an unauthenticated TRACE would be 401 rather than 404/405.
+        # terminal, so an unauthenticated TRACE would be 401 rather than 405.
         @e2e-ci-shard-3
         Scenario: 13 Unsupported TRACE method is not enabled
              When an "TRACE" request is made to "/ed-fi/schools" with headers
                   | Key    | Value |
                   | Accept | */*   |
-             Then it should respond with 404 or 405
+             Then it should respond with 405
 
         @e2e-ci-shard-3
         Scenario: 14 Oversized request body is rejected with payload too large

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/StepDefinitions/StepDefinitions.cs
@@ -857,6 +857,27 @@ namespace EdFi.DataManagementService.Tests.E2E.StepDefinitions
             );
         }
 
+        // The authenticated twin above builds its headers from GetHeaders(), which always attaches a
+        // bearer token. This one deliberately sends none, so a scenario can assert that
+        // authentication is reached before the request's method is judged.
+        [When("an unauthenticated {string} request is made to {string}")]
+        public async Task WhenAnUnauthenticatedRequestIsMadeTo(string method, string url)
+        {
+            url = AddDataPrefixIfNecessary(url)
+                .Replace("{id}", _id)
+                .ReplacePlaceholdersWithDictionaryValues(_scenarioVariables.VariableByName);
+
+            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Accept"] = "*/*",
+            };
+
+            _apiResponse = await _playwrightContext.ApiRequestContext!.FetchAsync(
+                url,
+                new() { Method = method, Headers = headers }
+            );
+        }
+
         [When("a POST request larger than {int} MB is made to {string}")]
         public async Task WhenAPostRequestLargerThanMbIsMadeTo(int sizeInMb, string url)
         {


### PR DESCRIPTION
## What

Unsupported HTTP methods on data routes and tracked-change routes now return the Ed-Fi RFC 9457
problem-details body (`urn:ed-fi:api:method-not-allowed`, 405) with an `Allow` header and
`Content-Type: application/json; charset=utf-8`, instead of a bodiless 404.

## Why

ODS/API compatibility — DMS-1281.

**Correction to the ticket premise.** The reported "bare 405 with an `Allow` header and no body" is
not what DMS did. `MapFallback` registers an any-method endpoint, which suppresses ASP.NET's 405
synthesis entirely, so every unmapped verb returned **404**. Any fix that shapes a
framework-generated 405 — including the CMS `FrameworkErrorResponseMiddleware` pattern — cannot fire
here, because no framework 405 is ever produced. That is why the request is routed into Core instead
of being answered in the routing layer.

Routing into Core is also what buys the ODS/API **authentication → existence → method** ordering: an
unauthenticated request still answers 401, an unknown project namespace or resource still answers
404, and a malformed document id still answers 400. Only a request that has cleared all three
reaches the 405.

## Changes

**Frontend — route the request in**

- `CoreEndpointModule` maps a method-less terminal on the verb endpoints' own route template at
  `WithOrder(1)`. Defensive rather than load-bearing here: on a tied template and order,
  `HttpMethodMatcherPolicy`'s metadata comparer already ranks method-constrained endpoints first.
- `TrackedChangesEndpointModule` maps terminals on `/deletes` and `/keyChanges`. Here `WithOrder(1)`
  **is** load-bearing — those literal templates outrank the data catch-all on precedence, so at
  Order 0 they would intercept `POST`/`PUT`/`DELETE`, which today fall through to the catch-all verb
  endpoints.
- Two `AspNetCoreFrontend` entry points hand off to Core; `ToResult` carries Core's `Allow` header
  and content type to the wire unchanged.

**Core — the method-not-allowed pipeline**

- Two pipelines: `CreateMethodNotAllowedPipeline` and `CreateTrackedChangeMethodNotAllowedPipeline`.
  They differ by one step — `ParsePathMiddleware` vs `ParseTrackedChangePathMiddleware` — because a
  tracked-change path carries an operation suffix where a data path carries a document id.
  Deliberately *not* `GetRoutedResourceInitialSteps()`: the fingerprint, key-seed and mapping-set
  steps exist for data access and this request never reaches a backend. `ResolveDataStoreMiddleware`
  is kept, so an unsupported method cannot answer 405 where the equivalent supported request would
  answer 403/404.
- `MethodNotAllowedMiddleware` is the terminal. `Allow` is derived in Core — `GET, POST` on
  collections, `GET, PUT, DELETE` on items, `GET` on tracked-change routes — from the same constants
  `ValidateRouteSemanticsMiddleware` enforces, so the frontend holds no duplicate verb constants.
  Which route family the terminal serves is fixed by the pipeline at construction, not inferred from
  request state.
- `RequestMethod.UNSUPPORTED` (appended last, so no existing ordinal shifts) and
  `RequestInfo.UnsupportedMethodName`, read through a single `MethodName` accessor.

**Public API surface**

Two additions to `IApiService`: `MethodNotAllowed(FrontendRequest, string)` and
`MethodNotAllowedForTrackedChange(FrontendRequest, string)`. `RequestMethod.UNSUPPORTED` and
`RequestInfo.UnsupportedMethodName` are on `internal` types.

**Why HEAD and OPTIONS also answer 405**

Deliberate, and the most likely thing to look like a bug. RFC 9110 §9.1 would have a
general-purpose server support HEAD wherever GET is supported — ODS/API does not, and this endpoint
exists for ODS/API compatibility. Verified against live ODS `main` (`24fe66cfc`): no `[HttpHead]` or
`[HttpOptions]` anywhere in Ed-Fi-ODS or Ed-Fi-ODS-Implementation, `DataManagementControllerBase`
declares only GET/PUT/POST/DELETE, and both are pinned by ODS's own integration tests
(`GetAll_405_Tests/when_http_method_is_head_should_return_405` and `…_options_…`). Mapping HEAD onto
GET would answer 200 where ODS/API answers 405. Consequently `HEAD` must **not** be added to the
`Allow` sets — `SnapshotsAreReadOnlyResult.cs:40` sets `Allow: GET` on ODS's own read-only 405. A
real CORS preflight is different: it carries `Origin` and `Access-Control-Request-Method` and is
answered 204 by the CORS middleware before endpoint execution.

**Why `POST`/`PUT`/`DELETE` on `/deletes` and `/keyChanges` answer 400, not 405**

The second most likely thing to look like a bug — three reviewers reached it independently.

`WithOrder(1)` demotes the tracked-change terminals below the Order-0 catch-all verb endpoints, so
those three verbs still reach the data pipeline, where `ParsePathMiddleware` reads `deletes` as a
document id and rejects it as a malformed uuid — a 400. `Allow: GET` therefore states what the
*terminal* accepts, not what the whole URL accepts. Dropping `WithOrder(1)` would move all three to
405, which is outside AC 3 ("Existing GET/POST/PUT/DELETE behavior unchanged").

This is not specific to tracked-change routes, and it predates the branch. `ParsePathMiddleware`
sits in `GetRoutedResourceInitialSteps()`, ahead of `ValidateRouteSemanticsMiddleware` in every
write pipeline, so a malformed id always answers 400 before any method check. `GET
/data/ed-fi/schools/ffc0a272` has answered 400 since `@API-251` (`URLValidation` scenario 14), where
ODS answers 405: in `DataManagementControllerBase` the guid constraint is on `[HttpGet("{id:guid}")]`
alone, so a non-guid id leaves only the unconstrained `[HttpPut("{id}")]`, `[HttpPost("{id}")]` and
`[HttpDelete("{id}")]` matching the path, and the GET is rejected on method rather than parsed.
Aligning that is a broader change than this ticket.

**Incidental fixes surfaced by the above**

- `ValidateRouteSemanticsMiddleware` now sends `Allow` on its own 405s (RFC 9110 §15.5.6), so both
  `urn:ed-fi:api:method-not-allowed` producers carry it rather than only the new one. The
  profile-scoped 405 in `CachedProfileService` is a different contract
  (`urn:ed-fi:api:profile:method-usage`) and is left alone.
- `RequestResponseLoggingMiddleware` logs the real verb (`PATCH`) rather than the `UNSUPPORTED` enum
  name, so log searches by HTTP verb still work — still routed through `LoggingSanitizer`, since the
  value is client-supplied.
- `ResourceActionAuthorizationMiddleware` fails with a diagnostic `InvalidOperationException` rather
  than a bare `KeyNotFoundException` if ever reached with a method that has no resource action.

## Behavior changes to expect

- Data routes: `PATCH`, `OPTIONS`, `TRACE`, `HEAD` and unknown verbs move **404 → 405**.
- `/deletes` and `/keyChanges`: the same verbs move **404 → 405** with `Allow: GET`. `POST`, `PUT`
  and `DELETE` on those routes keep today's 400 — they still reach the catch-all verb endpoints, per
  AC 3 ("Existing GET/POST/PUT/DELETE behavior unchanged"), and there is a regression test pinning
  it.
- Unknown resource, unknown namespace and malformed paths keep their 404; a malformed document id
  keeps its 400; unauthenticated keeps its 401.
- CORS preflight `OPTIONS` is unaffected (204).
- `OwaspCriticalPaths` scenario 13 (TRACE) is tightened from `404 or 405` to `405`, since the answer
  is now deterministic.

## Test plan

- [ ] `dotnet build --no-restore ./src/dms/EdFi.DataManagementService.sln` — also confirms the new
      enum member left no `switch` non-exhaustive and no `IApiService` implementation unimplemented.
- [ ] `dotnet csharpier check` over the touched projects.
- [ ] Core unit — `MethodNotAllowedMiddlewareTests`: 405 status, correct `Allow` for collection vs
      item vs tracked-change routes, content type, the problem-details body member by member,
      `correlationId` from `TraceId`, terminal (never calls `next`), and `PATCH`/`OPTIONS`/`TRACE`/
      `FOO`/`HEAD` each echoed in `errors[0]`. These construct the middleware directly and pass the
      route-family flag in themselves, so the guard that the flag is *wired* correctly lives in
      `PipelineOrderingTests` instead.
- [ ] Core unit — `PipelineOrderingTests.Given_The_Method_Not_Allowed_Pipelines`: step order
      (`ValidateEndpointMiddleware` ahead of the terminal, the right parse step per pipeline,
      `ResolveDataStoreMiddleware` present) and the regression guard for the route-family
      discriminator — the terminal each factory actually constructed answers `Allow: GET, POST` on
      the data pipeline and `Allow: GET` on the tracked-change one. Mutation-verified: flipping the
      constructor flag in `ApiService` fails exactly this assertion and nothing else.
- [ ] Core unit — `RequestResponseLoggingMiddlewareTests` (2 new): an `UNSUPPORTED` request logs
      `Method` as `PATCH`, and a `PAT\r\nCH{unsafe}` method name is still sanitized.
- [ ] Core unit — `ValidateRouteSemanticsMiddlewareTests` (3 new): its 405s carry `Allow`.
- [ ] Frontend — `CoreEndpointModuleTests`: `PATCH` on collection and item routes reaches
      `IApiService.MethodNotAllowed` once with the right `dmsPath` and method name; Core's `Allow`
      and body reach the wire unmodified.
- [ ] Frontend regression guard — `GET`/`POST`/`PUT`/`DELETE` on the collection route and
      `GET`/`POST`/`PUT`/`DELETE` on the item route still reach their original `IApiService`
      methods. `POST` on an item route matters: it must still reach `Upsert` so
      `ValidateRouteSemanticsMiddleware` emits its own distinct 405 message.
- [ ] Frontend regression guard — on `/deletes` **and** `/keyChanges`: `GET` still reaches
      `GetTrackedChanges` and `POST`/`PUT`/`DELETE` still reach `Upsert`/`UpdateById`/`DeleteById`.
      This is the test that fails if the tracked terminals are left at Order 0.
- [ ] Frontend — an unsupported method on a tracked-change route surfaces Core's 401 rather than
      answering 405 before authentication; `HEAD` answers from the terminal on all three route
      shapes; `GET /nope` still 404s from `MapFallback`; CORS preflight still 204.
- [ ] Run **both whole** unit test projects, not just the filtered fixtures — the frontend host is
      shared with `TrackedChangesEndpointModuleTests`, `DiscoveryEndpointModuleTests`,
      `MetaDataModuleTests`, `EndpointsTests` and `RateLimitTests`, and the Core change touches a
      shared pipeline builder.
- [ ] E2E shard 4 — `URLValidation.feature` scenarios 23–34: 405 on collection/item/`deletes`/
      `keyChanges`/HEAD/OPTIONS, 404 for unknown resource and unknown namespace (the ODS-parity
      scenarios the frontend fixture cannot cover, since it fakes `IApiService`), 401 for
      unauthenticated, and 400 for a malformed id. Run via `./build-dms.ps1 E2ETest -Configuration
      Release -IdentityProvider self-contained -EnvironmentFile './.env.e2e' -TestFilter
      'Category=@e2e-ci-shard-4'` — the first run **must omit** `-SkipDockerBuild`, or it tests a
      stale image and false-greens.
- [ ] E2E shard 3 — `OwaspCriticalPaths` scenario 13 (TRACE) now asserts 405 (`-SkipDockerBuild` is
      fine here, reusing the shard-4 image).
- [ ] Manual ODS-parity check against the running stack, with a valid token: real collection → 405
      `Allow: GET, POST`; real item → 405 `Allow: GET, PUT, DELETE`; `/data/ed-fi/notaresource` →
      404; unauthenticated `PATCH` → 401; `/data/ed-fi/schools/deletes` → 405 `Allow: GET` with the
      full body and an echoed `correlationId`; `/data`, `/data/ed-fi`, `/data/ed-fi/schools/a/b` →
      404. Every one of these returned 404 with no `Allow` header before the change.

