### PR TITLE
[DMS-1300] Make env files authoritative for DMS E2E schema packages

### DIFF
--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -742,37 +742,6 @@ function Invoke-E2EDatabaseProvisioning {
     }
 }
 
-function Get-DockerContainerEnvironmentMap {
-    param(
-        [string]
-        $ContainerName
-    )
-
-    $environmentJson = docker inspect $ContainerName --format '{{json .Config.Env}}'
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unable to inspect Docker container '$ContainerName'."
-    }
-
-    $environmentEntries = @($environmentJson | ConvertFrom-Json)
-    $environmentValues = @{}
-
-    foreach ($entry in $environmentEntries) {
-        $entryText = [string]$entry
-        $separatorIndex = $entryText.IndexOf("=")
-
-        if ($separatorIndex -lt 0) {
-            continue
-        }
-
-        $key = $entryText.Substring(0, $separatorIndex)
-        $value = $entryText.Substring($separatorIndex + 1)
-        $environmentValues[$key] = $value
-    }
-
-    return $environmentValues
-}
-
 function Write-DmsSchemaContainerEnvironment {
     param(
         [hashtable]
@@ -834,7 +803,11 @@ function Assert-DmsRuntimeSchemaMatchesProvisionedDatabase {
 
     Write-Output "Validating DMS runtime effective schema before E2E tests..."
 
-    $environmentValues = Get-DockerContainerEnvironmentMap -ContainerName $ContainerName
+    # The single container-environment reader, exported by the module imported at the top of this
+    # script. This function used to carry its own copy under a different name; the two parsed the
+    # same 'docker inspect --format {{json .Config.Env}}' output the same way and both failed closed,
+    # so the copy only gave the next fix somewhere to land unnoticed.
+    $environmentValues = Get-DmsContainerEnvironment -ContainerName $ContainerName
     Write-DmsSchemaContainerEnvironment -EnvironmentValues $environmentValues
 
     $dmsRuntimeEffectiveSchemaHash = Get-DmsRuntimeEffectiveSchemaHash `

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -181,6 +181,14 @@ $maintainers = "Ed-Fi Alliance, LLC and contributors"
 Import-Module -Name "$PSScriptRoot/eng/build-helpers.psm1" -Force
 Import-Module -Name "$PSScriptRoot/eng/docker-compose/effective-schema-hash.psm1" -Force
 Import-Module -Name "$PSScriptRoot/package-helpers.psm1" -Force
+# The E2E setup wrappers' schema-settings guard. This script keeps its own -Enabled wrapper below and
+# delegates only the enabled body here, so the removal-and-restore sequence exists in one place.
+#
+# Without -Force, the same rule this module applies to its own nested imports: -Force removes a module
+# before re-importing it and removal is session-wide, so an already-loaded instance is reused instead.
+# This import can therefore only ADD command resolution, never take it away from a setup wrapper this
+# script invokes in-process.
+Import-Module -Name "$PSScriptRoot/eng/docker-compose/dms-schema-environment.psm1"
 
 function DotNetClean {
     Invoke-Execute { dotnet clean $defaultSolution -c $Configuration --nologo -v minimal }
@@ -501,39 +509,24 @@ function Invoke-WithEnvironmentFileSchemaSettings {
         $Action
     )
 
+    # The -Enabled pass-through is this script's own contract and stays here: several call sites gate
+    # the removal on a caller switch or on the E2E settings object, and their phases must run WITHOUT
+    # the removal when that gate is off.
     if (-not $Enabled) {
         & $Action
         return
     }
 
-    $schemaEnvironmentVariableNames = @(
-        "USE_API_SCHEMA_PATH",
-        "API_SCHEMA_PATH",
-        "SCHEMA_PACKAGES"
-    )
-    $previousValues = @{}
-
-    foreach ($name in $schemaEnvironmentVariableNames) {
-        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
-    }
-
-    try {
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
-        }
-
-        & $Action
-    }
-    finally {
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            if ($null -eq $previousValues[$name]) {
-                Remove-Item "Env:$name" -ErrorAction SilentlyContinue
-            }
-            else {
-                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
-            }
-        }
-    }
+    # Only the enabled body is delegated. The removal-and-restore sequence used to be a second copy of
+    # the module's, and the two had already drifted: this one cleared the three names without
+    # -LiteralPath, which the module had adopted. Keeping one implementation means the next fix cannot
+    # land in only one of them.
+    #
+    # This name must stay as it is. Renaming it to the module's would shadow the export for the setup
+    # wrapper this script invokes in-process with '& $instanceSetupScript': command lookup walks that
+    # child scope chain before it reaches the session state, so the wrapper's bare call would bind this
+    # -Enabled wrapper with the switch unset and remove nothing.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action $Action
 }
 
 function Stop-DockerEnvironment {

--- a/build-dms.ps1
+++ b/build-dms.ps1
@@ -181,8 +181,10 @@ $maintainers = "Ed-Fi Alliance, LLC and contributors"
 Import-Module -Name "$PSScriptRoot/eng/build-helpers.psm1" -Force
 Import-Module -Name "$PSScriptRoot/eng/docker-compose/effective-schema-hash.psm1" -Force
 Import-Module -Name "$PSScriptRoot/package-helpers.psm1" -Force
-# The E2E setup wrappers' schema-settings guard. This script keeps its own -Enabled wrapper below and
-# delegates only the enabled body here, so the removal-and-restore sequence exists in one place.
+# The E2E setup wrappers' schema-settings guard and container-environment reader. This script calls
+# both directly rather than through helpers of its own: its gated call sites pass the guard's -Enabled
+# parameter, so there is one implementation, one name, and nothing defined here for a setup wrapper's
+# own call to bind instead of the module's export.
 #
 # Without -Force, the same rule this module applies to its own nested imports: -Force removes a module
 # before re-importing it and removal is session-wide, so an already-loaded instance is reused instead.
@@ -499,36 +501,6 @@ function Invoke-WithE2ETestProcessContext {
     }
 }
 
-function Invoke-WithEnvironmentFileSchemaSettings {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Existing build-script helper name describes schema settings from an environment file.')]
-    param(
-        [switch]
-        $Enabled,
-
-        [scriptblock]
-        $Action
-    )
-
-    # The -Enabled pass-through is this script's own contract and stays here: several call sites gate
-    # the removal on a caller switch or on the E2E settings object, and their phases must run WITHOUT
-    # the removal when that gate is off.
-    if (-not $Enabled) {
-        & $Action
-        return
-    }
-
-    # Only the enabled body is delegated. The removal-and-restore sequence used to be a second copy of
-    # the module's, and the two had already drifted: this one cleared the three names without
-    # -LiteralPath, which the module had adopted. Keeping one implementation means the next fix cannot
-    # land in only one of them.
-    #
-    # This name must stay as it is. Renaming it to the module's would shadow the export for the setup
-    # wrapper this script invokes in-process with '& $instanceSetupScript': command lookup walks that
-    # child scope chain before it reaches the session state, so the wrapper's bare call would bind this
-    # -Enabled wrapper with the switch unset and remove nothing.
-    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action $Action
-}
-
 function Stop-DockerEnvironment {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Internal build orchestration helper; build-dms.ps1 does not expose -WhatIf end to end, so partial ShouldProcess support would create misleading no-op behavior.')]
     param(
@@ -558,10 +530,10 @@ function Stop-DockerEnvironment {
             # failing published down leaves a stopped-but-not-torn-down stack with no workspace to retry
             # against. The published down below still performs the removal on the success path, because an
             # absent project's down exits 0.
-            Invoke-WithEnvironmentFileSchemaSettings -Enabled:$UseEnvironmentFileSchemaSettings -Action {
+            Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$UseEnvironmentFileSchemaSettings -Action {
                 ./start-local-dms.ps1 -EnvironmentFile $EnvironmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $DatabaseEngine -d -v -RemoveBootstrap:$false
             }
-            Invoke-WithEnvironmentFileSchemaSettings -Enabled:$UseEnvironmentFileSchemaSettings -Action {
+            Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$UseEnvironmentFileSchemaSettings -Action {
                 ./start-published-dms.ps1 -EnvironmentFile $EnvironmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $DatabaseEngine -d -v -RemoveBootstrap:$RemoveBootstrap
             }
         }
@@ -909,7 +881,7 @@ function Start-DockerEnvironment {
                 # only infrastructure + Configuration Service now, then create the data store. DMS is
                 # started after provisioning by Initialize-E2EDatabase -StartDmsAfterProvisioning
                 # (mirrors setup-local-dms.ps1's InfraOnly -> configure -> provision -> DmsOnly sequence).
-                Invoke-WithEnvironmentFileSchemaSettings -Enabled:$UseEnvironmentFileSchemaSettings -Action {
+                Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$UseEnvironmentFileSchemaSettings -Action {
                     & $startupScriptPath -InfraOnly -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $resolvedDatabaseEngine -AddExtensionSecurityMetadata
                 }
                 # Neither start-published-dms.ps1 -InfraOnly nor start-local-dms.ps1 -InfraOnly creates a
@@ -920,7 +892,7 @@ function Start-DockerEnvironment {
             elseif ($UsePublishedImage) {
                 # Published image, PostgreSQL: full start. start-published-dms.ps1 creates the data store
                 # internally from -DataStoreDatabaseName.
-                Invoke-WithEnvironmentFileSchemaSettings -Enabled:$UseEnvironmentFileSchemaSettings -Action {
+                Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$UseEnvironmentFileSchemaSettings -Action {
                     & $startupScriptPath -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $resolvedDatabaseEngine -AddExtensionSecurityMetadata -DataStoreDatabaseName $DataStoreDatabaseName
                 }
             }
@@ -932,7 +904,7 @@ function Start-DockerEnvironment {
                 # -RemoveBootstrap teardown above guarantees no manifest is staged, so the claims-ready
                 # gate is skipped. The DMS container restarts until the configure step below lands the
                 # data store (restart: unless-stopped).
-                Invoke-WithEnvironmentFileSchemaSettings -Enabled:$UseEnvironmentFileSchemaSettings -Action {
+                Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$UseEnvironmentFileSchemaSettings -Action {
                     & $startupScriptPath -EnvironmentFile $environmentFilePath -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $resolvedDatabaseEngine -AddExtensionSecurityMetadata
                 }
 
@@ -1028,7 +1000,7 @@ function Start-BootstrapDockerEnvironment {
                 $bootstrapArgs.DataStandardVersion = $DataStandardVersion
             }
 
-            Invoke-WithEnvironmentFileSchemaSettings -Enabled -Action {
+            Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
                 if ($UsePublishedImage) {
                     ./bootstrap-published-dms.ps1 @bootstrapArgs
                 }
@@ -1082,7 +1054,7 @@ function Initialize-E2EDatabase {
         Invoke-Execute {
             try {
                 Push-Location "$PSScriptRoot/eng/docker-compose"
-                Invoke-WithEnvironmentFileSchemaSettings -Enabled:$E2ETestSettings.ShouldProvisionE2EDatabase -Action {
+                Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$E2ETestSettings.ShouldProvisionE2EDatabase -Action {
                     & $startupScriptPath -DmsOnly -EnvironmentFile $E2ETestSettings.EnvironmentFile -EnableConfig -IdentityProvider $IdentityProvider -DatabaseEngine $E2ETestSettings.DatabaseEngine -AddExtensionSecurityMetadata
                 }
             }

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -62,8 +62,10 @@ function Invoke-WithDmsEnvironmentFileSchemaAuthority {
         reason the verification below lives here: two copies drift, and only one of them gets the next
         fix. It remains a CALLER-side guard - start-local-dms.ps1 must not clear these names globally,
         because in bootstrap mode it sets them in-process on purpose so process precedence makes the
-        staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 keeps its own -Enabled
-        variant: it has phases that must run without this removal, which the wrappers do not.
+        staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 keeps an -Enabled WRAPPER
+        around this function rather than a second copy of it: several of its call sites gate the removal
+        on a switch or on the E2E settings object, and their phases must run without it - which the
+        setup wrappers never do, so they call this directly.
 
         THE NAME MUST STAY DISTINCT FROM build-dms.ps1's HELPER, and this one is deliberately not
         Invoke-WithEnvironmentFileSchemaSettings. build-dms.ps1 InstanceE2ETest invokes the Instance
@@ -421,6 +423,11 @@ function Get-DmsContainerEnvironment {
         throw "Unable to inspect Docker container '$ContainerName' to verify its schema environment."
     }
 
+    # A PowerShell hashtable, so its key lookups are case-INSENSITIVE, and that is deliberate here.
+    # Docker Compose is the sole writer of this container's environment and emits the exact
+    # AppSettings__* spelling local-dms.yml declares, so the gate never has two spellings to tell
+    # apart and a case-sensitive map would only add a way for the gate to miss its own keys. Casing
+    # matters for the VALUES, which is why Get-DmsSchemaEnvironmentToken compares those Ordinal.
     $containerEnvironment = @{}
 
     foreach ($entry in @($environmentJson | ConvertFrom-Json)) {
@@ -557,11 +564,11 @@ function Assert-DmsContainerSchemaEnvironment {
     Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green
 }
 
+# Only the two commands a caller outside this module invokes: the pre-phase guard (both E2E setup
+# wrappers, and build-dms.ps1's -Enabled wrapper delegating to it) and the post-start verification.
+# Everything else above is an internal of those two. The tests reach the internals by extracting the
+# function text through the AST and dot-sourcing it, so none of them is exported for testability - and
+# a narrower surface is also less of it exposed to the in-process shadowing described above.
 Export-ModuleMember -Function `
     Invoke-WithDmsEnvironmentFileSchemaAuthority, `
-    Get-DmsSchemaEnvironmentToken, `
-    Get-DmsContainerSchemaPackage, `
-    Get-DmsSchemaPackageIdentity, `
-    Get-DmsSchemaEnvironmentVerdict, `
-    Get-DmsContainerEnvironment, `
     Assert-DmsContainerSchemaEnvironment

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# Licensed to the Ed-Fi Alliance under one or more agreements.
+# The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+# See the LICENSE and NOTICES files in the project root for more information.
+
+<#
+.SYNOPSIS
+    Post-start verification that a started DMS container's ApiSchema package settings agree with the
+    environment file the E2E database was provisioned from.
+.DESCRIPTION
+    Shared by both E2E setup wrappers (EdFi.DataManagementService.Tests.E2E and
+    EdFi.InstanceManagement.Tests.E2E) so the direct and route-context flows verify the same thing in
+    the same way rather than carrying two copies of the check.
+
+    The provisioner reads SCHEMA_PACKAGES from the environment file only, so the E2E database is
+    always stamped for the file's package surface. DMS receives its settings through Docker Compose,
+    which resolves them ambient-first. When the two disagree the stack comes up healthy and then fails
+    every data-plane request with an EffectiveSchemaHash mismatch, so the disagreement is reported
+    here instead of as an HTTP 503 in every scenario of the suite.
+#>
+
+# Imported here rather than relied on from the caller's session, so the module resolves every command
+# it calls regardless of what the invoking script happened to import: Get-EnvValue (env-utility),
+# Resolve-ComposeEnvRawValue (database-safety), and Get-SchemaPackagesFromEnvironmentFile
+# (schema-package-utility, the same file-only reader the provision phase uses).
+Import-Module (Join-Path $PSScriptRoot "env-utility.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "database-safety.psm1") -Force
+Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1") -Force
+
+function Get-DmsSchemaEnvironmentToken {
+    <#
+    .SYNOPSIS
+        Classifies a container environment value without echoing it, so a failure message carries a
+        fixed vocabulary instead of interpolated container text.
+    .OUTPUTS
+        [string] One of "<absent>", "<blank>", "true", "false", or "<set>".
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment,
+
+        [Parameter(Mandatory)]
+        [string] $Key
+    )
+
+    if (-not $ContainerEnvironment.ContainsKey($Key)) {
+        return "<absent>"
+    }
+
+    $value = [string]$ContainerEnvironment[$Key]
+
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return "<blank>"
+    }
+
+    # Ordinal, deliberately not OrdinalIgnoreCase. run.sh:28 gates the entire package download on
+    # [ "$AppSettings__UseApiSchemaPath" = true ], a byte-exact POSIX string comparison, so only
+    # lowercase 'true' turns on the ApiSchema path at runtime. Accepting 'TRUE' or 'True' here passed a
+    # container that then downloaded nothing, which is precisely the EffectiveSchemaHash mismatch this
+    # gate exists to catch. Any other casing classifies as <set> below and fails.
+    if ([string]::Equals($value, "true", [System.StringComparison]::Ordinal)) {
+        return "true"
+    }
+
+    # OrdinalIgnoreCase is still correct here: this token is only message vocabulary for a value that
+    # fails whatever its casing, not the gate itself.
+    if ([string]::Equals($value, "false", [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "false"
+    }
+
+    return "<set>"
+}
+
+function Get-DmsContainerSchemaPackage {
+    <#
+    .SYNOPSIS
+        Returns the container's SCHEMA_PACKAGES entries as a parsed array, or $null when the value is
+        absent, blank, or not a JSON array.
+    .DESCRIPTION
+        The value itself is never returned to a caller that logs it: the entries only reach
+        Get-DmsSchemaPackageIdentity, which is used for comparison alone.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment
+    )
+
+    if (-not $ContainerEnvironment.ContainsKey("SCHEMA_PACKAGES")) {
+        return $null
+    }
+
+    $value = [string]$ContainerEnvironment["SCHEMA_PACKAGES"]
+
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $null
+    }
+
+    try {
+        # -NoEnumerate keeps a single-element array an array. Without it PowerShell unwraps
+        # '[{...}]' to one PSCustomObject, and the shape check below would reject a valid
+        # one-package container as "not a JSON array".
+        $parsed = $value | ConvertFrom-Json -NoEnumerate -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
+
+    # A JSON object parses without error but is not a package list; only an array is a package set.
+    # This check cannot be replaced by wrapping the parse result in @(...), which would make a JSON
+    # object look like a one-item package list.
+    if ($parsed -isnot [System.Collections.IList]) {
+        return $null
+    }
+
+    # The unary comma keeps an empty or single-entry result an array through the return: PowerShell
+    # would otherwise unroll '@()' to nothing, and the caller could not tell it from the $null above.
+    return , @($parsed)
+}
+
+function Get-DmsSchemaPackageIdentity {
+    <#
+    .SYNOPSIS
+        Reduces ApiSchema package entries to sorted, comparable identities.
+    .DESCRIPTION
+        The identity is built from the three fields that decide which schema artifact is downloaded -
+        name, version, and feedUrl - which is what run.sh and the provision phase's downloader both
+        consume. A count comparison alone accepts a container whose packages differ in any of them,
+        which is exactly the surface the E2E database was not provisioned for. A missing field
+        normalizes to an empty string rather than throwing, so a malformed entry compares unequal
+        instead of failing the verification.
+
+        The identities are only ever compared; they are never returned to a failure message, so no
+        container-supplied text can reach the console.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]] $Package
+    )
+
+    $identities = @(
+        foreach ($entry in $Package) {
+            $fields = [ordered]@{}
+            foreach ($fieldName in @("name", "version", "feedUrl")) {
+                $property = if ($null -eq $entry) { $null } else { $entry.PSObject.Properties[$fieldName] }
+                $fields[$fieldName] = if ($null -eq $property) { "" } else { [string]$property.Value }
+            }
+
+            # JSON rather than a delimiter join: a value containing the delimiter would otherwise let
+            # two different package sets normalize to the same identity text.
+            ConvertTo-Json -InputObject $fields -Compress
+        }
+    )
+
+    # Declaration order is not part of the package surface, so both sides are sorted before they are
+    # compared. Ordinal, so the result cannot vary with the host's culture.
+    [array]::Sort($identities, [System.StringComparer]::Ordinal)
+
+    return , $identities
+}
+
+function Get-DmsSchemaEnvironmentVerdict {
+    <#
+    .SYNOPSIS
+        Decides whether the started DMS container's schema environment agrees with the environment file
+        the E2E database was provisioned from, and returns a verdict plus a sanitized reason and
+        remediation. Pure, so the decision is unit-testable without Docker.
+    .DESCRIPTION
+        The provisioner reads SCHEMA_PACKAGES from the environment file only, so the database is always
+        stamped for the file's package surface. DMS, by contrast, receives its settings through Docker
+        Compose, which resolves them ambient-first. When the two disagree the stack comes up healthy
+        and then fails every data-plane request with an EffectiveSchemaHash mismatch, so the
+        disagreement is worth failing on at setup time.
+
+        Every requirement here is unconditional. The caller obtains ExpectedPackageIdentity from the same
+        reader the provision phase used, which throws unless the file declares at least one package, so
+        by the time this runs the database has been provisioned for a real package surface and the
+        runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH: a file that
+        declares packages but does not enable the ApiSchema path is internally inconsistent and
+        guarantees the mismatch, so it is reported rather than tolerated.
+    .OUTPUTS
+        [pscustomobject] with ShouldFail, Reason, and Remediation.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment,
+
+        # The environment file's declared ApiSchema package surface, as sorted identities from
+        # Get-DmsSchemaPackageIdentity. Constrained to at least one entry because the file-only reader
+        # the caller uses cannot produce less: an absent, malformed, or empty SCHEMA_PACKAGES
+        # declaration already failed the provision phase.
+        [Parameter(Mandatory)]
+        [ValidateCount(1, [int]::MaxValue)]
+        [string[]] $ExpectedPackageIdentity,
+
+        # The environment file's own USE_API_SCHEMA_PATH, read file-only (never with Compose
+        # precedence, which would let the ambient override this gate exists to catch decide the
+        # expected side and agree with a wrongly-started container).
+        [Parameter(Mandatory)]
+        [bool] $EnvironmentFileUsesApiSchemaPath,
+
+        # The environment file's API_SCHEMA_PATH, read file-only for the same reason. Compared
+        # Ordinal: this is the value Compose passes through verbatim, so any difference means the
+        # container is not using the path the environment file selected.
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $EnvironmentFileApiSchemaPath
+    )
+
+    # Cause-neutral by construction. Every branch below can be reached without any ambient value being
+    # involved - a wrong value in the file itself, a stale container, or an image whose settings differ
+    # all produce the same disagreement - so the remediation states what disagrees and offers the two
+    # actions that resolve it, rather than naming a cause the verdict cannot establish.
+    $ambientRemediation = "The environment file and the started DMS container disagree. Re-run setup from a shell that does not set USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES, or select a different -EnvironmentFile."
+    $expectedPackageCount = $ExpectedPackageIdentity.Count
+
+    if (-not $EnvironmentFileUsesApiSchemaPath) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the environment file declares $expectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
+            Remediation = "Set USE_API_SCHEMA_PATH=true in the environment file so its declared packages are the runtime schema surface."
+        }
+    }
+
+    $useApiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__UseApiSchemaPath"
+    if ($useApiSchemaPathToken -ne "true") {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $expectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    $apiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__ApiSchemaPath"
+    if ($apiSchemaPathToken -in @("<absent>", "<blank>")) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's AppSettings__ApiSchemaPath is $apiSchemaPathToken, so the declared ApiSchema packages have nowhere to be materialized."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    # A container path that is present but not the one the environment file selected means DMS is
+    # materializing packages somewhere other than where the file said, which the token check above
+    # cannot see. Ordinal comparison only: Compose passes the value through verbatim, so no path
+    # normalization is warranted here. Neither path is echoed.
+    if (-not [string]::Equals(
+            [string]$ContainerEnvironment["AppSettings__ApiSchemaPath"],
+            $EnvironmentFileApiSchemaPath,
+            [System.StringComparison]::Ordinal)) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's AppSettings__ApiSchemaPath differs from the environment file's API_SCHEMA_PATH, so DMS is not materializing the declared ApiSchema packages where the environment file selected."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    $containerPackages = Get-DmsContainerSchemaPackage -ContainerEnvironment $ContainerEnvironment
+    if ($null -eq $containerPackages) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $expectedPackageCount ApiSchema package(s)."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    if ($containerPackages.Count -ne $expectedPackageCount) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container received $($containerPackages.Count) ApiSchema package(s) but the E2E database was provisioned for the environment file's $expectedPackageCount."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    # Counts agreeing is not the surface agreeing. A container carrying the same number of packages at
+    # a different name, version, or feed URL downloads different schemas, computes a different runtime
+    # hash, and fails every data-plane request exactly as a count mismatch would. Both sides are already
+    # sorted, so this is a positional comparison of equal-length identity lists; neither side is echoed.
+    $containerPackageIdentity = Get-DmsSchemaPackageIdentity -Package $containerPackages
+    for ($index = 0; $index -lt $expectedPackageCount; $index++) {
+        if (-not [string]::Equals(
+                $containerPackageIdentity[$index],
+                $ExpectedPackageIdentity[$index],
+                [System.StringComparison]::Ordinal)) {
+            return [pscustomobject]@{
+                ShouldFail  = $true
+                Reason      = "the DMS container's $expectedPackageCount ApiSchema package(s) differ from the environment file's declared packages by name, version, or feed URL, so DMS is loading a different schema surface than the E2E database was provisioned for."
+                Remediation = $ambientRemediation
+            }
+        }
+    }
+
+    return [pscustomobject]@{
+        ShouldFail  = $false
+        Reason      = ""
+        Remediation = ""
+    }
+}
+
+function Get-DmsContainerEnvironment {
+    <#
+    .SYNOPSIS
+        Reads a container's environment into a key/value map.
+    .DESCRIPTION
+        Fails closed: an inspect that does not succeed is an inability to verify, never a pass.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string] $ContainerName
+    )
+
+    $environmentJson = docker inspect $ContainerName --format '{{json .Config.Env}}'
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to inspect Docker container '$ContainerName' to verify its schema environment."
+    }
+
+    $containerEnvironment = @{}
+
+    foreach ($entry in @($environmentJson | ConvertFrom-Json)) {
+        $entryText = [string]$entry
+        $separatorIndex = $entryText.IndexOf("=")
+
+        if ($separatorIndex -lt 0) {
+            continue
+        }
+
+        $containerEnvironment[$entryText.Substring(0, $separatorIndex)] = $entryText.Substring($separatorIndex + 1)
+    }
+
+    return $containerEnvironment
+}
+
+function Assert-DmsContainerSchemaEnvironment {
+    <#
+    .SYNOPSIS
+        Fails the setup when the started DMS container's schema environment disagrees with the
+        environment file the E2E database was provisioned from, so this class of mismatch surfaces here
+        instead of as HTTP 503 EffectiveSchemaHash failures in every scenario of the suite.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Reports setup progress to the console of a host-oriented setup script, matching its surrounding output.')]
+    param(
+        [Parameter(Mandatory)]
+        [string] $EnvironmentFilePath,
+
+        [Parameter(Mandatory)]
+        [hashtable] $EnvironmentValues,
+
+        [Parameter(Mandatory)]
+        [string] $ContainerName
+    )
+
+    # Both expectations come from the environment FILE. Get-SchemaPackagesFromEnvironmentFile is the
+    # same reader the provision phase used and it throws unless at least one package is declared, so a
+    # malformed or empty declaration has already failed provisioning rather than being treated as
+    # acceptable here. Get-EnvValue is file-only by contract; Get-ComposeResolvedEnvValue must not be
+    # used for either value, because resolving the expected side ambient-first would let the very
+    # override this gate exists to catch decide what "correct" means.
+    #
+    # Resolve-ComposeEnvRawValue is not a Compose-precedence reader either: it takes the file's raw
+    # value directly and applies the value semantics Compose gives a single --env-file entry -
+    # surrounding quotes stripped, an inline comment dropped, and ${VAR}/$VAR references resolved
+    # (single-quoted values stay literal). All three are legal Compose syntax that Compose itself
+    # applies before the container sees the value, so a declaration using any of them is compared as
+    # the container actually received it rather than failing on raw file text.
+    $declaredPackages = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath)
+    # Ordinal against lowercase 'true', matching run.sh's byte-exact gate. Compose passes the resolved
+    # value through verbatim, so a file declaring USE_API_SCHEMA_PATH=TRUE yields a container that
+    # skips the package download while provisioning still stamps the file's packages; reporting that
+    # against the file, with the remediation that names the file, is the actionable failure. The
+    # quote/comment/reference normalization still runs first, so "true", 'true' and ${SOMETHING} that
+    # resolves to true all pass, and only the casing is significant.
+    $environmentFileUsesApiSchemaPath = [string]::Equals(
+        (Resolve-ComposeEnvRawValue `
+            -EnvironmentValues $EnvironmentValues `
+            -RawValue (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")),
+        "true",
+        [System.StringComparison]::Ordinal
+    )
+    $environmentFileApiSchemaPath = Resolve-ComposeEnvRawValue `
+        -EnvironmentValues $EnvironmentValues `
+        -RawValue (Get-EnvValue -EnvValues $EnvironmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
+
+    $verdict = Get-DmsSchemaEnvironmentVerdict `
+        -ContainerEnvironment (Get-DmsContainerEnvironment -ContainerName $ContainerName) `
+        -ExpectedPackageIdentity (Get-DmsSchemaPackageIdentity -Package $declaredPackages) `
+        -EnvironmentFileUsesApiSchemaPath $environmentFileUsesApiSchemaPath `
+        -EnvironmentFileApiSchemaPath $environmentFileApiSchemaPath
+
+    if ($verdict.ShouldFail) {
+        throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation)"
+    }
+
+    Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green
+}
+
+Export-ModuleMember -Function `
+    Get-DmsSchemaEnvironmentToken, `
+    Get-DmsContainerSchemaPackage, `
+    Get-DmsSchemaPackageIdentity, `
+    Get-DmsSchemaEnvironmentVerdict, `
+    Get-DmsContainerEnvironment, `
+    Assert-DmsContainerSchemaEnvironment

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -68,25 +68,33 @@ function Invoke-WithDmsEnvironmentFileSchemaAuthority {
         reason the verification below lives here: two copies drift, and only one of them gets the next
         fix. It remains a CALLER-side guard - start-local-dms.ps1 must not clear these names globally,
         because in bootstrap mode it sets them in-process on purpose so process precedence makes the
-        staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 keeps an -Enabled WRAPPER
-        around this function rather than a second copy of it: several of its call sites gate the removal
-        on a switch or on the E2E settings object, and their phases must run without it - which the
-        setup wrappers never do, so they call this directly.
-
-        THE NAME MUST STAY DISTINCT FROM build-dms.ps1's HELPER, and this one is deliberately not
-        Invoke-WithEnvironmentFileSchemaSettings. build-dms.ps1 InstanceE2ETest invokes the Instance
-        Management wrapper IN-PROCESS with '& $instanceSetupScript', so the wrapper's scope is a CHILD
-        of build-dms.ps1's script scope, while this module's exports land in the session state. Command
-        lookup walks the scope chain before it reaches those exports, so a wrapper calling a name that
-        build-dms.ps1 also defines binds the BUILD SCRIPT's function - whose -Enabled switch is unset
-        on a bare call, making it a pass-through that removes nothing and leaves SCHEMA_PACKAGES
-        present for every guarded phase. Module-qualifying the call site would fix one call and leave
-        the next one to rediscover this, so the names are kept disjoint instead.
+        staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 imports this module and
+        calls this function directly at every one of its schema-guarded call sites; the -Enabled
+        parameter below is what lets it do that rather than keep a gating wrapper of its own.
     #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidDefaultValueSwitchParameter', '', Justification = 'Guarding is the safe default: a call site that omits -Enabled must remove the three schema names, not silently run its Compose phase with them present.')]
     param(
         [Parameter(Mandatory)]
-        [scriptblock] $Action
+        [scriptblock] $Action,
+
+        # Whether to guard at all, for the callers that gate the removal. build-dms.ps1 gates most of
+        # its call sites on a caller switch or on the E2E settings object, and those phases must run
+        # WITHOUT the removal when the gate is off - the developer-stack bootstrap path depends on the
+        # process precedence this otherwise removes.
+        #
+        # Defaults to ON, which is why it is a parameter here rather than a wrapper around this
+        # function: the E2E setup wrappers call without it and get the guard, a new call site that
+        # forgets it fails safe, and there is no second name for a caller's command lookup to bind
+        # instead of this one.
+        [switch] $Enabled = $true
     )
+
+    if (-not $Enabled) {
+        # A pass-through, deliberately: a gated-off call site must behave exactly as if the guard were
+        # not there, leaving the three names as its phase found them.
+        & $Action
+        return
+    }
 
     $schemaEnvironmentVariableNames = @(
         "USE_API_SCHEMA_PATH",
@@ -604,16 +612,16 @@ function Assert-DmsContainerSchemaEnvironment {
 }
 
 # Only the three commands a caller outside this module invokes: the pre-phase guard (both E2E setup
-# wrappers, and build-dms.ps1's -Enabled wrapper delegating to it), the post-start verification (both
-# wrappers), and the container-environment reader (build-dms.ps1's runtime hash gate, which reads the
-# same 'docker inspect' output to print the container's schema settings before comparing hashes).
-# Get-DmsContainerEnvironment is exported because build-dms.ps1 is a real external caller of it, not
-# for testability: it used to have a second copy of this reader under its own name.
+# wrappers, and build-dms.ps1, which passes -Enabled at its gated call sites), the post-start
+# verification (both wrappers), and the container-environment reader (build-dms.ps1's runtime hash
+# gate, which reads the same 'docker inspect' output to print the container's schema settings before
+# comparing hashes). Get-DmsContainerEnvironment is exported because build-dms.ps1 is a real external
+# caller of it, not for testability: it used to have a second copy of this reader under its own name.
 #
 # Nothing else above is exported. The remaining functions are internals of these three, and the tests
 # reach them by extracting the function text through the AST and dot-sourcing it, so none of them
-# needs an export - and a narrower surface is also less of it exposed to the in-process shadowing
-# described above.
+# needs an export - and a narrower surface is also less of it reachable from the E2E setup wrappers
+# build-dms.ps1 invokes in-process, whose scope chain is searched before this module's exports.
 Export-ModuleMember -Function `
     Invoke-WithDmsEnvironmentFileSchemaAuthority, `
     Assert-DmsContainerSchemaEnvironment, `

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -5,12 +5,13 @@
 
 <#
 .SYNOPSIS
-    Post-start verification that a started DMS container's ApiSchema package settings agree with the
-    environment file the E2E database was provisioned from.
+    The environment file's authority over a DMS E2E setup flow's ApiSchema package surface: the
+    pre-phase process guard that hands the file that authority, and the post-start verification that
+    the started DMS container actually received it.
 .DESCRIPTION
     Shared by both E2E setup wrappers (EdFi.DataManagementService.Tests.E2E and
-    EdFi.InstanceManagement.Tests.E2E) so the direct and route-context flows verify the same thing in
-    the same way rather than carrying two copies of the check.
+    EdFi.InstanceManagement.Tests.E2E) so the direct and route-context flows guard and verify the same
+    thing in the same way rather than carrying two copies of each.
 
     The provisioner reads SCHEMA_PACKAGES from the environment file only, so the E2E database is
     always stamped for the file's package surface. DMS receives its settings through Docker Compose,
@@ -32,6 +33,82 @@
 # caller - and it still loads the dependency when nothing else has.
 Import-Module (Join-Path $PSScriptRoot "database-safety.psm1")
 Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1")
+
+function Invoke-WithEnvironmentFileSchemaSettings {
+    <#
+    .SYNOPSIS
+        Runs a setup flow's Docker phases with the three schema package variables absent from this
+        process, so Docker Compose must resolve them from the selected --env-file, and restores the
+        caller's exact prior state afterward.
+    .DESCRIPTION
+        Compose gives process environment variables precedence over --env-file entries, and
+        local-dms.yml resolves all three with a ${VAR:-default} fallback. Because ':-' substitutes the
+        default for an empty value as well as an unset one, an ambient blank value silently wins over
+        the environment file: the DMS container is created with AppSettings__UseApiSchemaPath=false and
+        empty AppSettings__ApiSchemaPath/SCHEMA_PACKAGES, run.sh skips the package download entirely,
+        and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
+        SCHEMA_PACKAGES from the environment file only - so the provisioned database is stamped for the
+        file's full package surface while DMS computes a different runtime hash, and every data-plane
+        request fails with an EffectiveSchemaHash mismatch. That path is confirmed by construction from
+        Compose's documented precedence; it is not a diagnosis of any particular reported incident, and
+        this guard is cheap enough to hold regardless of which cause produced one.
+
+        Callers guard their WHOLE phase sequence rather than only the Compose-invoking phases: the
+        environment file is authoritative for the entire setup flow, and a Compose call added to any
+        phase later is covered by construction. Phases that do not read these three names from the
+        process environment are unaffected by the removal.
+
+        Defined in this shared module rather than copied into each E2E setup wrapper, for the same
+        reason the verification below lives here: two copies drift, and only one of them gets the next
+        fix. It remains a CALLER-side guard - start-local-dms.ps1 must not clear these names globally,
+        because in bootstrap mode it sets them in-process on purpose so process precedence makes the
+        staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 keeps its own -Enabled
+        variant: it has phases that must run without this removal, which the wrappers do not.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock] $Action
+    )
+
+    $schemaEnvironmentVariableNames = @(
+        "USE_API_SCHEMA_PATH",
+        "API_SCHEMA_PATH",
+        "SCHEMA_PACKAGES"
+    )
+
+    # $null distinguishes absent from present-and-empty, which is the distinction the restore below
+    # has to reproduce.
+    $previousValues = @{}
+    foreach ($name in $schemaEnvironmentVariableNames) {
+        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
+    }
+
+    try {
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            # Remove-Item, never an assignment: whether '$env:X = $null' removes the variable or
+            # leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank
+            # value satisfies ${VAR:-default} - so an assignment-based clear can leave this guard
+            # doing nothing at all, which is the bug it exists to prevent.
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+
+        & $Action
+    }
+    finally {
+        # Restore each variable to its exact prior state: re-create it with the verbatim prior value
+        # (including empty and whitespace) when it existed, otherwise remove it. This runs on the
+        # success path, when the action throws, and when the action calls exit.
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            if ($null -eq $previousValues[$name]) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+            else {
+                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
+            }
+        }
+    }
+}
 
 function Get-DmsSchemaEnvironmentToken {
     <#
@@ -181,9 +258,10 @@ function Get-DmsSchemaEnvironmentVerdict {
         Every requirement here is unconditional. The caller obtains ExpectedPackageIdentity from the same
         reader the provision phase used, which throws unless the file declares at least one package, so
         by the time this runs the database has been provisioned for a real package surface and the
-        runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH: a file that
-        declares packages but does not enable the ApiSchema path is internally inconsistent and
-        guarantees the mismatch, so it is reported rather than tolerated.
+        runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH and
+        API_SCHEMA_PATH: a file that declares packages but does not enable the ApiSchema path, or enables
+        it without selecting a path, is internally inconsistent and guarantees the mismatch, so each is
+        reported against the file rather than tolerated or reported against the container.
     .OUTPUTS
         [pscustomobject] with ShouldFail, Reason, and Remediation.
     #>
@@ -225,6 +303,19 @@ function Get-DmsSchemaEnvironmentVerdict {
             ShouldFail  = $true
             Reason      = "the environment file declares $expectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
             Remediation = "Set USE_API_SCHEMA_PATH=true in the environment file so its declared packages are the runtime schema surface."
+        }
+    }
+
+    # The symmetric file-side inconsistency, checked before any container value: a file that declares
+    # packages and enables the ApiSchema path but selects no path leaves those packages nowhere to be
+    # materialized. Reaching this only through the container's blank-path branch below would answer a
+    # missing file value with $ambientRemediation, which points at the invoking shell - and the shell
+    # cannot be the cause of a value the file never declared.
+    if ([string]::IsNullOrWhiteSpace($EnvironmentFileApiSchemaPath)) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the environment file declares $expectedPackageCount ApiSchema package(s) but no API_SCHEMA_PATH, so the E2E database was provisioned for those packages while the environment file selected nowhere for DMS to materialize them."
+            Remediation = "Set API_SCHEMA_PATH in the environment file so its declared packages have a materialization path."
         }
     }
 
@@ -458,6 +549,7 @@ function Assert-DmsContainerSchemaEnvironment {
 }
 
 Export-ModuleMember -Function `
+    Invoke-WithEnvironmentFileSchemaSettings, `
     Get-DmsSchemaEnvironmentToken, `
     Get-DmsContainerSchemaPackage, `
     Get-DmsSchemaPackageIdentity, `

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -34,7 +34,7 @@
 Import-Module (Join-Path $PSScriptRoot "database-safety.psm1")
 Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1")
 
-function Invoke-WithEnvironmentFileSchemaSettings {
+function Invoke-WithDmsEnvironmentFileSchemaAuthority {
     <#
     .SYNOPSIS
         Runs a setup flow's Docker phases with the three schema package variables absent from this
@@ -64,8 +64,17 @@ function Invoke-WithEnvironmentFileSchemaSettings {
         because in bootstrap mode it sets them in-process on purpose so process precedence makes the
         staged .bootstrap/ApiSchema workspace authoritative. build-dms.ps1 keeps its own -Enabled
         variant: it has phases that must run without this removal, which the wrappers do not.
+
+        THE NAME MUST STAY DISTINCT FROM build-dms.ps1's HELPER, and this one is deliberately not
+        Invoke-WithEnvironmentFileSchemaSettings. build-dms.ps1 InstanceE2ETest invokes the Instance
+        Management wrapper IN-PROCESS with '& $instanceSetupScript', so the wrapper's scope is a CHILD
+        of build-dms.ps1's script scope, while this module's exports land in the session state. Command
+        lookup walks the scope chain before it reaches those exports, so a wrapper calling a name that
+        build-dms.ps1 also defines binds the BUILD SCRIPT's function - whose -Enabled switch is unset
+        on a bare call, making it a pass-through that removes nothing and leaves SCHEMA_PACKAGES
+        present for every guarded phase. Module-qualifying the call site would fix one call and leave
+        the next one to rediscover this, so the names are kept disjoint instead.
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
     param(
         [Parameter(Mandatory)]
         [scriptblock] $Action
@@ -549,7 +558,7 @@ function Assert-DmsContainerSchemaEnvironment {
 }
 
 Export-ModuleMember -Function `
-    Invoke-WithEnvironmentFileSchemaSettings, `
+    Invoke-WithDmsEnvironmentFileSchemaAuthority, `
     Get-DmsSchemaEnvironmentToken, `
     Get-DmsContainerSchemaPackage, `
     Get-DmsSchemaPackageIdentity, `

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -578,6 +578,25 @@ function Assert-DmsContainerSchemaEnvironment {
     $sequentialEnvironmentFile = Resolve-DotenvFileSequentially `
         -Path (Resolve-Path -LiteralPath $EnvironmentFilePath).ProviderPath
 
+    # A gate key declared twice is legal Compose but makes the two sides of this check read DIFFERENT
+    # declarations, so it is reported against the file before any container value is compared.
+    # Get-SchemaPackagesFromEnvironmentFile above - the file-only reader the provision phase also uses -
+    # takes the FIRST SCHEMA_PACKAGES declaration, while Compose delivers the LAST one to the container:
+    # a file carrying two different values fails the package comparison below deterministically, and the
+    # container-side remediation would then send the developer to tear down and re-run a stack that
+    # reproduces it. The scalars are read last-declaration below and so agree with Compose today, but a
+    # duplicate leaves that agreement resting on which declaration each reader happens to take.
+    #
+    # Case-sensitive, matching the Ordinal keys the sequential resolver records: a lowercase decoy
+    # declaration is a different name to Compose and is not one of these keys.
+    $duplicateGateKey = @(
+        $sequentialEnvironmentFile.DuplicateKeys |
+            Where-Object { @("SCHEMA_PACKAGES", "USE_API_SCHEMA_PATH", "API_SCHEMA_PATH") -ccontains $_ }
+    )
+    if ($duplicateGateKey.Count -gt 0) {
+        throw "DMS E2E setup mismatch: the environment file '$EnvironmentFilePath' declares $($duplicateGateKey -join ', ') more than once. The file-only reader takes the first SCHEMA_PACKAGES declaration while Docker Compose delivers the last one to the container, so the two sides of this check would compare different values. Remove the duplicate declaration(s) from the environment file."
+    }
+
     # Ordinal against lowercase 'true', matching run.sh's byte-exact gate. Compose passes the resolved
     # value through verbatim, so a file declaring USE_API_SCHEMA_PATH=TRUE yields a container that
     # skips the package download while provisioning still stamps the file's packages; reporting that
@@ -605,7 +624,12 @@ function Assert-DmsContainerSchemaEnvironment {
         -EnvironmentFileApiSchemaPath $environmentFileApiSchemaPath
 
     if ($verdict.ShouldFail) {
-        throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation)"
+        # The capture command is a FIXED string, so the sanitization invariant holds: nothing
+        # container-supplied reaches the message and the raw SCHEMA_PACKAGES is still never logged. It
+        # earns its place because the reason names WHICH setting disagrees without ever echoing the
+        # value, and both remediation actions are ones the developer has already performed by the time
+        # they see this - so this is the one thing here that shows them what the container received.
+        throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation) Capture the container's actual settings with: docker inspect $ContainerName --format '{{json .Config.Env}}'"
     }
 
     Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -23,8 +23,15 @@
 # it calls regardless of what the invoking script happened to import: Resolve-DotenvFileSequentially
 # (database-safety) and Get-SchemaPackagesFromEnvironmentFile (schema-package-utility, the same
 # file-only reader the provision phase uses).
-Import-Module (Join-Path $PSScriptRoot "database-safety.psm1") -Force
-Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1") -Force
+#
+# Deliberately without -Force. -Force removes a module before re-importing it, and removal is
+# session-wide: a caller that had already imported database-safety.psm1 into its own session state
+# lost every command from it the moment this module loaded, and the E2E setup wrappers then failed at
+# their first database-safety call after this import. Without -Force an already-loaded module is
+# reused, so this import can only ADD command resolution for this module - never take it away from a
+# caller - and it still loads the dependency when nothing else has.
+Import-Module (Join-Path $PSScriptRoot "database-safety.psm1")
+Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1")
 
 function Get-DmsSchemaEnvironmentToken {
     <#

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -53,9 +53,15 @@ function Invoke-WithDmsEnvironmentFileSchemaAuthority {
         Compose's documented precedence; it is not a diagnosis of any particular reported incident, and
         this guard is cheap enough to hold regardless of which cause produced one.
 
-        Callers guard their WHOLE phase sequence rather than only the Compose-invoking phases: the
-        environment file is authoritative for the entire setup flow, and a Compose call added to any
-        phase later is covered by construction. Phases that do not read these three names from the
+        Callers guard EACH PHASE INVOCATION separately rather than wrapping their whole phase sequence
+        in one call. The removal lasts only for the duration of the action, because the restore below
+        has to put the caller's shell back the way it found it - so one call around the whole sequence
+        removes the three names exactly once, before the first phase. A phase script runs in the same
+        PowerShell process as the wrapper, and one that re-creates any of the three (start-local-dms.ps1
+        does exactly that in bootstrap mode, deliberately) would then still be setting it for every
+        later phase in that sequence, which is the state this guard exists to prevent. Guarding per
+        phase re-applies the removal immediately before each phase, so a Compose call added to any
+        phase later is covered by construction, and phases that do not read these three names from the
         process environment are unaffected by the removal.
 
         Defined in this shared module rather than copied into each E2E setup wrapper, for the same

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -223,8 +223,10 @@ function Get-DmsSchemaPackageIdentity {
         normalizes to an empty string rather than throwing, so a malformed entry compares unequal
         instead of failing the verification.
 
-        The identities are only ever compared; they are never returned to a failure message, so no
-        container-supplied text can reach the console.
+        Identities from BOTH sides are compared, but only the environment FILE's identity is ever
+        returned to a failure message - the surface-mismatch reason names the expected package at the
+        mismatching index, because "they differ somehow" is not something a developer can act on. The
+        CONTAINER's identity is never returned, so no container-supplied text can reach the console.
     #>
     param(
         [Parameter(Mandatory)]
@@ -302,11 +304,23 @@ function Get-DmsSchemaEnvironmentVerdict {
         [string] $EnvironmentFileApiSchemaPath
     )
 
-    # Cause-neutral by construction. Every branch below can be reached without any ambient value being
-    # involved - a wrong value in the file itself, a stale container, or an image whose settings differ
-    # all produce the same disagreement - so the remediation states what disagrees and offers the two
-    # actions that resolve it, rather than naming a cause the verdict cannot establish.
-    $ambientRemediation = "The environment file and the started DMS container disagree. Re-run setup from a shell that does not set USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES, or select a different -EnvironmentFile."
+    # Cause-neutral by construction, and named for what it reports rather than for a cause. Every
+    # branch below can be reached without any ambient value being involved - a wrong value in the file
+    # itself, a stale container left by an earlier run, or an image whose baked settings differ all
+    # produce the same disagreement - so the remediation offers the two actions that resolve those
+    # reachable causes rather than naming one the verdict cannot establish.
+    #
+    # Both actions are reachable from where a developer already is. The stack is torn down through the
+    # E2E suite's own teardown wrapper, so the container is REMOVED rather than reused, and the
+    # subsequent setup re-creates it from the selected environment file; if that file is the wrong one
+    # for the run, choosing another is the second action. Deliberately not a path to that wrapper: the
+    # setup flows run their phases from eng/docker-compose, where no such relative path resolves, and
+    # this module is shared by two suites that each have their own copy in their own directory.
+    #
+    # The advice this replaced asked for a re-run "from a shell that does not set USE_API_SCHEMA_PATH,
+    # API_SCHEMA_PATH, and SCHEMA_PACKAGES", which sent developers after a cause that cannot apply:
+    # the guard has already removed those three names from the process by the time this runs.
+    $containerDisagreementRemediation = "The environment file and the started DMS container disagree. Tear the stack down with this E2E suite's teardown-local-dms.ps1 wrapper and re-run setup, so the DMS container is re-created from the selected environment file, or select a different -EnvironmentFile."
     $expectedPackageCount = $ExpectedPackageIdentity.Count
 
     if (-not $EnvironmentFileUsesApiSchemaPath) {
@@ -320,8 +334,8 @@ function Get-DmsSchemaEnvironmentVerdict {
     # The symmetric file-side inconsistency, checked before any container value: a file that declares
     # packages and enables the ApiSchema path but selects no path leaves those packages nowhere to be
     # materialized. Reaching this only through the container's blank-path branch below would answer a
-    # missing file value with $ambientRemediation, which points at the invoking shell - and the shell
-    # cannot be the cause of a value the file never declared.
+    # missing file value with $containerDisagreementRemediation, which asks for a teardown and a re-run
+    # - and re-creating the container cannot fix a value the file never declared.
     if ([string]::IsNullOrWhiteSpace($EnvironmentFileApiSchemaPath)) {
         return [pscustomobject]@{
             ShouldFail  = $true
@@ -335,7 +349,7 @@ function Get-DmsSchemaEnvironmentVerdict {
         return [pscustomobject]@{
             ShouldFail  = $true
             Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $expectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
-            Remediation = $ambientRemediation
+            Remediation = $containerDisagreementRemediation
         }
     }
 
@@ -344,7 +358,7 @@ function Get-DmsSchemaEnvironmentVerdict {
         return [pscustomobject]@{
             ShouldFail  = $true
             Reason      = "the DMS container's AppSettings__ApiSchemaPath is $apiSchemaPathToken, so the declared ApiSchema packages have nowhere to be materialized."
-            Remediation = $ambientRemediation
+            Remediation = $containerDisagreementRemediation
         }
     }
 
@@ -359,7 +373,7 @@ function Get-DmsSchemaEnvironmentVerdict {
         return [pscustomobject]@{
             ShouldFail  = $true
             Reason      = "the DMS container's AppSettings__ApiSchemaPath differs from the environment file's API_SCHEMA_PATH, so DMS is not materializing the declared ApiSchema packages where the environment file selected."
-            Remediation = $ambientRemediation
+            Remediation = $containerDisagreementRemediation
         }
     }
 
@@ -368,7 +382,7 @@ function Get-DmsSchemaEnvironmentVerdict {
         return [pscustomobject]@{
             ShouldFail  = $true
             Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $expectedPackageCount ApiSchema package(s)."
-            Remediation = $ambientRemediation
+            Remediation = $containerDisagreementRemediation
         }
     }
 
@@ -376,14 +390,20 @@ function Get-DmsSchemaEnvironmentVerdict {
         return [pscustomobject]@{
             ShouldFail  = $true
             Reason      = "the DMS container received $($containerPackages.Count) ApiSchema package(s) but the E2E database was provisioned for the environment file's $expectedPackageCount."
-            Remediation = $ambientRemediation
+            Remediation = $containerDisagreementRemediation
         }
     }
 
     # Counts agreeing is not the surface agreeing. A container carrying the same number of packages at
     # a different name, version, or feed URL downloads different schemas, computes a different runtime
     # hash, and fails every data-plane request exactly as a count mismatch would. Both sides are already
-    # sorted, so this is a positional comparison of equal-length identity lists; neither side is echoed.
+    # sorted, so this is a positional comparison of equal-length identity lists.
+    #
+    # The FILE-side identity at the mismatching index is named, so the failure says which package the
+    # database was provisioned for rather than only that something differs - "differ by name, version,
+    # or feed URL" alone leaves a developer to diff two package sets by hand, neither of which the
+    # message showed them. The CONTAINER-side identity stays unechoed: it is the untrusted half, and
+    # naming the expected package is what makes the failure actionable anyway.
     $containerPackageIdentity = Get-DmsSchemaPackageIdentity -Package $containerPackages
     for ($index = 0; $index -lt $expectedPackageCount; $index++) {
         if (-not [string]::Equals(
@@ -392,8 +412,8 @@ function Get-DmsSchemaEnvironmentVerdict {
                 [System.StringComparison]::Ordinal)) {
             return [pscustomobject]@{
                 ShouldFail  = $true
-                Reason      = "the DMS container's $expectedPackageCount ApiSchema package(s) differ from the environment file's declared packages by name, version, or feed URL, so DMS is loading a different schema surface than the E2E database was provisioned for."
-                Remediation = $ambientRemediation
+                Reason      = "the DMS container's $expectedPackageCount ApiSchema package(s) differ from the environment file's declared packages by name, version, or feed URL, so DMS is loading a different schema surface than the E2E database was provisioned for. The first difference is at sorted position $($index + 1) of $expectedPackageCount, where the environment file declares $($ExpectedPackageIdentity[$index])."
+                Remediation = $containerDisagreementRemediation
             }
         }
     }
@@ -411,6 +431,11 @@ function Get-DmsContainerEnvironment {
         Reads a container's environment into a key/value map.
     .DESCRIPTION
         Fails closed: an inspect that does not succeed is an inability to verify, never a pass.
+
+        Exported, because build-dms.ps1's runtime effective-schema-hash gate reads the same
+        'docker inspect' output to print the container's schema settings before it compares hashes.
+        That script carried a second copy of this reader; one implementation means the next fix
+        cannot land in only one of them.
     #>
     param(
         [Parameter(Mandatory)]
@@ -501,6 +526,14 @@ function Assert-DmsContainerSchemaEnvironment {
         Fails the setup when the started DMS container's schema environment disagrees with the
         environment file the E2E database was provisioned from, so this class of mismatch surfaces here
         instead of as HTTP 503 EffectiveSchemaHash failures in every scenario of the suite.
+    .DESCRIPTION
+        Verification is at the CONFIGURATION level - the container's schema settings against the
+        environment file's - rather than at the effective-schema-hash level, which is the stronger
+        check. The stronger one is not available on this path: the direct setup wrappers do not
+        capture the provisioned hash that provision-e2e-database.ps1 reports, so there is nothing
+        here to compare a runtime hash against. build-dms.ps1 E2ETest does capture it and already
+        gates on the hash comparison, so that path is covered by the stronger check and this one adds
+        the same protection to the direct wrappers without reworking their phase output capture.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '', Justification = 'Reports setup progress to the console of a host-oriented setup script, matching its surrounding output.')]
     param(
@@ -564,11 +597,18 @@ function Assert-DmsContainerSchemaEnvironment {
     Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green
 }
 
-# Only the two commands a caller outside this module invokes: the pre-phase guard (both E2E setup
-# wrappers, and build-dms.ps1's -Enabled wrapper delegating to it) and the post-start verification.
-# Everything else above is an internal of those two. The tests reach the internals by extracting the
-# function text through the AST and dot-sourcing it, so none of them is exported for testability - and
-# a narrower surface is also less of it exposed to the in-process shadowing described above.
+# Only the three commands a caller outside this module invokes: the pre-phase guard (both E2E setup
+# wrappers, and build-dms.ps1's -Enabled wrapper delegating to it), the post-start verification (both
+# wrappers), and the container-environment reader (build-dms.ps1's runtime hash gate, which reads the
+# same 'docker inspect' output to print the container's schema settings before comparing hashes).
+# Get-DmsContainerEnvironment is exported because build-dms.ps1 is a real external caller of it, not
+# for testability: it used to have a second copy of this reader under its own name.
+#
+# Nothing else above is exported. The remaining functions are internals of these three, and the tests
+# reach them by extracting the function text through the AST and dot-sourcing it, so none of them
+# needs an export - and a narrower surface is also less of it exposed to the in-process shadowing
+# described above.
 Export-ModuleMember -Function `
     Invoke-WithDmsEnvironmentFileSchemaAuthority, `
-    Assert-DmsContainerSchemaEnvironment
+    Assert-DmsContainerSchemaEnvironment, `
+    Get-DmsContainerEnvironment

--- a/eng/docker-compose/dms-schema-environment.psm1
+++ b/eng/docker-compose/dms-schema-environment.psm1
@@ -20,10 +20,9 @@
 #>
 
 # Imported here rather than relied on from the caller's session, so the module resolves every command
-# it calls regardless of what the invoking script happened to import: Get-EnvValue (env-utility),
-# Resolve-ComposeEnvRawValue (database-safety), and Get-SchemaPackagesFromEnvironmentFile
-# (schema-package-utility, the same file-only reader the provision phase uses).
-Import-Module (Join-Path $PSScriptRoot "env-utility.psm1") -Force
+# it calls regardless of what the invoking script happened to import: Resolve-DotenvFileSequentially
+# (database-safety) and Get-SchemaPackagesFromEnvironmentFile (schema-package-utility, the same
+# file-only reader the provision phase uses).
 Import-Module (Join-Path $PSScriptRoot "database-safety.psm1") -Force
 Import-Module (Join-Path $PSScriptRoot "../schema-package-utility.psm1") -Force
 
@@ -331,6 +330,57 @@ function Get-DmsContainerEnvironment {
     return $containerEnvironment
 }
 
+function Get-DmsEnvironmentFileDeclaredValue {
+    <#
+    .SYNOPSIS
+        Returns the value an environment FILE declares for a name, as Docker Compose froze it while
+        reading that file.
+    .DESCRIPTION
+        Docker Compose resolves an --env-file in declaration order: each value is resolved against
+        what is in effect at its own line, and a value it has resolved is terminal. A later
+        re-declaration of a name that an earlier line referenced therefore cannot change that earlier
+        value. A collapsed key/value map cannot express this - it keeps only the final value of every
+        name - so reading an expected value from one resolves references against declarations Compose
+        had not yet read, and reports a correctly started stack as a mismatch.
+
+        The LAST declaration of the requested name wins, which is what the compose file itself sees.
+        Read from Declarations rather than the Effective map deliberately: Effective applies ambient
+        precedence to the requested key, and the setup guard has removed these names from the process
+        before this runs, so the expected side must come from the file alone. Taking Effective would
+        let a shell value that Compose never saw define what "correct" means.
+
+        Names REFERENCED by a declaration are still resolved ambient-first inside the sequential
+        resolver, which is exactly what Compose does.
+    #>
+    param(
+        # A Resolve-DotenvFileSequentially result.
+        [Parameter(Mandatory)]
+        [object] $ResolvedEnvironmentFile,
+
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $DefaultValue
+    )
+
+    # Ordinal: a dotenv identifier is case-sensitive on the Linux CI and runtime path, and
+    # PowerShell's -eq is not, so a lowercase decoy declaration must not satisfy an uppercase lookup.
+    $declaration = @(
+        $ResolvedEnvironmentFile.Declarations |
+            Where-Object { [string]::Equals($_.Key, $Name, [System.StringComparison]::Ordinal) }
+    ) | Select-Object -Last 1
+
+    # Absent and resolving-to-nothing both fall back to the documented default, matching the
+    # file-only reader this replaced.
+    if ($null -eq $declaration -or [string]::IsNullOrWhiteSpace($declaration.ResolvedValue)) {
+        return $DefaultValue
+    }
+
+    return [string]$declaration.ResolvedValue
+}
+
 function Assert-DmsContainerSchemaEnvironment {
     <#
     .SYNOPSIS
@@ -344,42 +394,48 @@ function Assert-DmsContainerSchemaEnvironment {
         [string] $EnvironmentFilePath,
 
         [Parameter(Mandatory)]
-        [hashtable] $EnvironmentValues,
-
-        [Parameter(Mandatory)]
         [string] $ContainerName
     )
 
     # Both expectations come from the environment FILE. Get-SchemaPackagesFromEnvironmentFile is the
     # same reader the provision phase used and it throws unless at least one package is declared, so a
     # malformed or empty declaration has already failed provisioning rather than being treated as
-    # acceptable here. Get-EnvValue is file-only by contract; Get-ComposeResolvedEnvValue must not be
-    # used for either value, because resolving the expected side ambient-first would let the very
-    # override this gate exists to catch decide what "correct" means.
+    # acceptable here. Get-ComposeResolvedEnvValue must not be used for either scalar, because
+    # resolving the expected side ambient-first would let the very override this gate exists to catch
+    # decide what "correct" means.
     #
-    # Resolve-ComposeEnvRawValue is not a Compose-precedence reader either: it takes the file's raw
-    # value directly and applies the value semantics Compose gives a single --env-file entry -
-    # surrounding quotes stripped, an inline comment dropped, and ${VAR}/$VAR references resolved
-    # (single-quoted values stay literal). All three are legal Compose syntax that Compose itself
-    # applies before the container sees the value, so a declaration using any of them is compared as
-    # the container actually received it rather than failing on raw file text.
+    # Resolve-DotenvFileSequentially is this repository's model of how Compose actually reads an
+    # --env-file: line by line, in declaration order, so each value is frozen against what was in
+    # effect at its own line. It is the single canonical parser for that, which is why the scalars are
+    # read through it rather than through another normalization step layered on a collapsed map.
     $declaredPackages = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath)
+
+    # Resolved to an absolute path first: Resolve-DotenvFileSequentially reads through
+    # [System.IO.File], which resolves a relative path against the PROCESS working directory rather
+    # than PowerShell's current location. Get-SchemaPackagesFromEnvironmentFile above reads with
+    # Get-Content, which honours the location, so it has always accepted either form.
+    $sequentialEnvironmentFile = Resolve-DotenvFileSequentially `
+        -Path (Resolve-Path -LiteralPath $EnvironmentFilePath).ProviderPath
+
     # Ordinal against lowercase 'true', matching run.sh's byte-exact gate. Compose passes the resolved
     # value through verbatim, so a file declaring USE_API_SCHEMA_PATH=TRUE yields a container that
     # skips the package download while provisioning still stamps the file's packages; reporting that
     # against the file, with the remediation that names the file, is the actionable failure. The
-    # quote/comment/reference normalization still runs first, so "true", 'true' and ${SOMETHING} that
-    # resolves to true all pass, and only the casing is significant.
+    # sequential resolution above already applied Compose's quote, inline-comment and reference
+    # semantics, so "true", 'true' and a reference that resolves to true all pass, and only the casing
+    # is significant.
     $environmentFileUsesApiSchemaPath = [string]::Equals(
-        (Resolve-ComposeEnvRawValue `
-            -EnvironmentValues $EnvironmentValues `
-            -RawValue (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")),
+        (Get-DmsEnvironmentFileDeclaredValue `
+            -ResolvedEnvironmentFile $sequentialEnvironmentFile `
+            -Name "USE_API_SCHEMA_PATH" `
+            -DefaultValue "false"),
         "true",
         [System.StringComparison]::Ordinal
     )
-    $environmentFileApiSchemaPath = Resolve-ComposeEnvRawValue `
-        -EnvironmentValues $EnvironmentValues `
-        -RawValue (Get-EnvValue -EnvValues $EnvironmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
+    $environmentFileApiSchemaPath = Get-DmsEnvironmentFileDeclaredValue `
+        -ResolvedEnvironmentFile $sequentialEnvironmentFile `
+        -Name "API_SCHEMA_PATH" `
+        -DefaultValue ""
 
     $verdict = Get-DmsSchemaEnvironmentVerdict `
         -ContainerEnvironment (Get-DmsContainerEnvironment -ContainerName $ContainerName) `

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -1973,19 +1973,16 @@ exit 0
             # earlier compose helper left empty schema env vars in the process.
             $buildScript = Get-Content -LiteralPath (Join-Path $script:sourceRepoRoot "build-dms.ps1") -Raw
 
-            $buildScript | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings"
-            # The -Enabled pass-through stays this script's own: several call sites gate the removal on
-            # a caller switch or on the E2E settings object, and their phases must run WITHOUT the
-            # removal when that gate is off.
-            $buildScript | Should -Match '(?s)function Invoke-WithEnvironmentFileSchemaSettings.*?if \(-not \$Enabled\).*?& \$Action.*?return'
-            # Only the ENABLED body is delegated, to the single implementation in the module both E2E
-            # setup wrappers import. This script used to carry a second copy of the removal-and-restore
-            # sequence and the two had already drifted - this one cleared with a bare
-            # 'Remove-Item "Env:$name"' while the module had moved to -LiteralPath - so the removal
-            # spelling is asserted against the module (in the sibling test below) and must not come back
-            # here. Imported without -Force, because -Force removes a module session-wide before
-            # re-importing it.
-            $buildScript | Should -Match '(?s)function Invoke-WithEnvironmentFileSchemaSettings.*?Invoke-WithDmsEnvironmentFileSchemaAuthority -Action \$Action'
+            # The guard is the shared module's, imported and called by name. This script used to define
+            # a same-purpose helper of its own whose only remaining job was the -Enabled gate, and that
+            # gate is now a parameter of the guard: one implementation, and no name defined here for the
+            # setup wrappers this script invokes in-process to bind instead of the module's export.
+            #
+            # Imported without -Force, because -Force removes a module session-wide before re-importing
+            # it. The removal-and-restore spelling is asserted against the module, in the sibling test
+            # below, and must not come back here in either form.
+            $buildScript | Should -Not -Match 'function Invoke-WithEnvironmentFileSchemaSettings' -Because "the gating wrapper is a parameter of the shared guard now"
+            $buildScript | Should -Not -Match 'function Invoke-WithDmsEnvironmentFileSchemaAuthority' -Because "redefining the guard here would shadow the module's export for a setup wrapper invoked in-process"
             $buildScript | Should -Match 'Import-Module -Name "\$PSScriptRoot/eng/docker-compose/dms-schema-environment\.psm1"(?! -Force)'
             $buildScript | Should -Not -Match 'Remove-Item "Env:\$name"'
             $buildScript | Should -Not -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)'
@@ -1993,13 +1990,17 @@ exit 0
             # teardown paths and the three Start-DockerEnvironment startup shapes (deferred InfraOnly,
             # published full start, local full start). The deferred -DmsOnly start after provisioning
             # runs inside Initialize-E2EDatabase and is gated on the E2E settings object instead.
-            ([regex]::Matches($buildScript, 'Invoke-WithEnvironmentFileSchemaSettings -Enabled:\$UseEnvironmentFileSchemaSettings -Action')).Count | Should -Be 5
-            ([regex]::Matches($buildScript, 'Invoke-WithEnvironmentFileSchemaSettings -Enabled:\$E2ETestSettings\.ShouldProvisionE2EDatabase -Action')).Count | Should -Be 1
+            ([regex]::Matches($buildScript, 'Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:\$UseEnvironmentFileSchemaSettings -Action')).Count | Should -Be 5
+            ([regex]::Matches($buildScript, 'Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:\$E2ETestSettings\.ShouldProvisionE2EDatabase -Action')).Count | Should -Be 1
+            # The bootstrap StartEnvironment phase is the one always-on call site, so it passes no
+            # -Enabled at all and takes the guard's default. Counted, so a gated call site cannot lose
+            # its gate expression and land here silently.
+            ([regex]::Matches($buildScript, 'Invoke-WithDmsEnvironmentFileSchemaAuthority -Action')).Count | Should -Be 1
             # Literal start-script references: one per teardown path, plus the two image-mode
             # selection lines (Start-DockerEnvironment and Initialize-E2EDatabase) naming both scripts.
             ([regex]::Matches($buildScript, '\./start-(local|published)-dms\.ps1')).Count | Should -Be 6
-            $buildScript | Should -Match '(?s)Invoke-WithEnvironmentFileSchemaSettings[^{]+-Action\s+\{[^}]+start-local-dms\.ps1[^\n]+-d[^\n]+-v[^\n]+-RemoveBootstrap:\$false'
-            $buildScript | Should -Match '(?s)Invoke-WithEnvironmentFileSchemaSettings[^{]+-Action\s+\{[^}]+start-published-dms\.ps1[^\n]+-d[^\n]+-v[^\n]+-RemoveBootstrap:\$RemoveBootstrap'
+            $buildScript | Should -Match '(?s)Invoke-WithDmsEnvironmentFileSchemaAuthority[^{]+-Action\s+\{[^}]+start-local-dms\.ps1[^\n]+-d[^\n]+-v[^\n]+-RemoveBootstrap:\$false'
+            $buildScript | Should -Match '(?s)Invoke-WithDmsEnvironmentFileSchemaAuthority[^{]+-Action\s+\{[^}]+start-published-dms\.ps1[^\n]+-d[^\n]+-v[^\n]+-RemoveBootstrap:\$RemoveBootstrap'
             $buildScript | Should -Match '-UseEnvironmentFileSchemaSettings:\$e2eTestSettings\.ShouldProvisionE2EDatabase'
         }
 
@@ -2087,7 +2088,7 @@ exit 0
                 $wrapperName = [System.IO.Path]::GetFileName([System.IO.Path]::GetDirectoryName($path))
 
                 # Without -Force: removal is session-wide, while a plain import reuses the instance
-                # build-dms.ps1 has already loaded for its own -Enabled wrapper.
+                # build-dms.ps1 has already loaded for its own guarded call sites.
                 $content | Should -Match "Import-Module \./dms-schema-environment\.psm1(?! -Force)" -Because "$wrapperName must import the module that owns the guard"
                 $content | Should -Not -Match "Import-Module \./dms-schema-environment\.psm1 -Force" -Because "$wrapperName must not force a session-wide removal of the shared module"
                 $content | Should -Match "Invoke-WithDmsEnvironmentFileSchemaAuthority -Action" -Because "$wrapperName must guard its Docker phases"

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -1974,11 +1974,21 @@ exit 0
             $buildScript = Get-Content -LiteralPath (Join-Path $script:sourceRepoRoot "build-dms.ps1") -Raw
 
             $buildScript | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings"
-            $buildScript | Should -Match '"USE_API_SCHEMA_PATH"'
-            $buildScript | Should -Match '"API_SCHEMA_PATH"'
-            $buildScript | Should -Match '"SCHEMA_PACKAGES"'
-            $buildScript | Should -Match 'Remove-Item "Env:\$name"'
-            $buildScript | Should -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)'
+            # The -Enabled pass-through stays this script's own: several call sites gate the removal on
+            # a caller switch or on the E2E settings object, and their phases must run WITHOUT the
+            # removal when that gate is off.
+            $buildScript | Should -Match '(?s)function Invoke-WithEnvironmentFileSchemaSettings.*?if \(-not \$Enabled\).*?& \$Action.*?return'
+            # Only the ENABLED body is delegated, to the single implementation in the module both E2E
+            # setup wrappers import. This script used to carry a second copy of the removal-and-restore
+            # sequence and the two had already drifted - this one cleared with a bare
+            # 'Remove-Item "Env:$name"' while the module had moved to -LiteralPath - so the removal
+            # spelling is asserted against the module (in the sibling test below) and must not come back
+            # here. Imported without -Force, because -Force removes a module session-wide before
+            # re-importing it.
+            $buildScript | Should -Match '(?s)function Invoke-WithEnvironmentFileSchemaSettings.*?Invoke-WithDmsEnvironmentFileSchemaAuthority -Action \$Action'
+            $buildScript | Should -Match 'Import-Module -Name "\$PSScriptRoot/eng/docker-compose/dms-schema-environment\.psm1"(?! -Force)'
+            $buildScript | Should -Not -Match 'Remove-Item "Env:\$name"'
+            $buildScript | Should -Not -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)'
             # Five compose calls are gated on the caller's -UseEnvironmentFileSchemaSettings: the two
             # teardown paths and the three Start-DockerEnvironment startup shapes (deferred InfraOnly,
             # published full start, local full start). The deferred -DmsOnly start after provisioning
@@ -2043,7 +2053,10 @@ exit 0
                 $content = Get-Content -LiteralPath $path -Raw
                 $wrapperName = [System.IO.Path]::GetFileName([System.IO.Path]::GetDirectoryName($path))
 
-                $content | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force" -Because "$wrapperName must import the module that owns the guard"
+                # Without -Force: removal is session-wide, while a plain import reuses the instance
+                # build-dms.ps1 has already loaded for its own -Enabled wrapper.
+                $content | Should -Match "Import-Module \./dms-schema-environment\.psm1(?! -Force)" -Because "$wrapperName must import the module that owns the guard"
+                $content | Should -Not -Match "Import-Module \./dms-schema-environment\.psm1 -Force" -Because "$wrapperName must not force a session-wide removal of the shared module"
                 $content | Should -Match "Invoke-WithDmsEnvironmentFileSchemaAuthority -Action" -Because "$wrapperName must guard its Docker phases"
                 $content | Should -Not -Match "function Invoke-WithDmsEnvironmentFileSchemaAuthority" -Because "$wrapperName must use the shared guard rather than its own copy, which would take the next fix in only one place"
 

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -2012,6 +2012,54 @@ exit 0
             $buildScript | Should -Not -Match "DMS did not become ready, but continuing anyway"
         }
 
+        It "both E2E setup wrappers let the selected environment file provide the schema package settings" {
+            # DMS-1300. Docker Compose gives process env vars precedence over --env-file entries, and
+            # local-dms.yml resolves all three names with a ${VAR:-default} fallback that treats a
+            # present-but-blank value as unset. Both wrappers must therefore REMOVE the three names
+            # around their Docker phases, never blank them: an assignment-based clear is
+            # platform- and PowerShell-version-dependent and can leave a present-but-blank value,
+            # which satisfies the fallback and silently starts DMS on the image-baked schemas while
+            # provisioning already stamped the environment file's full package surface.
+            #
+            # The symmetric pair is asserted together so the two wrappers cannot drift apart: the
+            # direct DMS wrapper had no guard at all, and the Instance Management wrapper had one built
+            # on the unreliable assignment form.
+            foreach ($path in @(
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"),
+                (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1")
+            )) {
+                $content = Get-Content -LiteralPath $path -Raw
+                $wrapperName = [System.IO.Path]::GetFileName([System.IO.Path]::GetDirectoryName($path))
+
+                $content | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "$wrapperName must guard its Docker phases"
+                $content | Should -Match '"USE_API_SCHEMA_PATH"' -Because "$wrapperName must name USE_API_SCHEMA_PATH in the guard"
+                $content | Should -Match '"API_SCHEMA_PATH"' -Because "$wrapperName must name API_SCHEMA_PATH in the guard"
+                $content | Should -Match '"SCHEMA_PACKAGES"' -Because "$wrapperName must name SCHEMA_PACKAGES in the guard"
+                $content | Should -Match 'Remove-Item -LiteralPath "Env:\$name"' -Because "$wrapperName must clear by removal, not by assignment"
+                $content | Should -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)' -Because "$wrapperName must restore a present prior value verbatim"
+                $content | Should -Match 'if \(\$null -eq \$previousValues\[\$name\]\)' -Because "$wrapperName must distinguish an absent prior state from a present-but-empty one"
+
+                # The unreliable primitive, in either spelling, must not come back.
+                $content | Should -Not -Match '\$env:USE_API_SCHEMA_PATH\s*=' -Because "$wrapperName must not assign USE_API_SCHEMA_PATH"
+                $content | Should -Not -Match '\$env:API_SCHEMA_PATH\s*=' -Because "$wrapperName must not assign API_SCHEMA_PATH"
+                $content | Should -Not -Match '\$env:SCHEMA_PACKAGES\s*=' -Because "$wrapperName must not assign SCHEMA_PACKAGES"
+            }
+        }
+
+        It "start-local-dms.ps1 still owns the bootstrap schema activation the E2E guards must not clear" {
+            # DMS-1300 guards at the caller, deliberately. start-local-dms.ps1 must keep setting these
+            # in-process for bootstrap mode, because process precedence is what makes the staged
+            # .bootstrap/ApiSchema workspace authoritative over the environment file. A guard pushed
+            # down into the start script would strip its own activation values before the compose call.
+            $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1") -Raw
+            $manifestModule = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "bootstrap-manifest.psm1") -Raw
+
+            $startScript | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings"
+            $startScript | Should -Not -Match 'Remove-Item -LiteralPath "Env:USE_API_SCHEMA_PATH"'
+            $manifestModule | Should -Match '\$env:USE_API_SCHEMA_PATH = "true"'
+            $manifestModule | Should -Match '\$env:API_SCHEMA_PATH = "/app/ApiSchema"'
+        }
+
         It "E2E setup wrappers contain defensive .bootstrap removal step before non-bootstrap startup" {
             # Confirm that both E2E setup wrappers defensively remove .bootstrap/ before invoking
             # start-local-dms.ps1 so a stale bootstrap workspace cannot hijack the non-bootstrap run

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -2028,7 +2028,7 @@ exit 0
             # one built on the unreliable assignment form.
             $guardModule = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "dms-schema-environment.psm1") -Raw
 
-            $guardModule | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "the shared module must own the guard both wrappers run their Docker phases inside"
+            $guardModule | Should -Match "function Invoke-WithDmsEnvironmentFileSchemaAuthority" -Because "the shared module must own the guard both wrappers run their Docker phases inside"
             $guardModule | Should -Match '"USE_API_SCHEMA_PATH"' -Because "the guard must name USE_API_SCHEMA_PATH"
             $guardModule | Should -Match '"API_SCHEMA_PATH"' -Because "the guard must name API_SCHEMA_PATH"
             $guardModule | Should -Match '"SCHEMA_PACKAGES"' -Because "the guard must name SCHEMA_PACKAGES"
@@ -2044,8 +2044,8 @@ exit 0
                 $wrapperName = [System.IO.Path]::GetFileName([System.IO.Path]::GetDirectoryName($path))
 
                 $content | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force" -Because "$wrapperName must import the module that owns the guard"
-                $content | Should -Match "Invoke-WithEnvironmentFileSchemaSettings -Action" -Because "$wrapperName must guard its Docker phases"
-                $content | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "$wrapperName must use the shared guard rather than its own copy, which would take the next fix in only one place"
+                $content | Should -Match "Invoke-WithDmsEnvironmentFileSchemaAuthority -Action" -Because "$wrapperName must guard its Docker phases"
+                $content | Should -Not -Match "function Invoke-WithDmsEnvironmentFileSchemaAuthority" -Because "$wrapperName must use the shared guard rather than its own copy, which would take the next fix in only one place"
 
                 # The unreliable primitive, in either spelling, must not come back.
                 $content | Should -Not -Match '\$env:USE_API_SCHEMA_PATH\s*=' -Because "$wrapperName must not assign USE_API_SCHEMA_PATH"
@@ -2062,7 +2062,7 @@ exit 0
             $startScript = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "start-local-dms.ps1") -Raw
             $manifestModule = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "bootstrap-manifest.psm1") -Raw
 
-            $startScript | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings"
+            $startScript | Should -Not -Match "function Invoke-WithDmsEnvironmentFileSchemaAuthority"
             $startScript | Should -Not -Match 'Remove-Item -LiteralPath "Env:USE_API_SCHEMA_PATH"'
             $manifestModule | Should -Match '\$env:USE_API_SCHEMA_PATH = "true"'
             $manifestModule | Should -Match '\$env:API_SCHEMA_PATH = "/app/ApiSchema"'

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -2015,15 +2015,27 @@ exit 0
         It "both E2E setup wrappers let the selected environment file provide the schema package settings" {
             # DMS-1300. Docker Compose gives process env vars precedence over --env-file entries, and
             # local-dms.yml resolves all three names with a ${VAR:-default} fallback that treats a
-            # present-but-blank value as unset. Both wrappers must therefore REMOVE the three names
+            # present-but-blank value as unset. Both setup flows must therefore REMOVE the three names
             # around their Docker phases, never blank them: an assignment-based clear is
             # platform- and PowerShell-version-dependent and can leave a present-but-blank value,
             # which satisfies the fallback and silently starts DMS on the image-baked schemas while
             # provisioning already stamped the environment file's full package surface.
             #
-            # The symmetric pair is asserted together so the two wrappers cannot drift apart: the
-            # direct DMS wrapper had no guard at all, and the Instance Management wrapper had one built
-            # on the unreliable assignment form.
+            # The guard is defined once, in the module both wrappers import, so the removal-and-restore
+            # spelling is asserted against that module and each wrapper is asserted to reach it rather
+            # than to carry a copy. The pair is still asserted together so the two flows cannot drift
+            # apart: the direct DMS wrapper had no guard at all, and the Instance Management wrapper had
+            # one built on the unreliable assignment form.
+            $guardModule = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "dms-schema-environment.psm1") -Raw
+
+            $guardModule | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "the shared module must own the guard both wrappers run their Docker phases inside"
+            $guardModule | Should -Match '"USE_API_SCHEMA_PATH"' -Because "the guard must name USE_API_SCHEMA_PATH"
+            $guardModule | Should -Match '"API_SCHEMA_PATH"' -Because "the guard must name API_SCHEMA_PATH"
+            $guardModule | Should -Match '"SCHEMA_PACKAGES"' -Because "the guard must name SCHEMA_PACKAGES"
+            $guardModule | Should -Match 'Remove-Item -LiteralPath "Env:\$name"' -Because "the guard must clear by removal, not by assignment"
+            $guardModule | Should -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)' -Because "the guard must restore a present prior value verbatim"
+            $guardModule | Should -Match 'if \(\$null -eq \$previousValues\[\$name\]\)' -Because "the guard must distinguish an absent prior state from a present-but-empty one"
+
             foreach ($path in @(
                 (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"),
                 (Join-Path $script:sourceRepoRoot "src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1")
@@ -2031,13 +2043,9 @@ exit 0
                 $content = Get-Content -LiteralPath $path -Raw
                 $wrapperName = [System.IO.Path]::GetFileName([System.IO.Path]::GetDirectoryName($path))
 
-                $content | Should -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "$wrapperName must guard its Docker phases"
-                $content | Should -Match '"USE_API_SCHEMA_PATH"' -Because "$wrapperName must name USE_API_SCHEMA_PATH in the guard"
-                $content | Should -Match '"API_SCHEMA_PATH"' -Because "$wrapperName must name API_SCHEMA_PATH in the guard"
-                $content | Should -Match '"SCHEMA_PACKAGES"' -Because "$wrapperName must name SCHEMA_PACKAGES in the guard"
-                $content | Should -Match 'Remove-Item -LiteralPath "Env:\$name"' -Because "$wrapperName must clear by removal, not by assignment"
-                $content | Should -Match '\[System\.Environment\]::SetEnvironmentVariable\(\$name, \$previousValues\[\$name\]\)' -Because "$wrapperName must restore a present prior value verbatim"
-                $content | Should -Match 'if \(\$null -eq \$previousValues\[\$name\]\)' -Because "$wrapperName must distinguish an absent prior state from a present-but-empty one"
+                $content | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force" -Because "$wrapperName must import the module that owns the guard"
+                $content | Should -Match "Invoke-WithEnvironmentFileSchemaSettings -Action" -Because "$wrapperName must guard its Docker phases"
+                $content | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings" -Because "$wrapperName must use the shared guard rather than its own copy, which would take the next fix in only one place"
 
                 # The unreliable primitive, in either spelling, must not come back.
                 $content | Should -Not -Match '\$env:USE_API_SCHEMA_PATH\s*=' -Because "$wrapperName must not assign USE_API_SCHEMA_PATH"

--- a/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
+++ b/eng/docker-compose/tests/BootstrapSchemaAndSecuritySelection.Tests.ps1
@@ -2003,6 +2003,39 @@ exit 0
             $buildScript | Should -Match '-UseEnvironmentFileSchemaSettings:\$e2eTestSettings\.ShouldProvisionE2EDatabase'
         }
 
+        It "build-dms.ps1 reads the container environment through the shared module's exported reader" {
+            # DMS-1300. This script and dms-schema-environment.psm1 each had their own function that ran
+            # 'docker inspect --format {{json .Config.Env}}', parsed the entries the same way, and threw
+            # on a non-zero exit. Two copies of one reader means the next fix lands in only one of them,
+            # so the module's is now the single implementation and this script calls it - which is why
+            # the module exports it: build-dms.ps1's runtime effective-schema-hash gate is a real
+            # external caller, not a test.
+            $buildScript = Get-Content -LiteralPath (Join-Path $script:sourceRepoRoot "build-dms.ps1") -Raw
+            $guardModule = Get-Content -LiteralPath (Join-Path $script:sourceDockerComposeRoot "dms-schema-environment.psm1") -Raw
+
+            $buildScript | Should -Not -Match 'function Get-DockerContainerEnvironmentMap' -Because "the second copy of the container-environment reader must not come back"
+            $buildScript | Should -Not -Match 'Get-DockerContainerEnvironmentMap -ContainerName' -Because "no call site may reach for the deleted copy"
+            $buildScript | Should -Match 'Get-DmsContainerEnvironment -ContainerName \$ContainerName' -Because "the runtime hash gate reads the container environment through the module's reader"
+            $buildScript | Should -Not -Match 'function Get-DmsContainerEnvironment' -Because "this script must call the module's reader rather than redefine the name, which would shadow the export"
+
+            # Exactly the three commands with a caller outside the module: the pre-phase guard, the
+            # post-start verification, and this reader. The other five functions stay unexported - their
+            # tests reach them by extracting the function text through the AST - so a wider surface would
+            # only add names exposed to the in-process shadowing the guard's own name avoids.
+            #
+            # Read as a SET of names rather than as a pattern over the statement's line wrapping, so the
+            # assertion is about what the module exports and not about how the continuation happens to be
+            # formatted.
+            $exportStatement = [regex]::Match($guardModule, '(?s)Export-ModuleMember\s+-Function\s*`?\s*(?<names>[A-Za-z][\w-]*(\s*,\s*`?\s*[A-Za-z][\w-]*)*)')
+
+            $exportStatement.Success | Should -BeTrue -Because "the module must declare its export surface explicitly"
+            @($exportStatement.Groups["names"].Value -split '[,`\s]+' | Where-Object { $_ }) | Should -Be @(
+                "Invoke-WithDmsEnvironmentFileSchemaAuthority",
+                "Assert-DmsContainerSchemaEnvironment",
+                "Get-DmsContainerEnvironment"
+            )
+        }
+
         It "build-dms.ps1 StartEnvironment uses the bootstrap phase contract" {
             # StartEnvironment is a developer stack command, not the E2E generated-database path.
             # It must use the bootstrap wrapper so configure-local-data-store.ps1 and

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -190,13 +190,12 @@ Describe "setup-local-dms.ps1 wires the resolved environment file into teardown 
     }
 }
 
-Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the <Wrapper> setup phases (DMS-1300)" -ForEach @(
-    @{ Wrapper = "direct DMS E2E"; RelativePath = "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1" }
-    @{ Wrapper = "Instance Management E2E"; RelativePath = "../../../src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1" }
-) {
-    # Both wrappers carry their own copy of this guard, so both copies are executed here rather than
-    # only the direct one. A copy that drifted - an assignment-based clear, a restore that collapses
-    # present-but-empty to absent, a finally that does not run on exit - fails in its own iteration.
+Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the E2E setup phases (DMS-1300)" {
+    # One guard, in the module both E2E setup wrappers import, so it is executed once here rather than
+    # once per wrapper copy. That the wrappers reach THIS definition - importing the module, defining no
+    # guard of their own, and running every Docker phase inside it - is asserted by the wiring blocks
+    # below; this block is about what the guard does when it runs: an assignment-based clear, a restore
+    # that collapses present-but-empty to absent, or a finally that does not run on exit each fail here.
     #
     # Docker Compose gives process environment variables precedence over --env-file entries, and
     # local-dms.yml resolves USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES with
@@ -241,8 +240,8 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
             return $functionAst.Extent.Text
         }
 
-        $script:wrapperScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $RelativePath))
-        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:wrapperScript -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
         . ([scriptblock]::Create($script:guardFunctionText))
 
         $script:schemaVariables = @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")
@@ -477,9 +476,10 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                 $true
             ) | Where-Object {
                 # Only the wrapper's own body dispatches phases. Commands inside a function definition
-                # are the wrapper's helpers - including the guard's own '& $Action', which is variable-
-                # dispatched and by construction sits outside the -Action block it invokes - so
-                # including them would report the guard as a phase escaping itself.
+                # belong to a helper rather than to the phase sequence - including the guard's own
+                # '& $Action' (in the shared module for the wrappers, inline in the fixture below),
+                # which is variable-dispatched and by construction sits outside the -Action block it
+                # invokes, so including it would report the guard as a phase escaping itself.
                 $ancestor = $_.Parent
                 $insideFunction = $false
                 while ($null -ne $ancestor) {
@@ -933,6 +933,24 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "the environment file declares 4 ApiSchema package\(s\) but does not set USE_API_SCHEMA_PATH=true"
         $verdict.Remediation | Should -Match "Set USE_API_SCHEMA_PATH=true in the environment file"
+    }
+
+    It "reports a package-bearing environment file with no API_SCHEMA_PATH against the file, not the shell" {
+        # The symmetric file-side inconsistency to the case above. Without its own branch this reaches
+        # the container's blank-path check, whose remediation opens by asking for a re-run from a shell
+        # that sets none of the three names - a cause that cannot apply to a value the FILE never
+        # declared, and one the gate can rule out because it runs inside the guard that already removed
+        # those names.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -ApiSchemaPath "") `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath ""
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "the environment file declares 4 ApiSchema package\(s\) but no API_SCHEMA_PATH"
+        $verdict.Remediation | Should -Match "Set API_SCHEMA_PATH in the environment file"
+        $verdict.Remediation | Should -Not -Match "Re-run setup from a shell"
     }
 
     It "refuses an empty declared package surface, because the file-only reader cannot produce one" {
@@ -1558,18 +1576,20 @@ Describe "Both E2E setup wrappers verify the started container against the envir
             Should -BeTrue
     }
 
-    It "imports the shared verifier in the <Name> wrapper rather than carrying its own copy" -ForEach @(
+    It "imports the shared guard and verifier in the <Name> wrapper rather than carrying its own copies" -ForEach @(
         @{ Name = "DataManagementService E2E" }
         @{ Name = "InstanceManagement E2E" }
     ) {
         # A second copy is what this module exists to prevent: two verifiers drift, and only one of
-        # them gets the next fix.
+        # them gets the next fix. The same argument applies to the pre-phase schema-settings guard, so
+        # neither wrapper may redefine it either.
         $source = Get-Content -LiteralPath $script:setupWrapperScripts[$Name] -Raw
 
         $source | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force"
         $source | Should -Not -Match "function Assert-DmsContainerSchemaEnvironment"
         $source | Should -Not -Match "function Get-DmsSchemaEnvironmentVerdict"
         $source | Should -Not -Match "function Get-DmsContainerEnvironment"
+        $source | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings"
     }
 
     It "reads both expectations from the environment file through the canonical sequential resolver" {
@@ -1655,7 +1675,8 @@ foreach (`$commandName in @(
         'Assert-E2EDatabaseIsDedicated',
         'Get-ComposeResolvedEnvValue',
         'Resolve-DotenvFileSequentially',
-        'Assert-DmsContainerSchemaEnvironment'
+        'Assert-DmsContainerSchemaEnvironment',
+        'Invoke-WithEnvironmentFileSchemaSettings'
     )) {
     `$commandName + '=' + [string][bool](Get-Command `$commandName -ErrorAction SilentlyContinue) |
         Add-Content -LiteralPath '$escapedObservationPath'
@@ -1674,6 +1695,10 @@ foreach (`$commandName in @(
         $observations | Should -Contain "Resolve-DotenvFileSequentially=True" -Because "no import may strip the caller's sequential env-file resolver"
         # The import still has to do its own job, so this is not satisfiable by removing it outright.
         $observations | Should -Contain "Assert-DmsContainerSchemaEnvironment=True" -Because "the module must still export the verifier the wrappers import it for"
+        # Every other guard test extracts the function text through the AST, so only a real import can
+        # catch the guard being defined in the module but left out of Export-ModuleMember - which would
+        # leave both wrappers unable to resolve it at their first phase.
+        $observations | Should -Contain "Invoke-WithEnvironmentFileSchemaSettings=True" -Because "both wrappers now reach the schema-settings guard through this module's exports"
     }
 }
 
@@ -1920,5 +1945,34 @@ Describe "The container schema gate accepts the repository's own tracked environ
         $referencedDuplicates = @($sequential.DuplicateKeys | Where-Object { $referencedNames -contains $_ })
 
         $referencedDuplicates | Should -BeNullOrEmpty -Because "a re-declared name that another line resolves against makes the file's meaning depend on declaration order"
+    }
+
+    It "the tracked <Label> declares each gate key at most once, because the provisioner reads the first declaration and Compose delivers the last" -ForEach @(
+        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
+        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
+    ) {
+        # A repeated declaration of one of the three keys the gate compares is legal Compose but not
+        # safe here. For SCHEMA_PACKAGES the two sides read different declarations: Get-QuotedEnvJson -
+        # the file-only reader behind both the provisioner and the gate's expected side - matches the
+        # FIRST declaration, while Compose passes the LAST into the container (the last-wins rule pinned
+        # for scalars above). A tracked or composed file carrying two different SCHEMA_PACKAGES values
+        # therefore aborts every production setup deterministically, while this block's fixtures agree
+        # with themselves and stay green, because they build the container side from the same first
+        # match. For USE_API_SCHEMA_PATH and API_SCHEMA_PATH the gate already reads the last declaration
+        # and so agrees with Compose today; they are held to the same rule because a duplicate leaves
+        # that agreement resting on which declaration each reader happens to take. Scoped to the gate
+        # keys, not to duplicates in general: overlay composition can legitimately re-declare other
+        # names, which the sibling assertion above covers.
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
+
+        $duplicatedGateKeys = @(
+            $sequential.DuplicateKeys |
+                Where-Object { $_ -in @("SCHEMA_PACKAGES", "USE_API_SCHEMA_PATH", "API_SCHEMA_PATH") }
+        )
+
+        $duplicatedGateKeys | Should -BeNullOrEmpty -Because "the file-only reader takes the first SCHEMA_PACKAGES declaration while Compose passes the last into the container, so a repeated gate key leaves the gate's two sides depending on which declaration each reader took"
     }
 }

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -190,7 +190,14 @@ Describe "setup-local-dms.ps1 wires the resolved environment file into teardown 
     }
 }
 
-Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the direct DMS E2E setup phases (DMS-1300)" {
+Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the <Wrapper> setup phases (DMS-1300)" -ForEach @(
+    @{ Wrapper = "direct DMS E2E"; RelativePath = "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1" }
+    @{ Wrapper = "Instance Management E2E"; RelativePath = "../../../src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1" }
+) {
+    # Both wrappers carry their own copy of this guard, so both copies are executed here rather than
+    # only the direct one. A copy that drifted - an assignment-based clear, a restore that collapses
+    # present-but-empty to absent, a finally that does not run on exit - fails in its own iteration.
+    #
     # Docker Compose gives process environment variables precedence over --env-file entries, and
     # local-dms.yml resolves USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES with
     # ${VAR:-default} fallbacks. Because ':-' substitutes the default for an empty value as well as an
@@ -234,8 +241,8 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
             return $functionAst.Extent.Text
         }
 
-        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
-        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
+        $script:wrapperScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot $RelativePath))
+        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:wrapperScript -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
         . ([scriptblock]::Create($script:guardFunctionText))
 
         $script:schemaVariables = @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")
@@ -371,6 +378,10 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
         # the restored state, and the recorded exit code proves the phase's status still propagates.
         $observationPath = Join-Path $TestDrive "schema-env-exit-observations.txt"
         $childScriptPath = Join-Path $TestDrive "schema-env-exit-child.ps1"
+        # The path is embedded in single-quoted literals in the generated child script, so an
+        # apostrophe in it (possible in a temp path derived from a user name) would close the quote
+        # early and break the child. Doubling it keeps the literal intact.
+        $escapedObservationPath = $observationPath -replace "'", "''"
         $childScript = @"
 $($script:guardFunctionText)
 
@@ -383,7 +394,7 @@ try {
         'inside:' + [string](Test-Path -LiteralPath 'Env:USE_API_SCHEMA_PATH') +
             ',' + [string](Test-Path -LiteralPath 'Env:API_SCHEMA_PATH') +
             ',' + [string](Test-Path -LiteralPath 'Env:SCHEMA_PACKAGES') |
-            Add-Content -LiteralPath '$observationPath'
+            Add-Content -LiteralPath '$escapedObservationPath'
         exit 42
     }
 }
@@ -393,7 +404,7 @@ finally {
         ',' + [string](Test-Path -LiteralPath 'Env:API_SCHEMA_PATH') +
         ',' + [string](Test-Path -LiteralPath 'Env:SCHEMA_PACKAGES') +
         '=' + [string]`$env:SCHEMA_PACKAGES |
-        Add-Content -LiteralPath '$observationPath'
+        Add-Content -LiteralPath '$escapedObservationPath'
 }
 "@
         Set-Content -LiteralPath $childScriptPath -Value $childScript -Encoding utf8
@@ -547,13 +558,40 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
 
         $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
 
-        # The verdict delegates classification and counting, so all three come across together.
+        # The verdict delegates classification, parsing, and identity normalization, so all four come
+        # across together.
         foreach ($functionName in @(
                 "Get-DmsSchemaEnvironmentToken",
-                "Get-DmsContainerSchemaPackageCount",
+                "Get-DmsContainerSchemaPackage",
+                "Get-DmsSchemaPackageIdentity",
                 "Get-DmsSchemaEnvironmentVerdict"
             )) {
             . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName $functionName)))
+        }
+
+        # The path both sides of a passing comparison use, so a test that means "container agrees with
+        # the environment file" cannot drift from the fixture's default.
+        $script:fixtureApiSchemaPath = "/app/ApiSchema"
+
+        function New-SchemaPackageFixture {
+            # One generator for both sides of a comparison, carrying all three identity fields, so a
+            # fixture that means "the container agrees with the environment file" agrees on the whole
+            # package surface rather than only on how many packages there are.
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Pure in-memory test fixture factory despite the New- verb; it creates no system state, so -WhatIf/-Confirm semantics add no value.')]
+            param(
+                [int] $Count = 4,
+                [string] $NamePrefix = "EdFi.ApiSchema.Package",
+                [string] $Version = "1.0.0",
+                [string] $FeedUrl = "https://pkgs.example.org/v3/index.json"
+            )
+
+            if ($Count -lt 1) {
+                return , @()
+            }
+
+            return @(1..$Count | ForEach-Object {
+                    [pscustomobject]@{ name = "$NamePrefix$_"; version = $Version; feedUrl = $FeedUrl }
+                })
         }
 
         function Get-ContainerEnvironmentFixture {
@@ -561,6 +599,7 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
                 [string] $UseApiSchemaPath = "true",
                 [string] $ApiSchemaPath = "/app/ApiSchema",
                 [int] $PackageCount = 4,
+                [object[]] $Package,
                 [string] $RawSchemaPackages,
                 [switch] $OmitUseApiSchemaPath,
                 [switch] $OmitApiSchemaPath,
@@ -583,19 +622,32 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
                         $RawSchemaPackages
                     }
                     else {
-                        ConvertTo-Json -InputObject @(1..$PackageCount | ForEach-Object { @{ name = "Package$_" } }) -Compress -Depth 5
+                        $containerPackages =
+                            if ($PSBoundParameters.ContainsKey("Package")) {
+                                @($Package)
+                            }
+                            else {
+                                New-SchemaPackageFixture -Count $PackageCount
+                            }
+
+                        ConvertTo-Json -InputObject @($containerPackages) -Compress -Depth 5
                     }
             }
 
             return $containerEnvironment
         }
+
+        # The environment file's declared surface for every case that is not about the surface itself:
+        # four packages from the same generator the container fixture uses.
+        $script:fixturePackageIdentity = Get-DmsSchemaPackageIdentity -Package (New-SchemaPackageFixture -Count 4)
     }
 
     It "passes when the container carries exactly the environment file's package surface" {
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 4) `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeFalse
         $verdict.Reason | Should -BeNullOrEmpty
@@ -606,8 +658,9 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         # local-dms.yml's ${VAR:-default} produces when the process carries blank schema variables.
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -UseApiSchemaPath "false" -ApiSchemaPath "" -RawSchemaPackages "") `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "AppSettings__UseApiSchemaPath is false"
@@ -620,11 +673,17 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         @{ Label = "blank"; Container = @{ UseApiSchemaPath = "" }; ExpectedToken = "<blank>" }
         @{ Label = "whitespace"; Container = @{ UseApiSchemaPath = "   " }; ExpectedToken = "<blank>" }
         @{ Label = "an unrecognized value"; Container = @{ UseApiSchemaPath = "yes" }; ExpectedToken = "<set>" }
+        # run.sh:28 gates the package download on a byte-exact [ "$AppSettings__UseApiSchemaPath" = true ],
+        # so an uppercase or title-case value downloads nothing while the database is already stamped for
+        # the file's packages. Accepting it here passed a container that could only 503.
+        @{ Label = "uppercase TRUE"; Container = @{ UseApiSchemaPath = "TRUE" }; ExpectedToken = "<set>" }
+        @{ Label = "title-case True"; Container = @{ UseApiSchemaPath = "True" }; ExpectedToken = "<set>" }
     ) {
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "AppSettings__UseApiSchemaPath is $([regex]::Escape($ExpectedToken))"
@@ -637,8 +696,9 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
     ) {
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "AppSettings__ApiSchemaPath is $([regex]::Escape($ExpectedToken))"
@@ -647,12 +707,85 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
     It "fails when the container's package count differs from the provisioned surface" {
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 2) `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "received 2 ApiSchema package"
         $verdict.Reason | Should -Match "provisioned for the environment file's 4"
+    }
+
+    It "fails when the count matches but every package's <Field> differs" -ForEach @(
+        @{ Field = "name"; Override = @{ NamePrefix = "Contoso.ApiSchema.Package" } }
+        @{ Field = "version"; Override = @{ Version = "9.9.9" } }
+        @{ Field = "feedUrl"; Override = @{ FeedUrl = "https://other-feed.example.net/v3/index.json" } }
+    ) {
+        # Exactly what a count-only comparison cannot see. Four packages resolved from a different
+        # name, version, or feed are a different schema surface than the E2E database was provisioned
+        # for, so DMS computes a different runtime hash and every data-plane request fails with an
+        # EffectiveSchemaHash mismatch - the failure this gate exists to turn into a setup-time error.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package (New-SchemaPackageFixture -Count 4 @Override)) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "differ from the environment file's declared packages by name, version, or feed URL"
+        # Not misreported as a count problem: the counts agree.
+        $verdict.Reason | Should -Not -Match "but the E2E database was provisioned for the environment file's"
+    }
+
+    It "fails when the count matches and only one of the packages differs" {
+        # The comparison is over the whole set, not a sampled or first-entry check.
+        $divergentPackages = @(New-SchemaPackageFixture -Count 4)
+        $divergentPackages[2] = [pscustomobject]@{
+            name    = $divergentPackages[2].name
+            version = "7.7.7"
+            feedUrl = $divergentPackages[2].feedUrl
+        }
+
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package $divergentPackages) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "differ from the environment file's declared packages by name, version, or feed URL"
+    }
+
+    It "never echoes the differing package values into the surface-mismatch failure text" {
+        # The mismatch message is derived vocabulary, so container-supplied package text cannot forge
+        # log lines or leak a feed URL into the console.
+        $sentinelPackages = @(New-SchemaPackageFixture -Count 4 -FeedUrl "https://SENTINEL-FEED-DO-NOT-ECHO.example.net/index.json")
+
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package $sentinelPackages) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "SENTINEL-FEED-DO-NOT-ECHO"
+    }
+
+    It "accepts the same package surface declared in a different order" {
+        # Declaration order is not part of the surface: run.sh downloads the same packages either way,
+        # so both sides are sorted ordinally before they are compared. Without the sort this passing
+        # case would be reported as a mismatch.
+        $reorderedPackages = @(New-SchemaPackageFixture -Count 4)
+        [array]::Reverse($reorderedPackages)
+
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package $reorderedPackages) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeFalse
+        $verdict.Reason | Should -BeNullOrEmpty
     }
 
     # ConvertFrom-Json is lenient about some structurally invalid JSON: it accepts a missing closing
@@ -671,11 +804,43 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict = $null
         { $script:verdict = Get-DmsSchemaEnvironmentVerdict `
                 -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
-                -ExpectedPackageCount 4 `
-                -EnvironmentFileUsesApiSchemaPath $true } | Should -Not -Throw
+                -ExpectedPackageIdentity $script:fixturePackageIdentity `
+                -EnvironmentFileUsesApiSchemaPath $true `
+                -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath } | Should -Not -Throw
 
         $script:verdict.ShouldFail | Should -BeTrue
         $script:verdict.Reason | Should -Match "SCHEMA_PACKAGES is absent, blank, or not a JSON array"
+    }
+
+    It "fails when the container's ApiSchemaPath is present but not the path the environment file selected" {
+        # The token check only proves the path is non-blank. A container pointed at a different path is
+        # materializing packages somewhere other than where the environment file said, which no other
+        # check in the verdict can see.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -ApiSchemaPath "/somewhere/else") `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "AppSettings__ApiSchemaPath differs from the environment file's API_SCHEMA_PATH"
+        # Neither path is echoed, so a container-supplied value cannot reach the message.
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "/somewhere/else"
+    }
+
+    It "treats an empty container SCHEMA_PACKAGES array as zero packages, not as a malformed value" {
+        # '[]' is a valid JSON array, so it belongs on the count-mismatch path: reporting it as
+        # malformed would misdescribe a container that simply received no packages.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -RawSchemaPackages "[]") `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "received 0 ApiSchema package"
+        $verdict.Reason | Should -Match "provisioned for the environment file's 4"
+        $verdict.Reason | Should -Not -Match "not a JSON array"
     }
 
     It "accepts a one-package JSON array without mistaking a JSON object for a one-item list" {
@@ -683,18 +848,22 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         # -NoEnumerate rejected a valid one-package container as "not a JSON array". The shape check
         # cannot be relaxed by wrapping the parse result in @(...) instead, because that would make a
         # JSON object look like a one-item package list, so both halves are pinned together here.
+        $onePackageIdentity = Get-DmsSchemaPackageIdentity -Package (New-SchemaPackageFixture -Count 1)
+
         $onePackageArray = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 1) `
-            -ExpectedPackageCount 1 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $onePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $onePackageArray.ShouldFail |
             Should -BeFalse -Because "a one-package container matches a one-package environment file"
 
         $jsonObject = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -RawSchemaPackages '{"name":"Package1"}') `
-            -ExpectedPackageCount 1 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $onePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $jsonObject.ShouldFail | Should -BeTrue -Because "a JSON object is not a package list"
         $jsonObject.Reason | Should -Match "SCHEMA_PACKAGES is absent, blank, or not a JSON array"
@@ -705,22 +874,24 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         # such a file guarantees the mismatch, and the remediation belongs on the file, not the shell.
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -UseApiSchemaPath "false" -ApiSchemaPath "" -RawSchemaPackages "") `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $false
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $false `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "the environment file declares 4 ApiSchema package\(s\) but does not set USE_API_SCHEMA_PATH=true"
         $verdict.Remediation | Should -Match "Set USE_API_SCHEMA_PATH=true in the environment file"
     }
 
-    It "refuses a package count below one, because the file-only reader cannot produce one" {
+    It "refuses an empty declared package surface, because the file-only reader cannot produce one" {
         # There is no "no packages declared" branch by design: an absent, malformed, or empty
         # SCHEMA_PACKAGES already fails the provision phase, so it can never reach the gate and be
         # classified as acceptable. The contract is encoded as parameter validation.
         { Get-DmsSchemaEnvironmentVerdict `
                 -ContainerEnvironment (Get-ContainerEnvironmentFixture) `
-                -ExpectedPackageCount 0 `
-                -EnvironmentFileUsesApiSchemaPath $true } | Should -Throw
+                -ExpectedPackageIdentity @() `
+                -EnvironmentFileUsesApiSchemaPath $true `
+                -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath } | Should -Throw
     }
 
     It "never echoes the container's raw SCHEMA_PACKAGES value into the failure text" {
@@ -729,13 +900,356 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $rawSchemaPackages = "[{`"name`":`"SENTINEL-DO-NOT-ECHO`"}]`nforged-log-line"
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -RawSchemaPackages $rawSchemaPackages) `
-            -ExpectedPackageCount 4 `
-            -EnvironmentFileUsesApiSchemaPath $true
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
 
         $verdict.ShouldFail | Should -BeTrue
         "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "SENTINEL-DO-NOT-ECHO"
         "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "forged-log-line"
         "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "`n"
+    }
+}
+
+Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns on agreement (DMS-1300)" {
+    # Executes the assertion itself, against stubbed readers, so the wiring between the file-only
+    # expectations, the verdict, and the throw is a real result rather than a source assertion. An
+    # inverted 'if ($verdict.ShouldFail)' branch fails both cases below.
+    BeforeAll {
+        function Get-ScriptFunctionText {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+            $functionAst = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return $functionAst.Extent.Text
+        }
+
+        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+
+        foreach ($functionName in @(
+                "Get-DmsSchemaEnvironmentToken",
+                "Get-DmsContainerSchemaPackage",
+                "Get-DmsSchemaPackageIdentity",
+                "Get-DmsSchemaEnvironmentVerdict",
+                "Assert-DmsContainerSchemaEnvironment"
+            )) {
+            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName $functionName)))
+        }
+
+        # The real Compose value semantics, not a stub: the quoting and inline-comment cases below are
+        # only meaningful if the assertion normalizes the environment file's raw text the way Docker
+        # Compose does. Production reaches this function through the same module import.
+        Import-Module (Join-Path $PSScriptRoot "../database-safety.psm1") -Force
+
+        # Stubs for the three readers the assertion depends on, so no Docker and no environment file are
+        # involved. Each returns whatever the current test arranged.
+        # Each stub declares the parameters production binds by name, so a renamed argument at the call
+        # site fails here rather than silently passing. The values themselves are not needed, hence the
+        # discards.
+        function Get-DmsContainerEnvironment {
+            param([Parameter(Mandatory)] [string] $ContainerName)
+
+            $null = $ContainerName
+            return $script:stubContainerEnvironment
+        }
+
+        function Get-SchemaPackagesFromEnvironmentFile {
+            param([Parameter(Mandatory)] [string] $EnvironmentFilePath)
+
+            $null = $EnvironmentFilePath
+            return $script:stubDeclaredPackages
+        }
+
+        function Get-EnvValue {
+            param(
+                [hashtable] $EnvValues,
+                [Parameter(Mandatory)] [string] $Name,
+                [string] $DefaultValue = ""
+            )
+
+            $null = $EnvValues
+
+            if ($script:stubEnvironmentFileValues.ContainsKey($Name)) {
+                return $script:stubEnvironmentFileValues[$Name]
+            }
+
+            return $DefaultValue
+        }
+    }
+
+    BeforeEach {
+        # A four-package environment file and a container that agrees with it. The declared packages are
+        # PSCustomObjects carrying all three identity fields, which is what ConvertFrom-Json hands back
+        # from a real SCHEMA_PACKAGES declaration.
+        $script:stubDeclaredPackages = @(1..4 | ForEach-Object {
+                [pscustomobject]@{
+                    name    = "EdFi.ApiSchema.Package$_"
+                    version = "1.0.0"
+                    feedUrl = "https://pkgs.example.org/v3/index.json"
+                }
+            })
+        $script:stubEnvironmentFileValues = @{
+            USE_API_SCHEMA_PATH = "true"
+            API_SCHEMA_PATH     = "/app/ApiSchema"
+        }
+        $script:stubContainerEnvironment = @{
+            "AppSettings__UseApiSchemaPath" = "true"
+            "AppSettings__ApiSchemaPath"    = "/app/ApiSchema"
+            "SCHEMA_PACKAGES"               = ConvertTo-Json -InputObject $script:stubDeclaredPackages -Compress -Depth 5
+        }
+    }
+
+    It "returns without throwing when the container agrees with the environment file" {
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "throws with the setup-mismatch prefix when the container <Label>" -ForEach @(
+        @{ Label = "has UseApiSchemaPath false"; Mutate = { $script:stubContainerEnvironment["AppSettings__UseApiSchemaPath"] = "false" } }
+        @{ Label = "has a blank ApiSchemaPath"; Mutate = { $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "" } }
+        @{ Label = "points at a different ApiSchemaPath"; Mutate = { $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/somewhere/else" } }
+        @{ Label = "received a different package count"; Mutate = { $script:stubContainerEnvironment["SCHEMA_PACKAGES"] = '[{"name":"Package1"}]' } }
+        @{ Label = "received the same number of packages at a different version"; Mutate = {
+                $script:stubContainerEnvironment["SCHEMA_PACKAGES"] = ConvertTo-Json -Compress -Depth 5 -InputObject @(
+                    $script:stubDeclaredPackages | ForEach-Object {
+                        [pscustomobject]@{ name = $_.name; version = "9.9.9"; feedUrl = $_.feedUrl }
+                    })
+            }
+        }
+    ) {
+        & $Mutate
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It "throws when the environment file declares packages without enabling the ApiSchema path" {
+        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = "false"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It "compares against the environment file's API_SCHEMA_PATH, not a hardcoded default" {
+        # Both sides move together: a container matching a non-default environment-file path must pass.
+        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = "/custom/ApiSchema"
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/custom/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "accepts a Compose-legal <Label> API_SCHEMA_PATH declaration" -ForEach @(
+        @{ Label = "double-quoted"; RawValue = '"/custom/ApiSchema"' }
+        @{ Label = "single-quoted"; RawValue = "'/custom/ApiSchema'" }
+        @{ Label = "inline-commented"; RawValue = "/custom/ApiSchema # where the E2E packages are mounted" }
+        @{ Label = "quoted and inline-commented"; RawValue = '"/custom/ApiSchema" # where the E2E packages are mounted' }
+    ) {
+        # Docker Compose strips surrounding quotes and a whitespace-preceded inline comment before it
+        # passes the value into the container, so a correctly started container legitimately carries the
+        # bare path. Comparing the environment file's raw text failed such a stack at setup time even
+        # though nothing was wrong with it - a false failure a custom -EnvironmentFile can easily hit.
+        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = $RawValue
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/custom/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "still fails a genuinely different path when the declaration is quoted" {
+        # Normalization must not turn the path comparison into a no-op.
+        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '"/custom/ApiSchema"'
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/somewhere/else"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It "accepts a Compose-legal <Label> USE_API_SCHEMA_PATH declaration" -ForEach @(
+        @{ Label = "double-quoted"; RawValue = '"true"' }
+        @{ Label = "single-quoted"; RawValue = "'true'" }
+        @{ Label = "inline-commented"; RawValue = "true # file-based ApiSchema packages" }
+    ) {
+        # Same false failure on the other file-read expectation: raw quoted text is not equal to "true",
+        # so the gate reported a correctly configured environment file as internally inconsistent.
+        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = $RawValue
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "throws when the environment file spells USE_API_SCHEMA_PATH as <Label>" -ForEach @(
+        @{ Label = "uppercase TRUE"; RawValue = "TRUE" }
+        @{ Label = "title-case True"; RawValue = "True" }
+        @{ Label = "quoted uppercase TRUE"; RawValue = '"TRUE"' }
+    ) {
+        # Compose passes the value through verbatim and run.sh:28 compares it byte-exact, so a file
+        # declaring TRUE starts a container that downloads no packages while phase 3 already stamped the
+        # database for the file's full surface. Normalization strips the quotes but must not fold case,
+        # which the quoted variant pins.
+        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = $RawValue
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It "throws when the container's AppSettings__UseApiSchemaPath is <Label>" -ForEach @(
+        @{ Label = "uppercase TRUE"; Value = "TRUE" }
+        @{ Label = "title-case True"; Value = "True" }
+    ) {
+        # The container side of the same rule: an ambient TRUE reaching Compose produces a container
+        # that run.sh treats as "not set", so the gate must not accept it as agreement.
+        $script:stubContainerEnvironment["AppSettings__UseApiSchemaPath"] = $Value
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{} `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+}
+
+Describe "Get-DmsContainerEnvironment reads the container environment and fails closed (DMS-1300)" {
+    # Executes the reader against a stubbed 'docker', so its parsing rules and its fail-closed behavior
+    # are real results rather than a source pattern, and no Docker daemon is required.
+    BeforeAll {
+        function Get-ScriptFunctionText {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+            $functionAst = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return $functionAst.Extent.Text
+        }
+
+        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+        . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName "Get-DmsContainerEnvironment")))
+
+        # A PowerShell function shadows the native command of the same name, so the reader's
+        # 'docker inspect' resolves here. Production decides success from $LASTEXITCODE, which only a
+        # native command normally writes, so the stub sets it explicitly.
+        function docker {
+            $script:stubDockerArguments = @($args)
+            $global:LASTEXITCODE = $script:stubDockerExitCode
+            return $script:stubDockerOutput
+        }
+    }
+
+    BeforeEach {
+        $script:stubDockerExitCode = 0
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @("AppSettings__UseApiSchemaPath=true")
+        $script:stubDockerArguments = @()
+    }
+
+    It "inspects the requested container for its environment only" {
+        $null = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $script:stubDockerArguments | Should -Be @("inspect", "ed-fi-api", "--format", "{{json .Config.Env}}")
+    }
+
+    It "reads each entry into a key and value" {
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @(
+            "AppSettings__UseApiSchemaPath=true",
+            "AppSettings__ApiSchemaPath=/app/ApiSchema"
+        )
+
+        $containerEnvironment = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $containerEnvironment["AppSettings__UseApiSchemaPath"] | Should -Be "true"
+        $containerEnvironment["AppSettings__ApiSchemaPath"] | Should -Be "/app/ApiSchema"
+    }
+
+    It "keeps every '=' after the first inside the value" {
+        # Container values routinely contain '=' - connection strings and the SCHEMA_PACKAGES JSON both
+        # do - so splitting on every separator would truncate exactly the values the gate compares.
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @(
+            'AppSettings__DataStoreConnectionString=Host=dms-postgresql;Database=edfi_e2e;Username=postgres',
+            'SCHEMA_PACKAGES=[{"name":"EdFi.ApiSchema.Package1","version":"1.0.0"}]'
+        )
+
+        $containerEnvironment = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $containerEnvironment["AppSettings__DataStoreConnectionString"] |
+            Should -Be "Host=dms-postgresql;Database=edfi_e2e;Username=postgres"
+        $containerEnvironment["SCHEMA_PACKAGES"] |
+            Should -Be '[{"name":"EdFi.ApiSchema.Package1","version":"1.0.0"}]'
+    }
+
+    It "keeps an entry whose value is empty, so a blank container value stays distinguishable from an absent one" {
+        # Get-DmsSchemaEnvironmentToken reports <blank> and <absent> as different findings, which only
+        # works if the reader preserves the difference.
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @("AppSettings__ApiSchemaPath=")
+
+        $containerEnvironment = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $containerEnvironment.ContainsKey("AppSettings__ApiSchemaPath") | Should -BeTrue
+        $containerEnvironment["AppSettings__ApiSchemaPath"] | Should -Be ""
+    }
+
+    It "skips an entry that has no '=' rather than failing or inventing a key" {
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @(
+            "MALFORMED_ENTRY",
+            "AppSettings__ApiSchemaPath=/app/ApiSchema"
+        )
+
+        $containerEnvironment = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $containerEnvironment.ContainsKey("MALFORMED_ENTRY") | Should -BeFalse
+        $containerEnvironment["AppSettings__ApiSchemaPath"] | Should -Be "/app/ApiSchema"
+    }
+
+    It "throws when docker inspect fails, so an inability to verify is never read as a pass" {
+        $script:stubDockerExitCode = 1
+        $script:stubDockerOutput = ""
+
+        { Get-DmsContainerEnvironment -ContainerName "ed-fi-api" } |
+            Should -Throw -ExpectedMessage "Unable to inspect Docker container 'ed-fi-api'*"
     }
 }
 
@@ -849,16 +1363,6 @@ Describe "The direct DMS E2E setup wrapper verifies the started container agains
 
     It "imports the same file-only package reader the provision phase uses" {
         $script:directSetupSource | Should -Match "Import-Module \.\./schema-package-utility\.psm1 -Force"
-    }
-
-    It "fails closed when the container cannot be inspected" {
-        $inspectFunction = [regex]::Match(
-            $script:directSetupSource,
-            '(?ms)^function Get-DmsContainerEnvironment \{.*?^\}'
-        ).Value
-
-        $inspectFunction | Should -Match 'if \(\$LASTEXITCODE -ne 0\) \{'
-        $inspectFunction | Should -Match "Unable to inspect Docker container"
     }
 
     It "throws rather than warning when the verdict fails" {

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -655,12 +655,17 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.Reason | Should -Match "provisioned for the environment file's 4"
     }
 
+    # ConvertFrom-Json is lenient about some structurally invalid JSON: it accepts a missing closing
+    # bracket and a trailing comma, parsing both as arrays. Those shapes are therefore classified by
+    # entry count, not as malformed, and still fail the verdict whenever the count disagrees with the
+    # environment file. Only inputs the parser actually rejects belong in this table.
     It "fails without throwing when the container's SCHEMA_PACKAGES is <Label>" -ForEach @(
         @{ Label = "absent"; Container = @{ OmitSchemaPackages = $true } }
         @{ Label = "blank"; Container = @{ RawSchemaPackages = "" } }
         @{ Label = "whitespace"; Container = @{ RawSchemaPackages = "   " } }
         @{ Label = "not JSON at all"; Container = @{ RawSchemaPackages = "not-json" } }
-        @{ Label = "a truncated array"; Container = @{ RawSchemaPackages = '[{"name":"Package1"}' } }
+        @{ Label = "an array with a malformed element"; Container = @{ RawSchemaPackages = '[{"name":}]' } }
+        @{ Label = "JSON null"; Container = @{ RawSchemaPackages = "null" } }
         @{ Label = "a JSON object rather than an array"; Container = @{ RawSchemaPackages = '{"name":"Package1"}' } }
     ) {
         $verdict = $null
@@ -671,6 +676,28 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
 
         $script:verdict.ShouldFail | Should -BeTrue
         $script:verdict.Reason | Should -Match "SCHEMA_PACKAGES is absent, blank, or not a JSON array"
+    }
+
+    It "accepts a one-package JSON array without mistaking a JSON object for a one-item list" {
+        # ConvertFrom-Json unwraps a single-element array to one PSCustomObject, so parsing without
+        # -NoEnumerate rejected a valid one-package container as "not a JSON array". The shape check
+        # cannot be relaxed by wrapping the parse result in @(...) instead, because that would make a
+        # JSON object look like a one-item package list, so both halves are pinned together here.
+        $onePackageArray = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 1) `
+            -ExpectedPackageCount 1 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $onePackageArray.ShouldFail |
+            Should -BeFalse -Because "a one-package container matches a one-package environment file"
+
+        $jsonObject = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -RawSchemaPackages '{"name":"Package1"}') `
+            -ExpectedPackageCount 1 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $jsonObject.ShouldFail | Should -BeTrue -Because "a JSON object is not a package list"
+        $jsonObject.Reason | Should -Match "SCHEMA_PACKAGES is absent, blank, or not a JSON array"
     }
 
     It "reports a package-bearing environment file that does not enable the ApiSchema path as the inconsistency" {

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -475,16 +475,36 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                     $node -is [System.Management.Automation.Language.CommandAst]
                 },
                 $true
-            ) | ForEach-Object {
-                # Bareword script invocations report their own name; a script dispatched through a
-                # variable (the Instance Management provision call) reports none, so fall back to the
-                # variable name so that form is covered too.
+            ) | Where-Object {
+                # Only the wrapper's own body dispatches phases. Commands inside a function definition
+                # are the wrapper's helpers - including the guard's own '& $Action', which is variable-
+                # dispatched and by construction sits outside the -Action block it invokes - so
+                # including them would report the guard as a phase escaping itself.
+                $ancestor = $_.Parent
+                $insideFunction = $false
+                while ($null -ne $ancestor) {
+                    if ($ancestor -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+                        $insideFunction = $true
+                        break
+                    }
+                    $ancestor = $ancestor.Parent
+                }
+
+                -not $insideFunction
+            } | ForEach-Object {
+                # Bareword script invocations report their own name. A phase dispatched through a
+                # VARIABLE reports none, and every such call in a wrapper body is a phase invocation,
+                # so all of them are collected rather than only the ones whose variable happens to be
+                # named '...Script'. Narrowing on the name silently dropped forms like '& $phase' from
+                # the result set, and the sibling "nothing outside the guard" assertion then passed
+                # vacuously for exactly the call it was meant to cover.
                 $name = $_.GetCommandName()
-                if ($null -eq $name -and $_.CommandElements[0] -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                $isVariableDispatched = $_.CommandElements[0] -is [System.Management.Automation.Language.VariableExpressionAst]
+                if ($null -eq $name -and $isVariableDispatched) {
                     $name = '$' + $_.CommandElements[0].VariablePath.UserPath
                 }
 
-                if ($name -and ($name -like "*.ps1" -or $name -like '$*Script')) {
+                if ($name -and ($isVariableDispatched -or $name -like "*.ps1")) {
                     [pscustomobject]@{
                         Name        = $name
                         Line        = $_.Extent.StartLineNumber
@@ -522,6 +542,37 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
         @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { "$($_.Name) (line $($_.Line))" }) |
             Should -BeNullOrEmpty -Because "a Compose-invoking phase outside the guard would resolve the schema variables from the ambient process again"
     }
+
+    It "detects a variable-dispatched phase whose variable is not named '...Script'" {
+        # The detector's own regression guard. It previously matched only '*.ps1' barewords and
+        # variables named '$*Script', so a future phase dispatched as '& $provisionPath' or '& $phase'
+        # was dropped from the result set entirely - and the sibling "nothing outside the guard"
+        # assertion then passed vacuously for precisely the call it exists to cover. The fixture puts
+        # such a call OUTSIDE the guard, so a detector that misses it reports no escape at all.
+        $fixturePath = Join-Path $TestDrive "variable-dispatched-phase.ps1"
+        Set-Content -LiteralPath $fixturePath -Encoding utf8 -Value @'
+function Invoke-WithEnvironmentFileSchemaSettings {
+    param([scriptblock] $Action)
+    & $Action
+}
+
+$guardedPhase = "./start-local-dms.ps1"
+$escapedPhase = "./provision-e2e-database.ps1"
+
+Invoke-WithEnvironmentFileSchemaSettings -Action {
+    & $guardedPhase -InfraOnly
+}
+
+& $escapedPhase -DatabaseName "edfi_e2e"
+'@
+
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $fixturePath)
+
+        # '& $Action' inside the guard function is excluded: it is the guard's own dispatch, not a phase.
+        @($invocations | ForEach-Object { $_.Name }) | Should -Be @('$guardedPhase', '$escapedPhase')
+        @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { $_.Name }) |
+            Should -Be @('$escapedPhase')
+    }
 }
 
 Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container disagrees with the provisioned package surface (DMS-1300)" {
@@ -556,7 +607,8 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
             return $functionAst.Extent.Text
         }
 
-        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+        # The verifier lives in the module both E2E setup wrappers import, not in either wrapper.
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
 
         # The verdict delegates classification, parsing, and identity normalization, so all four come
         # across together.
@@ -566,7 +618,7 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
                 "Get-DmsSchemaPackageIdentity",
                 "Get-DmsSchemaEnvironmentVerdict"
             )) {
-            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName $functionName)))
+            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName $functionName)))
         }
 
         # The path both sides of a passing comparison use, so a test that means "container agrees with
@@ -940,7 +992,7 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
             return $functionAst.Extent.Text
         }
 
-        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
 
         foreach ($functionName in @(
                 "Get-DmsSchemaEnvironmentToken",
@@ -949,7 +1001,7 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                 "Get-DmsSchemaEnvironmentVerdict",
                 "Assert-DmsContainerSchemaEnvironment"
             )) {
-            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName $functionName)))
+            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName $functionName)))
         }
 
         # The real Compose value semantics, not a stub: the quoting and inline-comment cases below are
@@ -1108,6 +1160,44 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
+    It 'resolves a ${VAR} reference in API_SCHEMA_PATH the way Docker Compose does' {
+        # Compose interpolates ${VAR}/$VAR in an --env-file entry before the container sees it, so the
+        # container legitimately carries the RESOLVED path. Comparing the literal reference text kept
+        # the expected side as '${SCHEMA_ROOT}/ApiSchema', which can never equal what the container
+        # received - a hard setup abort on a stack that came up correctly.
+        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '${SCHEMA_ROOT}/ApiSchema'
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/app/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{ SCHEMA_ROOT = "/app" } `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It 'resolves a ${VAR} reference in USE_API_SCHEMA_PATH the way Docker Compose does' {
+        # Same false failure on the other file-read expectation: the unresolved reference is not
+        # "true", so the gate reported an internally consistent environment file as declaring packages
+        # without enabling the ApiSchema path.
+        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = '${ENABLE_SCHEMA_PATH}'
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{ ENABLE_SCHEMA_PATH = "true" } `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It 'still fails a genuinely different path when the declaration is a ${VAR} reference' {
+        # Reference resolution must not turn the path comparison into a no-op: a file pointing
+        # somewhere the container is not is still the mismatch this gate exists to report.
+        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '${SCHEMA_ROOT}/ApiSchema'
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/app/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
+                -EnvironmentValues @{ SCHEMA_ROOT = "/somewhere/else" } `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
     It "throws when the environment file spells USE_API_SCHEMA_PATH as <Label>" -ForEach @(
         @{ Label = "uppercase TRUE"; RawValue = "TRUE" }
         @{ Label = "title-case True"; RawValue = "True" }
@@ -1168,8 +1258,8 @@ Describe "Get-DmsContainerEnvironment reads the container environment and fails 
             return $functionAst.Extent.Text
         }
 
-        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
-        . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName "Get-DmsContainerEnvironment")))
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+        . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Get-DmsContainerEnvironment")))
 
         # A PowerShell function shadows the native command of the same name, so the reader's
         # 'docker inspect' resolves here. Production decides success from $LASTEXITCODE, which only a
@@ -1253,10 +1343,18 @@ Describe "Get-DmsContainerEnvironment reads the container environment and fails 
     }
 }
 
-Describe "The direct DMS E2E setup wrapper verifies the started container against the environment file only (DMS-1300)" {
+Describe "Both E2E setup wrappers verify the started container against the environment file only (DMS-1300)" {
     BeforeAll {
-        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
-        $script:directSetupSource = Get-Content -LiteralPath $script:directSetupScript -Raw
+        # The verifier is shared, so the wrappers own only the call site and the import; the module
+        # owns how the expectations are read. Assertions are aimed at whichever file now holds the
+        # behavior, never at the wrapper for code that has moved.
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+        $script:schemaEnvironmentModuleSource = Get-Content -LiteralPath $script:schemaEnvironmentModule -Raw
+
+        $script:setupWrapperScripts = [ordered]@{
+            "DataManagementService E2E" = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+            "InstanceManagement E2E"    = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"))
+        }
 
         function Test-CommandInsideSchemaGuard {
             param(
@@ -1338,11 +1436,29 @@ Describe "The direct DMS E2E setup wrapper verifies the started container agains
         }
     }
 
-    It "runs the container verification inside the schema-settings guard" {
+    It "runs the container verification inside the schema-settings guard in the <Name> wrapper" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
         # Inside the guard, so the file-only expectation cannot be contaminated by an ambient override
-        # even if a future edit reaches for a Compose-precedence reader.
-        Test-CommandInsideSchemaGuard -ScriptPath $script:directSetupScript -CommandName "Assert-DmsContainerSchemaEnvironment" |
+        # even if a future edit reaches for a Compose-precedence reader. Both wrappers provision from
+        # the environment file and start DMS through ambient-first Compose, so both need the check.
+        Test-CommandInsideSchemaGuard -ScriptPath $script:setupWrapperScripts[$Name] -CommandName "Assert-DmsContainerSchemaEnvironment" |
             Should -BeTrue
+    }
+
+    It "imports the shared verifier in the <Name> wrapper rather than carrying its own copy" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
+        # A second copy is what this module exists to prevent: two verifiers drift, and only one of
+        # them gets the next fix.
+        $source = Get-Content -LiteralPath $script:setupWrapperScripts[$Name] -Raw
+
+        $source | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force"
+        $source | Should -Not -Match "function Assert-DmsContainerSchemaEnvironment"
+        $source | Should -Not -Match "function Get-DmsSchemaEnvironmentVerdict"
+        $source | Should -Not -Match "function Get-DmsContainerEnvironment"
     }
 
     It "reads both expectations from the environment file, never with Compose precedence" {
@@ -1352,21 +1468,186 @@ Describe "The direct DMS E2E setup wrapper verifies the started container agains
         #
         # Get-ComposeResolvedEnvValue resolves ambient-first. Using it for either expectation would let
         # the very override this gate exists to catch decide what "correct" means, so the gate would
-        # agree with a wrongly-started container and pass.
-        $invoked = @(Get-FunctionCommandName -ScriptPath $script:directSetupScript -FunctionName "Assert-DmsContainerSchemaEnvironment")
+        # agree with a wrongly-started container and pass. Resolve-ComposeEnvRawValue is not that
+        # reader: it takes the file's raw value directly and applies only the value semantics Compose
+        # gives one --env-file entry, so the expected side stays file-authored while still matching
+        # what Compose actually rendered into the container.
+        $invoked = @(Get-FunctionCommandName -ScriptPath $script:schemaEnvironmentModule -FunctionName "Assert-DmsContainerSchemaEnvironment")
 
         $invoked | Should -Contain "Get-SchemaPackagesFromEnvironmentFile"
         $invoked | Should -Contain "Get-EnvValue"
+        $invoked | Should -Contain "Resolve-ComposeEnvRawValue"
         $invoked | Should -Not -Contain "Get-ComposeResolvedEnvValue"
-        $script:directSetupSource | Should -Match 'Get-EnvValue -EnvValues \$EnvironmentValues -Name "USE_API_SCHEMA_PATH"'
+        $script:schemaEnvironmentModuleSource | Should -Match 'Get-EnvValue -EnvValues \$EnvironmentValues -Name "USE_API_SCHEMA_PATH"'
     }
 
     It "imports the same file-only package reader the provision phase uses" {
-        $script:directSetupSource | Should -Match "Import-Module \.\./schema-package-utility\.psm1 -Force"
+        # The module imports its own dependencies rather than relying on whatever the invoking wrapper
+        # happened to import, so command resolution does not depend on the call site.
+        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "\.\./schema-package-utility\.psm1"\) -Force'
+        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "database-safety\.psm1"\) -Force'
+        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "env-utility\.psm1"\) -Force'
     }
 
     It "throws rather than warning when the verdict fails" {
-        $script:directSetupSource | Should -Match 'throw "DMS E2E setup mismatch: '
-        $script:directSetupSource | Should -Not -Match 'Write-Warning[^\r\n]*setup mismatch'
+        $script:schemaEnvironmentModuleSource | Should -Match 'throw "DMS E2E setup mismatch: '
+        $script:schemaEnvironmentModuleSource | Should -Not -Match 'Write-Warning[^\r\n]*setup mismatch'
+    }
+}
+
+Describe "The container schema gate accepts the repository's own tracked environment files (DMS-1300)" {
+    # The rest of this suite stubs every reader, so nothing pins that the env files the E2E flows
+    # actually ship with satisfy the gate. The coupling that matters in production is "what the
+    # file-only readers extract from the file" versus "what Compose puts in the container", and it is
+    # fragile in ways pure-logic tests cannot see: Get-QuotedEnvJson matches only a single-quoted
+    # SCHEMA_PACKAGES='[...]' via a non-greedy regex, and a legal Compose value shape (quoting, an
+    # inline comment, a ${VAR} reference) can silently break the comparison. No Docker: the container
+    # side is a fixture built from the same file, exactly as Compose would pass it through.
+    BeforeAll {
+        function Get-ScriptFunctionText {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+            $functionAst = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return $functionAst.Extent.Text
+        }
+
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+
+        foreach ($functionName in @(
+                "Get-DmsSchemaEnvironmentToken",
+                "Get-DmsContainerSchemaPackage",
+                "Get-DmsSchemaPackageIdentity",
+                "Get-DmsSchemaEnvironmentVerdict",
+                "Assert-DmsContainerSchemaEnvironment"
+            )) {
+            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName $functionName)))
+        }
+
+        # The REAL readers, exactly the ones production reaches through the module's own imports:
+        # ReadValuesFromEnvFile / Get-EnvValue / Resolve-DataStandardEnvironmentFile (env-utility),
+        # Resolve-ComposeEnvRawValue (database-safety), Get-SchemaPackagesFromEnvironmentFile
+        # (schema-package-utility). Nothing about the file side is stubbed here.
+        Import-Module (Join-Path $PSScriptRoot "../env-utility.psm1") -Force
+        Import-Module (Join-Path $PSScriptRoot "../database-safety.psm1") -Force
+        Import-Module (Join-Path $PSScriptRoot "../../schema-package-utility.psm1") -Force
+
+        # The one reader that would need Docker. Everything else runs for real.
+        function Get-DmsContainerEnvironment {
+            param([Parameter(Mandatory)] [string] $ContainerName)
+
+            $null = $ContainerName
+            return $script:stubContainerEnvironment
+        }
+
+        function Get-TrackedSchemaPackagesRawValue {
+            # The file's VERBATIM single-quoted SCHEMA_PACKAGES text, which is what Compose passes into
+            # the container (single-quoted, so Compose strips the quotes and interpolates nothing).
+            # Deliberately not a re-serialization of what Get-SchemaPackagesFromEnvironmentFile parsed:
+            # the container side has to be the file's own bytes, so the gate's parse of the container
+            # value and the production reader's parse of the file are two independent paths that this
+            # test requires to agree.
+            param([Parameter(Mandatory)] [string] $EnvironmentFilePath)
+
+            $content = Get-Content -LiteralPath $EnvironmentFilePath -Raw
+            $match = [regex]::Match($content, "(?ms)^[ \t]*SCHEMA_PACKAGES='(?<value>\[.*?\])'")
+
+            if (-not $match.Success) {
+                throw "'$EnvironmentFilePath' carries no single-quoted SCHEMA_PACKAGES array."
+            }
+
+            return $match.Groups["value"].Value
+        }
+
+        # .env.ds52 / .env.ds61 are OVERLAYS: they carry SCHEMA_PACKAGES but not USE_API_SCHEMA_PATH or
+        # API_SCHEMA_PATH, so they are only ever consumed composed onto a base file. Composed here with
+        # the same production helper the setup wrappers use, into an isolated root so nothing is written
+        # into the repository.
+        $script:dockerComposeRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+        $script:overlayRoot = Join-Path $TestDrive "overlay-root"
+        New-Item -ItemType Directory -Path $script:overlayRoot -Force | Out-Null
+        foreach ($overlayName in @(".env.ds52", ".env.ds61")) {
+            Copy-Item -LiteralPath (Join-Path $script:dockerComposeRoot $overlayName) -Destination (Join-Path $script:overlayRoot $overlayName)
+        }
+
+        function Resolve-TrackedEnvironmentFile {
+            param(
+                [Parameter(Mandatory)] [string] $BaseName,
+                [string] $DataStandardVersion
+            )
+
+            $basePath = Join-Path $script:dockerComposeRoot $BaseName
+
+            if ([string]::IsNullOrWhiteSpace($DataStandardVersion)) {
+                return $basePath
+            }
+
+            return Resolve-DataStandardEnvironmentFile `
+                -DataStandardVersion $DataStandardVersion `
+                -BaseEnvironmentFile $basePath `
+                -DockerComposeRoot $script:overlayRoot
+        }
+    }
+
+    It "the tracked <Label> satisfies the container schema gate" -ForEach @(
+        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
+        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
+    ) {
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $environmentValues = ReadValuesFromEnvFile $environmentFilePath
+
+        # The container fixture is what Compose renders from this same file: each scalar resolved with
+        # Compose's single-entry value semantics, and SCHEMA_PACKAGES passed through verbatim.
+        $script:stubContainerEnvironment = @{
+            "AppSettings__UseApiSchemaPath" = Resolve-ComposeEnvRawValue `
+                -EnvironmentValues $environmentValues `
+                -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")
+            "AppSettings__ApiSchemaPath"    = Resolve-ComposeEnvRawValue `
+                -EnvironmentValues $environmentValues `
+                -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
+            "SCHEMA_PACKAGES"              = Get-TrackedSchemaPackagesRawValue -EnvironmentFilePath $environmentFilePath
+        }
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath $environmentFilePath `
+                -EnvironmentValues $environmentValues `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "the tracked <Label> enables the ApiSchema path and declares at least one package" -ForEach @(
+        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
+        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
+    ) {
+        # Without this, the gate assertion above could pass on a file that declares no packages at all
+        # or leaves the ApiSchema path off, because the fixture would agree with it either way.
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $environmentValues = ReadValuesFromEnvFile $environmentFilePath
+
+        Resolve-ComposeEnvRawValue `
+            -EnvironmentValues $environmentValues `
+            -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false") |
+            Should -BeExactly "true"
+        @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $environmentFilePath).Count |
+            Should -BeGreaterThan 0
     }
 }

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -550,7 +550,12 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             the chance to re-create one of the three names in this process.
             #>
             param(
-                [Parameter(Mandatory)] [string] $ScriptPath
+                [Parameter(Mandatory)] [string] $ScriptPath,
+
+                # For a script whose phases all live inside functions, which is build-dms.ps1's shape.
+                # Off by default, because for the wrappers a command inside a function belongs to a
+                # helper rather than to the phase sequence.
+                [switch] $IncludeFunctionBody
             )
 
             $actionExtent = @(Get-SchemaGuardActionExtent -ScriptPath $ScriptPath)
@@ -575,6 +580,15 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                 # '& $Action' (in the shared module for the wrappers, inline in the fixture below),
                 # which is variable-dispatched and by construction sits outside the -Action block it
                 # invokes, so including it would report the guard as a phase escaping itself.
+                #
+                # -IncludeFunctionBody lifts that exclusion for a script that dispatches its phases from
+                # inside functions, where this filter would otherwise remove every phase AND every guard
+                # call and return an empty set. A caller using it has to scope the result by name, since a
+                # script's other functions invoke commands that are not phases at all.
+                if ($IncludeFunctionBody) {
+                    return $true
+                }
+
                 $ancestor = $_.Parent
                 $insideFunction = $false
                 while ($null -ne $ancestor) {
@@ -844,6 +858,43 @@ Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
 
         @($invocations | ForEach-Object { $_.Name }) | Should -Be @("./provision-e2e-database.ps1")
         @($invocations | Where-Object { -not $_.InsideGuard }) | Should -BeNullOrEmpty
+    }
+
+    It "runs every DMS start and bootstrap phase in build-dms.ps1 inside the schema guard" {
+        # build-dms.ps1 was structurally EXEMPT from this invariant while being the caller CI actually
+        # invokes for both E2ETest and InstanceE2ETest: every one of its guard call sites and guarded
+        # phases sits inside a function, and the wrapper-shaped detector excludes function bodies, so
+        # pointing it at this script returned an empty set and passed vacuously. -IncludeFunctionBody is
+        # what makes the same question answerable here.
+        #
+        # Scoped to the phases that CREATE the DMS container from an --env-file: the two start scripts,
+        # the two bootstrap scripts, and the image-mode-selected '& $startupScriptPath'. Those are the
+        # invocations whose Compose resolution the guard governs, and the scoping is what keeps the
+        # assertion about them rather than about every command the script's other functions run - the
+        # ad-hoc 'docker run' of DockerRun, or the data-store and provision phases, none of which create
+        # a DMS container from these three names.
+        #
+        # '& $instanceSetupScript' is allowlisted for a different reason: it hands off to the Instance
+        # Management setup wrapper, which guards each of its own phases - asserted for that wrapper
+        # elsewhere in this block - so it is guarded internally rather than at the hand-off.
+        $buildScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../build-dms.ps1"))
+        $dmsStartPhaseName = @(
+            "./start-local-dms.ps1"
+            "./start-published-dms.ps1"
+            "./bootstrap-local-dms.ps1"
+            "./bootstrap-published-dms.ps1"
+            '$startupScriptPath'
+        )
+
+        $invocations = @(
+            Get-GuardedPhaseInvocation -ScriptPath $buildScriptPath -IncludeFunctionBody |
+                Where-Object { $dmsStartPhaseName -contains $_.Name }
+        )
+
+        $invocations.Count |
+            Should -BeGreaterThan 0 -Because "build-dms.ps1 starts the DMS container for both E2E lanes, so finding none of those phases would mean this assertion measures nothing"
+        @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { "$($_.Name) (line $($_.Line))" }) |
+            Should -BeNullOrEmpty -Because "a DMS start phase outside the guard resolves the schema variables from the ambient process again, and build-dms.ps1 is the caller CI runs"
     }
 
     It "defines no function in build-dms.ps1 that shadows one of the module's exports" {
@@ -1519,6 +1570,23 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
+    It "carries the fixed docker inspect capture command, without echoing any container value" {
+        # The reason names WHICH setting disagrees but deliberately never echoes the container's value,
+        # and both remediation actions are things the developer has already done by the time they see this
+        # - so without a capture command the failure names nothing they can escalate. Appended as a FIXED
+        # string carrying only the container name the CALLER passed, which is why the sanitization
+        # invariant is unchanged: the sentinel on the container side must still not appear.
+        $script:stubContainerEnvironment["SCHEMA_PACKAGES"] = '[{"name":"SENTINEL-DO-NOT-ECHO"}]'
+
+        $failure = { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } | Should -Throw -PassThru
+
+        $failure.Exception.Message |
+            Should -BeLike "*Capture the container's actual settings with: docker inspect ed-fi-api --format '{{json .Config.Env}}'"
+        $failure.Exception.Message | Should -Not -BeLike "*SENTINEL-DO-NOT-ECHO*"
+    }
+
     It "throws when the environment file declares packages without enabling the ApiSchema path" {
         $script:environmentFileLines = @(
             "USE_API_SCHEMA_PATH=false"
@@ -1733,16 +1801,65 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
     It 'uses the last declaration of a repeated key, which is what the compose file itself sees' {
         # Declaration order decides a referencing line's value, but for the key being read it is the
         # LAST declaration that Compose hands to the compose file. Both rules have to hold at once.
+        #
+        # Asserted on the file reader directly rather than through the whole gate, because a repeated GATE
+        # key is now rejected before anything is compared (the case below). The last-wins rule still
+        # decides what this reader takes - that rejection exists precisely BECAUSE the package reader
+        # takes the first declaration while this one takes the last.
         $script:environmentFileLines = @(
             "USE_API_SCHEMA_PATH=true"
             "API_SCHEMA_PATH=/first/ApiSchema"
             "API_SCHEMA_PATH=/last/ApiSchema"
         )
-        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/last/ApiSchema"
+        $sequential = Resolve-DotenvFileSequentially -Path (New-EnvironmentFileFixture)
+
+        Get-DmsEnvironmentFileDeclaredValue `
+            -ResolvedEnvironmentFile $sequential `
+            -Name "API_SCHEMA_PATH" `
+            -DefaultValue "" |
+            Should -BeExactly "/last/ApiSchema"
+    }
+
+    It "reports the file-side failure when the environment file declares <Label> more than once" -ForEach @(
+        @{ Label = "SCHEMA_PACKAGES"; Lines = @(
+                "USE_API_SCHEMA_PATH=true"
+                "API_SCHEMA_PATH=/app/ApiSchema"
+                "SCHEMA_PACKAGES='[{""name"":""EdFi.ApiSchema.Package1""}]'"
+                "SCHEMA_PACKAGES='[{""name"":""EdFi.ApiSchema.Package1""},{""name"":""EdFi.ApiSchema.Package2""}]'"
+            )
+        }
+        @{ Label = "API_SCHEMA_PATH"; Lines = @(
+                "USE_API_SCHEMA_PATH=true"
+                "API_SCHEMA_PATH=/first/ApiSchema"
+                "API_SCHEMA_PATH=/app/ApiSchema"
+            )
+        }
+        @{ Label = "USE_API_SCHEMA_PATH"; Lines = @(
+                "USE_API_SCHEMA_PATH=false"
+                "USE_API_SCHEMA_PATH=true"
+                "API_SCHEMA_PATH=/app/ApiSchema"
+            )
+        }
+    ) {
+        # A duplicated gate key is legal Compose, but the two sides of this gate then read the same file
+        # with two parsers that disagree on which declaration wins: Get-QuotedEnvJson - behind
+        # Get-SchemaPackagesFromEnvironmentFile, which is both the expected side and the provisioner's own
+        # reader - matches the FIRST SCHEMA_PACKAGES declaration, while Compose delivers the LAST one to
+        # the container. That produced a real but misattributed abort: "the container received N
+        # package(s)" with a remediation asking for a teardown and re-run that reproduces it every time,
+        # over a file the developer can simply fix. A supplied -EnvironmentFile is a documented input, so
+        # this has to be reported against the file rather than pinned for tracked files alone.
+        #
+        # Each fixture's container AGREES with the last declaration, so a check placed after the
+        # comparisons would let all three pass. The two scalars are held to the same rule as
+        # SCHEMA_PACKAGES because their agreement with Compose otherwise rests on which declaration each
+        # reader happens to take.
+        $script:environmentFileLines = $Lines
 
         { Assert-DmsContainerSchemaEnvironment `
                 -EnvironmentFilePath (New-EnvironmentFileFixture) `
-                -ContainerName "ed-fi-api" } | Should -Not -Throw
+                -ContainerName "ed-fi-api" } |
+            Should -Throw -ExpectedMessage "DMS E2E setup mismatch: the environment file *declares $Label more than once.*Remove the duplicate declaration(s) from the environment file."
     }
 
     It "throws when the environment file spells USE_API_SCHEMA_PATH as <Label>" -ForEach @(
@@ -1833,6 +1950,25 @@ Describe "Get-DmsContainerEnvironment reads the container environment and fails 
             Should -Be "Host=dms-postgresql;Database=edfi_e2e;Username=postgres"
         $containerEnvironment["SCHEMA_PACKAGES"] |
             Should -Be '[{"name":"EdFi.ApiSchema.Package1","version":"1.0.0"}]'
+    }
+
+    It "keeps the literal newlines inside a multi-line SCHEMA_PACKAGES entry" {
+        # The shape production actually hands this reader: .env.e2e declares SCHEMA_PACKAGES='[ across
+        # several lines, so the container's .Config.Env entry carries literal newlines. The reader splits
+        # on the FIRST '=' and keeps the remainder verbatim, which is what makes the value parseable by
+        # Get-DmsContainerSchemaPackage - a move to line-splitting, or a trim, would truncate exactly the
+        # value the gate compares, and every other case here is single-line.
+        $multiLineValue = @'
+[
+  {"name":"EdFi.ApiSchema.Package1","version":"1.0.0"},
+  {"name":"EdFi.ApiSchema.Package2","version":"1.0.0"}
+]
+'@
+        $script:stubDockerOutput = ConvertTo-Json -Compress -InputObject @("SCHEMA_PACKAGES=$multiLineValue")
+
+        $containerEnvironment = Get-DmsContainerEnvironment -ContainerName "ed-fi-api"
+
+        $containerEnvironment["SCHEMA_PACKAGES"] | Should -BeExactly $multiLineValue
     }
 
     It "keeps an entry whose value is empty, so a blank container value stays distinguishable from an absent one" {

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -1607,16 +1607,73 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $script:schemaEnvironmentModuleSource | Should -Match 'Select-Object -Last 1'
     }
 
-    It "imports the same file-only package reader the provision phase uses" {
+    It "imports the same file-only package reader the provision phase uses, without -Force" {
         # The module imports its own dependencies rather than relying on whatever the invoking wrapper
         # happened to import, so command resolution does not depend on the call site.
-        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "\.\./schema-package-utility\.psm1"\) -Force'
-        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "database-safety\.psm1"\) -Force'
+        #
+        # Never with -Force on these nested imports. -Force removes the module before re-importing it
+        # and removal is session-wide, so it strips an already-imported dependency out of the CALLER's
+        # session state and re-imports it into this module's scope alone - which is what left both setup
+        # wrappers unable to resolve any database-safety command. The behavioral regression is below;
+        # this pins the spelling that causes it.
+        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "\.\./schema-package-utility\.psm1"\)(?! -Force)'
+        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "database-safety\.psm1"\)(?! -Force)'
+        $script:schemaEnvironmentModuleSource | Should -Not -Match 'Import-Module[^\r\n]*\.psm1"\) -Force'
     }
 
     It "throws rather than warning when the verdict fails" {
         $script:schemaEnvironmentModuleSource | Should -Match 'throw "DMS E2E setup mismatch: '
         $script:schemaEnvironmentModuleSource | Should -Not -Match 'Write-Warning[^\r\n]*setup mismatch'
+    }
+
+    It "leaves the wrappers' already-imported database-safety commands resolvable after this module loads" {
+        # A real import, not a source assertion. Every other test in this suite reaches this module by
+        # extracting function text through the AST, so nothing here ever executed its import block - and
+        # a nested 'Import-Module ... -Force' unloaded database-safety out of the importing session,
+        # leaving both wrappers to fail at their first database-safety call after the import while every
+        # test stayed green.
+        #
+        # Run in a child pwsh, in the wrappers' own order and from the wrappers' own working directory,
+        # so the observation is a fresh session's command resolution rather than one this suite has
+        # already populated with -Force imports of its own.
+        $dockerComposeRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+        $observationPath = Join-Path $TestDrive "wrapper-import-observations.txt"
+        $childScriptPath = Join-Path $TestDrive "wrapper-import-child.ps1"
+        # Both paths are embedded in single-quoted literals in the generated child script, so an
+        # apostrophe in either would close the quote early. Doubling keeps the literals intact.
+        $escapedObservationPath = $observationPath -replace "'", "''"
+        $escapedComposeRoot = $dockerComposeRoot -replace "'", "''"
+        $childScript = @"
+Set-Location -LiteralPath '$escapedComposeRoot'
+
+# Verbatim the order both wrappers use: the leaf dependency first, the shared verifier module last.
+Import-Module ./env-utility.psm1 -Force
+Import-Module ./database-safety.psm1 -Force
+Import-Module ./dms-schema-environment.psm1 -Force
+
+foreach (`$commandName in @(
+        'Assert-E2EDatabaseIsDedicated',
+        'Get-ComposeResolvedEnvValue',
+        'Resolve-DotenvFileSequentially',
+        'Assert-DmsContainerSchemaEnvironment'
+    )) {
+    `$commandName + '=' + [string][bool](Get-Command `$commandName -ErrorAction SilentlyContinue) |
+        Add-Content -LiteralPath '$escapedObservationPath'
+}
+"@
+        Set-Content -LiteralPath $childScriptPath -Value $childScript -Encoding utf8
+
+        & (Get-Process -Id $PID).Path -NoProfile -File $childScriptPath
+        $LASTEXITCODE | Should -Be 0 -Because "the wrappers' import sequence must not fail"
+
+        $observations = @(Get-Content -LiteralPath $observationPath)
+        # The three the wrappers call after importing this module: the up-front dedicated-database gate,
+        # the Compose-equivalent scalar reader, and the sequential env-file resolver.
+        $observations | Should -Contain "Assert-E2EDatabaseIsDedicated=True" -Because "the Instance Management wrapper's up-front dedicated-database gate runs after this import"
+        $observations | Should -Contain "Get-ComposeResolvedEnvValue=True" -Because "both wrappers read a scalar through it after this import"
+        $observations | Should -Contain "Resolve-DotenvFileSequentially=True" -Because "no import may strip the caller's sequential env-file resolver"
+        # The import still has to do its own job, so this is not satisfiable by removing it outright.
+        $observations | Should -Contain "Assert-DmsContainerSchemaEnvironment=True" -Because "the module must still export the verifier the wrappers import it for"
     }
 }
 

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -557,7 +557,25 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                     $name = '$' + $_.CommandElements[0].VariablePath.UserPath
                 }
 
-                if ($name -and ($isVariableDispatched -or $name -like "*.ps1")) {
+                # A bareword 'docker' can orchestrate Compose directly - 'docker compose --env-file ...
+                # up ...' - and such a call is a phase for this detector's purposes: it resolves the
+                # three schema names ambient-first exactly as a phase script's own compose call does, so
+                # one added outside the guard is the same escape. Matching only '*.ps1' barewords made
+                # every such call invisible, and the sibling "nothing outside the guard" assertion would
+                # have passed while the orchestration ran unguarded.
+                #
+                # Classified by what the command DOES, not by being named 'docker': both wrappers run
+                # 'docker version' as a pre-flight daemon check that reads none of the three names and
+                # legitimately sits before the guard, so it must stay excluded. The backtick in the
+                # character class keeps a line-continued 'docker `<newline> compose' matching.
+                $isComposeOrchestration = $false
+                if ($name -eq "docker") {
+                    $commandText = $_.Extent.Text
+                    $isComposeOrchestration =
+                        $commandText -match 'docker[\s`]+compose' -or $commandText -match '--env-file'
+                }
+
+                if ($name -and ($isVariableDispatched -or $name -like "*.ps1" -or $isComposeOrchestration)) {
                     [pscustomobject]@{
                         Name        = $name
                         Line        = $_.Extent.StartLineNumber
@@ -652,6 +670,37 @@ Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         @($invocations | ForEach-Object { $_.Name }) | Should -Be @('$guardedPhase', '$escapedPhase')
         @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { $_.Name }) |
             Should -Be @('$escapedPhase')
+    }
+
+    It "detects a bareword 'docker compose --env-file' call outside the guard while ignoring 'docker version'" {
+        # The detector's second regression guard. A phase does not have to be a .ps1 script: a compose
+        # call written inline resolves USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES
+        # ambient-first exactly as a phase script's does, so one added outside the guard is the same
+        # escape - and a detector that only recognized '*.ps1' barewords reported no escape at all.
+        # 'docker version' is in the fixture too, unguarded, because both wrappers really do run it as a
+        # pre-flight daemon check before the guard: it reads none of the three names, so classifying it
+        # as an escape would fail the wiring tests on correct wrappers.
+        $fixturePath = Join-Path $TestDrive "bareword-compose-phase.ps1"
+        Set-Content -LiteralPath $fixturePath -Encoding utf8 -Value @'
+function Invoke-WithDmsEnvironmentFileSchemaAuthority {
+    param([scriptblock] $Action)
+    & $Action
+}
+
+docker version 2>&1
+
+Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
+    ./start-local-dms.ps1 -InfraOnly
+}
+
+docker compose -p dms-local --env-file ./.env.e2e -f local-dms.yml up -d dms
+'@
+
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $fixturePath)
+
+        @($invocations | ForEach-Object { $_.Name }) | Should -Be @("./start-local-dms.ps1", "docker")
+        @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { $_.Name }) |
+            Should -Be @("docker") -Because "an unguarded compose call resolves the schema variables from the ambient process again"
     }
 
     It "reads the -Action argument rather than counting script blocks, so a nested block is not a detector error" {
@@ -864,7 +913,18 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "AppSettings__UseApiSchemaPath is false"
         $verdict.Reason | Should -Match "4 ApiSchema package"
-        $verdict.Remediation | Should -Match "USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES"
+        # The remediation names actions that reach the causes this verdict can actually have. It used to
+        # ask for a re-run "from a shell that does not set USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and
+        # SCHEMA_PACKAGES", which cannot apply: the gate runs inside the guard that has already removed
+        # those three names from the process, so a developer following that advice changed nothing. A
+        # stale container and a wrong environment file are reachable, and both of these address them.
+        $verdict.Remediation | Should -Match "teardown-local-dms\.ps1"
+        $verdict.Remediation | Should -Match "re-run setup"
+        $verdict.Remediation | Should -Match "-EnvironmentFile"
+        $verdict.Remediation | Should -Not -Match "Re-run setup from a shell"
+        # No path to the teardown wrapper: the setup flows run their phases from eng/docker-compose,
+        # where no relative path to either suite's copy resolves.
+        $verdict.Remediation | Should -Not -Match "\./teardown-local-dms\.ps1"
     }
 
     It "fails when AppSettings__UseApiSchemaPath is <Label>, reporting a fixed token" -ForEach @(
@@ -934,6 +994,10 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.Reason | Should -Match "differ from the environment file's declared packages by name, version, or feed URL"
         # Not misreported as a count problem: the counts agree.
         $verdict.Reason | Should -Not -Match "but the E2E database was provisioned for the environment file's"
+        # Actionable: the FILE's expected identity at the mismatching index is named, so the failure says
+        # which package the E2E database was provisioned for. Every entry differs in this case, so the
+        # first sorted position is the one reported.
+        $verdict.Reason | Should -Match ([regex]::Escape($script:fixturePackageIdentity[0]))
     }
 
     It "fails when the count matches and only one of the packages differs" {
@@ -955,9 +1019,39 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.Reason | Should -Match "differ from the environment file's declared packages by name, version, or feed URL"
     }
 
-    It "never echoes the differing package values into the surface-mismatch failure text" {
-        # The mismatch message is derived vocabulary, so container-supplied package text cannot forge
-        # log lines or leak a feed URL into the console.
+    It "names the environment file's expected package at the mismatching sorted position" {
+        # The point of reporting the expected identity: with one entry diverging, the message has to
+        # identify THAT package rather than the first one, or a developer is sent to diff the wrong
+        # entry. Only Package3's version differs, and the identities sort by their JSON text - which
+        # begins with the name - so the mismatch lands at sorted position 3.
+        $divergentPackages = @(New-SchemaPackageFixture -Count 4)
+        $divergentPackages[2] = [pscustomobject]@{
+            name    = $divergentPackages[2].name
+            version = "7.7.7"
+            feedUrl = $divergentPackages[2].feedUrl
+        }
+
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package $divergentPackages) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "The first difference is at sorted position 3 of 4"
+        $verdict.Reason | Should -Match ([regex]::Escape($script:fixturePackageIdentity[2]))
+        $verdict.Reason | Should -Match "EdFi\.ApiSchema\.Package3"
+        # The expected identity, not the container's: the container is on 7.7.7 at that position, and the
+        # environment file's 1.0.0 is what the E2E database was provisioned for.
+        $verdict.Reason | Should -Match '"version":"1\.0\.0"'
+        $verdict.Reason | Should -Not -Match "7\.7\.7"
+    }
+
+    It "never echoes the container's package values into the surface-mismatch failure text" {
+        # The container-supplied half stays out of the message, so it cannot forge log lines or leak a
+        # feed URL into the console. Only the environment FILE's expected identity is named, and this
+        # fixture keeps the sentinel on the container side to pin that split: the file's own packages
+        # carry the default feed.
         $sentinelPackages = @(New-SchemaPackageFixture -Count 4 -FeedUrl "https://SENTINEL-FEED-DO-NOT-ECHO.example.net/index.json")
 
         $verdict = Get-DmsSchemaEnvironmentVerdict `
@@ -968,6 +1062,22 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
 
         $verdict.ShouldFail | Should -BeTrue
         "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "SENTINEL-FEED-DO-NOT-ECHO"
+        # Not satisfiable by dropping the expected identity too: the actionable half must still be there.
+        $verdict.Reason | Should -Match ([regex]::Escape($script:fixturePackageIdentity[0]))
+    }
+
+    It "keeps the surface-mismatch failure text single-line, so a package blob cannot forge log lines" {
+        # The expected identity comes from the environment file rather than the container, but it is
+        # still interpolated into the message, so it is pinned to the same shape the rest of this
+        # vocabulary has: compact JSON on one line, which is what Get-DmsSchemaPackageIdentity emits.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -Package (New-SchemaPackageFixture -Count 4 -Version "9.9.9")) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "`n"
     }
 
     It "accepts the same package surface declared in a different order" {
@@ -1082,12 +1192,10 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.Remediation | Should -Match "Set USE_API_SCHEMA_PATH=true in the environment file"
     }
 
-    It "reports a package-bearing environment file with no API_SCHEMA_PATH against the file, not the shell" {
+    It "reports a package-bearing environment file with no API_SCHEMA_PATH against the file, not the container" {
         # The symmetric file-side inconsistency to the case above. Without its own branch this reaches
-        # the container's blank-path check, whose remediation opens by asking for a re-run from a shell
-        # that sets none of the three names - a cause that cannot apply to a value the FILE never
-        # declared, and one the gate can rule out because it runs inside the guard that already removed
-        # those names.
+        # the container's blank-path check, whose remediation asks for a teardown and a re-run - and
+        # re-creating the container cannot fix a value the FILE never declared.
         $verdict = Get-DmsSchemaEnvironmentVerdict `
             -ContainerEnvironment (Get-ContainerEnvironmentFixture -ApiSchemaPath "") `
             -ExpectedPackageIdentity $script:fixturePackageIdentity `
@@ -1097,7 +1205,37 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
         $verdict.ShouldFail | Should -BeTrue
         $verdict.Reason | Should -Match "the environment file declares 4 ApiSchema package\(s\) but no API_SCHEMA_PATH"
         $verdict.Remediation | Should -Match "Set API_SCHEMA_PATH in the environment file"
+        $verdict.Remediation | Should -Not -Match "teardown-local-dms"
+    }
+
+    It "answers every container-side branch with the teardown-and-re-run remediation and no stale shell advice" -ForEach @(
+        @{ Label = "UseApiSchemaPath false"; Container = @{ UseApiSchemaPath = "false" } }
+        @{ Label = "a blank ApiSchemaPath"; Container = @{ ApiSchemaPath = "" } }
+        @{ Label = "a different ApiSchemaPath"; Container = @{ ApiSchemaPath = "/somewhere/else" } }
+        @{ Label = "a non-array SCHEMA_PACKAGES"; Container = @{ RawSchemaPackages = "not-json" } }
+        @{ Label = "a different package count"; Container = @{ PackageCount = 2 } }
+        @{ Label = "the same count at a different version"; Container = @{ Package = @(1..4 | ForEach-Object {
+                    [pscustomobject]@{ name = "EdFi.ApiSchema.Package$_"; version = "9.9.9"; feedUrl = "https://pkgs.example.org/v3/index.json" }
+                }) }
+        }
+    ) {
+        # Every branch the CONTAINER can fail on, held to the same remediation in one table rather than
+        # one branch at a time: the advice that had to be replaced ("Re-run setup from a shell that does
+        # not set USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES") reached all six, and it
+        # named a cause the gate has already ruled out - it runs inside the guard that removed those
+        # three names. A future edit that restores it in any one branch fails here.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
+            -ExpectedPackageIdentity $script:fixturePackageIdentity `
+            -EnvironmentFileUsesApiSchemaPath $true `
+            -EnvironmentFileApiSchemaPath $script:fixtureApiSchemaPath
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Remediation | Should -Match "teardown-local-dms\.ps1"
+        $verdict.Remediation | Should -Match "re-created from the selected environment file"
+        $verdict.Remediation | Should -Match "select a different -EnvironmentFile"
         $verdict.Remediation | Should -Not -Match "Re-run setup from a shell"
+        $verdict.Remediation | Should -Not -Match "\./teardown-local-dms\.ps1"
     }
 
     It "refuses an empty declared package surface, because the file-only reader cannot produce one" {
@@ -1736,47 +1874,103 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $script:schemaEnvironmentModuleSource | Should -Not -Match 'Write-Warning[^\r\n]*setup mismatch'
     }
 
-    It "leaves the wrappers' already-imported database-safety commands resolvable after this module loads" {
+    It "leaves every imported command resolvable, and the verifier's own dependencies resolvable, in the <Label> import order" -ForEach @(
+        @{
+            Label       = "direct wrapper"
+            ImportOrder = @(
+                "Import-Module ./env-utility.psm1 -Force"
+                "Import-Module ./database-safety.psm1 -Force"
+                "Import-Module ./dms-schema-environment.psm1"
+            )
+        }
+        @{
+            # The build path. build-dms.ps1 imports this module at the top of the script and then invokes
+            # a setup wrapper IN-PROCESS, so the wrapper's own three imports run against a session where
+            # this module is already loaded - and its two -Force imports remove and re-import the very
+            # leaf modules this module nested-imported for itself. The wrapper's final plain import
+            # cannot repair that: an already-loaded module is reused, not re-processed, so its import
+            # block does not run again. Only exercising this order proves the module's internal
+            # dependency resolution survives it.
+            Label       = "build-dms.ps1"
+            ImportOrder = @(
+                "Import-Module ./dms-schema-environment.psm1"
+                "Import-Module ./env-utility.psm1 -Force"
+                "Import-Module ./database-safety.psm1 -Force"
+                "Import-Module ./dms-schema-environment.psm1"
+            )
+        }
+    ) {
         # A real import, not a source assertion. Every other test in this suite reaches this module by
         # extracting function text through the AST, so nothing here ever executed its import block - and
         # a nested 'Import-Module ... -Force' unloaded database-safety out of the importing session,
         # leaving both wrappers to fail at their first database-safety call after the import while every
         # test stayed green.
         #
-        # Run in a child pwsh, in the wrappers' own order and from the wrappers' own working directory,
-        # so the observation is a fresh session's command resolution rather than one this suite has
-        # already populated with -Force imports of its own.
+        # Run in a child pwsh, in a real import order and from the wrappers' own working directory, so
+        # the observation is a fresh session's command resolution rather than one this suite has already
+        # populated with -Force imports of its own.
         $dockerComposeRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
-        $observationPath = Join-Path $TestDrive "wrapper-import-observations.txt"
-        $childScriptPath = Join-Path $TestDrive "wrapper-import-child.ps1"
-        # Both paths are embedded in single-quoted literals in the generated child script, so an
-        # apostrophe in either would close the quote early. Doubling keeps the literals intact.
+        $observationPath = Join-Path $TestDrive "wrapper-import-observations-$Label.txt"
+        $childScriptPath = Join-Path $TestDrive "wrapper-import-child-$Label.ps1"
+        $environmentFilePath = Join-Path $TestDrive "wrapper-import-fixture-$Label.env"
+        # A package-bearing environment file, so the verifier gets past its file-only reader and reaches
+        # the container read. Written here rather than pointing at a tracked .env file, so the case does
+        # not depend on repository content it is not about.
+        Set-Content -LiteralPath $environmentFilePath -Encoding utf8 -Value @'
+USE_API_SCHEMA_PATH=true
+API_SCHEMA_PATH=/app/ApiSchema
+SCHEMA_PACKAGES='[{"name":"EdFi.ApiSchema.Package1","version":"1.0.0","feedUrl":"https://pkgs.example.org/v3/index.json"}]'
+'@
+
+        # Every path is embedded in a single-quoted literal in the generated child script, so an
+        # apostrophe in any of them would close the quote early. Doubling keeps the literals intact.
         $escapedObservationPath = $observationPath -replace "'", "''"
         $escapedComposeRoot = $dockerComposeRoot -replace "'", "''"
+        $escapedEnvironmentFilePath = $environmentFilePath -replace "'", "''"
+        $importBlock = $ImportOrder -join [System.Environment]::NewLine
         $childScript = @"
 Set-Location -LiteralPath '$escapedComposeRoot'
 
-# Verbatim what both wrappers do: the leaf dependency first, the shared verifier module last and
-# without -Force.
-Import-Module ./env-utility.psm1 -Force
-Import-Module ./database-safety.psm1 -Force
-Import-Module ./dms-schema-environment.psm1
+$importBlock
 
 foreach (`$commandName in @(
         'Assert-E2EDatabaseIsDedicated',
         'Get-ComposeResolvedEnvValue',
         'Resolve-DotenvFileSequentially',
         'Assert-DmsContainerSchemaEnvironment',
-        'Invoke-WithDmsEnvironmentFileSchemaAuthority'
+        'Invoke-WithDmsEnvironmentFileSchemaAuthority',
+        'Get-DmsContainerEnvironment',
+        'Get-DmsSchemaEnvironmentVerdict',
+        'Get-DmsSchemaPackageIdentity'
     )) {
     `$commandName + '=' + [string][bool](Get-Command `$commandName -ErrorAction SilentlyContinue) |
         Add-Content -LiteralPath '$escapedObservationPath'
+}
+
+# GLOBAL, so the module's own 'docker inspect' resolves to it: a module function looks up commands in
+# its own session state and then in the global one, never in this script's scope. Fails closed, which
+# is the outcome the verifier turns into a throw.
+function global:docker {
+    `$global:LASTEXITCODE = 1
+    return ''
+}
+
+# Reaching 'docker inspect' means every module-internal dependency resolved on the way there:
+# Get-SchemaPackagesFromEnvironmentFile (schema-package-utility) and Resolve-DotenvFileSequentially
+# (database-safety), both nested-imported by this module. A broken one throws CommandNotFoundException
+# BEFORE the container read, so the observation distinguishes them.
+try {
+    Assert-DmsContainerSchemaEnvironment -EnvironmentFilePath '$escapedEnvironmentFilePath' -ContainerName 'ed-fi-api'
+    'VerifierOutcome=returned-without-reading-the-container' | Add-Content -LiteralPath '$escapedObservationPath'
+}
+catch {
+    'VerifierOutcome=' + `$_.Exception.Message | Add-Content -LiteralPath '$escapedObservationPath'
 }
 "@
         Set-Content -LiteralPath $childScriptPath -Value $childScript -Encoding utf8
 
         & (Get-Process -Id $PID).Path -NoProfile -File $childScriptPath
-        $LASTEXITCODE | Should -Be 0 -Because "the wrappers' import sequence must not fail"
+        $LASTEXITCODE | Should -Be 0 -Because "the $Label import sequence must not fail"
 
         $observations = @(Get-Content -LiteralPath $observationPath)
         # The three the wrappers call after importing this module: the up-front dedicated-database gate,
@@ -1790,6 +1984,19 @@ foreach (`$commandName in @(
         # catch the guard being defined in the module but left out of Export-ModuleMember - which would
         # leave both wrappers unable to resolve it at their first phase.
         $observations | Should -Contain "Invoke-WithDmsEnvironmentFileSchemaAuthority=True" -Because "both wrappers now reach the schema-settings guard through this module's exports"
+        # build-dms.ps1's runtime hash gate calls this reader by name after importing the module, having
+        # dropped its own copy of it, so the export is load-bearing for that script the same way.
+        $observations | Should -Contain "Get-DmsContainerEnvironment=True" -Because "build-dms.ps1 reads the container environment through this module's export"
+        # The export surface stays at the three commands with an external caller. The internals reach
+        # their tests through AST extraction, so exporting them would buy nothing and widen what the
+        # in-process shadowing described above can bind to.
+        $observations | Should -Contain "Get-DmsSchemaEnvironmentVerdict=False" -Because "the verdict has no caller outside the module"
+        $observations | Should -Contain "Get-DmsSchemaPackageIdentity=False" -Because "the identity reducer has no caller outside the module"
+
+        # The behavioral half: resolving the exports says nothing about whether the module can still
+        # resolve the commands IT calls. Only a run that gets all the way to the container read proves
+        # that, which a source assertion or a Get-Command check cannot.
+        $observations | Should -Contain "VerifierOutcome=Unable to inspect Docker container 'ed-fi-api' to verify its schema environment." -Because "the verifier must reach its 'docker inspect' step, which means the module resolved its own nested-imported dependencies in this order"
     }
 }
 

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -90,6 +90,82 @@ BeforeAll {
             $true
         ))
     }
+
+    function Get-SchemaGuardActionExtent {
+        <#
+        .SYNOPSIS
+        Returns the extent of the -Action script block of EVERY
+        Invoke-WithDmsEnvironmentFileSchemaAuthority invocation in a setup wrapper, in source order, so
+        a containment test can ask whether something is inside ANY guard.
+        .DESCRIPTION
+        One or more, deliberately not exactly one. Each phase invocation is guarded separately: the
+        guard restores the caller's prior environment when its action returns, so a single call around
+        a whole phase sequence removes the three schema names only once, before the first phase, and a
+        phase that re-creates one of them leaves it set for every later phase in that sequence.
+
+        Shared by the phase detector and the verifier-placement check below, so "which blocks count as
+        the guard" is decided in one place rather than in two that drift apart.
+        #>
+        param(
+            [Parameter(Mandatory)] [string] $ScriptPath
+        )
+
+        $parseErrors = $null
+        $tokens = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+
+        if ($parseErrors.Count -gt 0) {
+            throw "'$ScriptPath' has $($parseErrors.Count) parse error(s)."
+        }
+
+        $guardCalls = @($ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq "Invoke-WithDmsEnvironmentFileSchemaAuthority"
+            },
+            $true
+        ))
+
+        if ($guardCalls.Count -lt 1) {
+            throw "Expected at least one Invoke-WithDmsEnvironmentFileSchemaAuthority invocation in '$ScriptPath'; found none."
+        }
+
+        return @(
+            foreach ($guardCall in $guardCalls) {
+                # Bound to the ARGUMENT of -Action, not to "the one script block anywhere under the
+                # guard call". Counting descendants made any legitimate nested script block - a
+                # ForEach-Object over the route-context databases, a Where-Object filter - break the
+                # wiring test with a detector error rather than a finding. Both spellings are accepted:
+                # '-Action { }', where the block is the following element, and '-Action:{ }', where the
+                # parser attaches it to the parameter itself.
+                $guardElements = @($guardCall.CommandElements)
+                $actionArgument = $null
+                for ($elementIndex = 0; $elementIndex -lt $guardElements.Count; $elementIndex++) {
+                    $element = $guardElements[$elementIndex]
+                    if ($element -isnot [System.Management.Automation.Language.CommandParameterAst] -or
+                        $element.ParameterName -ne "Action") {
+                        continue
+                    }
+
+                    $actionArgument = if ($null -ne $element.Argument) {
+                        $element.Argument
+                    }
+                    elseif ($elementIndex + 1 -lt $guardElements.Count) {
+                        $guardElements[$elementIndex + 1]
+                    }
+
+                    break
+                }
+
+                if ($actionArgument -isnot [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+                    throw "The guard invocation at line $($guardCall.Extent.StartLineNumber) in '$ScriptPath' does not pass a script block to -Action."
+                }
+
+                $actionArgument.Extent
+            }
+        )
+    }
 }
 
 Describe "Invoke-WithE2ETestProcessContext restores prior environment state exactly (DMS-1284)" {
@@ -461,13 +537,21 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             <#
             .SYNOPSIS
             Returns one record per phase-script invocation in a setup wrapper, with whether the
-            invocation is lexically inside the wrapper's single Invoke-WithDmsEnvironmentFileSchemaAuthority
-            -Action block. Uses the AST rather than a text pattern, so the assertion is about the
-            structure production actually has, and is not defeated by reformatting or reindentation.
+            invocation is lexically inside ANY Invoke-WithDmsEnvironmentFileSchemaAuthority -Action
+            block, and which one. Uses the AST rather than a text pattern, so the assertion is about
+            the structure production actually has, and is not defeated by reformatting or
+            reindentation.
+            .DESCRIPTION
+            One or more guards, not exactly one: each phase is guarded on its own, so the question a
+            phase record answers is "is this phase inside SOME guard", and GuardIndex identifies which
+            - a phase sharing a guard block with an earlier phase runs after that phase has already had
+            the chance to re-create one of the three names in this process.
             #>
             param(
                 [Parameter(Mandatory)] [string] $ScriptPath
             )
+
+            $actionExtent = @(Get-SchemaGuardActionExtent -ScriptPath $ScriptPath)
 
             $parseErrors = $null
             $tokens = $null
@@ -476,50 +560,6 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             if ($parseErrors.Count -gt 0) {
                 throw "'$ScriptPath' has $($parseErrors.Count) parse error(s)."
             }
-
-            $guardCalls = @($ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.CommandAst] -and
-                    $node.GetCommandName() -eq "Invoke-WithDmsEnvironmentFileSchemaAuthority"
-                },
-                $true
-            ))
-
-            if ($guardCalls.Count -ne 1) {
-                throw "Expected exactly one Invoke-WithDmsEnvironmentFileSchemaAuthority invocation in '$ScriptPath'; found $($guardCalls.Count)."
-            }
-
-            # Bound to the ARGUMENT of -Action, not to "the one script block anywhere under the guard
-            # call". Counting descendants made any legitimate nested script block - a ForEach-Object
-            # over the route-context databases, a Where-Object filter - break the wiring test with a
-            # detector error rather than a finding. Both spellings are accepted: '-Action { }', where
-            # the block is the following element, and '-Action:{ }', where the parser attaches it to
-            # the parameter itself.
-            $guardElements = @($guardCalls[0].CommandElements)
-            $actionArgument = $null
-            for ($elementIndex = 0; $elementIndex -lt $guardElements.Count; $elementIndex++) {
-                $element = $guardElements[$elementIndex]
-                if ($element -isnot [System.Management.Automation.Language.CommandParameterAst] -or
-                    $element.ParameterName -ne "Action") {
-                    continue
-                }
-
-                $actionArgument = if ($null -ne $element.Argument) {
-                    $element.Argument
-                }
-                elseif ($elementIndex + 1 -lt $guardElements.Count) {
-                    $guardElements[$elementIndex + 1]
-                }
-
-                break
-            }
-
-            if ($actionArgument -isnot [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
-                throw "The guard invocation in '$ScriptPath' does not pass a script block to -Action."
-            }
-
-            $actionExtent = $actionArgument.Extent
 
             return @($ast.FindAll(
                 {
@@ -576,13 +616,29 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                 }
 
                 if ($name -and ($isVariableDispatched -or $name -like "*.ps1" -or $isComposeOrchestration)) {
+                    # The index of the FIRST guard block containing this invocation, or $null when no
+                    # guard does. The guards are siblings in these wrappers, so at most one contains a
+                    # given phase.
+                    $phaseExtent = $_.Extent
+                    $guardIndex = $null
+                    for ($extentIndex = 0; $extentIndex -lt $actionExtent.Count; $extentIndex++) {
+                        if ($phaseExtent.StartOffset -ge $actionExtent[$extentIndex].StartOffset -and
+                            $phaseExtent.EndOffset -le $actionExtent[$extentIndex].EndOffset) {
+                            $guardIndex = $extentIndex
+                            break
+                        }
+                    }
+
                     [pscustomobject]@{
                         Name        = $name
-                        Line        = $_.Extent.StartLineNumber
+                        Line        = $phaseExtent.StartLineNumber
                         # Carried so an assertion can order the phases against another command's
                         # position, which line numbers alone cannot do for two calls on one line.
-                        EndOffset   = $_.Extent.EndOffset
-                        InsideGuard = ($_.Extent.StartOffset -ge $actionExtent.StartOffset -and $_.Extent.EndOffset -le $actionExtent.EndOffset)
+                        EndOffset   = $phaseExtent.EndOffset
+                        InsideGuard = ($null -ne $guardIndex)
+                        # Which guard block, so an assertion can tell "every phase is guarded" from
+                        # "every phase is guarded SEPARATELY".
+                        GuardIndex  = $guardIndex
                     }
                 }
             })
@@ -592,6 +648,12 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             "DataManagementService E2E" = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
             "InstanceManagement E2E"    = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"))
         }
+
+        # The real guard, for the replay below: the leak regression has to run the same
+        # removal-and-restore production runs, not a stand-in for it.
+        . ([scriptblock]::Create((Get-ScriptFunctionText `
+                        -ScriptPath ([System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))) `
+                        -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority")))
     }
 
     It "runs the direct DMS E2E phase sequence inside the guard, in order" {
@@ -615,6 +677,61 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
         $invocations.Count | Should -BeGreaterThan 0 -Because "the wrapper must invoke phase scripts"
         @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { "$($_.Name) (line $($_.Line))" }) |
             Should -BeNullOrEmpty -Because "a Compose-invoking phase outside the guard would resolve the schema variables from the ambient process again"
+    }
+
+    It "removes SCHEMA_PACKAGES again for every later phase in the <Name> wrapper, so a phase that re-creates it cannot leak into the next" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
+        # THE GUARD-SHAPE REGRESSION, replayed rather than pattern-matched. Inside the guard is not the
+        # whole requirement; inside a guard of its OWN is. The guard restores the caller's prior
+        # environment when its action returns, so one call wrapped around the whole phase sequence
+        # removes the three schema names exactly once, before phase 1. Phase scripts run in this same
+        # PowerShell process and can re-create one of them - start-local-dms.ps1 sets them in-process on
+        # purpose in bootstrap mode - after which every later phase in that one guarded sequence sees
+        # the re-created value and Compose resolves it ambient-first again.
+        #
+        # The grouping comes from production (which guard block each phase invocation actually sits in)
+        # and the guard is the real one, so this fails on a wrapper that guards its sequence once and
+        # passes on one that guards each phase. The phases themselves are not executed: what is being
+        # replayed is the removal boundary around them.
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $script:wrapperScripts[$Name] | Sort-Object EndOffset)
+
+        $invocations.Count |
+            Should -BeGreaterThan 1 -Because "the replay needs a later phase to observe what an earlier one left behind"
+        @($invocations | Where-Object { -not $_.InsideGuard }) |
+            Should -BeNullOrEmpty -Because "an unguarded phase has no removal boundary to replay"
+
+        # Script-scoped: '& $Action' runs the block in a child scope, so a plain assignment inside it
+        # would be discarded when the guard returns.
+        $script:replayedPhaseCount = 0
+        $script:phaseObservingLeakedPackages = @()
+
+        foreach ($guardIndex in @($invocations | ForEach-Object { $_.GuardIndex } | Select-Object -Unique)) {
+            $guardedPhases = @($invocations | Where-Object { $_.GuardIndex -eq $guardIndex })
+
+            Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
+                foreach ($phase in $guardedPhases) {
+                    $script:replayedPhaseCount++
+
+                    if ($script:replayedPhaseCount -eq 1) {
+                        # Phase 1 re-creates SCHEMA_PACKAGES in this process, as a phase script that
+                        # activates bootstrap mode does.
+                        [System.Environment]::SetEnvironmentVariable("SCHEMA_PACKAGES", '[{"name":"ReCreatedByPhaseOne"}]')
+                        continue
+                    }
+
+                    if (Test-Path -LiteralPath "Env:SCHEMA_PACKAGES") {
+                        $script:phaseObservingLeakedPackages += "$($phase.Name) (line $($phase.Line))"
+                    }
+                }
+            }
+        }
+
+        # The guard's own restore returns SCHEMA_PACKAGES to whatever this shell had, so the replay
+        # leaves no state behind whichever shape the wrapper has.
+        $script:phaseObservingLeakedPackages |
+            Should -BeNullOrEmpty -Because "each phase must be guarded on its own, so SCHEMA_PACKAGES re-created by an earlier phase is removed again before the next phase runs"
     }
 
     It "verifies the started container after the LAST guarded phase in the <Name> wrapper" -ForEach @(
@@ -1409,6 +1526,43 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
+    It "reports the file-side failure when the environment file declares packages and <Label> USE_API_SCHEMA_PATH" -ForEach @(
+        @{ Label = "omits"; Lines = @("API_SCHEMA_PATH=/app/ApiSchema") }
+        @{ Label = "blanks"; Lines = @("USE_API_SCHEMA_PATH=", "API_SCHEMA_PATH=/app/ApiSchema") }
+    ) {
+        # The file-only read's fallback, exercised rather than pattern-matched: an undeclared (or
+        # blank) USE_API_SCHEMA_PATH must resolve to false, so the verdict is the FILE-side "declares
+        # packages but does not set USE_API_SCHEMA_PATH=true" - the file is internally inconsistent and
+        # re-creating the container cannot fix it. The container in this fixture agrees with everything
+        # it can, so a fallback that defaulted the missing name to true would let this pass, and one
+        # that reported it against the container would give the wrong remediation.
+        $script:environmentFileLines = $Lines
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } |
+            Should -Throw -ExpectedMessage "DMS E2E setup mismatch: the environment file declares 4 ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true,*Set USE_API_SCHEMA_PATH=true in the environment file*"
+    }
+
+    It "reports the file-side failure when the environment file declares packages and <Label> API_SCHEMA_PATH" -ForEach @(
+        @{ Label = "omits"; Lines = @("USE_API_SCHEMA_PATH=true") }
+        @{ Label = "blanks"; Lines = @("USE_API_SCHEMA_PATH=true", "API_SCHEMA_PATH=") }
+        @{ Label = "whitespaces"; Lines = @("USE_API_SCHEMA_PATH=true", 'API_SCHEMA_PATH="   "') }
+    ) {
+        # The other file-only fallback. An undeclared, blank, or whitespace API_SCHEMA_PATH resolves to
+        # the empty string, and the file-side branch must be reached BEFORE the container's own blank
+        # path branch: the container's path is populated here, so a gate that only noticed a blank
+        # CONTAINER path would pass this file, and one that answered a missing file value with the
+        # container remediation would send a developer to tear the stack down over a value the file
+        # never declared.
+        $script:environmentFileLines = $Lines
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } |
+            Should -Throw -ExpectedMessage "DMS E2E setup mismatch: the environment file declares 4 ApiSchema package(s) but no API_SCHEMA_PATH,*Set API_SCHEMA_PATH in the environment file*"
+    }
+
     It "compares against the environment file's API_SCHEMA_PATH, not a hardcoded default" {
         # Both sides move together: a container matching a non-default environment-file path must pass.
         $script:environmentFileLines = @(
@@ -1728,18 +1882,10 @@ Describe "Both E2E setup wrappers verify the started container against the envir
                 [Parameter(Mandatory)] [string] $CommandName
             )
 
-            $guardCall = @(Get-ScriptCommandInvocation `
-                    -ScriptPath $ScriptPath `
-                    -CommandName "Invoke-WithDmsEnvironmentFileSchemaAuthority") |
-                Select-Object -First 1
-
-            $actionExtent = (@($guardCall.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]
-                },
-                $true
-            )) | Select-Object -First 1).Extent
+            # ANY guard block, not the first one. Each phase is guarded separately, so the verification
+            # sits in its own guard after the DMS-only start; a check bound to the first guard call
+            # would report the correctly placed verification as unguarded.
+            $actionExtent = @(Get-SchemaGuardActionExtent -ScriptPath $ScriptPath)
 
             $calls = @(Get-ScriptCommandInvocation -ScriptPath $ScriptPath -CommandName $CommandName)
 
@@ -1747,7 +1893,9 @@ Describe "Both E2E setup wrappers verify the started container against the envir
                 throw "Expected exactly one '$CommandName' invocation in '$ScriptPath'; found $($calls.Count)."
             }
 
-            return ($calls[0].Extent.StartOffset -ge $actionExtent.StartOffset -and $calls[0].Extent.EndOffset -le $actionExtent.EndOffset)
+            return @($actionExtent | Where-Object {
+                    $calls[0].Extent.StartOffset -ge $_.StartOffset -and $calls[0].Extent.EndOffset -le $_.EndOffset
+                }).Count -gt 0
         }
 
         function Get-FunctionCommandName {
@@ -1842,7 +1990,10 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $invoked | Should -Not -Contain "Get-ComposeResolvedEnvValue"
         $invoked | Should -Not -Contain "Get-EnvValue"
         $invoked | Should -Not -Contain "Resolve-ComposeEnvRawValue"
-        $script:schemaEnvironmentModuleSource | Should -Match '-Name "USE_API_SCHEMA_PATH" `\r?\n\s*-DefaultValue "false"'
+        # What each name FALLS BACK TO when the file does not declare it is asserted behaviorally,
+        # against real environment-file fixtures, in the Assert-DmsContainerSchemaEnvironment block
+        # above - not as a source pattern over the -DefaultValue arguments, which pinned the call's
+        # line wrapping and said nothing about the resulting verdict.
     }
 
     It "reads the frozen declaration rather than the ambient-precedence Effective map" {

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -318,7 +318,6 @@ Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment fil
 
     BeforeAll {
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
-        $script:buildScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../build-dms.ps1"))
         $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority"
         . ([scriptblock]::Create($script:guardFunctionText))
 
@@ -448,35 +447,38 @@ Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment fil
         [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES") | Should -Be ""
     }
 
-    It "removes the variables through this guard for build-dms.ps1's -Enabled wrapper, and not for a bare call" {
-        # build-dms.ps1 keeps its own -Enabled wrapper - several call sites gate the removal on a switch
-        # or on the E2E settings object - and delegates only the enabled body here, so the
-        # removal-and-restore sequence exists in one place instead of two that drift.
+    It "guards a call that omits -Enabled and passes through one made with -Enabled:`$false" {
+        # The gate build-dms.ps1 needs - several of its call sites gate the removal on a caller switch
+        # or on the E2E settings object, and their phases must run WITHOUT it - is a PARAMETER of this
+        # guard rather than a wrapper around it. build-dms.ps1 used to carry that wrapper, and its name
+        # was one more name in the scope chain of the setup wrappers it invokes in-process.
         #
-        # Executed, not pattern-matched. A delegation that forwards no -Action, or an inverted switch
-        # test, reads correctly in source and still leaves every gated compose call running with the
-        # ambient variables present, which is the whole defect the wrapper exists to prevent.
-        . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:buildScriptPath -FunctionName "Invoke-WithEnvironmentFileSchemaSettings")))
-
+        # Both directions matter and both are executed, not pattern-matched. A default that came out
+        # false would leave every unparameterized caller - which is both E2E setup wrappers - running
+        # its Compose phases with the ambient variables present, and an inverted test would do the same
+        # to the gated build-script call sites; either reads correctly in source.
         foreach ($name in $script:schemaVariables) {
             [System.Environment]::SetEnvironmentVariable($name, "ambient-$name")
         }
 
-        $script:observedWhenEnabled = $null
-        Invoke-WithEnvironmentFileSchemaSettings -Enabled -Action {
-            $script:observedWhenEnabled = Get-SchemaVariableState
+        $script:observedWhenDefault = $null
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
+            $script:observedWhenDefault = Get-SchemaVariableState
         }
 
-        $script:observedWhenBare = $null
-        Invoke-WithEnvironmentFileSchemaSettings -Action {
-            $script:observedWhenBare = Get-SchemaVariableState
+        $script:observedWhenDisabled = $null
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Enabled:$false -Action {
+            $script:observedWhenDisabled = Get-SchemaVariableState
         }
+
+        # A disabled call still RUNS the action: it is a pass-through, not a skip.
+        $script:observedWhenDisabled | Should -Not -BeNullOrEmpty -Because "-Enabled:`$false must still invoke the action"
 
         foreach ($name in $script:schemaVariables) {
-            $script:observedWhenEnabled[$name].Exists |
-                Should -BeFalse -Because "-Enabled must reach this module's guard, which removes $name"
-            $script:observedWhenBare[$name].Value |
-                Should -Be "ambient-$name" -Because "a bare call is a pass-through, so it must not remove $name"
+            $script:observedWhenDefault[$name].Exists |
+                Should -BeFalse -Because "a call that omits -Enabled must guard, which removes $name"
+            $script:observedWhenDisabled[$name].Value |
+                Should -Be "ambient-$name" -Because "-Enabled:`$false must be a pass-through, so it must not remove $name"
             [System.Environment]::GetEnvironmentVariable($name) |
                 Should -Be "ambient-$name" -Because "the caller's $name must be restored either way"
         }
@@ -844,13 +846,17 @@ Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         @($invocations | Where-Object { -not $_.InsideGuard }) | Should -BeNullOrEmpty
     }
 
-    It "gives the shared module's guard a name build-dms.ps1 does not also define" {
+    It "defines no function in build-dms.ps1 that shadows one of the module's exports" {
         # THE REGRESSION FOR THE IN-PROCESS BINDING DEFECT. build-dms.ps1 InstanceE2ETest invokes the
         # Instance Management wrapper with '& $instanceSetupScript', so the wrapper's scope is a CHILD of
         # build-dms.ps1's script scope. Command lookup walks that scope chain before it reaches the
         # session state this module's exports live in, so any name build-dms.ps1 also defines binds the
-        # BUILD SCRIPT's function - and its schema helper is a pass-through when -Enabled is unset, which
-        # a bare call leaves so. The guarded phases then ran with SCHEMA_PACKAGES still present.
+        # BUILD SCRIPT's function rather than the export the wrapper meant to call.
+        #
+        # build-dms.ps1 no longer defines a same-purpose helper at all - it imports this module and
+        # calls the guard directly, passing -Enabled where its call sites gate the removal - so there is
+        # nothing to collide today. This holds that property: a helper reintroduced here under an
+        # exported name silently rebinds the wrappers' calls.
         #
         # Asserted over the whole export surface rather than the one guard: every name this module
         # exports is reachable from a wrapper the build script invokes in-process, so every one of them
@@ -888,13 +894,12 @@ Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         $collidingName | Should -BeNullOrEmpty -Because "build-dms.ps1 invokes a setup wrapper in-process, so a name it also defines shadows the module export the wrapper means to call"
     }
 
-    It "calls the module's guard in the <Name> wrapper and never build-dms.ps1's same-purpose helper" -ForEach @(
+    It "reaches the guard by its exported name in the <Name> wrapper" -ForEach @(
         @{ Name = "DataManagementService E2E" }
         @{ Name = "InstanceManagement E2E" }
     ) {
-        # Over the AST, not the text: both wrappers CARRY a comment naming build-dms.ps1's helper in
-        # order to explain why they must not call it, and a text search cannot tell a prohibition from a
-        # call.
+        # Over the AST, not the text: both wrappers name commands in comments in order to explain what
+        # they must not do, and a text search cannot tell a prohibition from a call.
         $parseErrors = $null
         $tokens = $null
         $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:wrapperScripts[$Name], [ref]$tokens, [ref]$parseErrors)
@@ -908,7 +913,6 @@ Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         ) | ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
 
         $invokedName | Should -Contain "Invoke-WithDmsEnvironmentFileSchemaAuthority"
-        $invokedName | Should -Not -Contain "Invoke-WithEnvironmentFileSchemaSettings"
     }
 }
 
@@ -1958,8 +1962,8 @@ Describe "Both E2E setup wrappers verify the started container against the envir
 
         # Imported, and without -Force: -Force removes a module session-wide before re-importing it,
         # while a plain import reuses an already-loaded instance - which is what build-dms.ps1 loads for
-        # its own -Enabled wrapper before invoking a setup wrapper in-process. The same rule the module
-        # applies to its own nested imports.
+        # its own guarded call sites before invoking a setup wrapper in-process. The same rule the
+        # module applies to its own nested imports.
         $source | Should -Match "Import-Module \./dms-schema-environment\.psm1(?! -Force)"
         $source | Should -Not -Match "Import-Module \./dms-schema-environment\.psm1 -Force"
         $source | Should -Not -Match "function Assert-DmsContainerSchemaEnvironment"
@@ -2409,5 +2413,178 @@ Describe "The container schema gate accepts the repository's own tracked environ
         )
 
         $duplicatedGateKeys | Should -BeNullOrEmpty -Because "the file-only reader takes the first SCHEMA_PACKAGES declaration while Compose passes the last into the container, so a repeated gate key leaves the gate's two sides depending on which declaration each reader took"
+    }
+}
+
+Describe "The guard removes exactly the names local-dms.yml resolves for the DMS schema surface (DMS-1300)" {
+    # The guard's variable list and the compose file's ${VAR:-default} references are two halves of one
+    # contract, and nothing in this suite held them together. The guard removes names so Compose has to
+    # fall back to the --env-file; a name local-dms.yml resolves for one of the three DMS schema
+    # settings but the guard does not remove is resolved ambient-first again, which is the whole defect.
+    # A rename on either side, or a fourth schema setting added to the compose file, would leave the
+    # guard silently short while every behavioral test above still passed - they arrange the names the
+    # guard already knows.
+    #
+    # Read with a narrow reader rather than a YAML dependency: only the dms service's environment block
+    # is parsed, and only the three keys below are looked up in it. Both sides are also asserted
+    # non-empty, so neither a compose-file restructure that the reader cannot follow nor a guard whose
+    # list stops being a literal can turn this into an empty-equals-empty pass.
+
+    BeforeAll {
+        $script:composeFilePath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../local-dms.yml"))
+        $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+
+        # The compose keys the DMS container's schema surface is delivered through: the two
+        # AppSettings__* names run.sh and DMS read, and SCHEMA_PACKAGES, which run.sh downloads from.
+        $script:schemaComposeKey = @(
+            "AppSettings__UseApiSchemaPath",
+            "AppSettings__ApiSchemaPath",
+            "SCHEMA_PACKAGES"
+        )
+
+        function Get-ComposeServiceEnvironmentEntry {
+            <#
+            .SYNOPSIS
+            Returns one compose service's 'environment:' mapping as an ordered key/value map of the
+            VERBATIM value text, so a caller can read the ${VAR:-default} references a key resolves.
+            .DESCRIPTION
+            Scoped to this file's one question rather than general: the repository's compose files are
+            two-space-indented block mappings with an inline 'environment:' map, so the block is located
+            by indentation depth and left the moment the indentation returns to the service's own level.
+            Any other shape - a list-form environment block, a different indent width, a renamed service
+            - produces no entries, which the caller turns into a failure rather than a vacuous pass.
+            #>
+            param(
+                [Parameter(Mandatory)] [string] $ComposeFilePath,
+                [Parameter(Mandatory)] [string] $ServiceName
+            )
+
+            $entries = [ordered]@{}
+            $inServices = $false
+            $inService = $false
+            $inEnvironment = $false
+
+            foreach ($line in (Get-Content -LiteralPath $ComposeFilePath)) {
+                # Blank lines and whole-line comments carry no structure, and a comment can be indented
+                # to any depth, so neither may move the state machine.
+                if ($line -match '^\s*(#.*)?$') {
+                    continue
+                }
+
+                if ($line -match '^\S') {
+                    $inServices = $line -match '^services:\s*$'
+                    $inService = $false
+                    $inEnvironment = $false
+                    continue
+                }
+
+                if ($inServices -and $line -match '^  (?<name>[^\s:]+):\s*$') {
+                    # Ordinal: a compose service name is case-sensitive.
+                    $inService = [string]::Equals($Matches["name"], $ServiceName, [System.StringComparison]::Ordinal)
+                    $inEnvironment = $false
+                    continue
+                }
+
+                if ($inService -and $line -match '^    (?<key>[^\s:]+):') {
+                    # Any other key at the service's own depth ends the environment block.
+                    $inEnvironment = $Matches["key"] -ceq "environment"
+                    continue
+                }
+
+                if ($inEnvironment -and $line -match '^      (?<key>[^\s:]+):[ \t]*(?<value>.*)$') {
+                    $entries[$Matches["key"]] = $Matches["value"]
+                }
+            }
+
+            return $entries
+        }
+
+        function Get-ComposeInterpolatedName {
+            <#
+            .SYNOPSIS
+            Returns every environment-variable name a compose value interpolates, in order.
+            .DESCRIPTION
+            Both '${VAR}' and '${VAR:-default}' - the name runs to the first character that cannot be
+            part of one, which is where a ':-' default or the closing brace begins.
+            #>
+            param(
+                [Parameter(Mandatory)] [AllowEmptyString()] [string] $Value
+            )
+
+            return @(
+                [regex]::Matches($Value, '\$\{(?<name>[A-Za-z_][A-Za-z0-9_]*)') |
+                    ForEach-Object { $_.Groups["name"].Value }
+            )
+        }
+
+        function Get-SchemaGuardVariableName {
+            <#
+            .SYNOPSIS
+            Returns the names the guard removes, read as the string literals of its
+            $schemaEnvironmentVariableNames assignment.
+            .DESCRIPTION
+            Over the AST rather than by executing the guard, so the list is read even though it is a
+            local variable of the function - and so this test states the guard's own list rather than
+            re-deriving it from the observable behavior the other blocks already cover.
+            #>
+            param(
+                [Parameter(Mandatory)] [string] $ModulePath
+            )
+
+            $guardAst = [scriptblock]::Create(
+                (Get-ScriptFunctionText -ScriptPath $ModulePath -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority")
+            ).Ast
+
+            $assignment = @($guardAst.FindAll(
+                    {
+                        param($node)
+                        $node -is [System.Management.Automation.Language.AssignmentStatementAst] -and
+                        $node.Left -is [System.Management.Automation.Language.VariableExpressionAst] -and
+                        $node.Left.VariablePath.UserPath -eq "schemaEnvironmentVariableNames"
+                    },
+                    $true
+                )) | Select-Object -First 1
+
+            if ($null -eq $assignment) {
+                throw "The guard in '$ModulePath' no longer assigns `$schemaEnvironmentVariableNames, so the names it removes cannot be read."
+            }
+
+            return @(
+                $assignment.Right.FindAll(
+                    {
+                        param($node)
+                        $node -is [System.Management.Automation.Language.StringConstantExpressionAst]
+                    },
+                    $true
+                ) | ForEach-Object { $_.Value }
+            )
+        }
+    }
+
+    It "names the same set local-dms.yml resolves for the dms service's schema settings" {
+        $dmsEnvironment = Get-ComposeServiceEnvironmentEntry -ComposeFilePath $script:composeFilePath -ServiceName "dms"
+
+        $dmsEnvironment.Count |
+            Should -BeGreaterThan 0 -Because "the reader must have found the dms service's environment block in local-dms.yml"
+
+        $composeReferencedName = @(
+            foreach ($key in $script:schemaComposeKey) {
+                $dmsEnvironment.Contains($key) |
+                    Should -BeTrue -Because "local-dms.yml's dms service must still deliver $key, which is what the gate reads off the container"
+
+                $referenced = @(Get-ComposeInterpolatedName -Value ([string]$dmsEnvironment[$key]))
+                $referenced.Count |
+                    Should -BeGreaterThan 0 -Because "$key must resolve from an environment variable, which is what makes the guard's removal decide its value"
+
+                $referenced
+            }
+        ) | Select-Object -Unique
+
+        $guardVariableName = @(Get-SchemaGuardVariableName -ModulePath $script:schemaEnvironmentModule)
+
+        # Set equality, sorted Ordinal so the comparison cannot vary with the host's culture, and
+        # -BeExactly because a dotenv name is case-sensitive on the Linux runtime path these resolve on.
+        @($guardVariableName | Sort-Object -CaseSensitive) |
+            Should -BeExactly @($composeReferencedName | Sort-Object -CaseSensitive) -Because "the guard must remove exactly the names local-dms.yml resolves for the DMS schema surface: one it misses is resolved ambient-first again, and one it removes that compose does not read is a name it clears for no reason"
     }
 }

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -19,32 +19,48 @@
 
 param()
 
-Describe "Invoke-WithE2ETestProcessContext restores prior environment state exactly (DMS-1284)" {
-    BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
+# Defined once here, in the file's root BeforeAll, so every Describe below extracts functions the same
+# way. Seven identical copies used to live in seven per-Describe BeforeAll blocks, which is exactly the
+# kind of duplication that drifts. A plain top-level function definition would not work: Pester runs the
+# file body during discovery only, so the run phase would not see it.
+BeforeAll {
+    function Get-ScriptFunctionText {
+        <#
+        .SYNOPSIS
+        Returns the source text of one function definition from a script or module, so a test can
+        dot-source just that function without executing the file's top-level body.
+        #>
+        param(
+            [Parameter(Mandatory)] [string] $ScriptPath,
+            [Parameter(Mandatory)] [string] $FunctionName
+        )
 
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
+        $parseErrors = $null
+        $tokens = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
 
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
+        if ($parseErrors.Count -gt 0) {
+            throw "'$ScriptPath' has $($parseErrors.Count) parse error(s)."
         }
 
+        $functionAst = $ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+            },
+            $true
+        ) | Select-Object -First 1
+
+        if ($null -eq $functionAst) {
+            throw "Function '$FunctionName' was not found in '$ScriptPath'."
+        }
+
+        return $functionAst.Extent.Text
+    }
+}
+
+Describe "Invoke-WithE2ETestProcessContext restores prior environment state exactly (DMS-1284)" {
+    BeforeAll {
         $buildScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../build-dms.ps1"))
         . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $buildScript -FunctionName "Invoke-WithE2ETestProcessContext")))
 
@@ -132,30 +148,6 @@ Describe "Invoke-WithE2ETestProcessContext restores prior environment state exac
 
 Describe "Get-DirectSetupTeardownCommand carries the engine and resolved environment file (DMS-1284)" {
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         $setupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
         . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $setupScript -FunctionName "Get-DirectSetupTeardownCommand")))
     }
@@ -216,30 +208,6 @@ Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment fil
     }
 
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
         $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority"
         . ([scriptblock]::Create($script:guardFunctionText))
@@ -691,30 +659,6 @@ Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container dis
     # into a setup-time failure. Pure function, so no Docker is involved.
 
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         # The verifier lives in the module both E2E setup wrappers import, not in either wrapper.
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
 
@@ -1094,30 +1038,6 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
     # expectations, the verdict, and the throw is a real result rather than a source assertion. An
     # inverted 'if ($verdict.ShouldFail)' branch fails both cases below.
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
 
         foreach ($functionName in @(
@@ -1471,30 +1391,6 @@ Describe "Get-DmsContainerEnvironment reads the container environment and fails 
     # Executes the reader against a stubbed 'docker', so its parsing rules and its fail-closed behavior
     # are real results rather than a source pattern, and no Docker daemon is required.
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
         . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Get-DmsContainerEnvironment")))
 
@@ -1840,30 +1736,6 @@ Describe "The container schema gate accepts the repository's own tracked environ
     )
 
     BeforeAll {
-        function Get-ScriptFunctionText {
-            param(
-                [Parameter(Mandatory)] [string] $ScriptPath,
-                [Parameter(Mandatory)] [string] $FunctionName
-            )
-
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-            $functionAst = $ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
-                },
-                $true
-            ) | Select-Object -First 1
-
-            if ($null -eq $functionAst) {
-                throw "Function '$FunctionName' was not found in '$ScriptPath'."
-            }
-
-            return $functionAst.Extent.Text
-        }
-
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
 
         foreach ($functionName in @(

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -12,6 +12,10 @@
 #   and whitespace-valued environment variables).
 # - Get-DirectSetupTeardownCommand (standard setup-local-dms.ps1) must print a teardown command carrying
 #   the selected engine and the resolved environment-file path, safely single-quoted.
+#
+# DMS-1300 adds the same treatment for Invoke-WithEnvironmentFileSchemaSettings (both E2E setup
+# wrappers), which must make the selected environment file the sole authority for the schema package
+# surface of the Docker phases, and must round-trip the caller's exact prior environment.
 
 param()
 
@@ -183,5 +187,328 @@ Describe "setup-local-dms.ps1 wires the resolved environment file into teardown 
             Should -Match 'Get-DirectSetupTeardownCommand -DatabaseEngine \$DatabaseEngine -EnvironmentFile \$resolvedEnvironmentFile'
         $script:setupSource |
             Should -Not -Match 'Get-DirectSetupTeardownCommand[^\r\n]*-EnvironmentFile \$baseEnvironmentFile'
+    }
+}
+
+Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the direct DMS E2E setup phases (DMS-1300)" {
+    # Docker Compose gives process environment variables precedence over --env-file entries, and
+    # local-dms.yml resolves USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES with
+    # ${VAR:-default} fallbacks. Because ':-' substitutes the default for an empty value as well as an
+    # unset one, an ambient blank value silently wins over the selected environment file: DMS starts on
+    # the image-baked schemas while provisioning already stamped the file's full package surface, and
+    # every data-plane request fails with an EffectiveSchemaHash mismatch. These tests execute the
+    # guard rather than pattern-matching it, so the removal and the exact round-trip are real results.
+
+    # Discovery-phase table: every guarded variable crossed with every prior-state shape that has to
+    # round-trip. Built here rather than in BeforeAll because -ForEach is bound during discovery.
+    $restoreCases = foreach ($variableName in @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")) {
+        @{ VariableName = $variableName; Label = "absent"; PriorValue = $null }
+        @{ VariableName = $variableName; Label = "empty"; PriorValue = "" }
+        @{ VariableName = $variableName; Label = "whitespace"; PriorValue = "   " }
+        @{ VariableName = $variableName; Label = "false"; PriorValue = "false" }
+        @{ VariableName = $variableName; Label = "valued"; PriorValue = "prior-$variableName" }
+    }
+
+    BeforeAll {
+        function Get-ScriptFunctionText {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+            $functionAst = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return $functionAst.Extent.Text
+        }
+
+        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
+        . ([scriptblock]::Create($script:guardFunctionText))
+
+        $script:schemaVariables = @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")
+
+        # The running pwsh, resolved from the process rather than from PATH, so the child-process test
+        # below needs neither a PATH lookup nor a skip guard that could hide it in CI.
+        $script:pwshPath = (Get-Process -Id $PID).Path
+
+        function Get-SchemaVariableState {
+            $state = @{}
+            foreach ($name in @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")) {
+                $state[$name] = [pscustomobject]@{
+                    Exists = [bool](Test-Path -LiteralPath "Env:$name")
+                    Value  = [System.Environment]::GetEnvironmentVariable($name)
+                }
+            }
+
+            return $state
+        }
+    }
+
+    BeforeEach {
+        foreach ($name in $script:schemaVariables) {
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+    }
+
+    AfterEach {
+        foreach ($name in $script:schemaVariables) {
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "removes every schema variable for the guarded phases when the ambient state is <Label>" -ForEach @(
+        @{ Label = "absent"; Ambient = @{} }
+        @{ Label = "the compose fallback shape (false and blank)"; Ambient = @{ USE_API_SCHEMA_PATH = "false"; API_SCHEMA_PATH = ""; SCHEMA_PACKAGES = "" } }
+        @{ Label = "all empty"; Ambient = @{ USE_API_SCHEMA_PATH = ""; API_SCHEMA_PATH = ""; SCHEMA_PACKAGES = "" } }
+        @{ Label = "all whitespace"; Ambient = @{ USE_API_SCHEMA_PATH = "   "; API_SCHEMA_PATH = "   "; SCHEMA_PACKAGES = "   " } }
+        @{ Label = "valued but wrong"; Ambient = @{ USE_API_SCHEMA_PATH = "true"; API_SCHEMA_PATH = "/ambient/ApiSchema"; SCHEMA_PACKAGES = '[{"name":"AmbientPackage"}]' } }
+    ) {
+        foreach ($entry in $Ambient.GetEnumerator()) {
+            [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value)
+        }
+
+        $script:observedInsideAction = $null
+        Invoke-WithEnvironmentFileSchemaSettings -Action {
+            $script:observedInsideAction = Get-SchemaVariableState
+        }
+
+        # Removed, not blanked. A present-but-blank value satisfies ${VAR:-default}, so leaving any of
+        # these present would reproduce the defect even though the guard appeared to run.
+        foreach ($name in $script:schemaVariables) {
+            $script:observedInsideAction[$name].Exists |
+                Should -BeFalse -Because "$name must be absent for the guarded phases so Docker Compose resolves it from --env-file"
+        }
+    }
+
+    It "round-trips <VariableName> from its prior <Label> state on the success path" -ForEach $restoreCases {
+        if ($null -ne $PriorValue) {
+            [System.Environment]::SetEnvironmentVariable($VariableName, $PriorValue)
+        }
+
+        # The arranged state is captured, not assumed. Whether a given runtime can hold a
+        # present-but-empty environment variable is exactly the platform-dependent behavior this guard
+        # must not depend on, so the property under test is that the guard restores whatever it found.
+        $arranged = Get-SchemaVariableState
+
+        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+
+        $restored = Get-SchemaVariableState
+        foreach ($name in $script:schemaVariables) {
+            $restored[$name].Exists | Should -Be $arranged[$name].Exists -Because "$name presence must round-trip"
+            $restored[$name].Value | Should -Be $arranged[$name].Value -Because "$name value must round-trip verbatim"
+        }
+    }
+
+    It "round-trips <VariableName> from its prior <Label> state when a guarded phase throws" -ForEach $restoreCases {
+        if ($null -ne $PriorValue) {
+            [System.Environment]::SetEnvironmentVariable($VariableName, $PriorValue)
+        }
+
+        $arranged = Get-SchemaVariableState
+
+        { Invoke-WithEnvironmentFileSchemaSettings -Action { throw "phase failed" } } |
+            Should -Throw -ExpectedMessage "phase failed"
+
+        $restored = Get-SchemaVariableState
+        foreach ($name in $script:schemaVariables) {
+            $restored[$name].Exists | Should -Be $arranged[$name].Exists -Because "$name presence must round-trip after a failure"
+            $restored[$name].Value | Should -Be $arranged[$name].Value -Because "$name value must round-trip verbatim after a failure"
+        }
+    }
+
+    It "restores a mixed absent, empty, whitespace, and valued starting state per variable" {
+        Remove-Item -LiteralPath "Env:USE_API_SCHEMA_PATH" -ErrorAction SilentlyContinue
+        [System.Environment]::SetEnvironmentVariable("API_SCHEMA_PATH", "   ")
+        [System.Environment]::SetEnvironmentVariable("SCHEMA_PACKAGES", "prior-packages")
+
+        $arranged = Get-SchemaVariableState
+
+        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+
+        $restored = Get-SchemaVariableState
+        $restored["USE_API_SCHEMA_PATH"].Exists | Should -BeFalse
+        $restored["API_SCHEMA_PATH"].Value | Should -Be "   "
+        $restored["SCHEMA_PACKAGES"].Value | Should -Be "prior-packages"
+        foreach ($name in $script:schemaVariables) {
+            $restored[$name].Exists | Should -Be $arranged[$name].Exists
+            $restored[$name].Value | Should -Be $arranged[$name].Value
+        }
+    }
+
+    It "keeps a present-but-empty variable present rather than collapsing it to absent" {
+        # The distinction the previous assignment-based clear/restore could not express. Self-gated:
+        # if this runtime cannot represent a present-but-empty environment variable at all, there is
+        # no distinction to preserve and the case is recorded as skipped rather than failed.
+        [System.Environment]::SetEnvironmentVariable("SCHEMA_PACKAGES", "")
+        if (-not (Test-Path -LiteralPath "Env:SCHEMA_PACKAGES")) {
+            Set-ItResult -Skipped -Because "this runtime cannot hold a present-but-empty environment variable"
+            return
+        }
+
+        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+
+        (Test-Path -LiteralPath "Env:SCHEMA_PACKAGES") | Should -BeTrue
+        [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES") | Should -Be ""
+    }
+
+    It "restores the prior state when a guarded phase calls exit" {
+        # The wrapper's phase failure paths use 'exit $LASTEXITCODE', so the guard has to survive an
+        # exit as well as a throw. This runs in a child pwsh because an in-process exit would terminate
+        # the Pester run: the child's own outer finally runs after the guard's finally, so it observes
+        # the restored state, and the recorded exit code proves the phase's status still propagates.
+        $observationPath = Join-Path $TestDrive "schema-env-exit-observations.txt"
+        $childScriptPath = Join-Path $TestDrive "schema-env-exit-child.ps1"
+        $childScript = @"
+$($script:guardFunctionText)
+
+`$env:USE_API_SCHEMA_PATH = 'prior-use'
+Remove-Item -LiteralPath 'Env:API_SCHEMA_PATH' -ErrorAction SilentlyContinue
+`$env:SCHEMA_PACKAGES = 'prior-packages'
+
+try {
+    Invoke-WithEnvironmentFileSchemaSettings -Action {
+        'inside:' + [string](Test-Path -LiteralPath 'Env:USE_API_SCHEMA_PATH') +
+            ',' + [string](Test-Path -LiteralPath 'Env:API_SCHEMA_PATH') +
+            ',' + [string](Test-Path -LiteralPath 'Env:SCHEMA_PACKAGES') |
+            Add-Content -LiteralPath '$observationPath'
+        exit 42
+    }
+}
+finally {
+    'after:' + [string](Test-Path -LiteralPath 'Env:USE_API_SCHEMA_PATH') +
+        '=' + [string]`$env:USE_API_SCHEMA_PATH +
+        ',' + [string](Test-Path -LiteralPath 'Env:API_SCHEMA_PATH') +
+        ',' + [string](Test-Path -LiteralPath 'Env:SCHEMA_PACKAGES') +
+        '=' + [string]`$env:SCHEMA_PACKAGES |
+        Add-Content -LiteralPath '$observationPath'
+}
+"@
+        Set-Content -LiteralPath $childScriptPath -Value $childScript -Encoding utf8
+
+        & $script:pwshPath -NoProfile -File $childScriptPath
+        $childExitCode = $LASTEXITCODE
+
+        $childExitCode | Should -Be 42 -Because "the guard must not swallow the phase's exit code"
+
+        $observations = @(Get-Content -LiteralPath $observationPath)
+        $observations[0] | Should -Be "inside:False,False,False"
+        $observations[1] | Should -Be "after:True=prior-use,False,True=prior-packages"
+    }
+}
+
+Describe "Both E2E setup wrappers run every Docker phase inside the schema-settings guard (DMS-1300)" {
+    BeforeAll {
+        function Get-GuardedPhaseInvocation {
+            <#
+            .SYNOPSIS
+            Returns one record per phase-script invocation in a setup wrapper, with whether the
+            invocation is lexically inside the wrapper's single Invoke-WithEnvironmentFileSchemaSettings
+            -Action block. Uses the AST rather than a text pattern, so the assertion is about the
+            structure production actually has, and is not defeated by reformatting or reindentation.
+            #>
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+
+            if ($parseErrors.Count -gt 0) {
+                throw "'$ScriptPath' has $($parseErrors.Count) parse error(s)."
+            }
+
+            $guardCalls = @($ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq "Invoke-WithEnvironmentFileSchemaSettings"
+                },
+                $true
+            ))
+
+            if ($guardCalls.Count -ne 1) {
+                throw "Expected exactly one Invoke-WithEnvironmentFileSchemaSettings invocation in '$ScriptPath'; found $($guardCalls.Count)."
+            }
+
+            $actionBlocks = @($guardCalls[0].FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]
+                },
+                $true
+            ))
+
+            if ($actionBlocks.Count -ne 1) {
+                throw "Expected exactly one -Action script block on the guard invocation in '$ScriptPath'; found $($actionBlocks.Count)."
+            }
+
+            $actionExtent = $actionBlocks[0].Extent
+
+            return @($ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst]
+                },
+                $true
+            ) | ForEach-Object {
+                # Bareword script invocations report their own name; a script dispatched through a
+                # variable (the Instance Management provision call) reports none, so fall back to the
+                # variable name so that form is covered too.
+                $name = $_.GetCommandName()
+                if ($null -eq $name -and $_.CommandElements[0] -is [System.Management.Automation.Language.VariableExpressionAst]) {
+                    $name = '$' + $_.CommandElements[0].VariablePath.UserPath
+                }
+
+                if ($name -and ($name -like "*.ps1" -or $name -like '$*Script')) {
+                    [pscustomobject]@{
+                        Name        = $name
+                        Line        = $_.Extent.StartLineNumber
+                        InsideGuard = ($_.Extent.StartOffset -ge $actionExtent.StartOffset -and $_.Extent.EndOffset -le $actionExtent.EndOffset)
+                    }
+                }
+            })
+        }
+
+        $script:wrapperScripts = [ordered]@{
+            "DataManagementService E2E" = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+            "InstanceManagement E2E"    = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1"))
+        }
+    }
+
+    It "runs the direct DMS E2E phase sequence inside the guard, in order" {
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $script:wrapperScripts["DataManagementService E2E"])
+
+        @($invocations | ForEach-Object { $_.Name }) | Should -Be @(
+            "./start-local-dms.ps1",
+            "./configure-local-data-store.ps1",
+            "./provision-e2e-database.ps1",
+            "./start-local-dms.ps1"
+        )
+        @($invocations | Where-Object { -not $_.InsideGuard }) | Should -BeNullOrEmpty
+    }
+
+    It "leaves no phase invocation outside the guard in the <Name> wrapper" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $script:wrapperScripts[$Name])
+
+        $invocations.Count | Should -BeGreaterThan 0 -Because "the wrapper must invoke phase scripts"
+        @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { "$($_.Name) (line $($_.Line))" }) |
+            Should -BeNullOrEmpty -Because "a Compose-invoking phase outside the guard would resolve the schema variables from the ambient process again"
     }
 }

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -512,3 +512,330 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             Should -BeNullOrEmpty -Because "a Compose-invoking phase outside the guard would resolve the schema variables from the ambient process again"
     }
 }
+
+Describe "Get-DmsSchemaEnvironmentVerdict fails setup when the DMS container disagrees with the provisioned package surface (DMS-1300)" {
+    # The provisioner reads SCHEMA_PACKAGES from the environment file only, so the E2E database is
+    # always stamped for the file's package surface; DMS receives its settings through Compose, which
+    # resolves them ambient-first. When the two disagree the stack comes up healthy and then fails
+    # every data-plane request with an EffectiveSchemaHash mismatch, so the verdict is what turns that
+    # into a setup-time failure. Pure function, so no Docker is involved.
+
+    BeforeAll {
+        function Get-ScriptFunctionText {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+            $functionAst = $ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            ) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return $functionAst.Extent.Text
+        }
+
+        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+
+        # The verdict delegates classification and counting, so all three come across together.
+        foreach ($functionName in @(
+                "Get-DmsSchemaEnvironmentToken",
+                "Get-DmsContainerSchemaPackageCount",
+                "Get-DmsSchemaEnvironmentVerdict"
+            )) {
+            . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:directSetupScript -FunctionName $functionName)))
+        }
+
+        function Get-ContainerEnvironmentFixture {
+            param(
+                [string] $UseApiSchemaPath = "true",
+                [string] $ApiSchemaPath = "/app/ApiSchema",
+                [int] $PackageCount = 4,
+                [string] $RawSchemaPackages,
+                [switch] $OmitUseApiSchemaPath,
+                [switch] $OmitApiSchemaPath,
+                [switch] $OmitSchemaPackages
+            )
+
+            $containerEnvironment = @{ "AppSettings__Datastore" = "postgresql" }
+
+            if (-not $OmitUseApiSchemaPath) {
+                $containerEnvironment["AppSettings__UseApiSchemaPath"] = $UseApiSchemaPath
+            }
+
+            if (-not $OmitApiSchemaPath) {
+                $containerEnvironment["AppSettings__ApiSchemaPath"] = $ApiSchemaPath
+            }
+
+            if (-not $OmitSchemaPackages) {
+                $containerEnvironment["SCHEMA_PACKAGES"] =
+                    if ($PSBoundParameters.ContainsKey("RawSchemaPackages")) {
+                        $RawSchemaPackages
+                    }
+                    else {
+                        ConvertTo-Json -InputObject @(1..$PackageCount | ForEach-Object { @{ name = "Package$_" } }) -Compress -Depth 5
+                    }
+            }
+
+            return $containerEnvironment
+        }
+    }
+
+    It "passes when the container carries exactly the environment file's package surface" {
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 4) `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeFalse
+        $verdict.Reason | Should -BeNullOrEmpty
+    }
+
+    It "fails on the reported compose-fallback shape, naming AppSettings__UseApiSchemaPath" {
+        # The exact container state DMS-1300 reported: false plus two blanks, which is what
+        # local-dms.yml's ${VAR:-default} produces when the process carries blank schema variables.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -UseApiSchemaPath "false" -ApiSchemaPath "" -RawSchemaPackages "") `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "AppSettings__UseApiSchemaPath is false"
+        $verdict.Reason | Should -Match "4 ApiSchema package"
+        $verdict.Remediation | Should -Match "USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES"
+    }
+
+    It "fails when AppSettings__UseApiSchemaPath is <Label>, reporting a fixed token" -ForEach @(
+        @{ Label = "absent"; Container = @{ OmitUseApiSchemaPath = $true }; ExpectedToken = "<absent>" }
+        @{ Label = "blank"; Container = @{ UseApiSchemaPath = "" }; ExpectedToken = "<blank>" }
+        @{ Label = "whitespace"; Container = @{ UseApiSchemaPath = "   " }; ExpectedToken = "<blank>" }
+        @{ Label = "an unrecognized value"; Container = @{ UseApiSchemaPath = "yes" }; ExpectedToken = "<set>" }
+    ) {
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "AppSettings__UseApiSchemaPath is $([regex]::Escape($ExpectedToken))"
+    }
+
+    It "fails when AppSettings__ApiSchemaPath is <Label>, so declared packages have nowhere to land" -ForEach @(
+        @{ Label = "absent"; Container = @{ OmitApiSchemaPath = $true }; ExpectedToken = "<absent>" }
+        @{ Label = "blank"; Container = @{ ApiSchemaPath = "" }; ExpectedToken = "<blank>" }
+        @{ Label = "whitespace"; Container = @{ ApiSchemaPath = "   " }; ExpectedToken = "<blank>" }
+    ) {
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "AppSettings__ApiSchemaPath is $([regex]::Escape($ExpectedToken))"
+    }
+
+    It "fails when the container's package count differs from the provisioned surface" {
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -PackageCount 2) `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "received 2 ApiSchema package"
+        $verdict.Reason | Should -Match "provisioned for the environment file's 4"
+    }
+
+    It "fails without throwing when the container's SCHEMA_PACKAGES is <Label>" -ForEach @(
+        @{ Label = "absent"; Container = @{ OmitSchemaPackages = $true } }
+        @{ Label = "blank"; Container = @{ RawSchemaPackages = "" } }
+        @{ Label = "whitespace"; Container = @{ RawSchemaPackages = "   " } }
+        @{ Label = "not JSON at all"; Container = @{ RawSchemaPackages = "not-json" } }
+        @{ Label = "a truncated array"; Container = @{ RawSchemaPackages = '[{"name":"Package1"}' } }
+        @{ Label = "a JSON object rather than an array"; Container = @{ RawSchemaPackages = '{"name":"Package1"}' } }
+    ) {
+        $verdict = $null
+        { $script:verdict = Get-DmsSchemaEnvironmentVerdict `
+                -ContainerEnvironment (Get-ContainerEnvironmentFixture @Container) `
+                -ExpectedPackageCount 4 `
+                -EnvironmentFileUsesApiSchemaPath $true } | Should -Not -Throw
+
+        $script:verdict.ShouldFail | Should -BeTrue
+        $script:verdict.Reason | Should -Match "SCHEMA_PACKAGES is absent, blank, or not a JSON array"
+    }
+
+    It "reports a package-bearing environment file that does not enable the ApiSchema path as the inconsistency" {
+        # Not a skip. The provisioner stamps the file's packages regardless of USE_API_SCHEMA_PATH, so
+        # such a file guarantees the mismatch, and the remediation belongs on the file, not the shell.
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -UseApiSchemaPath "false" -ApiSchemaPath "" -RawSchemaPackages "") `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $false
+
+        $verdict.ShouldFail | Should -BeTrue
+        $verdict.Reason | Should -Match "the environment file declares 4 ApiSchema package\(s\) but does not set USE_API_SCHEMA_PATH=true"
+        $verdict.Remediation | Should -Match "Set USE_API_SCHEMA_PATH=true in the environment file"
+    }
+
+    It "refuses a package count below one, because the file-only reader cannot produce one" {
+        # There is no "no packages declared" branch by design: an absent, malformed, or empty
+        # SCHEMA_PACKAGES already fails the provision phase, so it can never reach the gate and be
+        # classified as acceptable. The contract is encoded as parameter validation.
+        { Get-DmsSchemaEnvironmentVerdict `
+                -ContainerEnvironment (Get-ContainerEnvironmentFixture) `
+                -ExpectedPackageCount 0 `
+                -EnvironmentFileUsesApiSchemaPath $true } | Should -Throw
+    }
+
+    It "never echoes the container's raw SCHEMA_PACKAGES value into the failure text" {
+        # The message vocabulary is fixed and derived, so container-supplied text cannot forge log
+        # lines or bloat the failure with a package blob.
+        $rawSchemaPackages = "[{`"name`":`"SENTINEL-DO-NOT-ECHO`"}]`nforged-log-line"
+        $verdict = Get-DmsSchemaEnvironmentVerdict `
+            -ContainerEnvironment (Get-ContainerEnvironmentFixture -RawSchemaPackages $rawSchemaPackages) `
+            -ExpectedPackageCount 4 `
+            -EnvironmentFileUsesApiSchemaPath $true
+
+        $verdict.ShouldFail | Should -BeTrue
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "SENTINEL-DO-NOT-ECHO"
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "forged-log-line"
+        "$($verdict.Reason) $($verdict.Remediation)" | Should -Not -Match "`n"
+    }
+}
+
+Describe "The direct DMS E2E setup wrapper verifies the started container against the environment file only (DMS-1300)" {
+    BeforeAll {
+        $script:directSetupScript = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1"))
+        $script:directSetupSource = Get-Content -LiteralPath $script:directSetupScript -Raw
+
+        function Test-CommandInsideSchemaGuard {
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $CommandName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+
+            $guardCall = @($ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst] -and
+                    $node.GetCommandName() -eq "Invoke-WithEnvironmentFileSchemaSettings"
+                },
+                $true
+            )) | Select-Object -First 1
+
+            $actionExtent = (@($guardCall.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]
+                },
+                $true
+            )) | Select-Object -First 1).Extent
+
+            $calls = @($ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq $CommandName
+                },
+                $true
+            ))
+
+            if ($calls.Count -ne 1) {
+                throw "Expected exactly one '$CommandName' invocation in '$ScriptPath'; found $($calls.Count)."
+            }
+
+            return ($calls[0].Extent.StartOffset -ge $actionExtent.StartOffset -and $calls[0].Extent.EndOffset -le $actionExtent.EndOffset)
+        }
+
+        function Get-FunctionCommandName {
+            <#
+            .SYNOPSIS
+            Returns the distinct command names a named function invokes, from the AST. Comment text and
+            string literals are excluded by construction, so an assertion about what the function CALLS
+            cannot be satisfied or defeated by what it merely mentions.
+            #>
+            param(
+                [Parameter(Mandatory)] [string] $ScriptPath,
+                [Parameter(Mandatory)] [string] $FunctionName
+            )
+
+            $parseErrors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+
+            $functionAst = @($ast.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $FunctionName
+                },
+                $true
+            )) | Select-Object -First 1
+
+            if ($null -eq $functionAst) {
+                throw "Function '$FunctionName' was not found in '$ScriptPath'."
+            }
+
+            return @($functionAst.FindAll(
+                {
+                    param($node)
+                    $node -is [System.Management.Automation.Language.CommandAst]
+                },
+                $true
+            ) | ForEach-Object { $_.GetCommandName() } | Where-Object { $_ } | Select-Object -Unique)
+        }
+    }
+
+    It "runs the container verification inside the schema-settings guard" {
+        # Inside the guard, so the file-only expectation cannot be contaminated by an ambient override
+        # even if a future edit reaches for a Compose-precedence reader.
+        Test-CommandInsideSchemaGuard -ScriptPath $script:directSetupScript -CommandName "Assert-DmsContainerSchemaEnvironment" |
+            Should -BeTrue
+    }
+
+    It "reads both expectations from the environment file, never with Compose precedence" {
+        # Asserted over the commands the function actually invokes, not its text: the function's own
+        # comment names Get-ComposeResolvedEnvValue in order to prohibit it, and a text search cannot
+        # tell a prohibition from a call.
+        #
+        # Get-ComposeResolvedEnvValue resolves ambient-first. Using it for either expectation would let
+        # the very override this gate exists to catch decide what "correct" means, so the gate would
+        # agree with a wrongly-started container and pass.
+        $invoked = @(Get-FunctionCommandName -ScriptPath $script:directSetupScript -FunctionName "Assert-DmsContainerSchemaEnvironment")
+
+        $invoked | Should -Contain "Get-SchemaPackagesFromEnvironmentFile"
+        $invoked | Should -Contain "Get-EnvValue"
+        $invoked | Should -Not -Contain "Get-ComposeResolvedEnvValue"
+        $script:directSetupSource | Should -Match 'Get-EnvValue -EnvValues \$EnvironmentValues -Name "USE_API_SCHEMA_PATH"'
+    }
+
+    It "imports the same file-only package reader the provision phase uses" {
+        $script:directSetupSource | Should -Match "Import-Module \.\./schema-package-utility\.psm1 -Force"
+    }
+
+    It "fails closed when the container cannot be inspected" {
+        $inspectFunction = [regex]::Match(
+            $script:directSetupSource,
+            '(?ms)^function Get-DmsContainerEnvironment \{.*?^\}'
+        ).Value
+
+        $inspectFunction | Should -Match 'if \(\$LASTEXITCODE -ne 0\) \{'
+        $inspectFunction | Should -Match "Unable to inspect Docker container"
+    }
+
+    It "throws rather than warning when the verdict fails" {
+        $script:directSetupSource | Should -Match 'throw "DMS E2E setup mismatch: '
+        $script:directSetupSource | Should -Not -Match 'Write-Warning[^\r\n]*setup mismatch'
+    }
+}

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -57,6 +57,39 @@ BeforeAll {
 
         return $functionAst.Extent.Text
     }
+
+    function Get-ScriptCommandInvocation {
+        <#
+        .SYNOPSIS
+        Returns every invocation of one command name in a script or module, as CommandAst nodes, so an
+        assertion about WHERE a command is called can read the extents production actually has.
+        .DESCRIPTION
+        Over the AST rather than the text, which matters in this file specifically: both setup wrappers
+        deliberately NAME commands they must not call, and a text search cannot tell a prohibition from
+        a call.
+        #>
+        param(
+            [Parameter(Mandatory)] [string] $ScriptPath,
+            [Parameter(Mandatory)] [string] $CommandName
+        )
+
+        $parseErrors = $null
+        $tokens = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
+
+        if ($parseErrors.Count -gt 0) {
+            throw "'$ScriptPath' has $($parseErrors.Count) parse error(s), so '$CommandName' invocations cannot be located."
+        }
+
+        return @($ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst] -and
+                $node.GetCommandName() -eq $CommandName
+            },
+            $true
+        ))
+    }
 }
 
 Describe "Invoke-WithE2ETestProcessContext restores prior environment state exactly (DMS-1284)" {
@@ -209,6 +242,7 @@ Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment fil
 
     BeforeAll {
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+        $script:buildScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../build-dms.ps1"))
         $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority"
         . ([scriptblock]::Create($script:guardFunctionText))
 
@@ -336,6 +370,40 @@ Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment fil
 
         (Test-Path -LiteralPath "Env:SCHEMA_PACKAGES") | Should -BeTrue
         [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES") | Should -Be ""
+    }
+
+    It "removes the variables through this guard for build-dms.ps1's -Enabled wrapper, and not for a bare call" {
+        # build-dms.ps1 keeps its own -Enabled wrapper - several call sites gate the removal on a switch
+        # or on the E2E settings object - and delegates only the enabled body here, so the
+        # removal-and-restore sequence exists in one place instead of two that drift.
+        #
+        # Executed, not pattern-matched. A delegation that forwards no -Action, or an inverted switch
+        # test, reads correctly in source and still leaves every gated compose call running with the
+        # ambient variables present, which is the whole defect the wrapper exists to prevent.
+        . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:buildScriptPath -FunctionName "Invoke-WithEnvironmentFileSchemaSettings")))
+
+        foreach ($name in $script:schemaVariables) {
+            [System.Environment]::SetEnvironmentVariable($name, "ambient-$name")
+        }
+
+        $script:observedWhenEnabled = $null
+        Invoke-WithEnvironmentFileSchemaSettings -Enabled -Action {
+            $script:observedWhenEnabled = Get-SchemaVariableState
+        }
+
+        $script:observedWhenBare = $null
+        Invoke-WithEnvironmentFileSchemaSettings -Action {
+            $script:observedWhenBare = Get-SchemaVariableState
+        }
+
+        foreach ($name in $script:schemaVariables) {
+            $script:observedWhenEnabled[$name].Exists |
+                Should -BeFalse -Because "-Enabled must reach this module's guard, which removes $name"
+            $script:observedWhenBare[$name].Value |
+                Should -Be "ambient-$name" -Because "a bare call is a pass-through, so it must not remove $name"
+            [System.Environment]::GetEnvironmentVariable($name) |
+                Should -Be "ambient-$name" -Because "the caller's $name must be restored either way"
+        }
     }
 
     It "restores the prior state when a guarded phase calls exit" {
@@ -493,6 +561,9 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                     [pscustomobject]@{
                         Name        = $name
                         Line        = $_.Extent.StartLineNumber
+                        # Carried so an assertion can order the phases against another command's
+                        # position, which line numbers alone cannot do for two calls on one line.
+                        EndOffset   = $_.Extent.EndOffset
                         InsideGuard = ($_.Extent.StartOffset -ge $actionExtent.StartOffset -and $_.Extent.EndOffset -le $actionExtent.EndOffset)
                     }
                 }
@@ -526,6 +597,30 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
         $invocations.Count | Should -BeGreaterThan 0 -Because "the wrapper must invoke phase scripts"
         @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { "$($_.Name) (line $($_.Line))" }) |
             Should -BeNullOrEmpty -Because "a Compose-invoking phase outside the guard would resolve the schema variables from the ambient process again"
+    }
+
+    It "verifies the started container after the LAST guarded phase in the <Name> wrapper" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
+        # Inside the guard is not the requirement; inside the guard AND after the DMS-only start is.
+        # The verification inspects a RUNNING container, so a call moved ahead of
+        # './start-local-dms.ps1 -DmsOnly' either inspects whatever the previous run left behind or
+        # fails to find a container at all - and neither outcome says anything about the stack the
+        # scenarios are about to run against. The sibling assertions elsewhere in this file only pin
+        # that the call sits inside the -Action block, which a verifier hoisted to the top of the
+        # guarded sequence still satisfies, so the ordering is pinned here.
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $script:wrapperScripts[$Name])
+        $lastGuardedPhase = @($invocations | Where-Object { $_.InsideGuard } | Sort-Object EndOffset)[-1]
+
+        $verifierCall = @(Get-ScriptCommandInvocation `
+                -ScriptPath $script:wrapperScripts[$Name] `
+                -CommandName "Assert-DmsContainerSchemaEnvironment")
+
+        $verifierCall.Count | Should -Be 1 -Because "the wrapper verifies the started container exactly once"
+        $lastGuardedPhase.Name | Should -Be "./start-local-dms.ps1" -Because "the last guarded phase is the -DmsOnly start whose container the verification reads"
+        $verifierCall[0].Extent.StartOffset |
+            Should -BeGreaterThan $lastGuardedPhase.EndOffset -Because "verifying before the last guarded phase ($($lastGuardedPhase.Name), line $($lastGuardedPhase.Line)) would read a container this run has not started yet"
     }
 
     It "detects a variable-dispatched phase whose variable is not named '...Script'" {
@@ -1495,18 +1590,10 @@ Describe "Both E2E setup wrappers verify the started container against the envir
                 [Parameter(Mandatory)] [string] $CommandName
             )
 
-            $parseErrors = $null
-            $tokens = $null
-            $ast = [System.Management.Automation.Language.Parser]::ParseFile($ScriptPath, [ref]$tokens, [ref]$parseErrors)
-
-            $guardCall = @($ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.CommandAst] -and
-                    $node.GetCommandName() -eq "Invoke-WithDmsEnvironmentFileSchemaAuthority"
-                },
-                $true
-            )) | Select-Object -First 1
+            $guardCall = @(Get-ScriptCommandInvocation `
+                    -ScriptPath $ScriptPath `
+                    -CommandName "Invoke-WithDmsEnvironmentFileSchemaAuthority") |
+                Select-Object -First 1
 
             $actionExtent = (@($guardCall.FindAll(
                 {
@@ -1516,13 +1603,7 @@ Describe "Both E2E setup wrappers verify the started container against the envir
                 $true
             )) | Select-Object -First 1).Extent
 
-            $calls = @($ast.FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.CommandAst] -and $node.GetCommandName() -eq $CommandName
-                },
-                $true
-            ))
+            $calls = @(Get-ScriptCommandInvocation -ScriptPath $ScriptPath -CommandName $CommandName)
 
             if ($calls.Count -ne 1) {
                 throw "Expected exactly one '$CommandName' invocation in '$ScriptPath'; found $($calls.Count)."
@@ -1589,7 +1670,12 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         # neither wrapper may redefine it either.
         $source = Get-Content -LiteralPath $script:setupWrapperScripts[$Name] -Raw
 
-        $source | Should -Match "Import-Module \./dms-schema-environment\.psm1 -Force"
+        # Imported, and without -Force: -Force removes a module session-wide before re-importing it,
+        # while a plain import reuses an already-loaded instance - which is what build-dms.ps1 loads for
+        # its own -Enabled wrapper before invoking a setup wrapper in-process. The same rule the module
+        # applies to its own nested imports.
+        $source | Should -Match "Import-Module \./dms-schema-environment\.psm1(?! -Force)"
+        $source | Should -Not -Match "Import-Module \./dms-schema-environment\.psm1 -Force"
         $source | Should -Not -Match "function Assert-DmsContainerSchemaEnvironment"
         $source | Should -Not -Match "function Get-DmsSchemaEnvironmentVerdict"
         $source | Should -Not -Match "function Get-DmsContainerEnvironment"
@@ -1670,10 +1756,11 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $childScript = @"
 Set-Location -LiteralPath '$escapedComposeRoot'
 
-# Verbatim the order both wrappers use: the leaf dependency first, the shared verifier module last.
+# Verbatim what both wrappers do: the leaf dependency first, the shared verifier module last and
+# without -Force.
 Import-Module ./env-utility.psm1 -Force
 Import-Module ./database-safety.psm1 -Force
-Import-Module ./dms-schema-environment.psm1 -Force
+Import-Module ./dms-schema-environment.psm1
 
 foreach (`$commandName in @(
         'Assert-E2EDatabaseIsDedicated',

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -13,7 +13,7 @@
 # - Get-DirectSetupTeardownCommand (standard setup-local-dms.ps1) must print a teardown command carrying
 #   the selected engine and the resolved environment-file path, safely single-quoted.
 #
-# DMS-1300 adds the same treatment for Invoke-WithEnvironmentFileSchemaSettings (both E2E setup
+# DMS-1300 adds the same treatment for Invoke-WithDmsEnvironmentFileSchemaAuthority (both E2E setup
 # wrappers), which must make the selected environment file the sole authority for the schema package
 # surface of the Docker phases, and must round-trip the caller's exact prior environment.
 
@@ -190,7 +190,7 @@ Describe "setup-local-dms.ps1 wires the resolved environment file into teardown 
     }
 }
 
-Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file authoritative for the E2E setup phases (DMS-1300)" {
+Describe "Invoke-WithDmsEnvironmentFileSchemaAuthority makes the environment file authoritative for the E2E setup phases (DMS-1300)" {
     # One guard, in the module both E2E setup wrappers import, so it is executed once here rather than
     # once per wrapper copy. That the wrappers reach THIS definition - importing the module, defining no
     # guard of their own, and running every Docker phase inside it - is asserted by the wiring blocks
@@ -241,7 +241,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
         }
 
         $script:schemaEnvironmentModule = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
-        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithEnvironmentFileSchemaSettings"
+        $script:guardFunctionText = Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName "Invoke-WithDmsEnvironmentFileSchemaAuthority"
         . ([scriptblock]::Create($script:guardFunctionText))
 
         $script:schemaVariables = @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")
@@ -287,7 +287,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
         }
 
         $script:observedInsideAction = $null
-        Invoke-WithEnvironmentFileSchemaSettings -Action {
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
             $script:observedInsideAction = Get-SchemaVariableState
         }
 
@@ -309,7 +309,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
         # must not depend on, so the property under test is that the guard restores whatever it found.
         $arranged = Get-SchemaVariableState
 
-        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action { }
 
         $restored = Get-SchemaVariableState
         foreach ($name in $script:schemaVariables) {
@@ -325,7 +325,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
 
         $arranged = Get-SchemaVariableState
 
-        { Invoke-WithEnvironmentFileSchemaSettings -Action { throw "phase failed" } } |
+        { Invoke-WithDmsEnvironmentFileSchemaAuthority -Action { throw "phase failed" } } |
             Should -Throw -ExpectedMessage "phase failed"
 
         $restored = Get-SchemaVariableState
@@ -342,7 +342,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
 
         $arranged = Get-SchemaVariableState
 
-        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action { }
 
         $restored = Get-SchemaVariableState
         $restored["USE_API_SCHEMA_PATH"].Exists | Should -BeFalse
@@ -364,7 +364,7 @@ Describe "Invoke-WithEnvironmentFileSchemaSettings makes the environment file au
             return
         }
 
-        Invoke-WithEnvironmentFileSchemaSettings -Action { }
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action { }
 
         (Test-Path -LiteralPath "Env:SCHEMA_PACKAGES") | Should -BeTrue
         [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES") | Should -Be ""
@@ -389,7 +389,7 @@ Remove-Item -LiteralPath 'Env:API_SCHEMA_PATH' -ErrorAction SilentlyContinue
 `$env:SCHEMA_PACKAGES = 'prior-packages'
 
 try {
-    Invoke-WithEnvironmentFileSchemaSettings -Action {
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         'inside:' + [string](Test-Path -LiteralPath 'Env:USE_API_SCHEMA_PATH') +
             ',' + [string](Test-Path -LiteralPath 'Env:API_SCHEMA_PATH') +
             ',' + [string](Test-Path -LiteralPath 'Env:SCHEMA_PACKAGES') |
@@ -425,7 +425,7 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
             <#
             .SYNOPSIS
             Returns one record per phase-script invocation in a setup wrapper, with whether the
-            invocation is lexically inside the wrapper's single Invoke-WithEnvironmentFileSchemaSettings
+            invocation is lexically inside the wrapper's single Invoke-WithDmsEnvironmentFileSchemaAuthority
             -Action block. Uses the AST rather than a text pattern, so the assertion is about the
             structure production actually has, and is not defeated by reformatting or reindentation.
             #>
@@ -445,28 +445,45 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
                 {
                     param($node)
                     $node -is [System.Management.Automation.Language.CommandAst] -and
-                    $node.GetCommandName() -eq "Invoke-WithEnvironmentFileSchemaSettings"
+                    $node.GetCommandName() -eq "Invoke-WithDmsEnvironmentFileSchemaAuthority"
                 },
                 $true
             ))
 
             if ($guardCalls.Count -ne 1) {
-                throw "Expected exactly one Invoke-WithEnvironmentFileSchemaSettings invocation in '$ScriptPath'; found $($guardCalls.Count)."
+                throw "Expected exactly one Invoke-WithDmsEnvironmentFileSchemaAuthority invocation in '$ScriptPath'; found $($guardCalls.Count)."
             }
 
-            $actionBlocks = @($guardCalls[0].FindAll(
-                {
-                    param($node)
-                    $node -is [System.Management.Automation.Language.ScriptBlockExpressionAst]
-                },
-                $true
-            ))
+            # Bound to the ARGUMENT of -Action, not to "the one script block anywhere under the guard
+            # call". Counting descendants made any legitimate nested script block - a ForEach-Object
+            # over the route-context databases, a Where-Object filter - break the wiring test with a
+            # detector error rather than a finding. Both spellings are accepted: '-Action { }', where
+            # the block is the following element, and '-Action:{ }', where the parser attaches it to
+            # the parameter itself.
+            $guardElements = @($guardCalls[0].CommandElements)
+            $actionArgument = $null
+            for ($elementIndex = 0; $elementIndex -lt $guardElements.Count; $elementIndex++) {
+                $element = $guardElements[$elementIndex]
+                if ($element -isnot [System.Management.Automation.Language.CommandParameterAst] -or
+                    $element.ParameterName -ne "Action") {
+                    continue
+                }
 
-            if ($actionBlocks.Count -ne 1) {
-                throw "Expected exactly one -Action script block on the guard invocation in '$ScriptPath'; found $($actionBlocks.Count)."
+                $actionArgument = if ($null -ne $element.Argument) {
+                    $element.Argument
+                }
+                elseif ($elementIndex + 1 -lt $guardElements.Count) {
+                    $guardElements[$elementIndex + 1]
+                }
+
+                break
             }
 
-            $actionExtent = $actionBlocks[0].Extent
+            if ($actionArgument -isnot [System.Management.Automation.Language.ScriptBlockExpressionAst]) {
+                throw "The guard invocation in '$ScriptPath' does not pass a script block to -Action."
+            }
+
+            $actionExtent = $actionArgument.Extent
 
             return @($ast.FindAll(
                 {
@@ -551,7 +568,7 @@ Describe "Both E2E setup wrappers run every Docker phase inside the schema-setti
         # such a call OUTSIDE the guard, so a detector that misses it reports no escape at all.
         $fixturePath = Join-Path $TestDrive "variable-dispatched-phase.ps1"
         Set-Content -LiteralPath $fixturePath -Encoding utf8 -Value @'
-function Invoke-WithEnvironmentFileSchemaSettings {
+function Invoke-WithDmsEnvironmentFileSchemaAuthority {
     param([scriptblock] $Action)
     & $Action
 }
@@ -559,7 +576,7 @@ function Invoke-WithEnvironmentFileSchemaSettings {
 $guardedPhase = "./start-local-dms.ps1"
 $escapedPhase = "./provision-e2e-database.ps1"
 
-Invoke-WithEnvironmentFileSchemaSettings -Action {
+Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
     & $guardedPhase -InfraOnly
 }
 
@@ -572,6 +589,97 @@ Invoke-WithEnvironmentFileSchemaSettings -Action {
         @($invocations | ForEach-Object { $_.Name }) | Should -Be @('$guardedPhase', '$escapedPhase')
         @($invocations | Where-Object { -not $_.InsideGuard } | ForEach-Object { $_.Name }) |
             Should -Be @('$escapedPhase')
+    }
+
+    It "reads the -Action argument rather than counting script blocks, so a nested block is not a detector error" {
+        # The detector used to require exactly ONE script block anywhere under the guard call, which made
+        # a legitimate nested block inside the guarded action - a ForEach-Object over the route-context
+        # databases, say - throw out of the detector instead of producing a finding.
+        $fixturePath = Join-Path $TestDrive "nested-script-block-phase.ps1"
+        Set-Content -LiteralPath $fixturePath -Encoding utf8 -Value @'
+function Invoke-WithDmsEnvironmentFileSchemaAuthority {
+    param([scriptblock] $Action)
+    & $Action
+}
+
+Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
+    @("edfi_a", "edfi_b") | ForEach-Object {
+        ./provision-e2e-database.ps1 -DatabaseName $_
+    }
+}
+'@
+
+        $invocations = @(Get-GuardedPhaseInvocation -ScriptPath $fixturePath)
+
+        @($invocations | ForEach-Object { $_.Name }) | Should -Be @("./provision-e2e-database.ps1")
+        @($invocations | Where-Object { -not $_.InsideGuard }) | Should -BeNullOrEmpty
+    }
+
+    It "gives the shared module's guard a name build-dms.ps1 does not also define" {
+        # THE REGRESSION FOR THE IN-PROCESS BINDING DEFECT. build-dms.ps1 InstanceE2ETest invokes the
+        # Instance Management wrapper with '& $instanceSetupScript', so the wrapper's scope is a CHILD of
+        # build-dms.ps1's script scope. Command lookup walks that scope chain before it reaches the
+        # session state this module's exports live in, so any name build-dms.ps1 also defines binds the
+        # BUILD SCRIPT's function - and its schema helper is a pass-through when -Enabled is unset, which
+        # a bare call leaves so. The guarded phases then ran with SCHEMA_PACKAGES still present.
+        #
+        # Asserted over the whole export surface rather than the one guard: every name this module
+        # exports is reachable from a wrapper the build script invokes in-process, so every one of them
+        # is exposed to the same shadowing.
+        $buildScriptPath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../../../build-dms.ps1"))
+        $modulePath = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "../dms-schema-environment.psm1"))
+
+        $definedFunctionName = @(
+            foreach ($path in @($buildScriptPath, $modulePath)) {
+                $parseErrors = $null
+                $tokens = $null
+                $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$parseErrors)
+
+                if ($parseErrors.Count -gt 0) {
+                    throw "'$path' has $($parseErrors.Count) parse error(s)."
+                }
+
+                , @($ast.FindAll(
+                    {
+                        param($node)
+                        $node -is [System.Management.Automation.Language.FunctionDefinitionAst]
+                    },
+                    $true
+                ) | ForEach-Object { $_.Name })
+            }
+        )
+
+        # Case-insensitive, which '-contains' is: PowerShell command resolution is too, so a module
+        # export differing from a build-script function only in casing shadows exactly the same way.
+        $collidingName = @(
+            $definedFunctionName[1] |
+                Where-Object { $definedFunctionName[0] -contains $_ }
+        )
+
+        $collidingName | Should -BeNullOrEmpty -Because "build-dms.ps1 invokes a setup wrapper in-process, so a name it also defines shadows the module export the wrapper means to call"
+    }
+
+    It "calls the module's guard in the <Name> wrapper and never build-dms.ps1's same-purpose helper" -ForEach @(
+        @{ Name = "DataManagementService E2E" }
+        @{ Name = "InstanceManagement E2E" }
+    ) {
+        # Over the AST, not the text: both wrappers CARRY a comment naming build-dms.ps1's helper in
+        # order to explain why they must not call it, and a text search cannot tell a prohibition from a
+        # call.
+        $parseErrors = $null
+        $tokens = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($script:wrapperScripts[$Name], [ref]$tokens, [ref]$parseErrors)
+
+        $invokedName = @($ast.FindAll(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.CommandAst]
+            },
+            $true
+        ) | ForEach-Object { $_.GetCommandName() } | Where-Object { $_ })
+
+        $invokedName | Should -Contain "Invoke-WithDmsEnvironmentFileSchemaAuthority"
+        $invokedName | Should -Not -Contain "Invoke-WithEnvironmentFileSchemaSettings"
     }
 }
 
@@ -1499,7 +1607,7 @@ Describe "Both E2E setup wrappers verify the started container against the envir
                 {
                     param($node)
                     $node -is [System.Management.Automation.Language.CommandAst] -and
-                    $node.GetCommandName() -eq "Invoke-WithEnvironmentFileSchemaSettings"
+                    $node.GetCommandName() -eq "Invoke-WithDmsEnvironmentFileSchemaAuthority"
                 },
                 $true
             )) | Select-Object -First 1
@@ -1589,7 +1697,7 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $source | Should -Not -Match "function Assert-DmsContainerSchemaEnvironment"
         $source | Should -Not -Match "function Get-DmsSchemaEnvironmentVerdict"
         $source | Should -Not -Match "function Get-DmsContainerEnvironment"
-        $source | Should -Not -Match "function Invoke-WithEnvironmentFileSchemaSettings"
+        $source | Should -Not -Match "function Invoke-WithDmsEnvironmentFileSchemaAuthority"
     }
 
     It "reads both expectations from the environment file through the canonical sequential resolver" {
@@ -1676,7 +1784,7 @@ foreach (`$commandName in @(
         'Get-ComposeResolvedEnvValue',
         'Resolve-DotenvFileSequentially',
         'Assert-DmsContainerSchemaEnvironment',
-        'Invoke-WithEnvironmentFileSchemaSettings'
+        'Invoke-WithDmsEnvironmentFileSchemaAuthority'
     )) {
     `$commandName + '=' + [string][bool](Get-Command `$commandName -ErrorAction SilentlyContinue) |
         Add-Content -LiteralPath '$escapedObservationPath'
@@ -1698,7 +1806,7 @@ foreach (`$commandName in @(
         # Every other guard test extracts the function text through the AST, so only a real import can
         # catch the guard being defined in the module but left out of Export-ModuleMember - which would
         # leave both wrappers unable to resolve it at their first phase.
-        $observations | Should -Contain "Invoke-WithEnvironmentFileSchemaSettings=True" -Because "both wrappers now reach the schema-settings guard through this module's exports"
+        $observations | Should -Contain "Invoke-WithDmsEnvironmentFileSchemaAuthority=True" -Because "both wrappers now reach the schema-settings guard through this module's exports"
     }
 }
 
@@ -1710,6 +1818,27 @@ Describe "The container schema gate accepts the repository's own tracked environ
     # SCHEMA_PACKAGES='[...]' via a non-greedy regex, and a legal Compose value shape (quoting, an
     # inline comment, a ${VAR} reference) can silently break the comparison. No Docker: the container
     # side is a fixture built from the same file, exactly as Compose would pass it through.
+
+    # Discovery-phase matrix of the artifacts the wrappers actually hand the gate, shared by every
+    # assertion below so a new artifact is covered by all of them at once rather than by whichever table
+    # someone remembered to extend. Both wrappers compose the data-standard overlay first and then the
+    # database-engine overlay, so a composed MSSQL file - the artifact an MSSQL run's gate is given, and
+    # the one the engine composition rewrites and reorders - belongs here alongside the base files.
+    # .env.routeContext.e2e is the Instance Management wrapper's base, and it takes DS overlays the same
+    # way .env.e2e does, so its overlaid forms are covered too. Built here rather than in BeforeAll
+    # because -ForEach is bound during discovery.
+    $trackedEnvironmentFileCases = @(
+        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = ""; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = ""; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2"; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1"; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.routeContext.e2e composed with .env.ds52"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "5.2"; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.routeContext.e2e composed with .env.ds61"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "6.1"; DatabaseEngine = "postgresql" }
+        @{ Label = ".env.e2e composed for mssql"; BaseName = ".env.e2e"; DataStandardVersion = ""; DatabaseEngine = "mssql" }
+        @{ Label = ".env.e2e composed with .env.ds61 for mssql"; BaseName = ".env.e2e"; DataStandardVersion = "6.1"; DatabaseEngine = "mssql" }
+        @{ Label = ".env.routeContext.e2e composed for mssql"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = ""; DatabaseEngine = "mssql" }
+    )
+
     BeforeAll {
         function Get-ScriptFunctionText {
             param(
@@ -1799,31 +1928,40 @@ Describe "The container schema gate accepts the repository's own tracked environ
         }
 
         # .env.ds52 / .env.ds61 are OVERLAYS: they carry SCHEMA_PACKAGES but not USE_API_SCHEMA_PATH or
-        # API_SCHEMA_PATH, so they are only ever consumed composed onto a base file. Composed here with
-        # the same production helper the setup wrappers use, into an isolated root so nothing is written
-        # into the repository.
+        # API_SCHEMA_PATH, so they are only ever consumed composed onto a base file. .env.mssql is the
+        # engine overlay for the same reason. All three are composed here with the same production
+        # helpers the setup wrappers use, into an isolated root so nothing is written into the
+        # repository - the derived output lands under <overlayRoot>/.derived, not under eng/docker-compose.
         $script:dockerComposeRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
         $script:overlayRoot = Join-Path $TestDrive "overlay-root"
         New-Item -ItemType Directory -Path $script:overlayRoot -Force | Out-Null
-        foreach ($overlayName in @(".env.ds52", ".env.ds61")) {
+        foreach ($overlayName in @(".env.ds52", ".env.ds61", ".env.mssql")) {
             Copy-Item -LiteralPath (Join-Path $script:dockerComposeRoot $overlayName) -Destination (Join-Path $script:overlayRoot $overlayName)
         }
 
         function Resolve-TrackedEnvironmentFile {
+            # Data standard FIRST, then database engine - the order both wrappers use, so an MSSQL case
+            # here is the same artifact production hands the gate. The engine step is a no-op for
+            # postgresql, which is why it is called unconditionally rather than branched around: the
+            # helper the wrappers call is the helper this exercises.
             param(
                 [Parameter(Mandatory)] [string] $BaseName,
-                [string] $DataStandardVersion
+                [string] $DataStandardVersion,
+                [string] $DatabaseEngine = "postgresql"
             )
 
-            $basePath = Join-Path $script:dockerComposeRoot $BaseName
+            $resolvedPath = Join-Path $script:dockerComposeRoot $BaseName
 
-            if ([string]::IsNullOrWhiteSpace($DataStandardVersion)) {
-                return $basePath
+            if (-not [string]::IsNullOrWhiteSpace($DataStandardVersion)) {
+                $resolvedPath = Resolve-DataStandardEnvironmentFile `
+                    -DataStandardVersion $DataStandardVersion `
+                    -BaseEnvironmentFile $resolvedPath `
+                    -DockerComposeRoot $script:overlayRoot
             }
 
-            return Resolve-DataStandardEnvironmentFile `
-                -DataStandardVersion $DataStandardVersion `
-                -BaseEnvironmentFile $basePath `
+            return Resolve-DatabaseEngineEnvironmentFile `
+                -DatabaseEngine $DatabaseEngine `
+                -BaseEnvironmentFile $resolvedPath `
                 -DockerComposeRoot $script:overlayRoot
         }
     }
@@ -1839,13 +1977,8 @@ Describe "The container schema gate accepts the repository's own tracked environ
         }
     }
 
-    It "the tracked <Label> satisfies the container schema gate" -ForEach @(
-        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
-        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
-    ) {
-        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+    It "the tracked <Label> satisfies the container schema gate" -ForEach $trackedEnvironmentFileCases {
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion -DatabaseEngine $DatabaseEngine
 
         # The container fixture is what Compose renders from this same file. Built through the
         # SEQUENTIAL model, the same one production reads: a fixture built from a collapsed key/value
@@ -1906,15 +2039,10 @@ Describe "The container schema gate accepts the repository's own tracked environ
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
-    It "the tracked <Label> enables the ApiSchema path and declares at least one package" -ForEach @(
-        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
-        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
-    ) {
+    It "the tracked <Label> enables the ApiSchema path and declares at least one package" -ForEach $trackedEnvironmentFileCases {
         # Without this, the gate assertion above could pass on a file that declares no packages at all
         # or leaves the ApiSchema path off, because the fixture would agree with it either way.
-        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion -DatabaseEngine $DatabaseEngine
         $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
 
         Get-DmsEnvironmentFileDeclaredValue `
@@ -1926,19 +2054,14 @@ Describe "The container schema gate accepts the repository's own tracked environ
             Should -BeGreaterThan 0
     }
 
-    It "declares no repeated key whose value another declaration resolves against" -ForEach @(
-        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
-        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
-    ) {
+    It "the tracked <Label> declares no repeated key whose value another declaration resolves against" -ForEach $trackedEnvironmentFileCases {
         # The tracked-file guard for the defect the unit fixtures cover synthetically. A key declared
         # twice is legal Compose, but if a LATER declaration re-defines a name an EARLIER line already
         # resolved against, the two models disagree - and the collapsed one silently wins arguments it
         # should lose. This reports that shape landing in a tracked file rather than waiting for a
         # setup abort. Overlay composition can legitimately introduce duplicates, so the assertion is
         # scoped to duplicates that something actually references.
-        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion -DatabaseEngine $DatabaseEngine
         $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
 
         $referencedNames = @($sequential.Declarations | ForEach-Object { $_.References }) | Select-Object -Unique
@@ -1947,12 +2070,7 @@ Describe "The container schema gate accepts the repository's own tracked environ
         $referencedDuplicates | Should -BeNullOrEmpty -Because "a re-declared name that another line resolves against makes the file's meaning depend on declaration order"
     }
 
-    It "the tracked <Label> declares each gate key at most once, because the provisioner reads the first declaration and Compose delivers the last" -ForEach @(
-        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
-        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
-        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
-    ) {
+    It "the tracked <Label> declares each gate key at most once, because the provisioner reads the first declaration and Compose delivers the last" -ForEach $trackedEnvironmentFileCases {
         # A repeated declaration of one of the three keys the gate compares is legal Compose but not
         # safe here. For SCHEMA_PACKAGES the two sides read different declarations: Get-QuotedEnvJson -
         # the file-only reader behind both the provisioner and the gate's expected side - matches the
@@ -1965,7 +2083,7 @@ Describe "The container schema gate accepts the repository's own tracked environ
         # that agreement resting on which declaration each reader happens to take. Scoped to the gate
         # keys, not to duplicates in general: overlay composition can legitimately re-declare other
         # names, which the sibling assertion above covers.
-        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion -DatabaseEngine $DatabaseEngine
         $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
 
         $duplicatedGateKeys = @(

--- a/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
+++ b/eng/docker-compose/tests/E2ETestProcessContext.Tests.ps1
@@ -999,21 +999,35 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                 "Get-DmsContainerSchemaPackage",
                 "Get-DmsSchemaPackageIdentity",
                 "Get-DmsSchemaEnvironmentVerdict",
+                "Get-DmsEnvironmentFileDeclaredValue",
                 "Assert-DmsContainerSchemaEnvironment"
             )) {
             . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName $functionName)))
         }
 
-        # The real Compose value semantics, not a stub: the quoting and inline-comment cases below are
-        # only meaningful if the assertion normalizes the environment file's raw text the way Docker
-        # Compose does. Production reaches this function through the same module import.
+        # The real sequential env-file resolver, not a stub: the quoting, inline-comment, reference and
+        # declaration-order cases below are only meaningful if the assertion reads the environment file
+        # the way Docker Compose does. Production reaches this function through the same module import.
         Import-Module (Join-Path $PSScriptRoot "../database-safety.psm1") -Force
 
-        # Stubs for the three readers the assertion depends on, so no Docker and no environment file are
-        # involved. Each returns whatever the current test arranged.
+        # Referenced names are resolved ambient-first inside the sequential resolver, exactly as Compose
+        # does, so the fixtures below would inherit a value from a dirty dev shell. Removed for the
+        # duration of this block and restored afterward, which also mirrors the production precondition:
+        # the setup guard has already removed the schema names before the gate runs.
+        $script:neutralizedNames = @(
+            "USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES", "SCHEMA_ROOT", "ENABLE_SCHEMA_PATH"
+        )
+        $script:neutralizedPriorValues = @{}
+        foreach ($name in $script:neutralizedNames) {
+            $script:neutralizedPriorValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+
+        # Only the two readers that would need Docker or a package declaration are stubbed. The
+        # environment file itself is real: production resolves it sequentially from disk, so a stubbed
+        # key/value map would reintroduce exactly the collapsed-map model this suite has to reject.
         # Each stub declares the parameters production binds by name, so a renamed argument at the call
-        # site fails here rather than silently passing. The values themselves are not needed, hence the
-        # discards.
+        # site fails here rather than silently passing.
         function Get-DmsContainerEnvironment {
             param([Parameter(Mandatory)] [string] $ContainerName)
 
@@ -1028,20 +1042,32 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
             return $script:stubDeclaredPackages
         }
 
-        function Get-EnvValue {
-            param(
-                [hashtable] $EnvValues,
-                [Parameter(Mandatory)] [string] $Name,
-                [string] $DefaultValue = ""
-            )
+        $script:environmentFileFixtureCount = 0
 
-            $null = $EnvValues
+        function New-EnvironmentFileFixture {
+            <#
+            .SYNOPSIS
+            Writes $script:environmentFileLines to a real file and returns its path, so declaration
+            ORDER is part of the fixture rather than being flattened into a hashtable.
+            #>
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Writes a throwaway fixture under TestDrive; -WhatIf/-Confirm semantics add no value.')]
+            param()
 
-            if ($script:stubEnvironmentFileValues.ContainsKey($Name)) {
-                return $script:stubEnvironmentFileValues[$Name]
+            $script:environmentFileFixtureCount++
+            $path = Join-Path $TestDrive "gate-fixture-$($script:environmentFileFixtureCount).env"
+            [System.IO.File]::WriteAllLines($path, [string[]]$script:environmentFileLines)
+            return $path
+        }
+    }
+
+    AfterAll {
+        foreach ($name in $script:neutralizedNames) {
+            if ($null -eq $script:neutralizedPriorValues[$name]) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
             }
-
-            return $DefaultValue
+            else {
+                [System.Environment]::SetEnvironmentVariable($name, $script:neutralizedPriorValues[$name])
+            }
         }
     }
 
@@ -1056,10 +1082,10 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
                     feedUrl = "https://pkgs.example.org/v3/index.json"
                 }
             })
-        $script:stubEnvironmentFileValues = @{
-            USE_API_SCHEMA_PATH = "true"
-            API_SCHEMA_PATH     = "/app/ApiSchema"
-        }
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "API_SCHEMA_PATH=/app/ApiSchema"
+        )
         $script:stubContainerEnvironment = @{
             "AppSettings__UseApiSchemaPath" = "true"
             "AppSettings__ApiSchemaPath"    = "/app/ApiSchema"
@@ -1069,8 +1095,7 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
 
     It "returns without throwing when the container agrees with the environment file" {
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
@@ -1090,28 +1115,31 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         & $Mutate
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
     It "throws when the environment file declares packages without enabling the ApiSchema path" {
-        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = "false"
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=false"
+            "API_SCHEMA_PATH=/app/ApiSchema"
+        )
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
     It "compares against the environment file's API_SCHEMA_PATH, not a hardcoded default" {
         # Both sides move together: a container matching a non-default environment-file path must pass.
-        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = "/custom/ApiSchema"
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "API_SCHEMA_PATH=/custom/ApiSchema"
+        )
         $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/custom/ApiSchema"
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
@@ -1125,23 +1153,27 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         # passes the value into the container, so a correctly started container legitimately carries the
         # bare path. Comparing the environment file's raw text failed such a stack at setup time even
         # though nothing was wrong with it - a false failure a custom -EnvironmentFile can easily hit.
-        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = $RawValue
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "API_SCHEMA_PATH=$RawValue"
+        )
         $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/custom/ApiSchema"
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
     It "still fails a genuinely different path when the declaration is quoted" {
         # Normalization must not turn the path comparison into a no-op.
-        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '"/custom/ApiSchema"'
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            'API_SCHEMA_PATH="/custom/ApiSchema"'
+        )
         $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/somewhere/else"
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
@@ -1152,11 +1184,13 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
     ) {
         # Same false failure on the other file-read expectation: raw quoted text is not equal to "true",
         # so the gate reported a correctly configured environment file as internally inconsistent.
-        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = $RawValue
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=$RawValue"
+            "API_SCHEMA_PATH=/app/ApiSchema"
+        )
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
@@ -1165,12 +1199,15 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         # container legitimately carries the RESOLVED path. Comparing the literal reference text kept
         # the expected side as '${SCHEMA_ROOT}/ApiSchema', which can never equal what the container
         # received - a hard setup abort on a stack that came up correctly.
-        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '${SCHEMA_ROOT}/ApiSchema'
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "SCHEMA_ROOT=/app"
+            'API_SCHEMA_PATH=${SCHEMA_ROOT}/ApiSchema'
+        )
         $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/app/ApiSchema"
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{ SCHEMA_ROOT = "/app" } `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
@@ -1178,24 +1215,97 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         # Same false failure on the other file-read expectation: the unresolved reference is not
         # "true", so the gate reported an internally consistent environment file as declaring packages
         # without enabling the ApiSchema path.
-        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = '${ENABLE_SCHEMA_PATH}'
+        $script:environmentFileLines = @(
+            "ENABLE_SCHEMA_PATH=true"
+            'USE_API_SCHEMA_PATH=${ENABLE_SCHEMA_PATH}'
+            "API_SCHEMA_PATH=/app/ApiSchema"
+        )
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{ ENABLE_SCHEMA_PATH = "true" } `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
     It 'still fails a genuinely different path when the declaration is a ${VAR} reference' {
         # Reference resolution must not turn the path comparison into a no-op: a file pointing
         # somewhere the container is not is still the mismatch this gate exists to report.
-        $script:stubEnvironmentFileValues["API_SCHEMA_PATH"] = '${SCHEMA_ROOT}/ApiSchema'
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "SCHEMA_ROOT=/somewhere/else"
+            'API_SCHEMA_PATH=${SCHEMA_ROOT}/ApiSchema'
+        )
         $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/app/ApiSchema"
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{ SCHEMA_ROOT = "/somewhere/else" } `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It 'freezes API_SCHEMA_PATH at its own line, so a later re-declaration of the name it referenced cannot change it' {
+        # Docker Compose resolves an --env-file in declaration ORDER: API_SCHEMA_PATH is frozen as
+        # /app/ApiSchema when Compose reads that line, and the later SCHEMA_ROOT=/other applies only to
+        # lines after it. Reading the expected value from a collapsed key/value map instead kept just
+        # the FINAL SCHEMA_ROOT, expected /other/ApiSchema, and failed a correctly started stack.
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "SCHEMA_ROOT=/app"
+            'API_SCHEMA_PATH=${SCHEMA_ROOT}/ApiSchema'
+            "SCHEMA_ROOT=/other"
+        )
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/app/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It 'still fails when the container carries what the collapsed key/value model would have expected' {
+        # The mirror of the case above, so the fix is not merely "accept both". The container is on
+        # /other/ApiSchema - the value the collapsed model computed - which Compose never produced from
+        # this file, and that must still be reported as a mismatch.
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "SCHEMA_ROOT=/app"
+            'API_SCHEMA_PATH=${SCHEMA_ROOT}/ApiSchema'
+            "SCHEMA_ROOT=/other"
+        )
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/other/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
+    }
+
+    It 'freezes USE_API_SCHEMA_PATH at its own line, so a later re-declaration of the name it referenced cannot change it' {
+        # The same declaration-order rule on the boolean. USE_API_SCHEMA_PATH is frozen as true; the
+        # later ENABLE_SCHEMA_PATH=false does not reach back. The collapsed model resolved the
+        # reference against the final false and reported the file as declaring packages without
+        # enabling the ApiSchema path.
+        $script:environmentFileLines = @(
+            "ENABLE_SCHEMA_PATH=true"
+            'USE_API_SCHEMA_PATH=${ENABLE_SCHEMA_PATH}'
+            "API_SCHEMA_PATH=/app/ApiSchema"
+            "ENABLE_SCHEMA_PATH=false"
+        )
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It 'uses the last declaration of a repeated key, which is what the compose file itself sees' {
+        # Declaration order decides a referencing line's value, but for the key being read it is the
+        # LAST declaration that Compose hands to the compose file. Both rules have to hold at once.
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=true"
+            "API_SCHEMA_PATH=/first/ApiSchema"
+            "API_SCHEMA_PATH=/last/ApiSchema"
+        )
+        $script:stubContainerEnvironment["AppSettings__ApiSchemaPath"] = "/last/ApiSchema"
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
     It "throws when the environment file spells USE_API_SCHEMA_PATH as <Label>" -ForEach @(
@@ -1207,11 +1317,13 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         # declaring TRUE starts a container that downloads no packages while phase 3 already stamped the
         # database for the file's full surface. Normalization strips the quotes but must not fold case,
         # which the quoted variant pins.
-        $script:stubEnvironmentFileValues["USE_API_SCHEMA_PATH"] = $RawValue
+        $script:environmentFileLines = @(
+            "USE_API_SCHEMA_PATH=$RawValue"
+            "API_SCHEMA_PATH=/app/ApiSchema"
+        )
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 
@@ -1224,8 +1336,7 @@ Describe "Assert-DmsContainerSchemaEnvironment throws on a mismatch and returns 
         $script:stubContainerEnvironment["AppSettings__UseApiSchemaPath"] = $Value
 
         { Assert-DmsContainerSchemaEnvironment `
-                -EnvironmentFilePath "/repo/eng/docker-compose/.env.e2e" `
-                -EnvironmentValues @{} `
+                -EnvironmentFilePath (New-EnvironmentFileFixture) `
                 -ContainerName "ed-fi-api" } | Should -Throw -ExpectedMessage "DMS E2E setup mismatch: *"
     }
 }
@@ -1461,24 +1572,39 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         $source | Should -Not -Match "function Get-DmsContainerEnvironment"
     }
 
-    It "reads both expectations from the environment file, never with Compose precedence" {
+    It "reads both expectations from the environment file through the canonical sequential resolver" {
         # Asserted over the commands the function actually invokes, not its text: the function's own
         # comment names Get-ComposeResolvedEnvValue in order to prohibit it, and a text search cannot
         # tell a prohibition from a call.
         #
         # Get-ComposeResolvedEnvValue resolves ambient-first. Using it for either expectation would let
         # the very override this gate exists to catch decide what "correct" means, so the gate would
-        # agree with a wrongly-started container and pass. Resolve-ComposeEnvRawValue is not that
-        # reader: it takes the file's raw value directly and applies only the value semantics Compose
-        # gives one --env-file entry, so the expected side stays file-authored while still matching
-        # what Compose actually rendered into the container.
+        # agree with a wrongly-started container and pass.
+        #
+        # Resolve-DotenvFileSequentially is this repository's one model of how Compose reads an
+        # --env-file. Pinning it by name is deliberate: the alternative that keeps being reached for is
+        # another normalization step layered on a COLLAPSED key/value map, which cannot express
+        # declaration order and is exactly how the frozen-value defect got in. Neither the collapsed
+        # reader nor a per-value resolver over it may come back for these two scalars.
         $invoked = @(Get-FunctionCommandName -ScriptPath $script:schemaEnvironmentModule -FunctionName "Assert-DmsContainerSchemaEnvironment")
 
         $invoked | Should -Contain "Get-SchemaPackagesFromEnvironmentFile"
-        $invoked | Should -Contain "Get-EnvValue"
-        $invoked | Should -Contain "Resolve-ComposeEnvRawValue"
+        $invoked | Should -Contain "Resolve-DotenvFileSequentially"
+        $invoked | Should -Contain "Get-DmsEnvironmentFileDeclaredValue"
         $invoked | Should -Not -Contain "Get-ComposeResolvedEnvValue"
-        $script:schemaEnvironmentModuleSource | Should -Match 'Get-EnvValue -EnvValues \$EnvironmentValues -Name "USE_API_SCHEMA_PATH"'
+        $invoked | Should -Not -Contain "Get-EnvValue"
+        $invoked | Should -Not -Contain "Resolve-ComposeEnvRawValue"
+        $script:schemaEnvironmentModuleSource | Should -Match '-Name "USE_API_SCHEMA_PATH" `\r?\n\s*-DefaultValue "false"'
+    }
+
+    It "reads the frozen declaration rather than the ambient-precedence Effective map" {
+        # Resolve-DotenvFileSequentially returns both. Effective applies ambient precedence to the
+        # requested key, so taking it would let a shell value Compose never saw define the expected
+        # side - the same class of defect as using Get-ComposeResolvedEnvValue.
+        $script:schemaEnvironmentModuleSource | Should -Match '\$ResolvedEnvironmentFile\.Declarations'
+        $script:schemaEnvironmentModuleSource | Should -Not -Match '\$ResolvedEnvironmentFile\.Effective'
+        # Last declaration wins, which is what the compose file itself sees.
+        $script:schemaEnvironmentModuleSource | Should -Match 'Select-Object -Last 1'
     }
 
     It "imports the same file-only package reader the provision phase uses" {
@@ -1486,7 +1612,6 @@ Describe "Both E2E setup wrappers verify the started container against the envir
         # happened to import, so command resolution does not depend on the call site.
         $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "\.\./schema-package-utility\.psm1"\) -Force'
         $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "database-safety\.psm1"\) -Force'
-        $script:schemaEnvironmentModuleSource | Should -Match 'Import-Module \(Join-Path \$PSScriptRoot "env-utility\.psm1"\) -Force'
     }
 
     It "throws rather than warning when the verdict fails" {
@@ -1535,18 +1660,34 @@ Describe "The container schema gate accepts the repository's own tracked environ
                 "Get-DmsContainerSchemaPackage",
                 "Get-DmsSchemaPackageIdentity",
                 "Get-DmsSchemaEnvironmentVerdict",
+                "Get-DmsEnvironmentFileDeclaredValue",
                 "Assert-DmsContainerSchemaEnvironment"
             )) {
             . ([scriptblock]::Create((Get-ScriptFunctionText -ScriptPath $script:schemaEnvironmentModule -FunctionName $functionName)))
         }
 
-        # The REAL readers, exactly the ones production reaches through the module's own imports:
-        # ReadValuesFromEnvFile / Get-EnvValue / Resolve-DataStandardEnvironmentFile (env-utility),
-        # Resolve-ComposeEnvRawValue (database-safety), Get-SchemaPackagesFromEnvironmentFile
-        # (schema-package-utility). Nothing about the file side is stubbed here.
+        # The REAL readers: Resolve-DotenvFileSequentially (database-safety) and
+        # Get-SchemaPackagesFromEnvironmentFile (schema-package-utility) are the two production reaches
+        # through the module's own imports; Resolve-DataStandardEnvironmentFile (env-utility) is the
+        # production overlay composer used below. Nothing about the file side is stubbed here.
         Import-Module (Join-Path $PSScriptRoot "../env-utility.psm1") -Force
         Import-Module (Join-Path $PSScriptRoot "../database-safety.psm1") -Force
         Import-Module (Join-Path $PSScriptRoot "../../schema-package-utility.psm1") -Force
+
+        # Production reaches Assert-DmsContainerSchemaEnvironment from inside the setup guard, after
+        # USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES have been REMOVED from the process.
+        # The container fixtures below are built from the sequential resolver's Effective map, which
+        # applies ambient precedence, so an invoking shell still carrying USE_API_SCHEMA_PATH=false - the
+        # exact dirty-shell shape the guard exists to tolerate - would define the fixture side from a
+        # value Compose never sees and fail this block while wrapper behavior is correct. Removed for the
+        # duration of the block and restored afterward, so the fixtures are built under the same
+        # precondition production's gate runs under.
+        $script:guardedSchemaNames = @("USE_API_SCHEMA_PATH", "API_SCHEMA_PATH", "SCHEMA_PACKAGES")
+        $script:guardedSchemaPriorValues = @{}
+        foreach ($name in $script:guardedSchemaNames) {
+            $script:guardedSchemaPriorValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
 
         # The one reader that would need Docker. Everything else runs for real.
         function Get-DmsContainerEnvironment {
@@ -1605,6 +1746,17 @@ Describe "The container schema gate accepts the repository's own tracked environ
         }
     }
 
+    AfterAll {
+        foreach ($name in $script:guardedSchemaNames) {
+            if ($null -eq $script:guardedSchemaPriorValues[$name]) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+            else {
+                [System.Environment]::SetEnvironmentVariable($name, $script:guardedSchemaPriorValues[$name])
+            }
+        }
+    }
+
     It "the tracked <Label> satisfies the container schema gate" -ForEach @(
         @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
         @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
@@ -1612,23 +1764,63 @@ Describe "The container schema gate accepts the repository's own tracked environ
         @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
     ) {
         $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
-        $environmentValues = ReadValuesFromEnvFile $environmentFilePath
 
-        # The container fixture is what Compose renders from this same file: each scalar resolved with
-        # Compose's single-entry value semantics, and SCHEMA_PACKAGES passed through verbatim.
+        # The container fixture is what Compose renders from this same file. Built through the
+        # SEQUENTIAL model, the same one production reads: a fixture built from a collapsed key/value
+        # map would mirror the very defect this suite has to catch. The Effective map is the right
+        # choice on THIS side - it is what the compose file receives, ambient precedence included - and
+        # it is a different code path from production's frozen-declaration read, so the two are not
+        # asserting each other into agreement. SCHEMA_PACKAGES is passed through verbatim.
+        $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
         $script:stubContainerEnvironment = @{
-            "AppSettings__UseApiSchemaPath" = Resolve-ComposeEnvRawValue `
-                -EnvironmentValues $environmentValues `
-                -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")
-            "AppSettings__ApiSchemaPath"    = Resolve-ComposeEnvRawValue `
-                -EnvironmentValues $environmentValues `
-                -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
-            "SCHEMA_PACKAGES"              = Get-TrackedSchemaPackagesRawValue -EnvironmentFilePath $environmentFilePath
+            "AppSettings__UseApiSchemaPath" = [string]$sequential.Effective["USE_API_SCHEMA_PATH"]
+            "AppSettings__ApiSchemaPath"    = [string]$sequential.Effective["API_SCHEMA_PATH"]
+            "SCHEMA_PACKAGES"               = Get-TrackedSchemaPackagesRawValue -EnvironmentFilePath $environmentFilePath
         }
 
         { Assert-DmsContainerSchemaEnvironment `
                 -EnvironmentFilePath $environmentFilePath `
-                -EnvironmentValues $environmentValues `
+                -ContainerName "ed-fi-api" } | Should -Not -Throw
+    }
+
+    It "builds its container fixture under production's precondition, so a dirty invoking shell cannot fail this block" {
+        # The regression for the exact shell state DMS-1300 exists to tolerate: a developer shell still
+        # carrying USE_API_SCHEMA_PATH=false. The fixtures here read the ambient-first Effective map, so
+        # without the block's removal of the three schema names that ambient value - not the file's -
+        # defines what the container is claimed to have, and every case above fails for a reason wrapper
+        # behavior has nothing to do with.
+        foreach ($name in $script:guardedSchemaNames) {
+            (Test-Path -LiteralPath "Env:$name") |
+                Should -BeFalse -Because "$name must be absent while these fixtures are built, which is the precondition the setup guard leaves for production's gate"
+        }
+
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName ".env.e2e" -DataStandardVersion ""
+
+        # The dirty shell is arranged here rather than assumed, so the mechanism is a real result on a
+        # clean CI runner as well as on a polluted developer shell.
+        [System.Environment]::SetEnvironmentVariable("USE_API_SCHEMA_PATH", "false")
+        try {
+            [string](Resolve-DotenvFileSequentially -Path $environmentFilePath).Effective["USE_API_SCHEMA_PATH"] |
+                Should -BeExactly "false" -Because "the Effective map applies ambient precedence, which is why the fixtures may only be built with these names removed"
+        }
+        finally {
+            foreach ($name in $script:guardedSchemaNames) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+        }
+
+        # Restored to the production precondition, the identical construction takes the FILE's value and
+        # the gate agrees.
+        $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
+        [string]$sequential.Effective["USE_API_SCHEMA_PATH"] | Should -BeExactly "true"
+        $script:stubContainerEnvironment = @{
+            "AppSettings__UseApiSchemaPath" = [string]$sequential.Effective["USE_API_SCHEMA_PATH"]
+            "AppSettings__ApiSchemaPath"    = [string]$sequential.Effective["API_SCHEMA_PATH"]
+            "SCHEMA_PACKAGES"               = Get-TrackedSchemaPackagesRawValue -EnvironmentFilePath $environmentFilePath
+        }
+
+        { Assert-DmsContainerSchemaEnvironment `
+                -EnvironmentFilePath $environmentFilePath `
                 -ContainerName "ed-fi-api" } | Should -Not -Throw
     }
 
@@ -1641,13 +1833,35 @@ Describe "The container schema gate accepts the repository's own tracked environ
         # Without this, the gate assertion above could pass on a file that declares no packages at all
         # or leaves the ApiSchema path off, because the fixture would agree with it either way.
         $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
-        $environmentValues = ReadValuesFromEnvFile $environmentFilePath
+        $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
 
-        Resolve-ComposeEnvRawValue `
-            -EnvironmentValues $environmentValues `
-            -RawValue (Get-EnvValue -EnvValues $environmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false") |
+        Get-DmsEnvironmentFileDeclaredValue `
+            -ResolvedEnvironmentFile $sequential `
+            -Name "USE_API_SCHEMA_PATH" `
+            -DefaultValue "false" |
             Should -BeExactly "true"
         @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $environmentFilePath).Count |
             Should -BeGreaterThan 0
+    }
+
+    It "declares no repeated key whose value another declaration resolves against" -ForEach @(
+        @{ Label = ".env.e2e"; BaseName = ".env.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.routeContext.e2e"; BaseName = ".env.routeContext.e2e"; DataStandardVersion = "" }
+        @{ Label = ".env.e2e composed with .env.ds52"; BaseName = ".env.e2e"; DataStandardVersion = "5.2" }
+        @{ Label = ".env.e2e composed with .env.ds61"; BaseName = ".env.e2e"; DataStandardVersion = "6.1" }
+    ) {
+        # The tracked-file guard for the defect the unit fixtures cover synthetically. A key declared
+        # twice is legal Compose, but if a LATER declaration re-defines a name an EARLIER line already
+        # resolved against, the two models disagree - and the collapsed one silently wins arguments it
+        # should lose. This reports that shape landing in a tracked file rather than waiting for a
+        # setup abort. Overlay composition can legitimately introduce duplicates, so the assertion is
+        # scoped to duplicates that something actually references.
+        $environmentFilePath = Resolve-TrackedEnvironmentFile -BaseName $BaseName -DataStandardVersion $DataStandardVersion
+        $sequential = Resolve-DotenvFileSequentially -Path $environmentFilePath
+
+        $referencedNames = @($sequential.Declarations | ForEach-Object { $_.References }) | Select-Object -Unique
+        $referencedDuplicates = @($sequential.DuplicateKeys | Where-Object { $referencedNames -contains $_ })
+
+        $referencedDuplicates | Should -BeNullOrEmpty -Because "a re-declared name that another line resolves against makes the file's meaning depend on declaration order"
     }
 }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -241,20 +241,21 @@ Playwright setup/teardown.
 - **All data-plane requests return 503 / `EffectiveSchemaHash` mismatch.** The provisioned
   database schema and the DMS runtime schema differ (often a `SCHEMA_PACKAGES` or engine
   mismatch). Tear down and rerun `E2ETest` so the database is reprovisioned to match the image.
-  One cause is worth knowing: Docker Compose gives **process** environment variables precedence
-  over `--env-file` entries, and `local-dms.yml` resolves `USE_API_SCHEMA_PATH`,
-  `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` with `${VAR:-default}` fallbacks that treat a
-  present-but-blank value exactly like an unset one. So blank or `false` values for those three
-  in your shell used to start DMS on the image-baked schemas while provisioning had already
-  stamped the environment file's full package surface. Both setup wrappers now remove those three
-  names around their Docker phases, so the selected `-EnvironmentFile` is authoritative and an
-  ambient value cannot reach Compose. The two entry points report a detected mismatch differently:
-  `build-dms.ps1 E2ETest` compares the provisioned and runtime schema hashes and fails with
-  `E2E setup mismatch: ...`, while the direct `setup-local-dms.ps1` verifies the started container's
-  schema settings against the environment file and fails with `DMS E2E setup mismatch: ...`. Either
-  way the failure happens before any scenario runs. To
-  point a run at a different package surface, select a different `-EnvironmentFile` — ambient
-  overrides of those three names are deliberately not a supported channel here.
+  One failure mode is worth knowing, though it is not the only way to reach this symptom: Docker
+  Compose gives **process** environment variables precedence over `--env-file` entries, and
+  `local-dms.yml` resolves `USE_API_SCHEMA_PATH`, `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` with
+  `${VAR:-default}` fallbacks that treat a present-but-blank value exactly like an unset one. Blank
+  or `false` values for those three in your shell will therefore start DMS on the image-baked
+  schemas while provisioning has already stamped the environment file's full package surface. Both
+  setup wrappers remove those three names around their Docker phases, so the selected
+  `-EnvironmentFile` is authoritative and an ambient value cannot reach Compose. Both also verify
+  the started container after the fact, so a mismatch from *any* cause fails setup rather than
+  every scenario: `build-dms.ps1 E2ETest` compares the provisioned and runtime schema hashes and
+  fails with `E2E setup mismatch: ...`, while the direct `setup-local-dms.ps1` verifies the started
+  container's schema settings against the environment file and fails with
+  `DMS E2E setup mismatch: ...`. Either way the failure happens before any scenario runs. To point a
+  run at a different package surface, select a different `-EnvironmentFile` — ambient overrides of
+  those three names are deliberately not a supported channel here.
 - **SQL Server stack fails to start or is unhealthy.** Treat an unavailable or unhealthy
   `dms-mssql` container as an infrastructure failure, not a test result — inspect
   `docker logs dms-mssql` and the container's health, and confirm the `1435` host port is free.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -248,8 +248,11 @@ Playwright setup/teardown.
   in your shell used to start DMS on the image-baked schemas while provisioning had already
   stamped the environment file's full package surface. Both setup wrappers now remove those three
   names around their Docker phases, so the selected `-EnvironmentFile` is authoritative and an
-  ambient value cannot reach Compose; `setup-local-dms.ps1` also verifies the started container
-  against that file and fails with `DMS E2E setup mismatch: ...` before any scenario runs. To
+  ambient value cannot reach Compose. The two entry points report a detected mismatch differently:
+  `build-dms.ps1 E2ETest` compares the provisioned and runtime schema hashes and fails with
+  `E2E setup mismatch: ...`, while the direct `setup-local-dms.ps1` verifies the started container's
+  schema settings against the environment file and fails with `DMS E2E setup mismatch: ...`. Either
+  way the failure happens before any scenario runs. To
   point a run at a different package surface, select a different `-EnvironmentFile` — ambient
   overrides of those three names are deliberately not a supported channel here.
 - **SQL Server stack fails to start or is unhealthy.** Treat an unavailable or unhealthy

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -241,21 +241,19 @@ Playwright setup/teardown.
 - **All data-plane requests return 503 / `EffectiveSchemaHash` mismatch.** The provisioned
   database schema and the DMS runtime schema differ (often a `SCHEMA_PACKAGES` or engine
   mismatch). Tear down and rerun `E2ETest` so the database is reprovisioned to match the image.
-  One failure mode is worth knowing, though it is not the only way to reach this symptom: Docker
-  Compose gives **process** environment variables precedence over `--env-file` entries, and
-  `local-dms.yml` resolves `USE_API_SCHEMA_PATH`, `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` with
-  `${VAR:-default}` fallbacks that treat a present-but-blank value exactly like an unset one. Blank
-  or `false` values for those three in your shell will therefore start DMS on the image-baked
-  schemas while provisioning has already stamped the environment file's full package surface. Both
-  setup wrappers remove those three names around their Docker phases, so the selected
-  `-EnvironmentFile` is authoritative and an ambient value cannot reach Compose. Both also verify
-  the started container after the fact, so a mismatch from *any* cause fails setup rather than
-  every scenario: `build-dms.ps1 E2ETest` compares the provisioned and runtime schema hashes and
-  fails with `E2E setup mismatch: ...`, while the direct `setup-local-dms.ps1` verifies the started
-  container's schema settings against the environment file and fails with
-  `DMS E2E setup mismatch: ...`. Either way the failure happens before any scenario runs. To point a
-  run at a different package surface, select a different `-EnvironmentFile` — ambient overrides of
-  those three names are deliberately not a supported channel here.
+  Both setup paths try to catch this before any scenario runs, and they catch different things.
+  `build-dms.ps1 E2ETest` compares the provisioned and runtime schema **hashes** and fails with
+  `E2E setup mismatch: ...`. The direct `setup-local-dms.ps1` compares the started container's schema
+  **settings** against the selected environment file and fails with `DMS E2E setup mismatch: ...`;
+  that gate catches settings divergence, not every possible hash divergence. Both wrappers also run
+  each Docker phase inside a guard that removes `USE_API_SCHEMA_PATH`, `API_SCHEMA_PATH`, and
+  `SCHEMA_PACKAGES` from the process, so the selected `-EnvironmentFile` is authoritative and an
+  ambient value cannot reach Compose. A blank or `false` value for one of those three in your shell
+  is one way to reach this symptom — confirmed by construction from Compose's documented precedence
+  rather than diagnosed from a particular incident — and it is not the only way. To point a run at a
+  different package surface, select a different `-EnvironmentFile`; ambient overrides of those three
+  names are deliberately not a supported channel here. The mechanism is explained in full in
+  `eng/docker-compose/dms-schema-environment.psm1`.
 - **SQL Server stack fails to start or is unhealthy.** Treat an unavailable or unhealthy
   `dms-mssql` container as an infrastructure failure, not a test result — inspect
   `docker logs dms-mssql` and the container's health, and confirm the `1435` host port is free.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/README.md
@@ -241,6 +241,17 @@ Playwright setup/teardown.
 - **All data-plane requests return 503 / `EffectiveSchemaHash` mismatch.** The provisioned
   database schema and the DMS runtime schema differ (often a `SCHEMA_PACKAGES` or engine
   mismatch). Tear down and rerun `E2ETest` so the database is reprovisioned to match the image.
+  One cause is worth knowing: Docker Compose gives **process** environment variables precedence
+  over `--env-file` entries, and `local-dms.yml` resolves `USE_API_SCHEMA_PATH`,
+  `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` with `${VAR:-default}` fallbacks that treat a
+  present-but-blank value exactly like an unset one. So blank or `false` values for those three
+  in your shell used to start DMS on the image-baked schemas while provisioning had already
+  stamped the environment file's full package surface. Both setup wrappers now remove those three
+  names around their Docker phases, so the selected `-EnvironmentFile` is authoritative and an
+  ambient value cannot reach Compose; `setup-local-dms.ps1` also verifies the started container
+  against that file and fails with `DMS E2E setup mismatch: ...` before any scenario runs. To
+  point a run at a different package surface, select a different `-EnvironmentFile` — ambient
+  overrides of those three names are deliberately not a supported channel here.
 - **SQL Server stack fails to start or is unhealthy.** Treat an unavailable or unhealthy
   `dms-mssql` container as an infrastructure failure, not a test result — inspect
   `docker logs dms-mssql` and the container's health, and confirm the `1435` host port is free.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -123,7 +123,7 @@ try {
     #
     # Without -Force, the same rule this module applies to its own nested imports: -Force removes a
     # module session-wide before re-importing it, while a plain import reuses an already-loaded
-    # instance. build-dms.ps1 loads this same module for its own -Enabled wrapper before invoking a
+    # instance. build-dms.ps1 loads this same module for its own guarded call sites before invoking a
     # setup wrapper in-process, so reusing that instance keeps one module serving both.
     Import-Module ./dms-schema-environment.psm1
 
@@ -176,10 +176,6 @@ try {
     # script runs in this same process, and one that re-creates any of the three - start-local-dms.ps1
     # does exactly that for bootstrap mode - would then still be setting it for every later phase.
     # Guarding per phase re-applies the removal immediately before each Compose call.
-    #
-    # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose:
-    # build-dms.ps1 invokes a setup wrapper in-process, so a shared name would resolve up the scope
-    # chain to the build script's pass-through variant instead of this module's export.
 
     # Start only the infrastructure and Configuration Service first. DMS starts after the
     # E2E data store exists and the relational schema has been provisioned.

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -119,7 +119,12 @@ try {
     # rather than carrying their own copies. The verification reads the environment file through the
     # same file-only package reader the provision phase uses, so the container is compared against
     # exactly the package surface the database was provisioned for.
-    Import-Module ./dms-schema-environment.psm1 -Force
+    #
+    # Without -Force, the same rule this module applies to its own nested imports: -Force removes a
+    # module session-wide before re-importing it, while a plain import reuses an already-loaded
+    # instance. build-dms.ps1 loads this same module for its own -Enabled wrapper before invoking a
+    # setup wrapper in-process, so reusing that instance keeps one module serving both.
+    Import-Module ./dms-schema-environment.psm1
 
     $baseEnvironmentFile = Resolve-LocalSettingsEnvironmentFile -Path $EnvironmentFile -DockerComposeRoot $dockerComposeDir
     # Compose the data-standard overlay first, then the database-engine overlay (same order as

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -22,6 +22,17 @@
     ./provision-e2e-database.ps1 -EnvironmentFile <selected env file> -DatabaseEngine <engine> -DatabaseName <E2E_DATABASE_NAME>
     ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile <selected env file> -DatabaseEngine <engine> -AddExtensionSecurityMetadata
 
+    Every Docker phase above runs with USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES
+    removed from this process, so the selected environment file is the sole authority for the schema
+    package surface of the whole direct setup flow. Docker Compose gives process environment
+    variables precedence over --env-file entries, and local-dms.yml resolves each of those three
+    with a ${VAR:-default} fallback that treats a present-but-blank value exactly like an unset one.
+    An ambient blank or false value therefore used to start DMS on the image-baked schemas while
+    provisioning had already stamped the environment file's full package surface, and every
+    data-plane request then failed with an EffectiveSchemaHash mismatch. The caller's original
+    environment is restored exactly on completion, including the absent, empty, whitespace, and
+    valued distinctions, and on failure paths.
+
     On completion the script prints a copyable teardown command carrying the same -DatabaseEngine and
     the resolved -EnvironmentFile, so a custom or MSSQL run is torn down against its own compose
     definition/environment rather than the teardown wrapper's postgresql/.env.e2e defaults:
@@ -56,6 +67,73 @@ function Get-DirectSetupTeardownCommand {
 
     $quotedEnvironmentFile = "'" + ($EnvironmentFile -replace "'", "''") + "'"
     return "./teardown-local-dms.ps1 -DatabaseEngine $DatabaseEngine -EnvironmentFile $quotedEnvironmentFile"
+}
+
+function Invoke-WithEnvironmentFileSchemaSettings {
+    # Runs the direct setup flow's Docker phases with the three schema package variables absent from
+    # this process, so Docker Compose must resolve them from the selected --env-file, and restores
+    # the caller's exact prior state afterward.
+    #
+    # Compose gives process environment variables precedence over --env-file entries, and
+    # local-dms.yml resolves all three with a ${VAR:-default} fallback. Because ':-' substitutes the
+    # default for an empty value as well as an unset one, an ambient blank value silently wins over
+    # the environment file: the DMS container is created with AppSettings__UseApiSchemaPath=false and
+    # empty AppSettings__ApiSchemaPath/SCHEMA_PACKAGES, run.sh skips the package download entirely,
+    # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
+    # SCHEMA_PACKAGES from the environment file only - so the database is stamped for the file's full
+    # package surface while DMS computes a different runtime hash, and every data-plane request fails
+    # with an EffectiveSchemaHash mismatch.
+    #
+    # The whole phase sequence is guarded rather than only the two start-local-dms.ps1 calls: the
+    # environment file is authoritative for the entire direct setup flow, and a Compose call added to
+    # any phase later is covered by construction. The configure and provision phases are unaffected
+    # by the removal, because neither reads these variables from the process environment.
+    #
+    # This is deliberately a caller-side guard. start-local-dms.ps1 must not clear these globally:
+    # in bootstrap mode it sets them in-process on purpose, so process precedence makes the staged
+    # .bootstrap/ApiSchema workspace authoritative.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock] $Action
+    )
+
+    $schemaEnvironmentVariableNames = @(
+        "USE_API_SCHEMA_PATH",
+        "API_SCHEMA_PATH",
+        "SCHEMA_PACKAGES"
+    )
+
+    # $null distinguishes absent from present-and-empty, which is the distinction the restore below
+    # has to reproduce.
+    $previousValues = @{}
+    foreach ($name in $schemaEnvironmentVariableNames) {
+        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
+    }
+
+    try {
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            # Remove-Item, never an assignment: whether '$env:X = $null' removes the variable or
+            # leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank
+            # value satisfies ${VAR:-default} - which is the bug this guard exists to prevent.
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+
+        & $Action
+    }
+    finally {
+        # Restore each variable to its exact prior state: re-create it with the verbatim prior value
+        # (including empty and whitespace) when it existed, otherwise remove it. This runs on the
+        # success path, when the action throws, and when the action calls exit.
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            if ($null -eq $previousValues[$name]) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+            else {
+                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
+            }
+        }
+    }
 }
 
 Write-Host @"
@@ -141,40 +219,42 @@ try {
 
     Write-Output "Using file-based schema packages from $resolvedEnvironmentFile for E2E (non-bootstrap compatibility path)."
 
-    # Start only the infrastructure and Configuration Service first. DMS starts after the
-    # E2E data store exists and the relational schema has been provisioned.
-    ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -r -AddExtensionSecurityMetadata
+    Invoke-WithEnvironmentFileSchemaSettings -Action {
+        # Start only the infrastructure and Configuration Service first. DMS starts after the
+        # E2E data store exists and the relational schema has been provisioned.
+        ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -r -AddExtensionSecurityMetadata
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
-        exit $LASTEXITCODE
-    }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
 
-    # Create the default data store via the configuration phase. start-local-dms.ps1 no longer
-    # creates a data store automatically; instance creation is owned by configure-local-data-store.ps1.
-    # Config Service is already healthy at this point because the -InfraOnly phase waits for
-    # CMS readiness before returning.
-    ./configure-local-data-store.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DataStoreDatabaseName $e2eDatabaseName
+        # Create the default data store via the configuration phase. start-local-dms.ps1 no longer
+        # creates a data store automatically; instance creation is owned by configure-local-data-store.ps1.
+        # Config Service is already healthy at this point because the -InfraOnly phase waits for
+        # CMS readiness before returning.
+        ./configure-local-data-store.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DataStoreDatabaseName $e2eDatabaseName
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to configure local data store. Exit code: $LASTEXITCODE"
-        exit $LASTEXITCODE
-    }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to configure local data store. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
 
-    Write-Host "`nProvisioning E2E database '$e2eDatabaseName'..." -ForegroundColor Cyan
-    ./provision-e2e-database.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DatabaseName $e2eDatabaseName
+        Write-Host "`nProvisioning E2E database '$e2eDatabaseName'..." -ForegroundColor Cyan
+        ./provision-e2e-database.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DatabaseName $e2eDatabaseName
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to provision E2E database '$e2eDatabaseName'. Exit code: $LASTEXITCODE"
-        exit $LASTEXITCODE
-    }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to provision E2E database '$e2eDatabaseName'. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
 
-    Write-Host "`nStarting DMS after E2E database provisioning..." -ForegroundColor Cyan
-    ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -AddExtensionSecurityMetadata
+        Write-Host "`nStarting DMS after E2E database provisioning..." -ForegroundColor Cyan
+        ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -AddExtensionSecurityMetadata
 
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to start DMS service after E2E database provisioning. Exit code: $LASTEXITCODE"
-        exit $LASTEXITCODE
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Failed to start DMS service after E2E database provisioning. Exit code: $LASTEXITCODE"
+            exit $LASTEXITCODE
+        }
     }
 
     # Pass the fully resolved environment file (data-standard then engine overlay) so teardown uses the

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -27,14 +27,15 @@
     package surface of the whole direct setup flow. Docker Compose gives process environment
     variables precedence over --env-file entries, and local-dms.yml resolves each of those three
     with a ${VAR:-default} fallback that treats a present-but-blank value exactly like an unset one.
-    An ambient blank or false value therefore used to start DMS on the image-baked schemas while
-    provisioning had already stamped the environment file's full package surface, and every
-    data-plane request then failed with an EffectiveSchemaHash mismatch. The caller's original
-    environment is restored exactly on completion, including the absent, empty, whitespace, and
-    valued distinctions, and on failure paths.
+    An ambient blank or false value is therefore one confirmed way to start DMS on the image-baked
+    schemas while provisioning has already stamped the environment file's full package surface, after
+    which every data-plane request fails with an EffectiveSchemaHash mismatch. That is a failure mode
+    this guard closes; it is not established as the source of any particular reported incident. The
+    caller's original environment is restored exactly on completion, including the absent, empty,
+    whitespace, and valued distinctions, and on failure paths.
 
     After DMS starts, the script verifies the container actually received that package surface and
-    fails the setup when it did not, so this class of mismatch is reported here rather than as an
+    fails the setup when it did not, so a mismatch from any cause is reported here rather than as an
     HTTP 503 EffectiveSchemaHash failure in every scenario of the suite. Both sides of the comparison
     are read from the environment file, never with Docker Compose precedence.
 
@@ -87,7 +88,9 @@ function Invoke-WithEnvironmentFileSchemaSettings {
     # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
     # SCHEMA_PACKAGES from the environment file only - so the database is stamped for the file's full
     # package surface while DMS computes a different runtime hash, and every data-plane request fails
-    # with an EffectiveSchemaHash mismatch.
+    # with an EffectiveSchemaHash mismatch. That path is confirmed by construction from Compose's
+    # documented precedence; it is not a diagnosis of any particular reported incident, and this guard
+    # is cheap enough to hold regardless of which cause produced one.
     #
     # The whole phase sequence is guarded rather than only the two start-local-dms.ps1 calls: the
     # environment file is authoritative for the entire direct setup flow, and a Compose call added to
@@ -141,343 +144,6 @@ function Invoke-WithEnvironmentFileSchemaSettings {
     }
 }
 
-function Get-DmsSchemaEnvironmentToken {
-    # Classifies a container environment value without echoing it, so a failure message carries a
-    # fixed vocabulary instead of interpolated container text.
-    param(
-        [Parameter(Mandatory)]
-        [hashtable] $ContainerEnvironment,
-
-        [Parameter(Mandatory)]
-        [string] $Key
-    )
-
-    if (-not $ContainerEnvironment.ContainsKey($Key)) {
-        return "<absent>"
-    }
-
-    $value = [string]$ContainerEnvironment[$Key]
-
-    if ([string]::IsNullOrWhiteSpace($value)) {
-        return "<blank>"
-    }
-
-    # Ordinal, deliberately not OrdinalIgnoreCase. run.sh:28 gates the entire package download on
-    # [ "$AppSettings__UseApiSchemaPath" = true ], a byte-exact POSIX string comparison, so only
-    # lowercase 'true' turns on the ApiSchema path at runtime. Accepting 'TRUE' or 'True' here passed a
-    # container that then downloaded nothing, which is precisely the EffectiveSchemaHash mismatch this
-    # gate exists to catch. Any other casing classifies as <set> below and fails.
-    if ([string]::Equals($value, "true", [System.StringComparison]::Ordinal)) {
-        return "true"
-    }
-
-    # OrdinalIgnoreCase is still correct here: this token is only message vocabulary for a value that
-    # fails whatever its casing, not the gate itself.
-    if ([string]::Equals($value, "false", [System.StringComparison]::OrdinalIgnoreCase)) {
-        return "false"
-    }
-
-    return "<set>"
-}
-
-function Get-DmsContainerSchemaPackage {
-    # Returns the container's SCHEMA_PACKAGES entries as a parsed array, or $null when the value is
-    # absent, blank, or not a JSON array. The value itself is never returned to a caller that logs it:
-    # the entries only reach Get-DmsSchemaPackageIdentity, which is used for comparison alone.
-    param(
-        [Parameter(Mandatory)]
-        [hashtable] $ContainerEnvironment
-    )
-
-    if (-not $ContainerEnvironment.ContainsKey("SCHEMA_PACKAGES")) {
-        return $null
-    }
-
-    $value = [string]$ContainerEnvironment["SCHEMA_PACKAGES"]
-
-    if ([string]::IsNullOrWhiteSpace($value)) {
-        return $null
-    }
-
-    try {
-        # -NoEnumerate keeps a single-element array an array. Without it PowerShell unwraps
-        # '[{...}]' to one PSCustomObject, and the shape check below would reject a valid
-        # one-package container as "not a JSON array".
-        $parsed = $value | ConvertFrom-Json -NoEnumerate -ErrorAction Stop
-    }
-    catch {
-        return $null
-    }
-
-    # A JSON object parses without error but is not a package list; only an array is a package set.
-    # This check cannot be replaced by wrapping the parse result in @(...), which would make a JSON
-    # object look like a one-item package list.
-    if ($parsed -isnot [System.Collections.IList]) {
-        return $null
-    }
-
-    # The unary comma keeps an empty or single-entry result an array through the return: PowerShell
-    # would otherwise unroll '@()' to nothing, and the caller could not tell it from the $null above.
-    return , @($parsed)
-}
-
-function Get-DmsSchemaPackageIdentity {
-    # Reduces ApiSchema package entries to sorted, comparable identities built from the three fields
-    # that decide which schema artifact is downloaded - name, version, and feedUrl - which is what
-    # run.sh and the provision phase's downloader both consume. A count comparison alone accepts a
-    # container whose packages differ in any of them, which is exactly the surface the E2E database was
-    # not provisioned for. A missing field normalizes to an empty string rather than throwing, so a
-    # malformed entry compares unequal instead of failing the verification.
-    #
-    # The identities are only ever compared; they are never returned to a failure message, so no
-    # container-supplied text can reach the console.
-    param(
-        [Parameter(Mandatory)]
-        [AllowEmptyCollection()]
-        [object[]] $Package
-    )
-
-    $identities = @(
-        foreach ($entry in $Package) {
-            $fields = [ordered]@{}
-            foreach ($fieldName in @("name", "version", "feedUrl")) {
-                $property = if ($null -eq $entry) { $null } else { $entry.PSObject.Properties[$fieldName] }
-                $fields[$fieldName] = if ($null -eq $property) { "" } else { [string]$property.Value }
-            }
-
-            # JSON rather than a delimiter join: a value containing the delimiter would otherwise let
-            # two different package sets normalize to the same identity text.
-            ConvertTo-Json -InputObject $fields -Compress
-        }
-    )
-
-    # Declaration order is not part of the package surface, so both sides are sorted before they are
-    # compared. Ordinal, so the result cannot vary with the host's culture.
-    [array]::Sort($identities, [System.StringComparer]::Ordinal)
-
-    return , $identities
-}
-
-function Get-DmsSchemaEnvironmentVerdict {
-    <#
-    .SYNOPSIS
-        Decides whether the started DMS container's schema environment agrees with the environment file
-        the E2E database was provisioned from, and returns a verdict plus a sanitized reason and
-        remediation. Pure, so the decision is unit-testable without Docker.
-    .DESCRIPTION
-        The provisioner reads SCHEMA_PACKAGES from the environment file only, so the database is always
-        stamped for the file's package surface. DMS, by contrast, receives its settings through Docker
-        Compose, which resolves them ambient-first. When the two disagree the stack comes up healthy
-        and then fails every data-plane request with an EffectiveSchemaHash mismatch, so the
-        disagreement is worth failing on at setup time.
-
-        Every requirement here is unconditional. The caller obtains ExpectedPackageIdentity from the same
-        reader the provision phase used, which throws unless the file declares at least one package, so
-        by the time this runs the database has been provisioned for a real package surface and the
-        runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH: a file that
-        declares packages but does not enable the ApiSchema path is internally inconsistent and
-        guarantees the mismatch, so it is reported rather than tolerated.
-    .OUTPUTS
-        [pscustomobject] with ShouldFail, Reason, and Remediation.
-    #>
-    param(
-        [Parameter(Mandatory)]
-        [hashtable] $ContainerEnvironment,
-
-        # The environment file's declared ApiSchema package surface, as sorted identities from
-        # Get-DmsSchemaPackageIdentity. Constrained to at least one entry because the file-only reader
-        # the caller uses cannot produce less: an absent, malformed, or empty SCHEMA_PACKAGES
-        # declaration already failed the provision phase.
-        [Parameter(Mandatory)]
-        [ValidateCount(1, [int]::MaxValue)]
-        [string[]] $ExpectedPackageIdentity,
-
-        # The environment file's own USE_API_SCHEMA_PATH, read file-only (never with Compose
-        # precedence, which would let the ambient override this gate exists to catch decide the
-        # expected side and agree with a wrongly-started container).
-        [Parameter(Mandatory)]
-        [bool] $EnvironmentFileUsesApiSchemaPath,
-
-        # The environment file's API_SCHEMA_PATH, read file-only for the same reason. Compared
-        # Ordinal: this is the value Compose passes through verbatim, so any difference means the
-        # container is not using the path the environment file selected.
-        [Parameter(Mandatory)]
-        [AllowEmptyString()]
-        [string] $EnvironmentFileApiSchemaPath
-    )
-
-    $ambientRemediation = "Remove USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES from the invoking shell, or select a different -EnvironmentFile, then re-run setup."
-    $expectedPackageCount = $ExpectedPackageIdentity.Count
-
-    if (-not $EnvironmentFileUsesApiSchemaPath) {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the environment file declares $expectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
-            Remediation = "Set USE_API_SCHEMA_PATH=true in the environment file so its declared packages are the runtime schema surface."
-        }
-    }
-
-    $useApiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__UseApiSchemaPath"
-    if ($useApiSchemaPathToken -ne "true") {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $expectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
-            Remediation = $ambientRemediation
-        }
-    }
-
-    $apiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__ApiSchemaPath"
-    if ($apiSchemaPathToken -in @("<absent>", "<blank>")) {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the DMS container's AppSettings__ApiSchemaPath is $apiSchemaPathToken, so the declared ApiSchema packages have nowhere to be materialized."
-            Remediation = $ambientRemediation
-        }
-    }
-
-    # A container path that is present but not the one the environment file selected means DMS is
-    # materializing packages somewhere other than where the file said, which the token check above
-    # cannot see. Ordinal comparison only: Compose passes the value through verbatim, so no path
-    # normalization is warranted here. Neither path is echoed.
-    if (-not [string]::Equals(
-            [string]$ContainerEnvironment["AppSettings__ApiSchemaPath"],
-            $EnvironmentFileApiSchemaPath,
-            [System.StringComparison]::Ordinal)) {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the DMS container's AppSettings__ApiSchemaPath differs from the environment file's API_SCHEMA_PATH, so DMS is not materializing the declared ApiSchema packages where the environment file selected."
-            Remediation = $ambientRemediation
-        }
-    }
-
-    $containerPackages = Get-DmsContainerSchemaPackage -ContainerEnvironment $ContainerEnvironment
-    if ($null -eq $containerPackages) {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $expectedPackageCount ApiSchema package(s)."
-            Remediation = $ambientRemediation
-        }
-    }
-
-    if ($containerPackages.Count -ne $expectedPackageCount) {
-        return [pscustomobject]@{
-            ShouldFail  = $true
-            Reason      = "the DMS container received $($containerPackages.Count) ApiSchema package(s) but the E2E database was provisioned for the environment file's $expectedPackageCount."
-            Remediation = $ambientRemediation
-        }
-    }
-
-    # Counts agreeing is not the surface agreeing. A container carrying the same number of packages at
-    # a different name, version, or feed URL downloads different schemas, computes a different runtime
-    # hash, and fails every data-plane request exactly as a count mismatch would. Both sides are already
-    # sorted, so this is a positional comparison of equal-length identity lists; neither side is echoed.
-    $containerPackageIdentity = Get-DmsSchemaPackageIdentity -Package $containerPackages
-    for ($index = 0; $index -lt $expectedPackageCount; $index++) {
-        if (-not [string]::Equals(
-                $containerPackageIdentity[$index],
-                $ExpectedPackageIdentity[$index],
-                [System.StringComparison]::Ordinal)) {
-            return [pscustomobject]@{
-                ShouldFail  = $true
-                Reason      = "the DMS container's $expectedPackageCount ApiSchema package(s) differ from the environment file's declared packages by name, version, or feed URL, so DMS is loading a different schema surface than the E2E database was provisioned for."
-                Remediation = $ambientRemediation
-            }
-        }
-    }
-
-    return [pscustomobject]@{
-        ShouldFail  = $false
-        Reason      = ""
-        Remediation = ""
-    }
-}
-
-function Get-DmsContainerEnvironment {
-    # Reads a container's environment into a key/value map. Fails closed: an inspect that does not
-    # succeed is an inability to verify, never a pass.
-    param(
-        [Parameter(Mandatory)]
-        [string] $ContainerName
-    )
-
-    $environmentJson = docker inspect $ContainerName --format '{{json .Config.Env}}'
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unable to inspect Docker container '$ContainerName' to verify its schema environment."
-    }
-
-    $containerEnvironment = @{}
-
-    foreach ($entry in @($environmentJson | ConvertFrom-Json)) {
-        $entryText = [string]$entry
-        $separatorIndex = $entryText.IndexOf("=")
-
-        if ($separatorIndex -lt 0) {
-            continue
-        }
-
-        $containerEnvironment[$entryText.Substring(0, $separatorIndex)] = $entryText.Substring($separatorIndex + 1)
-    }
-
-    return $containerEnvironment
-}
-
-function Assert-DmsContainerSchemaEnvironment {
-    <#
-    .SYNOPSIS
-        Fails the setup when the started DMS container's schema environment disagrees with the
-        environment file the E2E database was provisioned from, so this class of mismatch surfaces here
-        instead of as HTTP 503 EffectiveSchemaHash failures in every scenario of the suite.
-    #>
-    param(
-        [Parameter(Mandatory)]
-        [string] $EnvironmentFilePath,
-
-        [Parameter(Mandatory)]
-        [hashtable] $EnvironmentValues,
-
-        [Parameter(Mandatory)]
-        [string] $ContainerName
-    )
-
-    # Both expectations come from the environment FILE. Get-SchemaPackagesFromEnvironmentFile is the
-    # same reader the provision phase used and it throws unless at least one package is declared, so a
-    # malformed or empty declaration has already failed provisioning rather than being treated as
-    # acceptable here. Get-EnvValue is file-only by contract; Get-ComposeResolvedEnvValue must not be
-    # used for either value, because resolving the expected side ambient-first would let the very
-    # override this gate exists to catch decide what "correct" means.
-    #
-    # ConvertFrom-ComposeEnvironmentValue is not a Compose-precedence reader: it applies only the
-    # value semantics Compose gives a single --env-file entry (surrounding quotes stripped, an inline
-    # comment dropped), so a legally quoted or commented declaration in a custom -EnvironmentFile is
-    # compared as the container actually received it instead of failing on raw file text.
-    $declaredPackages = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath)
-    # Ordinal against lowercase 'true', matching run.sh's byte-exact gate. Compose passes the file's
-    # value through verbatim, so a file declaring USE_API_SCHEMA_PATH=TRUE yields a container that
-    # skips the package download while provisioning still stamps the file's packages; reporting that
-    # against the file, with the remediation that names the file, is the actionable failure. The
-    # quote/comment normalization still runs first, so "true" and 'true' pass and only the casing is
-    # significant.
-    $environmentFileUsesApiSchemaPath = [string]::Equals(
-        (ConvertFrom-ComposeEnvironmentValue -Value (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")),
-        "true",
-        [System.StringComparison]::Ordinal
-    )
-    $environmentFileApiSchemaPath = ConvertFrom-ComposeEnvironmentValue -Value (Get-EnvValue -EnvValues $EnvironmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
-
-    $verdict = Get-DmsSchemaEnvironmentVerdict `
-        -ContainerEnvironment (Get-DmsContainerEnvironment -ContainerName $ContainerName) `
-        -ExpectedPackageIdentity (Get-DmsSchemaPackageIdentity -Package $declaredPackages) `
-        -EnvironmentFileUsesApiSchemaPath $environmentFileUsesApiSchemaPath `
-        -EnvironmentFileApiSchemaPath $environmentFileApiSchemaPath
-
-    if ($verdict.ShouldFail) {
-        throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation)"
-    }
-
-    Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green
-}
-
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for E2E Testing
 =================================================
@@ -517,10 +183,11 @@ try {
     # Shared Compose-equivalent resolver so this wrapper selects the same E2E target database the
     # provision phase resets (an ambient E2E_DATABASE_NAME override wins over the env file).
     Import-Module ./database-safety.psm1 -Force
-    # The same file-only schema package reader the provision phase uses, so the post-start
-    # verification below compares the container against exactly the package surface the database was
-    # provisioned for.
-    Import-Module ../schema-package-utility.psm1 -Force
+    # The post-start container schema verification, shared with the Instance Management E2E wrapper so
+    # both flows verify the same thing the same way. It reads the environment file through the same
+    # file-only package reader the provision phase uses, so the container is compared against exactly
+    # the package surface the database was provisioned for.
+    Import-Module ./dms-schema-environment.psm1 -Force
 
     $baseEnvironmentFile = Resolve-LocalSettingsEnvironmentFile -Path $EnvironmentFile -DockerComposeRoot $dockerComposeDir
     # Compose the data-standard overlay first, then the database-engine overlay (same order as

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -192,13 +192,18 @@ function Get-DmsContainerSchemaPackageCount {
     }
 
     try {
-        $parsed = $value | ConvertFrom-Json -ErrorAction Stop
+        # -NoEnumerate keeps a single-element array an array. Without it PowerShell unwraps
+        # '[{...}]' to one PSCustomObject, and the shape check below would reject a valid
+        # one-package container as "not a JSON array".
+        $parsed = $value | ConvertFrom-Json -NoEnumerate -ErrorAction Stop
     }
     catch {
         return -1
     }
 
     # A JSON object parses without error but is not a package list; only an array is a package set.
+    # This check cannot be replaced by wrapping the parse result in @(...), which would make a JSON
+    # object look like a one-item package list.
     if ($parsed -isnot [System.Collections.IList]) {
         return -1
     }

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -75,75 +75,6 @@ function Get-DirectSetupTeardownCommand {
     return "./teardown-local-dms.ps1 -DatabaseEngine $DatabaseEngine -EnvironmentFile $quotedEnvironmentFile"
 }
 
-function Invoke-WithEnvironmentFileSchemaSettings {
-    # Runs the direct setup flow's Docker phases with the three schema package variables absent from
-    # this process, so Docker Compose must resolve them from the selected --env-file, and restores
-    # the caller's exact prior state afterward.
-    #
-    # Compose gives process environment variables precedence over --env-file entries, and
-    # local-dms.yml resolves all three with a ${VAR:-default} fallback. Because ':-' substitutes the
-    # default for an empty value as well as an unset one, an ambient blank value silently wins over
-    # the environment file: the DMS container is created with AppSettings__UseApiSchemaPath=false and
-    # empty AppSettings__ApiSchemaPath/SCHEMA_PACKAGES, run.sh skips the package download entirely,
-    # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
-    # SCHEMA_PACKAGES from the environment file only - so the database is stamped for the file's full
-    # package surface while DMS computes a different runtime hash, and every data-plane request fails
-    # with an EffectiveSchemaHash mismatch. That path is confirmed by construction from Compose's
-    # documented precedence; it is not a diagnosis of any particular reported incident, and this guard
-    # is cheap enough to hold regardless of which cause produced one.
-    #
-    # The whole phase sequence is guarded rather than only the two start-local-dms.ps1 calls: the
-    # environment file is authoritative for the entire direct setup flow, and a Compose call added to
-    # any phase later is covered by construction. The configure and provision phases are unaffected
-    # by the removal, because neither reads these variables from the process environment.
-    #
-    # This is deliberately a caller-side guard. start-local-dms.ps1 must not clear these globally:
-    # in bootstrap mode it sets them in-process on purpose, so process precedence makes the staged
-    # .bootstrap/ApiSchema workspace authoritative.
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
-    param(
-        [Parameter(Mandatory)]
-        [scriptblock] $Action
-    )
-
-    $schemaEnvironmentVariableNames = @(
-        "USE_API_SCHEMA_PATH",
-        "API_SCHEMA_PATH",
-        "SCHEMA_PACKAGES"
-    )
-
-    # $null distinguishes absent from present-and-empty, which is the distinction the restore below
-    # has to reproduce.
-    $previousValues = @{}
-    foreach ($name in $schemaEnvironmentVariableNames) {
-        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
-    }
-
-    try {
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            # Remove-Item, never an assignment: whether '$env:X = $null' removes the variable or
-            # leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank
-            # value satisfies ${VAR:-default} - which is the bug this guard exists to prevent.
-            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
-        }
-
-        & $Action
-    }
-    finally {
-        # Restore each variable to its exact prior state: re-create it with the verbatim prior value
-        # (including empty and whitespace) when it existed, otherwise remove it. This runs on the
-        # success path, when the action throws, and when the action calls exit.
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            if ($null -eq $previousValues[$name]) {
-                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
-            }
-            else {
-                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
-            }
-        }
-    }
-}
-
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for E2E Testing
 =================================================
@@ -183,10 +114,11 @@ try {
     # Shared Compose-equivalent resolver so this wrapper selects the same E2E target database the
     # provision phase resets (an ambient E2E_DATABASE_NAME override wins over the env file).
     Import-Module ./database-safety.psm1 -Force
-    # The post-start container schema verification, shared with the Instance Management E2E wrapper so
-    # both flows verify the same thing the same way. It reads the environment file through the same
-    # file-only package reader the provision phase uses, so the container is compared against exactly
-    # the package surface the database was provisioned for.
+    # The schema-settings guard and the post-start container schema verification, both shared with the
+    # Instance Management E2E wrapper so the two flows guard and verify the same thing the same way
+    # rather than carrying their own copies. The verification reads the environment file through the
+    # same file-only package reader the provision phase uses, so the container is compared against
+    # exactly the package surface the database was provisioned for.
     Import-Module ./dms-schema-environment.psm1 -Force
 
     $baseEnvironmentFile = Resolve-LocalSettingsEnvironmentFile -Path $EnvironmentFile -DockerComposeRoot $dockerComposeDir

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -33,6 +33,11 @@
     environment is restored exactly on completion, including the absent, empty, whitespace, and
     valued distinctions, and on failure paths.
 
+    After DMS starts, the script verifies the container actually received that package surface and
+    fails the setup when it did not, so this class of mismatch is reported here rather than as an
+    HTTP 503 EffectiveSchemaHash failure in every scenario of the suite. Both sides of the comparison
+    are read from the environment file, never with Docker Compose precedence.
+
     On completion the script prints a copyable teardown command carrying the same -DatabaseEngine and
     the resolved -EnvironmentFile, so a custom or MSSQL run is torn down against its own compose
     definition/environment rather than the teardown wrapper's postgresql/.env.e2e defaults:
@@ -136,6 +141,236 @@ function Invoke-WithEnvironmentFileSchemaSettings {
     }
 }
 
+function Get-DmsSchemaEnvironmentToken {
+    # Classifies a container environment value without echoing it, so a failure message carries a
+    # fixed vocabulary instead of interpolated container text.
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment,
+
+        [Parameter(Mandatory)]
+        [string] $Key
+    )
+
+    if (-not $ContainerEnvironment.ContainsKey($Key)) {
+        return "<absent>"
+    }
+
+    $value = [string]$ContainerEnvironment[$Key]
+
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return "<blank>"
+    }
+
+    if ([string]::Equals($value, "true", [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "true"
+    }
+
+    if ([string]::Equals($value, "false", [System.StringComparison]::OrdinalIgnoreCase)) {
+        return "false"
+    }
+
+    return "<set>"
+}
+
+function Get-DmsContainerSchemaPackageCount {
+    # Returns the number of entries in the container's SCHEMA_PACKAGES value, or -1 when it is absent,
+    # blank, or not a JSON array. The value itself is never returned or logged.
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment
+    )
+
+    if (-not $ContainerEnvironment.ContainsKey("SCHEMA_PACKAGES")) {
+        return -1
+    }
+
+    $value = [string]$ContainerEnvironment["SCHEMA_PACKAGES"]
+
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return -1
+    }
+
+    try {
+        $parsed = $value | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        return -1
+    }
+
+    # A JSON object parses without error but is not a package list; only an array is a package set.
+    if ($parsed -isnot [System.Collections.IList]) {
+        return -1
+    }
+
+    return @($parsed).Count
+}
+
+function Get-DmsSchemaEnvironmentVerdict {
+    <#
+    .SYNOPSIS
+        Decides whether the started DMS container's schema environment agrees with the environment file
+        the E2E database was provisioned from, and returns a verdict plus a sanitized reason and
+        remediation. Pure, so the decision is unit-testable without Docker.
+    .DESCRIPTION
+        The provisioner reads SCHEMA_PACKAGES from the environment file only, so the database is always
+        stamped for the file's package surface. DMS, by contrast, receives its settings through Docker
+        Compose, which resolves them ambient-first. When the two disagree the stack comes up healthy
+        and then fails every data-plane request with an EffectiveSchemaHash mismatch, so the
+        disagreement is worth failing on at setup time.
+
+        Every requirement here is unconditional. The caller obtains ExpectedPackageCount from the same
+        reader the provision phase used, which throws unless the file declares at least one package, so
+        by the time this runs the database has been provisioned for a real package surface and the
+        runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH: a file that
+        declares packages but does not enable the ApiSchema path is internally inconsistent and
+        guarantees the mismatch, so it is reported rather than tolerated.
+    .OUTPUTS
+        [pscustomobject] with ShouldFail, Reason, and Remediation.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [hashtable] $ContainerEnvironment,
+
+        # The environment file's declared ApiSchema package count. Constrained to at least one because
+        # the file-only reader the caller uses cannot produce less: an absent, malformed, or empty
+        # SCHEMA_PACKAGES declaration already failed the provision phase.
+        [Parameter(Mandatory)]
+        [ValidateRange(1, [int]::MaxValue)]
+        [int] $ExpectedPackageCount,
+
+        # The environment file's own USE_API_SCHEMA_PATH, read file-only (never with Compose
+        # precedence, which would let the ambient override this gate exists to catch decide the
+        # expected side and agree with a wrongly-started container).
+        [Parameter(Mandatory)]
+        [bool] $EnvironmentFileUsesApiSchemaPath
+    )
+
+    $ambientRemediation = "Remove USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES from the invoking shell, or select a different -EnvironmentFile, then re-run setup."
+
+    if (-not $EnvironmentFileUsesApiSchemaPath) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the environment file declares $ExpectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
+            Remediation = "Set USE_API_SCHEMA_PATH=true in the environment file so its declared packages are the runtime schema surface."
+        }
+    }
+
+    $useApiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__UseApiSchemaPath"
+    if ($useApiSchemaPathToken -ne "true") {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $ExpectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    $apiSchemaPathToken = Get-DmsSchemaEnvironmentToken -ContainerEnvironment $ContainerEnvironment -Key "AppSettings__ApiSchemaPath"
+    if ($apiSchemaPathToken -in @("<absent>", "<blank>")) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's AppSettings__ApiSchemaPath is $apiSchemaPathToken, so the declared ApiSchema packages have nowhere to be materialized."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    $containerPackageCount = Get-DmsContainerSchemaPackageCount -ContainerEnvironment $ContainerEnvironment
+    if ($containerPackageCount -lt 0) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $ExpectedPackageCount ApiSchema package(s)."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    if ($containerPackageCount -ne $ExpectedPackageCount) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container received $containerPackageCount ApiSchema package(s) but the E2E database was provisioned for the environment file's $ExpectedPackageCount."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    return [pscustomobject]@{
+        ShouldFail  = $false
+        Reason      = ""
+        Remediation = ""
+    }
+}
+
+function Get-DmsContainerEnvironment {
+    # Reads a container's environment into a key/value map. Fails closed: an inspect that does not
+    # succeed is an inability to verify, never a pass.
+    param(
+        [Parameter(Mandatory)]
+        [string] $ContainerName
+    )
+
+    $environmentJson = docker inspect $ContainerName --format '{{json .Config.Env}}'
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to inspect Docker container '$ContainerName' to verify its schema environment."
+    }
+
+    $containerEnvironment = @{}
+
+    foreach ($entry in @($environmentJson | ConvertFrom-Json)) {
+        $entryText = [string]$entry
+        $separatorIndex = $entryText.IndexOf("=")
+
+        if ($separatorIndex -lt 0) {
+            continue
+        }
+
+        $containerEnvironment[$entryText.Substring(0, $separatorIndex)] = $entryText.Substring($separatorIndex + 1)
+    }
+
+    return $containerEnvironment
+}
+
+function Assert-DmsContainerSchemaEnvironment {
+    <#
+    .SYNOPSIS
+        Fails the setup when the started DMS container's schema environment disagrees with the
+        environment file the E2E database was provisioned from, so this class of mismatch surfaces here
+        instead of as HTTP 503 EffectiveSchemaHash failures in every scenario of the suite.
+    #>
+    param(
+        [Parameter(Mandatory)]
+        [string] $EnvironmentFilePath,
+
+        [Parameter(Mandatory)]
+        [hashtable] $EnvironmentValues,
+
+        [Parameter(Mandatory)]
+        [string] $ContainerName
+    )
+
+    # Both expectations come from the environment FILE. Get-SchemaPackagesFromEnvironmentFile is the
+    # same reader the provision phase used and it throws unless at least one package is declared, so a
+    # malformed or empty declaration has already failed provisioning rather than being treated as
+    # acceptable here. Get-EnvValue is file-only by contract; Get-ComposeResolvedEnvValue must not be
+    # used for either value, because resolving the expected side ambient-first would let the very
+    # override this gate exists to catch decide what "correct" means.
+    $declaredPackageCount = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath).Count
+    $environmentFileUsesApiSchemaPath = [string]::Equals(
+        (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false"),
+        "true",
+        [System.StringComparison]::OrdinalIgnoreCase
+    )
+
+    $verdict = Get-DmsSchemaEnvironmentVerdict `
+        -ContainerEnvironment (Get-DmsContainerEnvironment -ContainerName $ContainerName) `
+        -ExpectedPackageCount $declaredPackageCount `
+        -EnvironmentFileUsesApiSchemaPath $environmentFileUsesApiSchemaPath
+
+    if ($verdict.ShouldFail) {
+        throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation)"
+    }
+
+    Write-Host "Verified DMS container schema environment matches the environment file ($declaredPackageCount ApiSchema package(s))." -ForegroundColor Green
+}
+
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for E2E Testing
 =================================================
@@ -175,6 +410,10 @@ try {
     # Shared Compose-equivalent resolver so this wrapper selects the same E2E target database the
     # provision phase resets (an ambient E2E_DATABASE_NAME override wins over the env file).
     Import-Module ./database-safety.psm1 -Force
+    # The same file-only schema package reader the provision phase uses, so the post-start
+    # verification below compares the container against exactly the package surface the database was
+    # provisioned for.
+    Import-Module ../schema-package-utility.psm1 -Force
 
     $baseEnvironmentFile = Resolve-LocalSettingsEnvironmentFile -Path $EnvironmentFile -DockerComposeRoot $dockerComposeDir
     # Compose the data-standard overlay first, then the database-engine overlay (same order as
@@ -255,6 +494,14 @@ try {
             Write-Error "Failed to start DMS service after E2E database provisioning. Exit code: $LASTEXITCODE"
             exit $LASTEXITCODE
         }
+
+        # Prove DMS actually came up on the environment file's schema package surface before any
+        # scenario runs. Inside the guard, so the file-only expectation cannot be contaminated by an
+        # ambient override even if a future edit reaches for a Compose-precedence reader.
+        Assert-DmsContainerSchemaEnvironment `
+            -EnvironmentFilePath $resolvedEnvironmentFile `
+            -EnvironmentValues $envValues `
+            -ContainerName "ed-fi-api"
     }
 
     # Pass the fully resolved environment file (data-standard then engine overlay) so teardown uses the

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -22,22 +22,23 @@
     ./provision-e2e-database.ps1 -EnvironmentFile <selected env file> -DatabaseEngine <engine> -DatabaseName <E2E_DATABASE_NAME>
     ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile <selected env file> -DatabaseEngine <engine> -AddExtensionSecurityMetadata
 
-    Every Docker phase above runs with USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES
-    removed from this process, so the selected environment file is the sole authority for the schema
-    package surface of the whole direct setup flow. Docker Compose gives process environment
-    variables precedence over --env-file entries, and local-dms.yml resolves each of those three
-    with a ${VAR:-default} fallback that treats a present-but-blank value exactly like an unset one.
-    An ambient blank or false value is therefore one confirmed way to start DMS on the image-baked
-    schemas while provisioning has already stamped the environment file's full package surface, after
-    which every data-plane request fails with an EffectiveSchemaHash mismatch. That is a failure mode
-    this guard closes; it is not established as the source of any particular reported incident. The
-    caller's original environment is restored exactly on completion, including the absent, empty,
-    whitespace, and valued distinctions, and on failure paths.
+    Each Docker phase above runs inside the shared schema-settings guard from
+    eng/docker-compose/dms-schema-environment.psm1, which removes USE_API_SCHEMA_PATH,
+    API_SCHEMA_PATH, and SCHEMA_PACKAGES from this process for the duration of that phase and then
+    restores the caller's exact prior state, including the absent, empty, whitespace, and valued
+    distinctions, and on failure paths. The selected environment file is therefore the sole authority
+    for the schema package surface of every phase. Each phase is guarded on its own rather than the
+    sequence as a whole, so a phase that re-creates one of the three names in this process cannot
+    leave it set for a later phase. That module explains why an ambient value would otherwise win
+    over the environment file.
 
-    After DMS starts, the script verifies the container actually received that package surface and
-    fails the setup when it did not, so a mismatch from any cause is reported here rather than as an
-    HTTP 503 EffectiveSchemaHash failure in every scenario of the suite. Both sides of the comparison
-    are read from the environment file, never with Docker Compose precedence.
+    After DMS starts, the script compares the started container's schema SETTINGS against the
+    selected environment file and fails the setup when they diverge, so that divergence is reported
+    here rather than as an HTTP 503 EffectiveSchemaHash failure in every scenario of the suite. This
+    is a settings-level check, not a schema-hash comparison: build-dms.ps1 E2ETest is the path that
+    compares the provisioned and runtime schema hashes, so a hash divergence whose settings agree is
+    caught there and not here. Both sides of this comparison are read from the environment file,
+    never with Docker Compose precedence.
 
     On completion the script prints a copyable teardown command carrying the same -DatabaseEngine and
     the resolved -EnvironmentFile, so a custom or MSSQL run is torn down against its own compose
@@ -169,49 +170,66 @@ try {
 
     Write-Output "Using file-based schema packages from $resolvedEnvironmentFile for E2E (non-bootstrap compatibility path)."
 
+    # Each phase is guarded INDIVIDUALLY rather than the sequence as a whole. The guard removes the
+    # three schema names for the phase it wraps and restores the caller's prior state when that phase
+    # returns, so wrapping the whole sequence would remove them exactly once, before phase 1: a phase
+    # script runs in this same process, and one that re-creates any of the three - start-local-dms.ps1
+    # does exactly that for bootstrap mode - would then still be setting it for every later phase.
+    # Guarding per phase re-applies the removal immediately before each Compose call.
+    #
     # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose:
     # build-dms.ps1 invokes a setup wrapper in-process, so a shared name would resolve up the scope
     # chain to the build script's pass-through variant instead of this module's export.
+
+    # Start only the infrastructure and Configuration Service first. DMS starts after the
+    # E2E data store exists and the relational schema has been provisioned.
     Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
-        # Start only the infrastructure and Configuration Service first. DMS starts after the
-        # E2E data store exists and the relational schema has been provisioned.
         ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -r -AddExtensionSecurityMetadata
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 
-        # Create the default data store via the configuration phase. start-local-dms.ps1 no longer
-        # creates a data store automatically; instance creation is owned by configure-local-data-store.ps1.
-        # Config Service is already healthy at this point because the -InfraOnly phase waits for
-        # CMS readiness before returning.
+    # Create the default data store via the configuration phase. start-local-dms.ps1 no longer
+    # creates a data store automatically; instance creation is owned by configure-local-data-store.ps1.
+    # Config Service is already healthy at this point because the -InfraOnly phase waits for
+    # CMS readiness before returning.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         ./configure-local-data-store.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DataStoreDatabaseName $e2eDatabaseName
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to configure local data store. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to configure local data store. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 
-        Write-Host "`nProvisioning E2E database '$e2eDatabaseName'..." -ForegroundColor Cyan
+    Write-Host "`nProvisioning E2E database '$e2eDatabaseName'..." -ForegroundColor Cyan
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         ./provision-e2e-database.ps1 -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -DatabaseName $e2eDatabaseName
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to provision E2E database '$e2eDatabaseName'. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to provision E2E database '$e2eDatabaseName'. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 
-        Write-Host "`nStarting DMS after E2E database provisioning..." -ForegroundColor Cyan
+    Write-Host "`nStarting DMS after E2E database provisioning..." -ForegroundColor Cyan
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -AddExtensionSecurityMetadata
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to start DMS service after E2E database provisioning. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start DMS service after E2E database provisioning. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 
-        # Prove DMS actually came up on the environment file's schema package surface before any
-        # scenario runs. Inside the guard, so the file-only expectation cannot be contaminated by an
-        # ambient override even if a future edit reaches for a Compose-precedence reader.
+    # Prove DMS actually came up on the environment file's schema package surface before any scenario
+    # runs. In its own guard, after the DMS-only start: the check reads a RUNNING container, and the
+    # guard keeps the file-only expectation from being contaminated by an ambient override even if a
+    # future edit reaches for a Compose-precedence reader.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         Assert-DmsContainerSchemaEnvironment `
             -EnvironmentFilePath $resolvedEnvironmentFile `
             -ContainerName "ed-fi-api"

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -274,7 +274,6 @@ try {
         # ambient override even if a future edit reaches for a Compose-precedence reader.
         Assert-DmsContainerSchemaEnvironment `
             -EnvironmentFilePath $resolvedEnvironmentFile `
-            -EnvironmentValues $envValues `
             -ContainerName "ed-fi-api"
     }
 

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -164,7 +164,10 @@ try {
 
     Write-Output "Using file-based schema packages from $resolvedEnvironmentFile for E2E (non-bootstrap compatibility path)."
 
-    Invoke-WithEnvironmentFileSchemaSettings -Action {
+    # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose:
+    # build-dms.ps1 invokes a setup wrapper in-process, so a shared name would resolve up the scope
+    # chain to the build script's pass-through variant instead of this module's export.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         # Start only the infrastructure and Configuration Service first. DMS starts after the
         # E2E data store exists and the relational schema has been provisioned.
         ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -r -AddExtensionSecurityMetadata

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/setup-local-dms.ps1
@@ -162,10 +162,17 @@ function Get-DmsSchemaEnvironmentToken {
         return "<blank>"
     }
 
-    if ([string]::Equals($value, "true", [System.StringComparison]::OrdinalIgnoreCase)) {
+    # Ordinal, deliberately not OrdinalIgnoreCase. run.sh:28 gates the entire package download on
+    # [ "$AppSettings__UseApiSchemaPath" = true ], a byte-exact POSIX string comparison, so only
+    # lowercase 'true' turns on the ApiSchema path at runtime. Accepting 'TRUE' or 'True' here passed a
+    # container that then downloaded nothing, which is precisely the EffectiveSchemaHash mismatch this
+    # gate exists to catch. Any other casing classifies as <set> below and fails.
+    if ([string]::Equals($value, "true", [System.StringComparison]::Ordinal)) {
         return "true"
     }
 
+    # OrdinalIgnoreCase is still correct here: this token is only message vocabulary for a value that
+    # fails whatever its casing, not the gate itself.
     if ([string]::Equals($value, "false", [System.StringComparison]::OrdinalIgnoreCase)) {
         return "false"
     }
@@ -173,22 +180,23 @@ function Get-DmsSchemaEnvironmentToken {
     return "<set>"
 }
 
-function Get-DmsContainerSchemaPackageCount {
-    # Returns the number of entries in the container's SCHEMA_PACKAGES value, or -1 when it is absent,
-    # blank, or not a JSON array. The value itself is never returned or logged.
+function Get-DmsContainerSchemaPackage {
+    # Returns the container's SCHEMA_PACKAGES entries as a parsed array, or $null when the value is
+    # absent, blank, or not a JSON array. The value itself is never returned to a caller that logs it:
+    # the entries only reach Get-DmsSchemaPackageIdentity, which is used for comparison alone.
     param(
         [Parameter(Mandatory)]
         [hashtable] $ContainerEnvironment
     )
 
     if (-not $ContainerEnvironment.ContainsKey("SCHEMA_PACKAGES")) {
-        return -1
+        return $null
     }
 
     $value = [string]$ContainerEnvironment["SCHEMA_PACKAGES"]
 
     if ([string]::IsNullOrWhiteSpace($value)) {
-        return -1
+        return $null
     }
 
     try {
@@ -198,17 +206,56 @@ function Get-DmsContainerSchemaPackageCount {
         $parsed = $value | ConvertFrom-Json -NoEnumerate -ErrorAction Stop
     }
     catch {
-        return -1
+        return $null
     }
 
     # A JSON object parses without error but is not a package list; only an array is a package set.
     # This check cannot be replaced by wrapping the parse result in @(...), which would make a JSON
     # object look like a one-item package list.
     if ($parsed -isnot [System.Collections.IList]) {
-        return -1
+        return $null
     }
 
-    return @($parsed).Count
+    # The unary comma keeps an empty or single-entry result an array through the return: PowerShell
+    # would otherwise unroll '@()' to nothing, and the caller could not tell it from the $null above.
+    return , @($parsed)
+}
+
+function Get-DmsSchemaPackageIdentity {
+    # Reduces ApiSchema package entries to sorted, comparable identities built from the three fields
+    # that decide which schema artifact is downloaded - name, version, and feedUrl - which is what
+    # run.sh and the provision phase's downloader both consume. A count comparison alone accepts a
+    # container whose packages differ in any of them, which is exactly the surface the E2E database was
+    # not provisioned for. A missing field normalizes to an empty string rather than throwing, so a
+    # malformed entry compares unequal instead of failing the verification.
+    #
+    # The identities are only ever compared; they are never returned to a failure message, so no
+    # container-supplied text can reach the console.
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [object[]] $Package
+    )
+
+    $identities = @(
+        foreach ($entry in $Package) {
+            $fields = [ordered]@{}
+            foreach ($fieldName in @("name", "version", "feedUrl")) {
+                $property = if ($null -eq $entry) { $null } else { $entry.PSObject.Properties[$fieldName] }
+                $fields[$fieldName] = if ($null -eq $property) { "" } else { [string]$property.Value }
+            }
+
+            # JSON rather than a delimiter join: a value containing the delimiter would otherwise let
+            # two different package sets normalize to the same identity text.
+            ConvertTo-Json -InputObject $fields -Compress
+        }
+    )
+
+    # Declaration order is not part of the package surface, so both sides are sorted before they are
+    # compared. Ordinal, so the result cannot vary with the host's culture.
+    [array]::Sort($identities, [System.StringComparer]::Ordinal)
+
+    return , $identities
 }
 
 function Get-DmsSchemaEnvironmentVerdict {
@@ -224,7 +271,7 @@ function Get-DmsSchemaEnvironmentVerdict {
         and then fails every data-plane request with an EffectiveSchemaHash mismatch, so the
         disagreement is worth failing on at setup time.
 
-        Every requirement here is unconditional. The caller obtains ExpectedPackageCount from the same
+        Every requirement here is unconditional. The caller obtains ExpectedPackageIdentity from the same
         reader the provision phase used, which throws unless the file declares at least one package, so
         by the time this runs the database has been provisioned for a real package surface and the
         runtime must match it. That includes the environment file's own USE_API_SCHEMA_PATH: a file that
@@ -237,26 +284,35 @@ function Get-DmsSchemaEnvironmentVerdict {
         [Parameter(Mandatory)]
         [hashtable] $ContainerEnvironment,
 
-        # The environment file's declared ApiSchema package count. Constrained to at least one because
-        # the file-only reader the caller uses cannot produce less: an absent, malformed, or empty
-        # SCHEMA_PACKAGES declaration already failed the provision phase.
+        # The environment file's declared ApiSchema package surface, as sorted identities from
+        # Get-DmsSchemaPackageIdentity. Constrained to at least one entry because the file-only reader
+        # the caller uses cannot produce less: an absent, malformed, or empty SCHEMA_PACKAGES
+        # declaration already failed the provision phase.
         [Parameter(Mandatory)]
-        [ValidateRange(1, [int]::MaxValue)]
-        [int] $ExpectedPackageCount,
+        [ValidateCount(1, [int]::MaxValue)]
+        [string[]] $ExpectedPackageIdentity,
 
         # The environment file's own USE_API_SCHEMA_PATH, read file-only (never with Compose
         # precedence, which would let the ambient override this gate exists to catch decide the
         # expected side and agree with a wrongly-started container).
         [Parameter(Mandatory)]
-        [bool] $EnvironmentFileUsesApiSchemaPath
+        [bool] $EnvironmentFileUsesApiSchemaPath,
+
+        # The environment file's API_SCHEMA_PATH, read file-only for the same reason. Compared
+        # Ordinal: this is the value Compose passes through verbatim, so any difference means the
+        # container is not using the path the environment file selected.
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string] $EnvironmentFileApiSchemaPath
     )
 
     $ambientRemediation = "Remove USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES from the invoking shell, or select a different -EnvironmentFile, then re-run setup."
+    $expectedPackageCount = $ExpectedPackageIdentity.Count
 
     if (-not $EnvironmentFileUsesApiSchemaPath) {
         return [pscustomobject]@{
             ShouldFail  = $true
-            Reason      = "the environment file declares $ExpectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
+            Reason      = "the environment file declares $expectedPackageCount ApiSchema package(s) but does not set USE_API_SCHEMA_PATH=true, so the E2E database was provisioned for those packages while DMS was configured to load only the schemas baked into the image."
             Remediation = "Set USE_API_SCHEMA_PATH=true in the environment file so its declared packages are the runtime schema surface."
         }
     }
@@ -265,7 +321,7 @@ function Get-DmsSchemaEnvironmentVerdict {
     if ($useApiSchemaPathToken -ne "true") {
         return [pscustomobject]@{
             ShouldFail  = $true
-            Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $ExpectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
+            Reason      = "the DMS container's AppSettings__UseApiSchemaPath is $useApiSchemaPathToken but the environment file declares $expectedPackageCount ApiSchema package(s), so DMS loaded only the schemas baked into the image while the E2E database was provisioned for those packages."
             Remediation = $ambientRemediation
         }
     }
@@ -279,20 +335,53 @@ function Get-DmsSchemaEnvironmentVerdict {
         }
     }
 
-    $containerPackageCount = Get-DmsContainerSchemaPackageCount -ContainerEnvironment $ContainerEnvironment
-    if ($containerPackageCount -lt 0) {
+    # A container path that is present but not the one the environment file selected means DMS is
+    # materializing packages somewhere other than where the file said, which the token check above
+    # cannot see. Ordinal comparison only: Compose passes the value through verbatim, so no path
+    # normalization is warranted here. Neither path is echoed.
+    if (-not [string]::Equals(
+            [string]$ContainerEnvironment["AppSettings__ApiSchemaPath"],
+            $EnvironmentFileApiSchemaPath,
+            [System.StringComparison]::Ordinal)) {
         return [pscustomobject]@{
             ShouldFail  = $true
-            Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $ExpectedPackageCount ApiSchema package(s)."
+            Reason      = "the DMS container's AppSettings__ApiSchemaPath differs from the environment file's API_SCHEMA_PATH, so DMS is not materializing the declared ApiSchema packages where the environment file selected."
             Remediation = $ambientRemediation
         }
     }
 
-    if ($containerPackageCount -ne $ExpectedPackageCount) {
+    $containerPackages = Get-DmsContainerSchemaPackage -ContainerEnvironment $ContainerEnvironment
+    if ($null -eq $containerPackages) {
         return [pscustomobject]@{
             ShouldFail  = $true
-            Reason      = "the DMS container received $containerPackageCount ApiSchema package(s) but the E2E database was provisioned for the environment file's $ExpectedPackageCount."
+            Reason      = "the DMS container's SCHEMA_PACKAGES is absent, blank, or not a JSON array, but the environment file declares $expectedPackageCount ApiSchema package(s)."
             Remediation = $ambientRemediation
+        }
+    }
+
+    if ($containerPackages.Count -ne $expectedPackageCount) {
+        return [pscustomobject]@{
+            ShouldFail  = $true
+            Reason      = "the DMS container received $($containerPackages.Count) ApiSchema package(s) but the E2E database was provisioned for the environment file's $expectedPackageCount."
+            Remediation = $ambientRemediation
+        }
+    }
+
+    # Counts agreeing is not the surface agreeing. A container carrying the same number of packages at
+    # a different name, version, or feed URL downloads different schemas, computes a different runtime
+    # hash, and fails every data-plane request exactly as a count mismatch would. Both sides are already
+    # sorted, so this is a positional comparison of equal-length identity lists; neither side is echoed.
+    $containerPackageIdentity = Get-DmsSchemaPackageIdentity -Package $containerPackages
+    for ($index = 0; $index -lt $expectedPackageCount; $index++) {
+        if (-not [string]::Equals(
+                $containerPackageIdentity[$index],
+                $ExpectedPackageIdentity[$index],
+                [System.StringComparison]::Ordinal)) {
+            return [pscustomobject]@{
+                ShouldFail  = $true
+                Reason      = "the DMS container's $expectedPackageCount ApiSchema package(s) differ from the environment file's declared packages by name, version, or feed URL, so DMS is loading a different schema surface than the E2E database was provisioned for."
+                Remediation = $ambientRemediation
+            }
         }
     }
 
@@ -357,23 +446,36 @@ function Assert-DmsContainerSchemaEnvironment {
     # acceptable here. Get-EnvValue is file-only by contract; Get-ComposeResolvedEnvValue must not be
     # used for either value, because resolving the expected side ambient-first would let the very
     # override this gate exists to catch decide what "correct" means.
-    $declaredPackageCount = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath).Count
+    #
+    # ConvertFrom-ComposeEnvironmentValue is not a Compose-precedence reader: it applies only the
+    # value semantics Compose gives a single --env-file entry (surrounding quotes stripped, an inline
+    # comment dropped), so a legally quoted or commented declaration in a custom -EnvironmentFile is
+    # compared as the container actually received it instead of failing on raw file text.
+    $declaredPackages = @(Get-SchemaPackagesFromEnvironmentFile -EnvironmentFilePath $EnvironmentFilePath)
+    # Ordinal against lowercase 'true', matching run.sh's byte-exact gate. Compose passes the file's
+    # value through verbatim, so a file declaring USE_API_SCHEMA_PATH=TRUE yields a container that
+    # skips the package download while provisioning still stamps the file's packages; reporting that
+    # against the file, with the remediation that names the file, is the actionable failure. The
+    # quote/comment normalization still runs first, so "true" and 'true' pass and only the casing is
+    # significant.
     $environmentFileUsesApiSchemaPath = [string]::Equals(
-        (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false"),
+        (ConvertFrom-ComposeEnvironmentValue -Value (Get-EnvValue -EnvValues $EnvironmentValues -Name "USE_API_SCHEMA_PATH" -DefaultValue "false")),
         "true",
-        [System.StringComparison]::OrdinalIgnoreCase
+        [System.StringComparison]::Ordinal
     )
+    $environmentFileApiSchemaPath = ConvertFrom-ComposeEnvironmentValue -Value (Get-EnvValue -EnvValues $EnvironmentValues -Name "API_SCHEMA_PATH" -DefaultValue "")
 
     $verdict = Get-DmsSchemaEnvironmentVerdict `
         -ContainerEnvironment (Get-DmsContainerEnvironment -ContainerName $ContainerName) `
-        -ExpectedPackageCount $declaredPackageCount `
-        -EnvironmentFileUsesApiSchemaPath $environmentFileUsesApiSchemaPath
+        -ExpectedPackageIdentity (Get-DmsSchemaPackageIdentity -Package $declaredPackages) `
+        -EnvironmentFileUsesApiSchemaPath $environmentFileUsesApiSchemaPath `
+        -EnvironmentFileApiSchemaPath $environmentFileApiSchemaPath
 
     if ($verdict.ShouldFail) {
         throw "DMS E2E setup mismatch: $($verdict.Reason) $($verdict.Remediation)"
     }
 
-    Write-Host "Verified DMS container schema environment matches the environment file ($declaredPackageCount ApiSchema package(s))." -ForegroundColor Green
+    Write-Host "Verified DMS container schema environment matches the environment file ($($declaredPackages.Count) ApiSchema package(s))." -ForegroundColor Green
 }
 
 Write-Host @"

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/README.md
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/README.md
@@ -200,7 +200,14 @@ clients, fixture state, and hydration), `Models/`, and `Hooks/` (`SetupHooks.cs`
   `dotnet test`.
 - **All routed requests return 503 / `EffectiveSchemaHash` mismatch.** A provisioned route
   database schema differs from the DMS runtime schema. Tear down and rerun so the databases are
-  reprovisioned to match the image.
+  reprovisioned to match the image. Setup tries to catch this before the suite runs: it removes
+  `USE_API_SCHEMA_PATH`, `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` from the process around its Docker
+  phases so the selected `-EnvironmentFile` is authoritative, then verifies the started `ed-fi-api`
+  container's schema settings against that file and fails with `DMS E2E setup mismatch: ...` before
+  any scenario runs. Select a different `-EnvironmentFile` to change the package surface; ambient
+  overrides of those three names are not a supported channel. See the standard suite's
+  [Troubleshooting](../EdFi.DataManagementService.Tests.E2E/README.md#troubleshooting) section for
+  the full failure mode.
 - **SQL Server stack fails to start or is unhealthy.** Treat an unavailable or unhealthy
   `dms-mssql` container as an infrastructure failure, not a test result — inspect
   `docker logs dms-mssql` and confirm the `1435` host port is free.

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -252,7 +252,12 @@ try {
     Import-Module ./database-safety.psm1 -Force
     # The schema-settings guard and the post-start container schema verification, both shared with the
     # direct DMS E2E wrapper rather than copied into each.
-    Import-Module ./dms-schema-environment.psm1 -Force
+    #
+    # Without -Force, the same rule this module applies to its own nested imports: -Force removes a
+    # module session-wide before re-importing it, while a plain import reuses an already-loaded
+    # instance. build-dms.ps1 loads this same module for its own -Enabled wrapper before invoking THIS
+    # script in-process, so reusing that instance keeps one module serving both.
+    Import-Module ./dms-schema-environment.psm1
 
     # Single environment resolution. The build path (build-dms.ps1 InstanceE2ETest) already composed
     # the data-standard and engine overlays exactly once in Get-InstanceE2ETestEnvironmentContext and

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -256,8 +256,8 @@ try {
     #
     # Without -Force, the same rule this module applies to its own nested imports: -Force removes a
     # module session-wide before re-importing it, while a plain import reuses an already-loaded
-    # instance. build-dms.ps1 loads this same module for its own -Enabled wrapper before invoking THIS
-    # script in-process, so reusing that instance keeps one module serving both.
+    # instance. build-dms.ps1 loads this same module for its own guarded call sites before invoking
+    # THIS script in-process, so reusing that instance keeps one module serving both.
     Import-Module ./dms-schema-environment.psm1
 
     # Single environment resolution. The build path (build-dms.ps1 InstanceE2ETest) already composed
@@ -346,12 +346,6 @@ try {
     # the first phase - and a phase script runs in this same process, so one that re-creates any of
     # them (start-local-dms.ps1 does exactly that for bootstrap mode) would still be setting it for
     # every later phase.
-    #
-    # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose.
-    # build-dms.ps1 InstanceE2ETest invokes THIS script in-process, so this scope is a child of the
-    # build script's: a shared name would resolve up the scope chain to its pass-through variant
-    # (-Enabled unset on a bare call) instead of this module's export, and every phase below would run
-    # with the ambient schema variables still present.
 
     # 1. Start only infrastructure and the Configuration Service. DMS starts after all three
     #    route-context schemas are provisioned and verified.

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -458,7 +458,6 @@ try {
         # this checks that the runtime is loading the packages those tables were generated from.
         Assert-DmsContainerSchemaEnvironment `
             -EnvironmentFilePath $resolvedEnvironmentFile `
-            -EnvironmentValues $envValues `
             -ContainerName "ed-fi-api"
     }
 

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -17,6 +17,14 @@
     DMS is not started until all three schemas are provisioned and verified. Unhealthy infrastructure
     or failed verification fails the setup (never skips).
 
+    Every Docker phase above runs with USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES
+    removed from this process, so the selected environment file is the sole authority for the schema
+    package surface. Docker Compose gives process environment variables precedence over --env-file
+    entries, and local-dms.yml resolves each of those three with a ${VAR:-default} fallback that
+    treats a present-but-blank value exactly like an unset one. The caller's original environment is
+    restored exactly on completion, including the absent, empty, whitespace, and valued distinctions,
+    and on failure paths.
+
     Suite-owned fixture registration (tenants, vendor, data stores, route contexts, applications) and
     the single post-registration DMS restart are performed by build-dms.ps1 InstanceE2ETest, not here.
 .PARAMETER SkipDockerBuild
@@ -199,6 +207,69 @@ function Assert-RouteContextDatabaseNamesAreDedicated {
     }
 }
 
+function Invoke-WithEnvironmentFileSchemaSettings {
+    # Runs the route-context setup flow's Docker phases with the three schema package variables absent
+    # from this process, so Docker Compose must resolve them from the selected --env-file, and restores
+    # the caller's exact prior state afterward.
+    #
+    # Compose gives process environment variables precedence over --env-file entries, and
+    # local-dms.yml resolves all three with a ${VAR:-default} fallback. Because ':-' substitutes the
+    # default for an empty value as well as an unset one, an ambient blank value silently wins over
+    # the environment file: the DMS container is created with AppSettings__UseApiSchemaPath=false and
+    # empty AppSettings__ApiSchemaPath/SCHEMA_PACKAGES, run.sh skips the package download entirely,
+    # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
+    # SCHEMA_PACKAGES from the environment file only - so each route-context database is stamped for
+    # the file's full package surface while DMS computes a different runtime hash, and every routed
+    # data request fails with an EffectiveSchemaHash mismatch.
+    #
+    # This is deliberately a caller-side guard. start-local-dms.ps1 must not clear these globally:
+    # in bootstrap mode it sets them in-process on purpose, so process precedence makes the staged
+    # .bootstrap/ApiSchema workspace authoritative.
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
+    param(
+        [Parameter(Mandatory)]
+        [scriptblock] $Action
+    )
+
+    $schemaEnvironmentVariableNames = @(
+        "USE_API_SCHEMA_PATH",
+        "API_SCHEMA_PATH",
+        "SCHEMA_PACKAGES"
+    )
+
+    # $null distinguishes absent from present-and-empty, which is the distinction the restore below
+    # has to reproduce.
+    $previousValues = @{}
+    foreach ($name in $schemaEnvironmentVariableNames) {
+        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
+    }
+
+    try {
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            # Remove-Item, never an assignment: whether '$env:X = $null' removes the variable or
+            # leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank
+            # value still satisfies ${VAR:-default} - so an assignment-based clear can leave this
+            # guard doing nothing at all.
+            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+        }
+
+        & $Action
+    }
+    finally {
+        # Restore each variable to its exact prior state: re-create it with the verbatim prior value
+        # (including empty and whitespace) when it existed, otherwise remove it. This runs on the
+        # success path, when the action throws, and when the action calls exit.
+        foreach ($name in $schemaEnvironmentVariableNames) {
+            if ($null -eq $previousValues[$name]) {
+                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
+            }
+            else {
+                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
+            }
+        }
+    }
+}
+
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for Instance Management E2E Testing
 ======================================================================
@@ -315,18 +386,11 @@ try {
 
     Write-Output "Using file-based schema packages from $resolvedEnvironmentFile for E2E (non-bootstrap compatibility path)."
 
-    $previousUseApiSchemaPath = [System.Environment]::GetEnvironmentVariable("USE_API_SCHEMA_PATH")
-    $previousApiSchemaPath = [System.Environment]::GetEnvironmentVariable("API_SCHEMA_PATH")
-    $previousSchemaPackages = [System.Environment]::GetEnvironmentVariable("SCHEMA_PACKAGES")
-    try {
-        # The resolved environment file carries the file-based ApiSchema package settings. Process env
-        # values win over docker compose --env-file entries, so clear stale overrides left by teardown
-        # or earlier bootstrap runs and let the env file provide
-        # USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES.
-        $env:USE_API_SCHEMA_PATH = $null
-        $env:API_SCHEMA_PATH = $null
-        $env:SCHEMA_PACKAGES = $null
-
+    # The resolved environment file carries the file-based ApiSchema package settings. Process env
+    # values win over docker compose --env-file entries, so the guard removes stale overrides left by
+    # teardown, an earlier bootstrap run, or the invoking shell and lets the env file provide
+    # USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES.
+    Invoke-WithEnvironmentFileSchemaSettings -Action {
         # 1. Start only infrastructure and the Configuration Service. DMS starts after all three
         #    route-context schemas are provisioned and verified.
         Write-Host "`nStarting infrastructure and Configuration Service (DMS not yet started)..." -ForegroundColor Cyan
@@ -377,11 +441,6 @@ try {
             Write-Error "Failed to start DMS service after route-context database provisioning. Exit code: $LASTEXITCODE"
             exit $LASTEXITCODE
         }
-    }
-    finally {
-        if ($null -eq $previousUseApiSchemaPath) { $env:USE_API_SCHEMA_PATH = $null } else { $env:USE_API_SCHEMA_PATH = $previousUseApiSchemaPath }
-        if ($null -eq $previousApiSchemaPath) { $env:API_SCHEMA_PATH = $null } else { $env:API_SCHEMA_PATH = $previousApiSchemaPath }
-        if ($null -eq $previousSchemaPackages) { $env:SCHEMA_PACKAGES = $null } else { $env:SCHEMA_PACKAGES = $previousSchemaPackages }
     }
 
     Write-Host "`n========================================" -ForegroundColor Green

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -25,6 +25,11 @@
     restored exactly on completion, including the absent, empty, whitespace, and valued distinctions,
     and on failure paths.
 
+    After DMS starts, the container's schema settings are verified against the environment file with
+    the shared Assert-DmsContainerSchemaEnvironment, the same check the direct DMS E2E wrapper runs, so
+    a disagreement is reported here rather than as opaque routed-request 503s across all three route
+    contexts.
+
     Suite-owned fixture registration (tenants, vendor, data stores, route contexts, applications) and
     the single post-registration DMS restart are performed by build-dms.ps1 InstanceE2ETest, not here.
 .PARAMETER SkipDockerBuild
@@ -220,7 +225,9 @@ function Invoke-WithEnvironmentFileSchemaSettings {
     # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
     # SCHEMA_PACKAGES from the environment file only - so each route-context database is stamped for
     # the file's full package surface while DMS computes a different runtime hash, and every routed
-    # data request fails with an EffectiveSchemaHash mismatch.
+    # data request fails with an EffectiveSchemaHash mismatch. That path is confirmed by construction
+    # from Compose's documented precedence; it is not a diagnosis of any particular reported incident,
+    # and this guard is cheap enough to hold regardless of which cause produced one.
     #
     # This is deliberately a caller-side guard. start-local-dms.ps1 must not clear these globally:
     # in bootstrap mode it sets them in-process on purpose, so process precedence makes the staged
@@ -308,6 +315,8 @@ try {
     Set-Location $dockerComposeDir
     Import-Module ./env-utility.psm1 -Force
     Import-Module ./database-safety.psm1 -Force
+    # The post-start container schema verification shared with the direct DMS E2E wrapper.
+    Import-Module ./dms-schema-environment.psm1 -Force
 
     # Single environment resolution. The build path (build-dms.ps1 InstanceE2ETest) already composed
     # the data-standard and engine overlays exactly once in Get-InstanceE2ETestEnvironmentContext and
@@ -441,6 +450,16 @@ try {
             Write-Error "Failed to start DMS service after route-context database provisioning. Exit code: $LASTEXITCODE"
             exit $LASTEXITCODE
         }
+
+        # Prove DMS actually came up on the environment file's schema package surface before the suite
+        # registers any route context. Inside the guard, so the file-only expectation cannot be
+        # contaminated by an ambient override even if a future edit reaches for a Compose-precedence
+        # reader. Assert-RouteContextSchemaProvisioned above checks that each database HAS the tables;
+        # this checks that the runtime is loading the packages those tables were generated from.
+        Assert-DmsContainerSchemaEnvironment `
+            -EnvironmentFilePath $resolvedEnvironmentFile `
+            -EnvironmentValues $envValues `
+            -ContainerName "ed-fi-api"
     }
 
     Write-Host "`n========================================" -ForegroundColor Green

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -335,7 +335,13 @@ try {
     # values win over docker compose --env-file entries, so the guard removes stale overrides left by
     # teardown, an earlier bootstrap run, or the invoking shell and lets the env file provide
     # USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES.
-    Invoke-WithEnvironmentFileSchemaSettings -Action {
+    #
+    # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose.
+    # build-dms.ps1 InstanceE2ETest invokes THIS script in-process, so this scope is a child of the
+    # build script's: a shared name would resolve up the scope chain to its pass-through variant
+    # (-Enabled unset on a bare call) instead of this module's export, and every phase below would run
+    # with the ambient schema variables still present.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         # 1. Start only infrastructure and the Configuration Service. DMS starts after all three
         #    route-context schemas are provisioned and verified.
         Write-Host "`nStarting infrastructure and Configuration Service (DMS not yet started)..." -ForegroundColor Cyan

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -212,71 +212,6 @@ function Assert-RouteContextDatabaseNamesAreDedicated {
     }
 }
 
-function Invoke-WithEnvironmentFileSchemaSettings {
-    # Runs the route-context setup flow's Docker phases with the three schema package variables absent
-    # from this process, so Docker Compose must resolve them from the selected --env-file, and restores
-    # the caller's exact prior state afterward.
-    #
-    # Compose gives process environment variables precedence over --env-file entries, and
-    # local-dms.yml resolves all three with a ${VAR:-default} fallback. Because ':-' substitutes the
-    # default for an empty value as well as an unset one, an ambient blank value silently wins over
-    # the environment file: the DMS container is created with AppSettings__UseApiSchemaPath=false and
-    # empty AppSettings__ApiSchemaPath/SCHEMA_PACKAGES, run.sh skips the package download entirely,
-    # and DMS loads only the image-baked schemas. Provisioning is not affected, because it reads
-    # SCHEMA_PACKAGES from the environment file only - so each route-context database is stamped for
-    # the file's full package surface while DMS computes a different runtime hash, and every routed
-    # data request fails with an EffectiveSchemaHash mismatch. That path is confirmed by construction
-    # from Compose's documented precedence; it is not a diagnosis of any particular reported incident,
-    # and this guard is cheap enough to hold regardless of which cause produced one.
-    #
-    # This is deliberately a caller-side guard. start-local-dms.ps1 must not clear these globally:
-    # in bootstrap mode it sets them in-process on purpose, so process precedence makes the staged
-    # .bootstrap/ApiSchema workspace authoritative.
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '', Justification = 'Names the schema settings carried by an environment file, matching the equivalent build-dms.ps1 helper.')]
-    param(
-        [Parameter(Mandatory)]
-        [scriptblock] $Action
-    )
-
-    $schemaEnvironmentVariableNames = @(
-        "USE_API_SCHEMA_PATH",
-        "API_SCHEMA_PATH",
-        "SCHEMA_PACKAGES"
-    )
-
-    # $null distinguishes absent from present-and-empty, which is the distinction the restore below
-    # has to reproduce.
-    $previousValues = @{}
-    foreach ($name in $schemaEnvironmentVariableNames) {
-        $previousValues[$name] = [System.Environment]::GetEnvironmentVariable($name)
-    }
-
-    try {
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            # Remove-Item, never an assignment: whether '$env:X = $null' removes the variable or
-            # leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank
-            # value still satisfies ${VAR:-default} - so an assignment-based clear can leave this
-            # guard doing nothing at all.
-            Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
-        }
-
-        & $Action
-    }
-    finally {
-        # Restore each variable to its exact prior state: re-create it with the verbatim prior value
-        # (including empty and whitespace) when it existed, otherwise remove it. This runs on the
-        # success path, when the action throws, and when the action calls exit.
-        foreach ($name in $schemaEnvironmentVariableNames) {
-            if ($null -eq $previousValues[$name]) {
-                Remove-Item -LiteralPath "Env:$name" -ErrorAction SilentlyContinue
-            }
-            else {
-                [System.Environment]::SetEnvironmentVariable($name, $previousValues[$name])
-            }
-        }
-    }
-}
-
 Write-Host @"
 Ed-Fi DMS Local Environment Setup for Instance Management E2E Testing
 ======================================================================
@@ -315,7 +250,8 @@ try {
     Set-Location $dockerComposeDir
     Import-Module ./env-utility.psm1 -Force
     Import-Module ./database-safety.psm1 -Force
-    # The post-start container schema verification shared with the direct DMS E2E wrapper.
+    # The schema-settings guard and the post-start container schema verification, both shared with the
+    # direct DMS E2E wrapper rather than copied into each.
     Import-Module ./dms-schema-environment.psm1 -Force
 
     # Single environment resolution. The build path (build-dms.ps1 InstanceE2ETest) already composed

--- a/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
+++ b/src/dms/tests/EdFi.InstanceManagement.Tests.E2E/setup-local-dms.ps1
@@ -17,18 +17,19 @@
     DMS is not started until all three schemas are provisioned and verified. Unhealthy infrastructure
     or failed verification fails the setup (never skips).
 
-    Every Docker phase above runs with USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES
-    removed from this process, so the selected environment file is the sole authority for the schema
-    package surface. Docker Compose gives process environment variables precedence over --env-file
-    entries, and local-dms.yml resolves each of those three with a ${VAR:-default} fallback that
-    treats a present-but-blank value exactly like an unset one. The caller's original environment is
-    restored exactly on completion, including the absent, empty, whitespace, and valued distinctions,
-    and on failure paths.
+    Each Docker phase above runs inside the shared schema-settings guard from
+    eng/docker-compose/dms-schema-environment.psm1 - individually, not as one sequence - so
+    USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES are absent for every Compose call, the
+    selected environment file is the sole authority for the schema package surface, and a phase that
+    re-creates one of the three names in this process cannot leave it set for a later phase. The
+    caller's original environment is restored exactly, including the absent, empty, whitespace, and
+    valued distinctions, and on failure paths. That module explains why an ambient value would
+    otherwise win over the environment file.
 
     After DMS starts, the container's schema settings are verified against the environment file with
-    the shared Assert-DmsContainerSchemaEnvironment, the same check the direct DMS E2E wrapper runs, so
-    a disagreement is reported here rather than as opaque routed-request 503s across all three route
-    contexts.
+    the shared Assert-DmsContainerSchemaEnvironment, the same settings-level check the direct DMS E2E
+    wrapper runs, so a settings divergence is reported here rather than as opaque routed-request 503s
+    across all three route contexts.
 
     Suite-owned fixture registration (tenants, vendor, data stores, route contexts, applications) and
     the single post-registration DMS restart are performed by build-dms.ps1 InstanceE2ETest, not here.
@@ -336,73 +337,93 @@ try {
 
     Write-Output "Using file-based schema packages from $resolvedEnvironmentFile for E2E (non-bootstrap compatibility path)."
 
-    # The resolved environment file carries the file-based ApiSchema package settings. Process env
-    # values win over docker compose --env-file entries, so the guard removes stale overrides left by
-    # teardown, an earlier bootstrap run, or the invoking shell and lets the env file provide
-    # USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES.
+    # The resolved environment file carries the file-based ApiSchema package settings, and process env
+    # values win over docker compose --env-file entries, so each phase below runs inside the shared
+    # guard that removes USE_API_SCHEMA_PATH, API_SCHEMA_PATH, and SCHEMA_PACKAGES for its duration.
+    #
+    # Guarded per phase, not once around the sequence. The guard restores the caller's prior state when
+    # the phase it wraps returns, so a single guard would remove the three names exactly once, before
+    # the first phase - and a phase script runs in this same process, so one that re-creates any of
+    # them (start-local-dms.ps1 does exactly that for bootstrap mode) would still be setting it for
+    # every later phase.
     #
     # Named distinctly from build-dms.ps1's own Invoke-WithEnvironmentFileSchemaSettings on purpose.
     # build-dms.ps1 InstanceE2ETest invokes THIS script in-process, so this scope is a child of the
     # build script's: a shared name would resolve up the scope chain to its pass-through variant
     # (-Enabled unset on a bare call) instead of this module's export, and every phase below would run
     # with the ambient schema variables still present.
-    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
-        # 1. Start only infrastructure and the Configuration Service. DMS starts after all three
-        #    route-context schemas are provisioned and verified.
-        Write-Host "`nStarting infrastructure and Configuration Service (DMS not yet started)..." -ForegroundColor Cyan
-        if ($SkipDockerBuild) {
+
+    # 1. Start only infrastructure and the Configuration Service. DMS starts after all three
+    #    route-context schemas are provisioned and verified.
+    Write-Host "`nStarting infrastructure and Configuration Service (DMS not yet started)..." -ForegroundColor Cyan
+    # The guard is inside each branch rather than around the if/else: exactly one of these runs, and
+    # one guard per phase invocation keeps the shape uniform across the wrapper.
+    if ($SkipDockerBuild) {
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
             ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -IdentityProvider self-contained -AddExtensionSecurityMetadata
         }
-        else {
+    }
+    else {
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
             ./start-local-dms.ps1 -InfraOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -r -IdentityProvider self-contained -AddExtensionSecurityMetadata
         }
+    }
 
-        if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
-        }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start DMS infrastructure. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
 
-        # 2. Provision the three route-context databases once with generated engine-correct DDL, then
-        #    verify each with the engine-dispatched schema check.
-        Write-Host "`nProvisioning and verifying route-context test databases..." -ForegroundColor Cyan
-        $provisionE2EDatabaseScript = Join-Path $dockerComposeDir "provision-e2e-database.ps1"
-        # PostgreSQL verification connects as the resolved role, not a hardcoded superuser, so a stack
-        # started with a non-default POSTGRES_USER still verifies. Resolved with Compose precedence
-        # (ambient wins) because Compose interpolates POSTGRES_USER into the container the same way
-        # and provisioning/registration already resolve it ambient-first. MSSQL verification reads its
-        # password inside dms-mssql from the container-resident MSSQL_SA_PASSWORD, so no SA password
-        # is resolved or passed on the host here.
-        $postgresUser = Get-ComposeResolvedEnvValue -EnvironmentValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
+    # 2. Provision the three route-context databases once with generated engine-correct DDL, then
+    #    verify each with the engine-dispatched schema check.
+    Write-Host "`nProvisioning and verifying route-context test databases..." -ForegroundColor Cyan
+    $provisionE2EDatabaseScript = Join-Path $dockerComposeDir "provision-e2e-database.ps1"
+    # PostgreSQL verification connects as the resolved role, not a hardcoded superuser, so a stack
+    # started with a non-default POSTGRES_USER still verifies. Resolved with Compose precedence
+    # (ambient wins) because Compose interpolates POSTGRES_USER into the container the same way
+    # and provisioning/registration already resolve it ambient-first. MSSQL verification reads its
+    # password inside dms-mssql from the container-resident MSSQL_SA_PASSWORD, so no SA password
+    # is resolved or passed on the host here.
+    $postgresUser = Get-ComposeResolvedEnvValue -EnvironmentValues $envValues -Name "POSTGRES_USER" -DefaultValue "postgres"
 
-        foreach ($db in $databases) {
+    foreach ($db in $databases) {
+        # Each provision call is its own guarded phase, for the same reason the starts are.
+        Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
             & $provisionE2EDatabaseScript `
                 -EnvironmentFile $resolvedEnvironmentFile `
                 -DatabaseEngine $DatabaseEngine `
                 -DatabaseName $db `
                 -Configuration Release
-
-            if ($LASTEXITCODE -ne 0) {
-                throw "Failed to provision route-context database '$db' (exit code $LASTEXITCODE)."
-            }
-
-            Assert-RouteContextSchemaProvisioned -Database $db -DatabaseEngine $DatabaseEngine -PostgresUser $postgresUser
-            Write-Host "  Provisioned and verified relational schema: $db" -ForegroundColor Green
         }
-
-        # 3. Start DMS now that all schemas exist, and wait for DMS health.
-        Write-Host "`nStarting DMS after route-context database provisioning..." -ForegroundColor Cyan
-        ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -IdentityProvider self-contained -AddExtensionSecurityMetadata
 
         if ($LASTEXITCODE -ne 0) {
-            Write-Error "Failed to start DMS service after route-context database provisioning. Exit code: $LASTEXITCODE"
-            exit $LASTEXITCODE
+            throw "Failed to provision route-context database '$db' (exit code $LASTEXITCODE)."
         }
 
-        # Prove DMS actually came up on the environment file's schema package surface before the suite
-        # registers any route context. Inside the guard, so the file-only expectation cannot be
-        # contaminated by an ambient override even if a future edit reaches for a Compose-precedence
-        # reader. Assert-RouteContextSchemaProvisioned above checks that each database HAS the tables;
-        # this checks that the runtime is loading the packages those tables were generated from.
+        # Outside the guard: this reads the provisioned database with docker exec and never resolves
+        # the three schema names.
+        Assert-RouteContextSchemaProvisioned -Database $db -DatabaseEngine $DatabaseEngine -PostgresUser $postgresUser
+        Write-Host "  Provisioned and verified relational schema: $db" -ForegroundColor Green
+    }
+
+    # 3. Start DMS now that all schemas exist, and wait for DMS health.
+    Write-Host "`nStarting DMS after route-context database provisioning..." -ForegroundColor Cyan
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
+        ./start-local-dms.ps1 -DmsOnly -EnableConfig -EnvironmentFile $resolvedEnvironmentFile -DatabaseEngine $DatabaseEngine -IdentityProvider self-contained -AddExtensionSecurityMetadata
+    }
+
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to start DMS service after route-context database provisioning. Exit code: $LASTEXITCODE"
+        exit $LASTEXITCODE
+    }
+
+    # Prove DMS actually came up on the environment file's schema package surface before the suite
+    # registers any route context. In its own guard, after the DMS-only start: the check reads a
+    # RUNNING container, and the guard keeps the file-only expectation from being contaminated by an
+    # ambient override even if a future edit reaches for a Compose-precedence reader.
+    # Assert-RouteContextSchemaProvisioned above checks that each database HAS the tables; this checks
+    # that the runtime is loading the packages those tables were generated from.
+    Invoke-WithDmsEnvironmentFileSchemaAuthority -Action {
         Assert-DmsContainerSchemaEnvironment `
             -EnvironmentFilePath $resolvedEnvironmentFile `
             -ContainerName "ed-fi-api"


### PR DESCRIPTION
## What

Makes the selected environment file authoritative for the ApiSchema package surface of the DMS E2E setup flows, and fails setup when the started DMS container disagrees with it, so a package-surface divergence is reported before any scenario runs instead of as an `EffectiveSchemaHash` 503 in every scenario of the suite.

## Why

The E2E setup wrappers run their Docker phases in one PowerShell process. Docker Compose gives process environment variables precedence over `--env-file` entries, and `local-dms.yml` resolves `USE_API_SCHEMA_PATH`, `API_SCHEMA_PATH`, and `SCHEMA_PACKAGES` with `${VAR:-default}` fallbacks. Because `:-` substitutes the default for an empty value as well as an unset one, an ambient blank or `false` value silently wins over the environment file: `ed-fi-api` is created with `AppSettings__UseApiSchemaPath=false` and empty `AppSettings__ApiSchemaPath` / `SCHEMA_PACKAGES` even though the container records `--env-file .env.e2e`. `run.sh` then skips the package download entirely and DMS loads only the image-baked schemas.

Provisioning is unaffected, because it reads `SCHEMA_PACKAGES` from the environment file only, so the database is stamped for the file's full package surface while DMS computes a different runtime hash. That asymmetry, a file-only provisioner against an ambient-first Compose resolution, is what made the divergence silent.

## Scope: prevention and detection, not a closure

This path is confirmed by construction from Compose's documented precedence. It is **not** a diagnosis of the reported incident — the ticket records the failure reproducing from clean shells, where no ambient override is in play. What this PR delivers is therefore:

- a guard that removes one cause class which would otherwise be invisible, and
- a post-start settings verification that turns container/environment-file disagreements, such as a stale container or a Compose run that used different schema settings than the selected `-EnvironmentFile`, into a named setup-time failure carrying remediation, rather than 503s in every scenario.

**Manual validation on the original macOS/Docker Desktop host remains pending.** That host was not available for this work, so neither the ticket's setup repro nor the `docker inspect ed-fi-api --format '{{json .Config.Env}}'` capture has been run against it. DMS-1300 should not be treated as fully closed on the strength of this PR's automated coverage alone.

## Changes

- New shared module `eng/docker-compose/dms-schema-environment.psm1` owns all three pieces: the pre-phase schema-settings guard, the post-start container schema verification, and the `docker inspect` container-environment reader. Both E2E setup wrappers and `build-dms.ps1` import it, so each exists once rather than once per caller — two copies drift, and only one of them gets the next fix.
- Each wrapper guards **every phase invocation individually**, not the phase sequence as a whole. The guard restores the caller's prior environment when its action returns, so a single call around a whole sequence would remove the three names exactly once, before the first phase; a phase script runs in the same process, and one that re-creates any of them (`start-local-dms.ps1` does exactly that in bootstrap mode, deliberately) would then still be setting it for every later phase.
- The guard clears with `Remove-Item`, never an assignment: whether `$env:X = $null` removes the variable or leaves it present-and-blank varies by platform and PowerShell/.NET version, and a blank value still satisfies `${VAR:-default}`. Prior state is restored exactly, preserving the absent, empty, whitespace, and valued distinctions, on the success path, when a phase throws, and when a phase calls `exit`.
- `build-dms.ps1` imports the module and calls the shared guard and the shared container-environment reader by name. Its gated call sites pass the guard's optional `-Enabled` parameter, which defaults to enabled; the always-on bootstrap call omits it. The build script defines no same-purpose helper of its own and no second copy of the reader, so there is one implementation and one name for each.
- Verification on the direct wrappers is at the **settings** level: the started container's schema settings against the selected environment file, failing with `DMS E2E setup mismatch: ...`. `build-dms.ps1 E2ETest` performs the **stronger** check on its own path — it captures the provisioned schema hash and compares it against the DMS runtime effective-schema hash — which the direct wrappers cannot do, because they do not capture the provisioned hash their phase output reports.
- Both sides of the settings comparison are read from the environment file only, never with Compose precedence, since resolving the expected side ambient-first would let the very override this gate exists to catch decide what "correct" means. Failure text is derived and sanitized: container values are classified into a fixed vocabulary, and only the environment file's own expected package identity is ever echoed.
- Pester coverage in files already registered in the bootstrap Pester CI job: executed guard behavior (removal, exact round-trip semantics, the `-Enabled` default and its pass-through), verdict behavior, AST-based wiring assertions that every phase invocation in both wrappers is lexically inside a guard of its own and that the verification follows the DMS-only start, the gate run against the repository's own tracked environment files, and a test pinning the guard's variable list to the names `local-dms.yml` actually resolves for the DMS schema surface.
- README troubleshooting for the 503 symptom in both E2E suites, including that selecting a different `-EnvironmentFile` is the supported way to change the package surface.

## Notes to consider

- The guard is deliberately caller-side. `start-local-dms.ps1` must not clear these three names globally, because in bootstrap mode it sets them in-process on purpose so process precedence makes the staged `.bootstrap/ApiSchema` workspace authoritative. A guard pushed down into the start script would strip its own activation values before the compose call.
- The fail-fast gate is unconditional by design. The file-only package reader the provision phase uses throws unless the file declares at least one package, so an absent, malformed, or empty `SCHEMA_PACKAGES` has already failed provisioning and cannot reach the gate to be classified as acceptable; that contract is encoded as a validated minimum on the expected count. An environment file that declares packages but does not set `USE_API_SCHEMA_PATH=true` is reported against the file rather than the container, because the provisioner stamps its packages either way. No tracked environment file is affected.
- No changes to `start-local-dms.ps1`, `local-dms.yml`, `run.sh`, `.env.e2e`, generated DDL, schema hashing, or any workflow.
- One local Pester failure is expected on Windows and is unrelated to this change: `BootstrapSchemaAndSecuritySelection.Tests.ps1`'s "run.sh clears stale generated package output" test has a skip guard checking `bash` and `jq` but not `chmod`, and `chmod` is not resolvable from pwsh on Windows. It fails identically on unmodified `main` and is green on CI's ubuntu-latest. Left untouched here as unrelated churn; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
