### PR TITLE
[DMS-1282] Return parameter-validation-failed problem-details for invalid pagination parameters

### DIFF
--- a/reference/design/backend-redesign/design-docs/change-queries.md
+++ b/reference/design/backend-redesign/design-docs/change-queries.md
@@ -2091,7 +2091,7 @@ Authorization-related ProblemDetails for Change Queries are owned by [auth.md](a
 
 #### 1. Parameter Validation Failures (400 Bad Request)
 
-These errors indicate invalid query string values on `/deletes`, `/keyChanges`, or live resource and descriptor GET-many requests using `minChangeVersion` / `maxChangeVersion`, and invalid `limit`, `offset`, or `totalCount` values on `/deletes` and `/keyChanges`. Pagination failures on live GET-many are governed by [partitioned-cursor-paging.md](partitioned-cursor-paging.md), which uses this same shell.
+These errors indicate invalid query string values on `/deletes`, `/keyChanges`, or live resource and descriptor GET-many requests using `minChangeVersion` / `maxChangeVersion`, and invalid `limit`, `offset`, or `totalCount` values on `/deletes` and `/keyChanges`. Pagination failures on live resource and descriptor GET-many are governed by [partitioned-cursor-paging.md](partitioned-cursor-paging.md), which uses this same shell.
 
 **Type**: `urn:ed-fi:api:bad-request:parameter-validation-failed`
 
@@ -2111,8 +2111,6 @@ These errors indicate invalid query string values on `/deletes`, `/keyChanges`, 
 | `totalCount` cannot be parsed as a boolean | `TotalCount must be a boolean value.` |
 
 The pagination rules are evaluated together rather than exclusively: a request with several invalid pagination parameters reports every one of them, in the order `offset`, `limit`, `totalCount`.
-
-The pagination parameter names are matched case-sensitively, unlike the change-version names, which are matched case-insensitively. A case variant such as `Limit` is therefore not a pagination parameter at all: it is reported as an invalid query field in the generic bad-request shell rather than in this one, so the two spellings of one client typo differ in `type`, `title`, and `detail`.
 
 The two families do not combine. Pagination is validated ahead of the change-version parameters and a fault there is answered immediately, so a request carrying faults in both reports only its pagination errors and its change-version values are never examined. Because both families answer with this same shell, the response does not distinguish change-version values that were accepted from ones that were never reached, and a client that corrects only the pagination values may receive a second 400.
 

--- a/reference/design/backend-redesign/design-docs/change-queries.md
+++ b/reference/design/backend-redesign/design-docs/change-queries.md
@@ -2112,6 +2112,8 @@ These errors indicate invalid query string values on `/deletes`, `/keyChanges`, 
 
 The pagination rules are evaluated together rather than exclusively: a request with several invalid pagination parameters reports every one of them, in the order `offset`, `limit`, `totalCount`.
 
+The pagination parameter names are matched case-sensitively, unlike the change-version names, which are matched case-insensitively. A case variant such as `Limit` is therefore not a pagination parameter at all: it is reported as an invalid query field in the generic bad-request shell rather than in this one, so the two spellings of one client typo differ in `type`, `title`, and `detail`.
+
 The two families do not combine. Pagination is validated ahead of the change-version parameters and a fault there is answered immediately, so a request carrying faults in both reports only its pagination errors and its change-version values are never examined. Because both families answer with this same shell, the response does not distinguish change-version values that were accepted from ones that were never reached, and a client that corrects only the pagination values may receive a second 400.
 
 

--- a/reference/design/backend-redesign/design-docs/change-queries.md
+++ b/reference/design/backend-redesign/design-docs/change-queries.md
@@ -2112,6 +2112,8 @@ These errors indicate invalid query string values on `/deletes`, `/keyChanges`, 
 
 The pagination rules are evaluated together rather than exclusively: a request with several invalid pagination parameters reports every one of them, in the order `offset`, `limit`, `totalCount`.
 
+The two families do not combine. Pagination is validated ahead of the change-version parameters and a fault there is answered immediately, so a request carrying faults in both reports only its pagination errors and its change-version values are never examined. Because both families answer with this same shell, the response does not distinguish change-version values that were accepted from ones that were never reached, and a client that corrects only the pagination values may receive a second 400.
+
 
 #### 2. Resource or Endpoint Not Found (404 Not Found)
 

--- a/reference/design/backend-redesign/design-docs/change-queries.md
+++ b/reference/design/backend-redesign/design-docs/change-queries.md
@@ -2091,7 +2091,7 @@ Authorization-related ProblemDetails for Change Queries are owned by [auth.md](a
 
 #### 1. Parameter Validation Failures (400 Bad Request)
 
-These errors indicate invalid query string values on `/deletes`, `/keyChanges`, or live resource and descriptor GET-many requests using `minChangeVersion` / `maxChangeVersion`.
+These errors indicate invalid query string values on `/deletes`, `/keyChanges`, or live resource and descriptor GET-many requests using `minChangeVersion` / `maxChangeVersion`, and invalid `limit`, `offset`, or `totalCount` values on `/deletes` and `/keyChanges`. Pagination failures on live GET-many are governed by [partitioned-cursor-paging.md](partitioned-cursor-paging.md), which uses this same shell.
 
 **Type**: `urn:ed-fi:api:bad-request:parameter-validation-failed`
 
@@ -2106,6 +2106,11 @@ These errors indicate invalid query string values on `/deletes`, `/keyChanges`, 
 | `minChangeVersion` cannot be parsed as an integer | `MinChangeVersion must be a numeric value greater than or equal to 0.` |
 | `maxChangeVersion` cannot be parsed as an integer | `MaxChangeVersion must be a numeric value greater than or equal to 0.` |
 | `minChangeVersion` is greater than `maxChangeVersion` | `MinChangeVersion must be less than or equal to MaxChangeVersion.` |
+| `offset` cannot be parsed as an integer, or is negative | `Offset must be a numeric value greater than or equal to 0.` |
+| `limit` cannot be parsed as an integer, or falls outside `0`–`{MaximumPageSize}` | `Limit must be omitted or set to a numeric value between 0 and {MaximumPageSize}.` |
+| `totalCount` cannot be parsed as a boolean | `TotalCount must be a boolean value.` |
+
+The pagination rules are evaluated together rather than exclusively: a request with several invalid pagination parameters reports every one of them, in the order `offset`, `limit`, `totalCount`.
 
 
 #### 2. Resource or Endpoint Not Found (404 Not Found)

--- a/reference/design/backend-redesign/design-docs/change-queries.md
+++ b/reference/design/backend-redesign/design-docs/change-queries.md
@@ -2110,7 +2110,7 @@ These errors indicate invalid query string values on `/deletes`, `/keyChanges`, 
 | `limit` cannot be parsed as an integer, or falls outside `0`–`{MaximumPageSize}` | `Limit must be omitted or set to a numeric value between 0 and {MaximumPageSize}.` |
 | `totalCount` cannot be parsed as a boolean | `TotalCount must be a boolean value.` |
 
-The pagination rules are evaluated together rather than exclusively: a request with several invalid pagination parameters reports every one of them, in the order `offset`, `limit`, `totalCount`.
+Within each family the rules are evaluated together rather than exclusively: a request with several invalid change-version parameters, or several invalid pagination parameters, reports every one of them — change-version in the order `minChangeVersion`, `maxChangeVersion`, then the inverted-range check, which is reached only when both bounds parse; pagination in the order `offset`, `limit`, `totalCount`.
 
 The two families do not combine. Pagination is validated ahead of the change-version parameters and a fault there is answered immediately, so a request carrying faults in both reports only its pagination errors and its change-version values are never examined. Because both families answer with this same shell, the response does not distinguish change-version values that were accepted from ones that were never reached, and a client that corrects only the pagination values may receive a second 400.
 

--- a/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
+++ b/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
@@ -216,8 +216,8 @@ The numbered rules are the within-phase tie-breakers. A phase-0 failure suppress
 a mixed-mode conflict suppresses relationship and syntax/range rules; a required-relationship
 failure suppresses syntax/range rules.
 
-New cursor and partition failures use HTTP 400 with this JSON shape and the current DMS
-`application/json` response media type:
+Cursor, partition, and traditional-paging failures use HTTP 400 with this JSON shape and the
+current DMS `application/json` response media type:
 
 ```json
 {

--- a/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
+++ b/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
@@ -232,7 +232,11 @@ New cursor and partition failures use HTTP 400 with this JSON shape and the curr
 ```
 
 For a cursor failure, `errors` contains exactly the one message selected above. A partition failure
-uses the same shell but may contain several ordered messages.
+uses the same shell but may contain several ordered messages. A traditional-paging failure also uses
+this shell, and reports every faulty parameter rather than the first, ordered `offset`, `limit`,
+`totalCount`. That order is not the phase-3 order above: phase 3 breaks ties to select a single
+error, while traditional parsing emits a list. Sharing one shell therefore does not mean sharing one
+cardinality — a client cannot infer from the response shape how many messages it may hold.
 
 #### Worked precedence examples
 

--- a/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
+++ b/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
@@ -161,8 +161,9 @@ last value in request order. Collapsing case variants MUST NOT throw.
 ### Cursor validation and ProblemDetails
 
 The presence of either `pageToken` or `pageSize` — including a blank or malformed value — selects
-the cursor validation path and its parameter-validation ProblemDetails shell. Traditional-only
-`limit`/`offset` failures retain the existing generic bad-request response and messages.
+the cursor validation path. Both that path and traditional-only `limit`/`offset` parsing answer a
+parameter fault with the parameter-validation ProblemDetails shell; the traditional failures retain
+their existing messages, which predate this design.
 
 A cursor request returns **exactly one** error. Evaluate the following four phases in order, use the
 exact message shown for each rule, and stop at the first match.

--- a/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
+++ b/reference/design/backend-redesign/design-docs/partitioned-cursor-paging.md
@@ -161,9 +161,9 @@ last value in request order. Collapsing case variants MUST NOT throw.
 ### Cursor validation and ProblemDetails
 
 The presence of either `pageToken` or `pageSize` — including a blank or malformed value — selects
-the cursor validation path. Both that path and traditional-only `limit`/`offset` parsing answer a
-parameter fault with the parameter-validation ProblemDetails shell; the traditional failures retain
-their existing messages, which predate this design.
+the cursor validation path. Both that path and traditional `limit`/`offset`/`totalCount` parsing
+answer a parameter fault with the parameter-validation ProblemDetails shell; the traditional
+failures retain their existing messages, which predate this design.
 
 A cursor request returns **exactly one** error. Evaluate the following four phases in order, use the
 exact message shown for each rule, and stop at the first match.

--- a/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
+++ b/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
@@ -87,9 +87,10 @@ story assert a presence semantic the other owns.
   and out-of-range `number`, including the blank case the design doc treats as malformed rather than
   absent, and prove resource-property and change-version filters are accepted rather than reported
   as unsupported.
-- Traditional-only pagination failures retain their current response shell and messages, and `limit`,
-  `offset`, and `totalCount` remain case-insensitive, with the fold made culture-invariant so a server
-  whose culture is not the invariant one recognizes them as well.
+- Traditional-only pagination failures answer with the parameter-validation shell while retaining
+  their existing messages, and `limit`, `offset`, and `totalCount` remain case-insensitive, with the
+  fold made culture-invariant so a server whose culture is not the invariant one recognizes them as
+  well.
 - `/deletes` and `/keyChanges` tests prove `pageToken` and `pageSize` are rejected rather than
   ignored.
 - Unit tests cover every typed path case, unknown child segments, extra segments, route qualifiers,

--- a/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
+++ b/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
@@ -51,8 +51,8 @@ story assert a presence semantic the other owns.
 - Add the separately phase-gated partition validator with `number` precedence over the
   unsupported-parameter phase and canonical unsupported-parameter ordering.
 - Add the approved parameter-validation ProblemDetails shell for cursor and partition failures, and
-  answer traditional-only `limit`/`offset` failures with that same shell while retaining their
-  existing messages, which predate this design.
+  answer traditional `limit`/`offset`/`totalCount` failures with that same shell while retaining
+  their existing messages, which predate this design.
 - Keep cursor parameter recognition operation-scoped so `/deletes` and `/keyChanges` retain their
   existing invalid-query-field HTTP 400 behavior instead of globally reserving the names.
 - Add typed `ResourcePathOperation` collection, by-id, and partition cases, and update path parsing,

--- a/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
+++ b/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/00b-cursor-and-partition-validation.md
@@ -50,8 +50,9 @@ story assert a presence semantic the other owns.
   conflict-ordering signal rather than deferring to a bound value.
 - Add the separately phase-gated partition validator with `number` precedence over the
   unsupported-parameter phase and canonical unsupported-parameter ordering.
-- Add the approved parameter-validation ProblemDetails shell for cursor and partition failures while
-  leaving traditional-only `limit`/`offset` failures on their existing generic bad-request response.
+- Add the approved parameter-validation ProblemDetails shell for cursor and partition failures, and
+  answer traditional-only `limit`/`offset` failures with that same shell while retaining their
+  existing messages, which predate this design.
 - Keep cursor parameter recognition operation-scoped so `/deletes` and `/keyChanges` retain their
   existing invalid-query-field HTTP 400 behavior instead of globally reserving the names.
 - Add typed `ResourcePathOperation` collection, by-id, and partition cases, and update path parsing,

--- a/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/08b-public-contract-parity-and-e2e.md
+++ b/reference/design/backend-redesign/epics/20-partitioned-cursor-paging/08b-public-contract-parity-and-e2e.md
@@ -70,8 +70,11 @@ scope.
   precedence table.
 - The partition token count never exceeds the requested `number`, and requesting more partitions
   than the minimum size allows returns fewer tokens rather than an error.
-- Existing traditional paging response bodies, status codes, and `Total-Count` semantics remain
+- Existing traditional paging success bodies, status codes, and `Total-Count` semantics remain
   unchanged; the additional `Next-Page-Token` header is covered as an intentional contract change.
+  Traditional pagination *failure* bodies are not covered by this parity statement: their
+  ProblemDetails shell is owned by
+  [00b-cursor-and-partition-validation.md](00b-cursor-and-partition-validation.md).
 
 ## Cross-Provider and Authorization Responsibilities
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -317,6 +317,27 @@ public class ValidateQueryMiddlewareCursorTests
                 MinChangeVersionNotNumeric
             );
         }
+
+        /// <summary>
+        /// The traditional twin of the cursor fixture's paging guard. Both properties are asserted
+        /// because they are kept unapplied by different mechanisms: CollectionPaging by the early
+        /// return preceding its single assignment site, and PaginationParameters by the errors-empty
+        /// guard inside the parsing helper, which is the only thing standing between a rejected
+        /// request and parsed pagination a Change Query handler would read directly.
+        /// </summary>
+        [Test]
+        public async Task It_leaves_paging_unapplied()
+        {
+            RequestInfo requestInfo = await Execute(true, ("limit", "-1"));
+
+            requestInfo
+                .CollectionPaging.Should()
+                .Be(No.CollectionPaging, "a rejected request must not leave partially applied paging behind");
+
+            requestInfo
+                .PaginationParameters.Should()
+                .Be(No.PaginationParameters, "a rejected request must not leave parsed pagination behind");
+        }
     }
 
     [TestFixture]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -102,6 +102,11 @@ public class ValidateQueryMiddlewareCursorTests
     /// the cursor and traditional fixtures, which answer a parameter fault identically. The expected
     /// messages are ordered: a cursor fault reports exactly one, a traditional fault reports every
     /// faulty parameter.
+    ///
+    /// The media type is asserted alongside the body because the middleware never states it: it
+    /// comes from the FrontendResponse default, and the frontend appends the charset the acceptance
+    /// criteria name. Every other ProblemDetails body in Core is served as problem+json by its
+    /// handler, so nothing but this assertion stops that convention reaching these responses.
     /// </summary>
     private static void AssertParameterValidationShell(
         RequestInfo requestInfo,
@@ -109,6 +114,7 @@ public class ValidateQueryMiddlewareCursorTests
     )
     {
         requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        requestInfo.FrontendResponse.ContentType.Should().Be("application/json");
 
         JsonNode body = requestInfo.FrontendResponse.Body!;
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -103,10 +103,9 @@ public class ValidateQueryMiddlewareCursorTests
     /// messages are ordered: a cursor fault reports exactly one, a traditional fault reports every
     /// faulty parameter.
     ///
-    /// The media type is asserted alongside the body because the middleware never states it: it
-    /// comes from the FrontendResponse default, and the frontend appends the charset the acceptance
-    /// criteria name. Every other ProblemDetails body in Core is served as problem+json by its
-    /// handler, so nothing but this assertion stops that convention reaching these responses.
+    /// The media type is asserted alongside the body because nothing at the call site states it: it
+    /// comes from the FrontendResponse default, and the frontend appends the charset that makes it
+    /// the documented `application/json; charset=utf-8` response type.
     /// </summary>
     private static void AssertParameterValidationShell(
         RequestInfo requestInfo,

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -17,8 +17,8 @@ using static EdFi.DataManagementService.Core.Tests.Unit.TestHelper;
 namespace EdFi.DataManagementService.Core.Tests.Unit.Middleware;
 
 /// <summary>
-/// Cursor recognition, the parameter-validation shell, the traditional shell it must not replace,
-/// and the collection paging applied to request state.
+/// Cursor recognition, the parameter-validation shell both paging modes answer a parameter fault
+/// with, and the collection paging applied to request state.
 /// </summary>
 [TestFixture]
 [Parallelizable]
@@ -97,6 +97,25 @@ public class ValidateQueryMiddlewareCursorTests
         return requestInfo;
     }
 
+    /// <summary>
+    /// The parameter-validation shell, asserted whole so a partial regression cannot pass. Shared by
+    /// the cursor and traditional fixtures, which answer a parameter fault identically.
+    /// </summary>
+    private static void AssertParameterValidationShell(RequestInfo requestInfo, string expectedError)
+    {
+        requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+
+        JsonNode body = requestInfo.FrontendResponse.Body!;
+
+        body["detail"]!.GetValue<string>().Should().Be("Parameters supplied to the request were invalid.");
+        body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+        body["title"]!.GetValue<string>().Should().Be("Parameter Validation Failed");
+        body["status"]!.GetValue<int>().Should().Be(400);
+        body["correlationId"]!.GetValue<string>().Should().Be(TraceId);
+        body["validationErrors"]!.AsObject().Should().BeEmpty();
+        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Equal(expectedError);
+    }
+
     [TestFixture]
     [Parallelizable]
     public class Given_A_Rejected_Cursor_Request : ValidateQueryMiddlewareCursorTests
@@ -144,31 +163,6 @@ public class ValidateQueryMiddlewareCursorTests
             requestInfo
                 .CollectionPaging.Should()
                 .Be(No.CollectionPaging, "a rejected request must not leave partially applied paging behind");
-        }
-
-        private static void AssertParameterValidationShell(RequestInfo requestInfo, string expectedError)
-        {
-            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
-
-            JsonNode body = requestInfo.FrontendResponse.Body!;
-
-            body["detail"]!
-                .GetValue<string>()
-                .Should()
-                .Be("Parameters supplied to the request were invalid.");
-            body["type"]!
-                .GetValue<string>()
-                .Should()
-                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
-            body["title"]!.GetValue<string>().Should().Be("Parameter Validation Failed");
-            body["status"]!.GetValue<int>().Should().Be(400);
-            body["correlationId"]!.GetValue<string>().Should().Be(TraceId);
-            body["validationErrors"]!.AsObject().Should().BeEmpty();
-            body["errors"]!
-                .AsArray()
-                .Select(error => error!.GetValue<string>())
-                .Should()
-                .Equal(expectedError);
         }
     }
 
@@ -223,49 +217,39 @@ public class ValidateQueryMiddlewareCursorTests
         }
     }
 
+    /// <summary>
+    /// A traditional pagination fault answers with the same parameter-validation shell as a cursor
+    /// fault, while keeping the messages that predate cursor paging.
+    /// </summary>
     [TestFixture]
     [Parallelizable]
     public class Given_A_Traditional_Request_With_A_Fault : ValidateQueryMiddlewareCursorTests
     {
-        [TestCase("limit", "-1", "Limit must be omitted or set to a numeric value between 0 and 500.")]
-        [TestCase("limit", "abc", "Limit must be omitted or set to a numeric value between 0 and 500.")]
+        private const string LimitOutOfRange =
+            "Limit must be omitted or set to a numeric value between 0 and 500.";
+
+        [TestCase("limit", "-1", LimitOutOfRange)]
+        [TestCase("limit", "abc", LimitOutOfRange)]
         [TestCase("offset", "-1", "Offset must be a numeric value greater than or equal to 0.")]
         [TestCase("offset", "abc", "Offset must be a numeric value greater than or equal to 0.")]
         [TestCase("totalCount", "x", "TotalCount must be a boolean value.")]
-        public async Task It_keeps_the_existing_bad_request_shell_and_message(
+        public async Task It_returns_the_parameter_validation_shell_with_the_existing_message(
             string parameter,
             string value,
             string expectedError
         )
         {
-            RequestInfo requestInfo = await Execute(true, (parameter, value));
-
-            requestInfo.FrontendResponse.StatusCode.Should().Be(400);
-
-            JsonNode body = requestInfo.FrontendResponse.Body!;
-
-            body["detail"]!
-                .GetValue<string>()
-                .Should()
-                .Be("The request could not be processed. See 'errors' for details.");
-            body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request");
-            body["title"]!.GetValue<string>().Should().Be("Bad Request");
-            body["errors"]!
-                .AsArray()
-                .Select(error => error!.GetValue<string>())
-                .Should()
-                .Contain(expectedError);
+            AssertParameterValidationShell(await Execute(true, (parameter, value)), expectedError);
         }
 
+        /// <summary>
+        /// The traditional branch runs in the Change Query composition as well, so a pagination
+        /// fault on /deletes or /keyChanges is answered the same way live GET-many answers it.
+        /// </summary>
         [Test]
-        public async Task It_does_not_acquire_the_parameter_validation_shell()
+        public async Task It_returns_the_parameter_validation_shell_without_cursor_recognition()
         {
-            RequestInfo requestInfo = await Execute(true, ("limit", "-1"));
-
-            requestInfo.FrontendResponse.Body!["type"]!
-                .GetValue<string>()
-                .Should()
-                .NotBe("urn:ed-fi:api:bad-request:parameter-validation-failed");
+            AssertParameterValidationShell(await Execute(false, ("limit", "-1")), LimitOutOfRange);
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -99,9 +99,14 @@ public class ValidateQueryMiddlewareCursorTests
 
     /// <summary>
     /// The parameter-validation shell, asserted whole so a partial regression cannot pass. Shared by
-    /// the cursor and traditional fixtures, which answer a parameter fault identically.
+    /// the cursor and traditional fixtures, which answer a parameter fault identically. The expected
+    /// messages are ordered: a cursor fault reports exactly one, a traditional fault reports every
+    /// faulty parameter.
     /// </summary>
-    private static void AssertParameterValidationShell(RequestInfo requestInfo, string expectedError)
+    private static void AssertParameterValidationShell(
+        RequestInfo requestInfo,
+        params string[] expectedErrors
+    )
     {
         requestInfo.FrontendResponse.StatusCode.Should().Be(400);
 
@@ -113,7 +118,7 @@ public class ValidateQueryMiddlewareCursorTests
         body["status"]!.GetValue<int>().Should().Be(400);
         body["correlationId"]!.GetValue<string>().Should().Be(TraceId);
         body["validationErrors"]!.AsObject().Should().BeEmpty();
-        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Equal(expectedError);
+        body["errors"]!.AsArray().Select(error => error!.GetValue<string>()).Should().Equal(expectedErrors);
     }
 
     [TestFixture]
@@ -266,6 +271,23 @@ public class ValidateQueryMiddlewareCursorTests
         )
         {
             AssertParameterValidationShell(await Execute(false, (parameter, value)), expectedError);
+        }
+
+        /// <summary>
+        /// The pagination rules are evaluated together rather than exclusively, so all three faults
+        /// are reported in one response. Pinned on this composition because change-queries.md states
+        /// the ordering as a contract of /deletes and /keyChanges, which is what recognizes no cursor
+        /// parameters. See change-queries.md, "Parameter Validation Failures".
+        /// </summary>
+        [Test]
+        public async Task It_reports_every_pagination_fault_in_the_documented_order()
+        {
+            AssertParameterValidationShell(
+                await Execute(false, ("offset", "-1"), ("limit", "-1"), ("totalCount", "x")),
+                OffsetNegative,
+                LimitOutOfRange,
+                TotalCountNotABoolean
+            );
         }
 
         /// <summary>

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareCursorTests.cs
@@ -219,7 +219,8 @@ public class ValidateQueryMiddlewareCursorTests
 
     /// <summary>
     /// A traditional pagination fault answers with the same parameter-validation shell as a cursor
-    /// fault, while keeping the messages that predate cursor paging.
+    /// fault, while keeping the messages that predate cursor paging, and is answered ahead of the
+    /// change-version parameters.
     /// </summary>
     [TestFixture]
     [Parallelizable]
@@ -228,11 +229,18 @@ public class ValidateQueryMiddlewareCursorTests
         private const string LimitOutOfRange =
             "Limit must be omitted or set to a numeric value between 0 and 500.";
 
+        private const string OffsetNegative = "Offset must be a numeric value greater than or equal to 0.";
+
+        private const string TotalCountNotABoolean = "TotalCount must be a boolean value.";
+
+        private const string MinChangeVersionNotNumeric =
+            "MinChangeVersion must be a numeric value greater than or equal to 0.";
+
         [TestCase("limit", "-1", LimitOutOfRange)]
         [TestCase("limit", "abc", LimitOutOfRange)]
-        [TestCase("offset", "-1", "Offset must be a numeric value greater than or equal to 0.")]
-        [TestCase("offset", "abc", "Offset must be a numeric value greater than or equal to 0.")]
-        [TestCase("totalCount", "x", "TotalCount must be a boolean value.")]
+        [TestCase("offset", "-1", OffsetNegative)]
+        [TestCase("offset", "abc", OffsetNegative)]
+        [TestCase("totalCount", "x", TotalCountNotABoolean)]
         public async Task It_returns_the_parameter_validation_shell_with_the_existing_message(
             string parameter,
             string value,
@@ -244,12 +252,48 @@ public class ValidateQueryMiddlewareCursorTests
 
         /// <summary>
         /// The traditional branch runs in the Change Query composition as well, so a pagination
-        /// fault on /deletes or /keyChanges is answered the same way live GET-many answers it.
+        /// fault on /deletes or /keyChanges is answered the same way live GET-many answers it. All
+        /// three parameters are covered rather than one representative, because this composition has
+        /// no cursor path and the traditional branch is the only thing answering them.
+        /// </summary>
+        [TestCase("limit", "-1", LimitOutOfRange)]
+        [TestCase("offset", "-1", OffsetNegative)]
+        [TestCase("totalCount", "x", TotalCountNotABoolean)]
+        public async Task It_returns_the_parameter_validation_shell_without_cursor_recognition(
+            string parameter,
+            string value,
+            string expectedError
+        )
+        {
+            AssertParameterValidationShell(await Execute(false, (parameter, value)), expectedError);
+        }
+
+        /// <summary>
+        /// Pagination is validated ahead of the change-version parameters and a fault there is
+        /// answered immediately, so the change-version values are never examined. Both families
+        /// answer with this same shell, so the reported messages are the only thing separating
+        /// "accepted" from "never reached".
         /// </summary>
         [Test]
-        public async Task It_returns_the_parameter_validation_shell_without_cursor_recognition()
+        public async Task It_reports_only_the_pagination_fault_when_change_version_is_also_invalid()
         {
-            AssertParameterValidationShell(await Execute(false, ("limit", "-1")), LimitOutOfRange);
+            AssertParameterValidationShell(
+                await Execute(true, ("limit", "-1"), ("minChangeVersion", "abc")),
+                LimitOutOfRange
+            );
+        }
+
+        /// <summary>
+        /// The same change-version value on its own, so the test above cannot pass because the
+        /// parameter is ignored outright rather than deferred behind the pagination fault.
+        /// </summary>
+        [Test]
+        public async Task It_reports_the_change_version_fault_once_pagination_is_clean()
+        {
+            AssertParameterValidationShell(
+                await Execute(true, ("minChangeVersion", "abc")),
+                MinChangeVersionNotNumeric
+            );
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -53,6 +53,10 @@ public class ValidateQueryMiddlewareTests
     /// on purpose: a null body or a missing key must fail the test rather than short-circuit the
     /// assertion that follows it. The reported messages are asserted separately by each fixture,
     /// which supplies its own faulty parameters.
+    ///
+    /// Every key of the shell is covered, including the two the shell carries empty, so a change
+    /// that stopped emitting one of them cannot pass here and be caught only by the cursor fixtures.
+    /// Every caller builds its request with an empty TraceId, which is what correlationId echoes.
     /// </summary>
     private static void AssertParameterValidationShell(RequestInfo requestInfo)
     {
@@ -62,6 +66,8 @@ public class ValidateQueryMiddlewareTests
         body["title"]!.GetValue<string>().Should().Be("Parameter Validation Failed");
         body["detail"]!.GetValue<string>().Should().Be("Parameters supplied to the request were invalid.");
         body["status"]!.GetValue<int>().Should().Be(400);
+        body["correlationId"]!.GetValue<string>().Should().BeEmpty();
+        body["validationErrors"]!.AsObject().Should().BeEmpty();
     }
 
     [TestFixture]
@@ -135,11 +141,14 @@ public class ValidateQueryMiddlewareTests
         [SetUp]
         public async Task Setup()
         {
+            // Only limit is at fault. A second faulty parameter here would satisfy the shell
+            // assertion below on its own, leaving the limit bound pinned by nothing but the
+            // message check.
             var queryParameters = new Dictionary<string, string>
             {
                 { "offset", "0" },
                 { "limit", "800" },
-                { "totalCount", "100" },
+                { "totalCount", "true" },
             };
 
             FrontendRequest frontendRequest = new(

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -176,13 +176,19 @@ public class ValidateQueryMiddlewareTests
             AssertParameterValidationShell(_requestInfo);
         }
 
+        /// <summary>
+        /// The only fixture covering the upper bound, so it is asserted as the whole ordered array
+        /// rather than a substring of the serialized body: cardinality is part of the contract here,
+        /// and a spurious second entry alongside the expected message would satisfy a substring check.
+        /// </summary>
         [Test]
-        public void It_should_be_limit_errors()
+        public void It_should_report_only_the_limit_error()
         {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
+            _requestInfo.FrontendResponse.Body!["errors"]!
+                .AsArray()
+                .Select(error => error!.GetValue<string>())
                 .Should()
-                .Contain($"Limit must be omitted or set to a numeric value between 0 and {_maxPageSize}.");
+                .Equal($"Limit must be omitted or set to a numeric value between 0 and {_maxPageSize}.");
         }
     }
 

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -57,9 +57,16 @@ public class ValidateQueryMiddlewareTests
     /// Every key of the shell is covered, including the two the shell carries empty, so a change
     /// that stopped emitting one of them cannot pass here and be caught only by the cursor fixtures.
     /// Every caller builds its request with an empty TraceId, which is what correlationId echoes.
+    ///
+    /// The media type is asserted alongside the body because the middleware never states it: it
+    /// comes from the FrontendResponse default, and the frontend appends the charset the acceptance
+    /// criteria name. Every other ProblemDetails body in Core is served as problem+json by its
+    /// handler, so nothing but this assertion stops that convention reaching these responses.
     /// </summary>
     private static void AssertParameterValidationShell(RequestInfo requestInfo)
     {
+        requestInfo.FrontendResponse.ContentType.Should().Be("application/json");
+
         JsonNode body = requestInfo.FrontendResponse.Body!;
 
         body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:parameter-validation-failed");

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -58,10 +58,9 @@ public class ValidateQueryMiddlewareTests
     /// that stopped emitting one of them cannot pass here and be caught only by the cursor fixtures.
     /// Every caller builds its request with an empty TraceId, which is what correlationId echoes.
     ///
-    /// The media type is asserted alongside the body because the middleware never states it: it
-    /// comes from the FrontendResponse default, and the frontend appends the charset the acceptance
-    /// criteria name. Every other ProblemDetails body in Core is served as problem+json by its
-    /// handler, so nothing but this assertion stops that convention reaching these responses.
+    /// The media type is asserted alongside the body because nothing at the call site states it: it
+    /// comes from the FrontendResponse default, and the frontend appends the charset that makes it
+    /// the documented `application/json; charset=utf-8` response type.
     /// </summary>
     private static void AssertParameterValidationShell(RequestInfo requestInfo)
     {

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -49,10 +49,10 @@ public class ValidateQueryMiddlewareTests
     }
 
     /// <summary>
-    /// The parameter-validation shell a pagination fault is answered with. Every dereference is hard
-    /// on purpose: a null body or a missing key must fail the test rather than short-circuit the
-    /// assertion that follows it. The reported messages are asserted separately by each fixture,
-    /// which supplies its own faulty parameters.
+    /// The parameter-validation shell a pagination or change-version fault is answered with. Every
+    /// dereference is hard on purpose: a null body or a missing key must fail the test rather than
+    /// short-circuit the assertion that follows it. The reported messages are asserted separately by
+    /// each fixture, which supplies its own faulty parameters.
     ///
     /// Every key of the shell is covered, including the two the shell carries empty, so a change
     /// that stopped emitting one of them cannot pass here and be caught only by the cursor fixtures.
@@ -850,8 +850,8 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_report_the_existing_invalid_query_field_error()
         {
-            _requestInfo
-                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+            _requestInfo.FrontendResponse.Body!["errors"]![0]!
+                .GetValue<string>()
                 .Should()
                 .Be("The query field 'invalidSchoolId' is not valid for this resource.");
         }
@@ -981,6 +981,12 @@ public class ValidateQueryMiddlewareTests
         public void It_should_send_bad_request()
         {
             _requestInfo.FrontendResponse.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void It_should_use_the_parameter_validation_failed_problem_details()
+        {
+            AssertParameterValidationShell(_requestInfo);
         }
 
         [Test]
@@ -1208,8 +1214,8 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_report_the_invalid_query_field()
         {
-            _requestInfo
-                .FrontendResponse.Body?["errors"]?[0]?.GetValue<string>()
+            _requestInfo.FrontendResponse.Body!["errors"]![0]!
+                .GetValue<string>()
                 .Should()
                 .Be("The query field 'Limit' is not valid for this resource.");
         }

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -48,6 +48,22 @@ public class ValidateQueryMiddlewareTests
         );
     }
 
+    /// <summary>
+    /// The parameter-validation shell a pagination fault is answered with. Every dereference is hard
+    /// on purpose: a null body or a missing key must fail the test rather than short-circuit the
+    /// assertion that follows it. The reported messages are asserted separately by each fixture,
+    /// which supplies its own faulty parameters.
+    /// </summary>
+    private static void AssertParameterValidationShell(RequestInfo requestInfo)
+    {
+        JsonNode body = requestInfo.FrontendResponse.Body!;
+
+        body["type"]!.GetValue<string>().Should().Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+        body["title"]!.GetValue<string>().Should().Be("Parameter Validation Failed");
+        body["detail"]!.GetValue<string>().Should().Be("Parameters supplied to the request were invalid.");
+        body["status"]!.GetValue<int>().Should().Be(400);
+    }
+
     [TestFixture]
     [Parallelizable]
     public class Given_Pipeline_Context_With_Wrong_Query_Parameters : ValidateQueryMiddlewareTests
@@ -86,42 +102,27 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            JsonNode? body = _requestInfo.FrontendResponse.Body;
-            body?["type"]?.GetValue<string>()
-                .Should()
-                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
-            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
-            body?["detail"]?.GetValue<string>()
-                .Should()
-                .Be("Parameters supplied to the request were invalid.");
-            body?["status"]?.GetValue<int>().Should().Be(400);
+            AssertParameterValidationShell(_requestInfo);
         }
 
+        /// <summary>
+        /// The pagination rules are evaluated together rather than exclusively, so all three faults
+        /// are reported. Asserted as an ordered array rather than three substring checks because the
+        /// order is a documented contract, and a substring check over the serialized body cannot see
+        /// it. See change-queries.md, "Parameter Validation Failures".
+        /// </summary>
         [Test]
-        public void It_should_be_offset_errors()
+        public void It_should_report_every_pagination_error_in_the_documented_order()
         {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
+            _requestInfo.FrontendResponse.Body!["errors"]!
+                .AsArray()
+                .Select(error => error!.GetValue<string>())
                 .Should()
-                .Contain("Offset must be a numeric value greater than or equal to 0.");
-        }
-
-        [Test]
-        public void It_should_be_limit_errors()
-        {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
-                .Should()
-                .Contain($"Limit must be omitted or set to a numeric value between 0 and {_maxPageSize}.");
-        }
-
-        [Test]
-        public void It_should_be_total_count_errors()
-        {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
-                .Should()
-                .Contain("TotalCount must be a boolean value.");
+                .Equal(
+                    "Offset must be a numeric value greater than or equal to 0.",
+                    $"Limit must be omitted or set to a numeric value between 0 and {_maxPageSize}.",
+                    "TotalCount must be a boolean value."
+                );
         }
     }
 
@@ -163,15 +164,7 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            JsonNode? body = _requestInfo.FrontendResponse.Body;
-            body?["type"]?.GetValue<string>()
-                .Should()
-                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
-            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
-            body?["detail"]?.GetValue<string>()
-                .Should()
-                .Be("Parameters supplied to the request were invalid.");
-            body?["status"]?.GetValue<int>().Should().Be(400);
+            AssertParameterValidationShell(_requestInfo);
         }
 
         [Test]
@@ -882,15 +875,7 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            JsonNode? body = _requestInfo.FrontendResponse.Body;
-            body?["type"]?.GetValue<string>()
-                .Should()
-                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
-            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
-            body?["detail"]?.GetValue<string>()
-                .Should()
-                .Be("Parameters supplied to the request were invalid.");
-            body?["status"]?.GetValue<int>().Should().Be(400);
+            AssertParameterValidationShell(_requestInfo);
         }
 
         [Test]
@@ -936,15 +921,7 @@ public class ValidateQueryMiddlewareTests
         [Test]
         public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            JsonNode? body = _requestInfo.FrontendResponse.Body;
-            body?["type"]?.GetValue<string>()
-                .Should()
-                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
-            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
-            body?["detail"]?.GetValue<string>()
-                .Should()
-                .Be("Parameters supplied to the request were invalid.");
-            body?["status"]?.GetValue<int>().Should().Be(400);
+            AssertParameterValidationShell(_requestInfo);
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core.Tests.Unit/Middleware/ValidateQueryMiddlewareTests.cs
@@ -84,12 +84,17 @@ public class ValidateQueryMiddlewareTests
         }
 
         [Test]
-        public void It_should_be_errors()
+        public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
+            JsonNode? body = _requestInfo.FrontendResponse.Body;
+            body?["type"]?.GetValue<string>()
                 .Should()
-                .Contain("The request could not be processed.");
+                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
+            body?["detail"]?.GetValue<string>()
+                .Should()
+                .Be("Parameters supplied to the request were invalid.");
+            body?["status"]?.GetValue<int>().Should().Be(400);
         }
 
         [Test]
@@ -156,12 +161,17 @@ public class ValidateQueryMiddlewareTests
         }
 
         [Test]
-        public void It_should_be_errors()
+        public void It_should_use_the_parameter_validation_failed_problem_details()
         {
-            _requestInfo
-                .FrontendResponse.Body?.ToJsonString()
+            JsonNode? body = _requestInfo.FrontendResponse.Body;
+            body?["type"]?.GetValue<string>()
                 .Should()
-                .Contain("The request could not be processed.");
+                .Be("urn:ed-fi:api:bad-request:parameter-validation-failed");
+            body?["title"]?.GetValue<string>().Should().Be("Parameter Validation Failed");
+            body?["detail"]?.GetValue<string>()
+                .Should()
+                .Be("Parameters supplied to the request were invalid.");
+            body?["status"]?.GetValue<int>().Should().Be(400);
         }
 
         [Test]

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -159,6 +159,17 @@ internal class ValidateQueryMiddleware(
             requestInfo.FrontendRequest.TraceId.Value
         );
 
+        // All three parameter faults below - cursor, traditional pagination, and change-version -
+        // answer with the same shell, so they share one construction. Three copies would have to be
+        // kept in step for status code, headers, and the media type, none of which this method
+        // states explicitly: the media type comes from the FrontendResponse default.
+        FrontendResponse ParameterValidationFailed(string[] errors) =>
+            new(
+                StatusCode: 400,
+                Body: ForParameterValidation(errors, requestInfo.FrontendRequest.TraceId),
+                Headers: []
+            );
+
         // A request that supplied either cursor parameter is validated by the cursor precedence.
         // Everything else keeps the traditional parsing and its existing messages. Both paths answer
         // a pagination fault with the parameter-validation shell, matching ODS/API.
@@ -173,14 +184,7 @@ internal class ValidateQueryMiddleware(
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
-            requestInfo.FrontendResponse = new FrontendResponse(
-                StatusCode: 400,
-                Body: ForParameterValidation(
-                    [invalidCursorRequest.Error],
-                    requestInfo.FrontendRequest.TraceId
-                ),
-                Headers: []
-            );
+            requestInfo.FrontendResponse = ParameterValidationFailed([invalidCursorRequest.Error]);
             return;
         }
 
@@ -209,11 +213,7 @@ internal class ValidateQueryMiddleware(
                     requestInfo.FrontendRequest.TraceId.Value
                 );
 
-                requestInfo.FrontendResponse = new FrontendResponse(
-                    StatusCode: 400,
-                    Body: ForParameterValidation([.. errors], requestInfo.FrontendRequest.TraceId),
-                    Headers: []
-                );
+                requestInfo.FrontendResponse = ParameterValidationFailed([.. errors]);
                 return;
             }
 
@@ -231,14 +231,7 @@ internal class ValidateQueryMiddleware(
                 requestInfo.FrontendRequest.TraceId.Value
             );
 
-            requestInfo.FrontendResponse = new FrontendResponse(
-                StatusCode: 400,
-                Body: ForParameterValidation(
-                    [.. changeVersionResult.Errors],
-                    requestInfo.FrontendRequest.TraceId
-                ),
-                Headers: []
-            );
+            requestInfo.FrontendResponse = ParameterValidationFailed([.. changeVersionResult.Errors]);
             return;
         }
 

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -76,21 +76,15 @@ internal class ValidateQueryMiddleware(
             }
         }
 
-        if (requestInfo.FrontendRequest.QueryParameters.ContainsKey("totalCount"))
+        // Unlike offset and limit, a parsed value needs no separate assignment: TryParse writes it
+        // straight to totalCount, and a failed parse writes false, which is also the value used when
+        // the parameter is omitted. The error recorded below stops the parameters being applied at all.
+        if (
+            requestInfo.FrontendRequest.QueryParameters.ContainsKey("totalCount")
+            && !bool.TryParse(requestInfo.FrontendRequest.QueryParameters["totalCount"], out totalCount)
+        )
         {
-            if (!bool.TryParse(requestInfo.FrontendRequest.QueryParameters["totalCount"], out totalCount))
-            {
-                errors.Add("TotalCount must be a boolean value.");
-            }
-            else
-            {
-                totalCount = bool.TryParse(
-                    requestInfo.FrontendRequest.QueryParameters["totalCount"],
-                    out bool totalValue
-                )
-                    ? totalValue
-                    : totalCount;
-            }
+            errors.Add("TotalCount must be a boolean value.");
         }
 
         if (errors.Count == 0)

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -165,9 +165,9 @@ internal class ValidateQueryMiddleware(
             requestInfo.FrontendRequest.TraceId.Value
         );
 
-        // A request that supplied either cursor parameter is validated by the cursor precedence and
-        // answered with the parameter-validation shell. Everything else keeps the traditional
-        // parsing, its generic bad-request shell, and its existing messages.
+        // A request that supplied either cursor parameter is validated by the cursor precedence.
+        // Everything else keeps the traditional parsing and its existing messages. Both paths answer
+        // a pagination fault with the parameter-validation shell, matching ODS/API.
         CursorValidationResult cursorResult = _cursorParametersRecognized
             ? CursorRequestValidator.Validate(requestInfo.FrontendRequest.QueryParameters, _maximumPageSize)
             : CursorValidationResult.NotCursorRequest.Instance;
@@ -208,13 +208,6 @@ internal class ValidateQueryMiddleware(
 
             if (errors.Count > 0)
             {
-                JsonNode failureResponse = FailureResponse.ForBadRequest(
-                    "The request could not be processed. See 'errors' for details.",
-                    requestInfo.FrontendRequest.TraceId,
-                    [],
-                    errors.ToArray()
-                );
-
                 _logger.LogDebug(
                     "'{Status}'.'{EndpointName}' - {TraceId}",
                     "400",
@@ -224,8 +217,8 @@ internal class ValidateQueryMiddleware(
 
                 requestInfo.FrontendResponse = new FrontendResponse(
                     StatusCode: 400,
-                    Body: failureResponse,
-                    []
+                    Body: ForParameterValidation([.. errors], requestInfo.FrontendRequest.TraceId),
+                    Headers: []
                 );
                 return;
             }

--- a/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
+++ b/src/dms/core/EdFi.DataManagementService.Core/Middleware/ValidateQueryMiddleware.cs
@@ -160,9 +160,9 @@ internal class ValidateQueryMiddleware(
         );
 
         // All three parameter faults below - cursor, traditional pagination, and change-version -
-        // answer with the same shell, so they share one construction. Three copies would have to be
-        // kept in step for status code, headers, and the media type, none of which this method
-        // states explicitly: the media type comes from the FrontendResponse default.
+        // answer with the same shell, so they share one construction rather than three copies that
+        // have to be kept in step. The media type is not stated here at all; it comes from the
+        // FrontendResponse default.
         FrontendResponse ParameterValidationFailed(string[] errors) =>
             new(
                 StatusCode: 400,

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/TrackedChangeDeletesByResource.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/TrackedChangeDeletesByResource.feature
@@ -366,18 +366,18 @@ Feature: TrackedChange /deletes endpoints across resource and key shapes.
 
         @ods-migrated
         @e2e-ci-shard-4
-        # NOTE: Expected body copied verbatim from DMS's actual ProblemDetails response. DMS reports
-        # invalid limit/offset as a generic bad-request (not parameter-validation-failed), lists Offset
-        # before Limit, and phrases the bounds as "numeric value between 0 and 500".
+        # NOTE: Expected body copied verbatim from DMS's actual ProblemDetails response. The envelope
+        # matches ODS's parameter-validation-failed shape; DMS still lists Offset before Limit and
+        # phrases the bounds as "numeric value between 0 and 500".
         Scenario: 10 Deletes response rejects invalid limit and offset
              When a GET request is made to "/ed-fi/schools/deletes?limit=-1&offset=-1"
              Then it should respond with 400
               And the response body is
                   """
                   {
-                    "detail": "The request could not be processed. See 'errors' for details.",
-                    "type": "urn:ed-fi:api:bad-request",
-                    "title": "Bad Request",
+                    "detail": "Parameters supplied to the request were invalid.",
+                    "type": "urn:ed-fi:api:bad-request:parameter-validation-failed",
+                    "title": "Parameter Validation Failed",
                     "status": 400,
                     "correlationId": null,
                     "validationErrors": {},

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/TrackedChangeKeyChangesByResource.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ChangeQueries/TrackedChangeKeyChangesByResource.feature
@@ -651,9 +651,9 @@ Feature: TrackedChange /keyChanges endpoints across resource and key shapes.
               And the response body path "0.oldKeyValues.staffUniqueId" should have value "SSECA-CO-STAFF"
               And the response body path "0.newKeyValues.staffUniqueId" should have value "SSECA-CO-STAFF"
 
-        # NOTE: Expected body copied verbatim from DMS's actual ProblemDetails response. DMS reports
-        # invalid limit/offset on /keyChanges as a generic bad-request (urn:ed-fi:api:bad-request),
-        # lists Offset before Limit, and phrases the bounds as "numeric value between 0 and 500".
+        # NOTE: Expected body copied verbatim from DMS's actual ProblemDetails response. The envelope
+        # matches ODS's parameter-validation-failed shape; DMS still lists Offset before Limit and
+        # phrases the bounds as "numeric value between 0 and 500".
         @ods-migrated
         @e2e-ci-shard-4
         Scenario: 07 KeyChanges response rejects invalid limit and offset
@@ -662,9 +662,9 @@ Feature: TrackedChange /keyChanges endpoints across resource and key shapes.
               And the response body is
                   """
                   {
-                    "detail": "The request could not be processed. See 'errors' for details.",
-                    "type": "urn:ed-fi:api:bad-request",
-                    "title": "Bad Request",
+                    "detail": "Parameters supplied to the request were invalid.",
+                    "type": "urn:ed-fi:api:bad-request:parameter-validation-failed",
+                    "title": "Parameter Validation Failed",
                     "status": 400,
                     "correlationId": null,
                     "validationErrors": {},

--- a/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
+++ b/src/dms/tests/EdFi.DataManagementService.Tests.E2E/Features/ResourceQueries/PagingQueryString.feature
@@ -123,9 +123,9 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
               And the response body is
                   """
                   {
-                        "detail": "The request could not be processed. See 'errors' for details.",
-                        "type": "urn:ed-fi:api:bad-request",
-                        "title": "Bad Request",
+                        "detail": "Parameters supplied to the request were invalid.",
+                        "type": "urn:ed-fi:api:bad-request:parameter-validation-failed",
+                        "title": "Parameter Validation Failed",
                         "status": 400,
                         "correlationId": null,
                         "validationErrors": {},
@@ -149,9 +149,9 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
               And the response body is
                   """
                   {
-                        "detail": "The request could not be processed. See 'errors' for details.",
-                        "type": "urn:ed-fi:api:bad-request",
-                        "title": "Bad Request",
+                        "detail": "Parameters supplied to the request were invalid.",
+                        "type": "urn:ed-fi:api:bad-request:parameter-validation-failed",
+                        "title": "Parameter Validation Failed",
                         "status": 400,
                         "correlationId": null,
                         "validationErrors": {},
@@ -164,3 +164,32 @@ Feature: Paging Support for GET requests for Ed-Fi Resources
                   | value |
                   | -1    |
                   | 900   |
+
+        @e2e-ci-shard-4
+        Scenario Outline: 14 Ensure clients can not GET information when using an invalid totalCount value
+             When a GET request is made to "/ed-fi/schools?totalCount=<value>"
+             Then it should respond with 400
+              And the response body is
+                  """
+                  {
+                        "detail": "Parameters supplied to the request were invalid.",
+                        "type": "urn:ed-fi:api:bad-request:parameter-validation-failed",
+                        "title": "Parameter Validation Failed",
+                        "status": 400,
+                        "correlationId": null,
+                        "validationErrors": {},
+                        "errors": [
+                            "TotalCount must be a boolean value."
+                        ]
+                    }
+                  """
+              And the response headers include
+                  """
+                  {
+                        "Content-Type": "application/json; charset=utf-8"
+                    }
+                  """
+        Examples:
+                  | value |
+                  | abc   |
+                  | 1     |


### PR DESCRIPTION
 ## Summary

  - Invalid `limit`, `offset`, and `totalCount` now return the `parameter-validation-failed`
    problem-details envelope (`urn:ed-fi:api:bad-request:parameter-validation-failed` /
    "Parameter Validation Failed" / "Parameters supplied to the request were invalid.")
    instead of the generic `urn:ed-fi:api:bad-request` shell, matching ODS/API (DMS-1282).
  - Consolidated the three 400 construction sites in `ValidateQueryMiddleware` — cursor,
    traditional pagination, and change-version — into one local `ParameterValidationFailed`
    helper, so the three faults can no longer drift apart. Media type is left to the
    `FrontendResponse` default, which the frontend renders as `application/json; charset=utf-8`.
  - Simplified `totalCount` parsing: the old code parsed the value twice (once to test, once
    to assign) inside a nested if/else. `bool.TryParse` already writes the parsed value, and a
    failed parse writes `false` — the same value used when the parameter is omitted — so a
    single guarded call is equivalent.
  - Existing messages and their order are unchanged (`offset`, `limit`, `totalCount`), and all
    faulty pagination parameters are still reported together rather than just the first.
  - Change-version validation behavior is unchanged. Pagination is still validated first and
    answered immediately, so a request faulty in both families reports only its pagination
    errors — now documented explicitly, since both families share one envelope and the response
    can no longer distinguish "accepted" from "never reached".
  - Unit tests: extracted a shared `AssertParameterValidationShell` in both middleware test
    classes that asserts the envelope whole (including `correlationId`, empty `validationErrors`,
    and content type), replacing substring checks over the serialized body with ordered array
    assertions so message order and cardinality are pinned. Added coverage for the
    change-queries composition (no cursor recognition), the pagination-before-change-version
    precedence, and that a rejected request leaves both `CollectionPaging` and
    `PaginationParameters` unapplied.
  - E2E: updated the three existing expected bodies in `PagingQueryString.feature`,
    `TrackedChangeDeletesByResource.feature`, and `TrackedChangeKeyChangesByResource.feature`;
    added scenario 14 covering invalid `totalCount` (`abc`, `1`), which had no E2E coverage.
  - Design docs updated to match: `change-queries.md` gains the three pagination messages and
    the cross-family precedence rule; `partitioned-cursor-paging.md` and the epic stories
    `00b`/`08b` no longer claim traditional paging keeps the generic bad-request shell.

  ## Test plan

  - [ ] `dotnet test src/dms/core/EdFi.DataManagementService.Core.Tests.Unit --filter "FullyQualifiedName~ValidateQueryMiddleware"` passes
  - [ ] `GET /ed-fi/schools?limit=-1` → 400 with `type: urn:ed-fi:api:bad-request:parameter-validation-failed`, `errors: ["Limit must be omitted or set to a numeric value between 0
  and 500."]`
  - [ ] `GET /ed-fi/schools?offset=-1` → same envelope, `errors: ["Offset must be a numeric value greater than or equal to 0."]`
  - [ ] `GET /ed-fi/schools?totalCount=abc` and `?totalCount=1` → same envelope, `errors: ["TotalCount must be a boolean value."]`
  - [ ] `GET /ed-fi/schools?offset=-1&limit=-1&totalCount=x` → all three messages, in that order
  - [ ] Response `Content-Type` is `application/json; charset=utf-8` on each of the above
  - [ ] `GET /ed-fi/schools/deletes?limit=-1&offset=-1` and `/keyChanges?limit=-1&offset=-1` → parameter-validation envelope (regression: these use the change-queries composition,
  which recognizes no cursor parameters)
  - [ ] Change-version unchanged: `?minChangeVersion=abc` alone still returns `MinChangeVersion must be a numeric value greater than or equal to 0.`;
  `?limit=-1&minChangeVersion=abc` returns only the limit error
  - [ ] Cursor faults unchanged: a `pageToken`/`pageSize` fault still returns exactly one error in the same envelope
  - [ ] Valid paging still works — `?limit=10&offset=0&totalCount=true` returns 200 with `Total-Count`
  - [ ] E2E (shard 4): `PagingQueryString.feature` scenarios 12–14, `TrackedChangeDeletesByResource.feature` scenario 10, `TrackedChangeKeyChangesByResource.feature` scenario 07
